### PR TITLE
Improve version aliases

### DIFF
--- a/default-plugins/cluster/README.md
+++ b/default-plugins/cluster/README.md
@@ -5,11 +5,15 @@ A default [c8ctl](https://github.com/camunda/c8ctl) plugin that provides an opin
 ## Usage
 
 ```bash
-# Start a local Camunda 8 cluster (downloads c8run automatically if needed)
-c8ctl cluster start
-
 # Start with a specific version
 c8ctl cluster start 8.9.0-alpha5
+
+# Start using a version alias
+c8ctl cluster start stable
+c8ctl cluster start alpha
+
+# Starting without specifying a version defaults to alpha
+c8ctl cluster start
 
 # Start with debug output (streams raw c8run logs)
 c8ctl cluster start --debug

--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -47,6 +47,10 @@ function resolveVersion(versionSpec) {
   return _versionAliases[versionSpec] ?? versionSpec;
 }
 
+function getVersionAliasEntries() {
+  return Object.entries(_versionAliases);
+}
+
 // ---------------------------------------------------------------------------
 // Plugin metadata
 // ---------------------------------------------------------------------------
@@ -712,18 +716,27 @@ export const commands = {
       console.log('  stop    Stop the running local Camunda 8 cluster');
       console.log('');
       console.log('Options:');
-      console.log('  <version>              Camunda version to use (default: alpha / 8.9)');
+      console.log('  <version>              Camunda version or alias (default: alpha)');
       console.log('  --c8-version <version> Alternative flag form for version');
       console.log('  --debug                Stream raw c8run output during start');
       console.log('');
+      console.log('Version aliases:');
+      for (const [alias, resolved] of getVersionAliasEntries()) {
+        console.log(`  ${alias.padEnd(22)} → ${resolved}`);
+      }
+      console.log('');
       console.log('Examples:');
-      console.log('  c8ctl cluster start              # Start latest alpha (8.9)');
+      console.log('  c8ctl cluster start              # Start using default alias (alpha)');
+      console.log('  c8ctl cluster start stable       # Start latest stable release');
       console.log('  c8ctl cluster start 8.9.0-alpha5 # Start specific version');
       console.log('  c8ctl cluster stop');
       return;
     }
 
     const versionSpec = parsed.version || 'alpha';
+    if (!parsed.version && parsed.subcommand === 'start') {
+      logger.info(`No version specified, using default: "${versionSpec}"`);
+    }
     try {
       validateVersionSpec(versionSpec);
     } catch (error) {

--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -27,16 +27,10 @@ import { fileURLToPath } from 'node:url';
 // Version aliases (loaded from package.json c8ctl.versionAliases)
 // ---------------------------------------------------------------------------
 
-let _versionAliases = {};
-try {
-  const _pluginPackageJson = JSON.parse(
-    readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'package.json'), 'utf-8'),
-  );
-  _versionAliases = _pluginPackageJson.c8ctl?.versionAliases ?? {};
-} catch (err) {
-  // Fall back to empty aliases if package.json is missing or malformed; plugin continues without alias support
-  console.error(`[cluster plugin] Warning: Failed to load version aliases from package.json, using defaults: ${err}`);
-}
+const _pluginPackageJson = JSON.parse(
+  readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'package.json'), 'utf-8'),
+);
+const _versionAliases = _pluginPackageJson.c8ctl.versionAliases;
 const VERSION_ALIASES = new Set(Object.keys(_versionAliases));
 
 function isVersionAlias(versionSpec) {

--- a/default-plugins/cluster/package.json
+++ b/default-plugins/cluster/package.json
@@ -7,10 +7,8 @@
   "main": "c8ctl-plugin.js",
   "c8ctl": {
     "versionAliases": {
-      "latest": "8.8",
       "stable": "8.8",
-      "alpha": "8.9",
-      "latest-alpha": "8.9"
+      "alpha": "8.9"
     }
   }
 }

--- a/tests/unit/cluster-plugin.test.ts
+++ b/tests/unit/cluster-plugin.test.ts
@@ -124,6 +124,15 @@ describe('Cluster Plugin – command usage output', () => {
     const output = captured.join('\n');
     assert.ok(output.includes('Examples'), 'Should contain an Examples section');
   });
+
+  test('usage lists version aliases', async () => {
+    await plugin.commands['cluster']([]);
+
+    const output = captured.join('\n');
+    assert.ok(output.includes('Version aliases'), 'Should contain a Version aliases section');
+    assert.ok(output.includes('alpha'), 'Should list the alpha alias');
+    assert.ok(output.includes('stable'), 'Should list the stable alias');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/unit/cluster-plugin.test.ts
+++ b/tests/unit/cluster-plugin.test.ts
@@ -130,8 +130,8 @@ describe('Cluster Plugin – command usage output', () => {
 
     const output = captured.join('\n');
     assert.ok(output.includes('Version aliases'), 'Should contain a Version aliases section');
-    assert.ok(output.includes('alpha'), 'Should list the alpha alias');
-    assert.ok(output.includes('stable'), 'Should list the stable alias');
+    assert.ok(/^\s+alpha\s+→/m.test(output), 'Should list the alpha alias with arrow separator');
+    assert.ok(/^\s+stable\s+→/m.test(output), 'Should list the stable alias with arrow separator');
   });
 });
 


### PR DESCRIPTION
Max:
* Expose available aliases to users
* Consolidate to two aliases (stable and alpha) - "latest" was ambigious, and this also reduces complexity
* Log default alias used, if no version is specified to avoid confusion
* Remove hard-coded alias version mappings from code (cenrally maintained in package.json)
* Simplification
  *  Following `"Don't add error handling for scenarios that can't happen. Only validate at system boundaries"` - we don't need extra handling for the case that package.json was removed or corrupted. It is an inherent part of the plugin.

AI:
- [x] Update test to use regex assertions checking for `→` separator in alias entries (e.g. `/^\s+stable\s+→/m`) instead of just checking that "stable"/"alpha" appear anywhere in output
- [x] Validated all cluster plugin unit tests pass (37/37)