### PR TITLE
fix: add pronunciation guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# c8ctl - Camunda 8 CLI
+# Cocktail (c8ctl) - Camunda 8 CLI
 
-A minimal-dependency CLI for Camunda 8 operations built on top of [`@camunda8/orchestration-cluster-api`](https://www.npmjs.com/package/@camunda8/orchestration-cluster-api).
+c8ctl (_pronounced: "cocktail"_) — a minimal-dependency CLI for Camunda 8 operations built on top of [`@camunda8/orchestration-cluster-api`](https://www.npmjs.com/package/@camunda8/orchestration-cluster-api).
 
 ## Features
 


### PR DESCRIPTION
This eases the user from cli -> c8ctl and introduces the naming convention so the community know what to call it.

Signed-off-by: Josh Wulf <josh.wulf@camunda.com>