### PR TITLE
feat(cluster): resolve version aliases dynamically from download server

### DIFF
--- a/default-plugins/cluster/README.md
+++ b/default-plugins/cluster/README.md
@@ -8,7 +8,7 @@ A default [c8ctl](https://github.com/camunda/c8ctl) plugin that provides an opin
 # Start with a specific version
 c8ctl cluster start 8.9.0-alpha5
 
-# Start using a version alias
+# Start using a version alias (dynamically resolved)
 c8ctl cluster start stable
 c8ctl cluster start alpha
 
@@ -21,6 +21,21 @@ c8ctl cluster start --debug
 # Stop the running cluster
 c8ctl cluster stop
 ```
+
+## Version aliases
+
+The `stable` and `alpha` aliases are resolved dynamically by querying the
+[Camunda Download Center](https://downloads.camunda.cloud/release/camunda/c8run/).
+This means you always get the latest available version without waiting for a
+plugin update.
+
+| Alias    | Resolves to |
+|----------|-------------|
+| `stable` | Highest minor release that is GA (e.g. `8.8`) |
+| `alpha`  | Highest minor release overall (e.g. `8.9`) |
+
+If the download server is unreachable, the aliases fall back to the values
+shipped in the plugin's `package.json`.
 
 ## How it works
 

--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -24,25 +24,112 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 // ---------------------------------------------------------------------------
-// Version aliases (loaded from package.json c8ctl.versionAliases)
+// Version aliases – dynamic discovery with package.json fallback
 // ---------------------------------------------------------------------------
+
+const DOWNLOAD_BASE_URL = 'https://downloads.camunda.cloud/release/camunda/c8run/';
 
 const _pluginPackageJson = JSON.parse(
   readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'package.json'), 'utf-8'),
 );
-const _versionAliases = _pluginPackageJson.c8ctl.versionAliases;
-const VERSION_ALIASES = new Set(Object.keys(_versionAliases));
+const _fallbackAliases = _pluginPackageJson.c8ctl.versionAliases;
+const KNOWN_ALIAS_NAMES = new Set(['stable', 'alpha']);
 
 function isVersionAlias(versionSpec) {
-  return VERSION_ALIASES.has(versionSpec);
+  return KNOWN_ALIAS_NAMES.has(versionSpec);
 }
 
-function resolveVersion(versionSpec) {
-  return _versionAliases[versionSpec] ?? versionSpec;
+/**
+ * Fetch the c8run download directory listing and discover the latest
+ * stable and alpha minor versions.
+ *
+ * Returns { stable: "X.Y", alpha: "X.Y" } or null on failure.
+ */
+export async function discoverLatestVersions() {
+  try {
+    const response = await fetch(DOWNLOAD_BASE_URL);
+    if (!response.ok) return null;
+    const html = await response.text();
+    return parseVersionsFromHtml(html);
+  } catch {
+    return null;
+  }
 }
 
-function getVersionAliasEntries() {
-  return Object.entries(_versionAliases);
+/**
+ * Parse the HTML directory listing from the download server to extract
+ * the latest stable and alpha minor versions.
+ *
+ * - Minor version directories (e.g. "8.8/", "8.9/") are rolling releases
+ *   updated in-place.
+ * - An alpha train exists when there are "X.Y.0-alphaN/" directories
+ *   for a given minor. The highest minor with alphas is the alpha alias.
+ * - The highest minor without alphas is the stable alias.
+ */
+export function parseVersionsFromHtml(html) {
+  // Match minor-version directories like "8.8/", "8.9/"
+  const minorMatches = [...html.matchAll(/href="(\d+\.\d+)\/"/g)].map(m => m[1]);
+  // Match alpha directories like "8.9.0-alpha5/"
+  const alphaMatches = [...html.matchAll(/href="(\d+\.\d+)\.0-alpha\d+\/"/g)].map(m => m[1]);
+
+  if (minorMatches.length === 0) return null;
+
+  const compareSemver = (a, b) => {
+    const [aMaj, aMin] = a.split('.').map(Number);
+    const [bMaj, bMin] = b.split('.').map(Number);
+    return aMaj - bMaj || aMin - bMin;
+  };
+
+  const sortedMinors = [...new Set(minorMatches)].sort(compareSemver);
+  const alphaSet = new Set(alphaMatches);
+
+  const highestMinor = sortedMinors[sortedMinors.length - 1];
+
+  // The alpha train is the highest minor that has alpha directories.
+  // The stable release is the minor just below the alpha train,
+  // or the highest minor if no alpha train exists.
+  const highestAlphaMinor = [...alphaSet].sort(compareSemver).pop();
+
+  let stable;
+  if (highestAlphaMinor) {
+    // Stable = the highest minor that is lower than the alpha train
+    stable = sortedMinors.filter(v => compareSemver(v, highestAlphaMinor) < 0).pop() || highestMinor;
+  } else {
+    stable = highestMinor;
+  }
+
+  return {
+    stable,
+    alpha: highestMinor,
+  };
+}
+
+// Cache the discovery result for the process lifetime
+let _dynamicAliases = undefined;
+
+async function getDynamicAliases() {
+  if (_dynamicAliases === undefined) {
+    _dynamicAliases = await discoverLatestVersions();
+  }
+  return _dynamicAliases;
+}
+
+async function resolveVersion(versionSpec) {
+  if (!isVersionAlias(versionSpec)) return versionSpec;
+  const dynamic = await getDynamicAliases();
+  if (dynamic?.[versionSpec]) return dynamic[versionSpec];
+  return _fallbackAliases[versionSpec] ?? versionSpec;
+}
+
+async function getVersionAliasEntries() {
+  const dynamic = await getDynamicAliases();
+  const aliases = dynamic || _fallbackAliases;
+  return Object.entries(aliases);
+}
+
+/** Reset the cached dynamic aliases (for testing). */
+export function _resetDynamicAliasCache() {
+  _dynamicAliases = undefined;
 }
 
 // ---------------------------------------------------------------------------
@@ -714,8 +801,8 @@ export const commands = {
       console.log('  --c8-version <version> Alternative flag form for version');
       console.log('  --debug                Stream raw c8run output during start');
       console.log('');
-      console.log('Version aliases:');
-      for (const [alias, resolved] of getVersionAliasEntries()) {
+      console.log('Version aliases (dynamically resolved):');
+      for (const [alias, resolved] of await getVersionAliasEntries()) {
         console.log(`  ${alias.padEnd(22)} → ${resolved}`);
       }
       console.log('');
@@ -737,7 +824,10 @@ export const commands = {
       logger.error(error.message);
       process.exit(1);
     }
-    const version = resolveVersion(versionSpec);
+    const version = await resolveVersion(versionSpec);
+    if (isVersionAlias(versionSpec)) {
+      logger.info(`Resolved alias "${versionSpec}" → ${version}`);
+    }
     const config = { cacheDir: getCacheDir(), version, isAlias: isVersionAlias(versionSpec) };
 
     if (parsed.subcommand === 'start') {

--- a/tests/unit/cluster-plugin.test.ts
+++ b/tests/unit/cluster-plugin.test.ts
@@ -133,6 +133,13 @@ describe('Cluster Plugin – command usage output', () => {
     assert.ok(/^\s+alpha\s+→/m.test(output), 'Should list the alpha alias with arrow separator');
     assert.ok(/^\s+stable\s+→/m.test(output), 'Should list the stable alias with arrow separator');
   });
+
+  test('usage indicates aliases are dynamically resolved', async () => {
+    await plugin.commands['cluster']([]);
+
+    const output = captured.join('\n');
+    assert.ok(output.includes('dynamically resolved'), 'Should indicate dynamic resolution');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -405,5 +412,77 @@ describe('Cluster Plugin – ensureC8RunInstalled', () => {
 
     assert.strictEqual(existsSync(installDir), false, 'install dir should be purged');
     assert.strictEqual(plugin.isC8RunInstalled(config), false, 'should not be installed after purge');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseVersionsFromHtml – dynamic version discovery
+// ---------------------------------------------------------------------------
+
+describe('Cluster Plugin – parseVersionsFromHtml', () => {
+  test('extracts stable and alpha from a realistic listing', () => {
+    // Real-world pattern: 8.8 went GA (but still has old alpha dirs), 8.9 is current alpha
+    // Stable = highest minor below the highest alpha train (8.9 has alphas → stable is 8.8)
+    const html = `
+      <a href="8.6/">8.6</a>
+      <a href="8.6.11/">8.6.11</a>
+      <a href="8.7/">8.7</a>
+      <a href="8.7.0-alpha5/">8.7.0-alpha5</a>
+      <a href="8.8.0-alpha2/">8.8.0-alpha2</a>
+      <a href="8.8.0-alpha3/">8.8.0-alpha3</a>
+      <a href="8.8/">8.8</a>
+      <a href="8.8.1/">8.8.1</a>
+      <a href="8.9.0-alpha1/">8.9.0-alpha1</a>
+      <a href="8.9.0-alpha5/">8.9.0-alpha5</a>
+      <a href="8.9/">8.9</a>
+    `;
+    const result = plugin.parseVersionsFromHtml(html);
+    assert.ok(result, 'should return a result');
+    assert.strictEqual(result.stable, '8.8', 'stable should be highest minor below the alpha train');
+    assert.strictEqual(result.alpha, '8.9', 'alpha should be highest minor overall');
+  });
+
+  test('when no alphas exist, stable and alpha are the same', () => {
+    const html = `
+      <a href="8.6/">8.6</a>
+      <a href="8.7/">8.7</a>
+      <a href="8.8/">8.8</a>
+    `;
+    const result = plugin.parseVersionsFromHtml(html);
+    assert.ok(result, 'should return a result');
+    assert.strictEqual(result.stable, '8.8');
+    assert.strictEqual(result.alpha, '8.8');
+  });
+
+  test('handles future major versions correctly', () => {
+    const html = `
+      <a href="8.8/">8.8</a>
+      <a href="8.9/">8.9</a>
+      <a href="9.0.0-alpha1/">9.0.0-alpha1</a>
+      <a href="9.0/">9.0</a>
+    `;
+    const result = plugin.parseVersionsFromHtml(html);
+    assert.ok(result, 'should return a result');
+    assert.strictEqual(result.stable, '8.9', 'stable is highest without alpha dirs');
+    assert.strictEqual(result.alpha, '9.0', 'alpha is highest overall');
+  });
+
+  test('returns null for empty or no-match HTML', () => {
+    assert.strictEqual(plugin.parseVersionsFromHtml(''), null);
+    assert.strictEqual(plugin.parseVersionsFromHtml('<html>no versions</html>'), null);
+  });
+
+  test('deduplicates minor versions', () => {
+    const html = `
+      <a href="8.8/">8.8</a>
+      <a href="8.8/">8.8</a>
+      <a href="8.9.0-alpha1/">8.9.0-alpha1</a>
+      <a href="8.9.0-alpha2/">8.9.0-alpha2</a>
+      <a href="8.9/">8.9</a>
+    `;
+    const result = plugin.parseVersionsFromHtml(html);
+    assert.ok(result);
+    assert.strictEqual(result.stable, '8.8');
+    assert.strictEqual(result.alpha, '8.9');
   });
 });


### PR DESCRIPTION
## Dynamic version alias resolution

Builds on #166 to make `stable` and `alpha` aliases resolve dynamically rather than requiring manual `package.json` updates when new versions ship.

### How it works

On startup, the plugin fetches the [c8run download directory listing](https://downloads.camunda.cloud/release/camunda/c8run/) (a lightweight HTML page) and parses it to discover available minor versions:

- **`alpha`** → highest minor version directory (e.g. `8.9`)
- **`stable`** → highest minor version below the alpha train (e.g. `8.8`)

The download server already provides "rolling" version directories (`8.8/`, `8.9/`) that are updated in-place when new patches ship, so the user always gets the latest patch.

### Heuristic

The highest minor that has `X.Y.0-alphaN/` directories is the alpha train. The minor immediately below it is stable. When no alpha directories exist, both aliases point to the same version.

### Fallback

If the download server is unreachable (offline, network error), the plugin silently falls back to the `package.json` values — so existing behavior is preserved.

### Changes

- `discoverLatestVersions()` — fetches and parses the directory listing
- `parseVersionsFromHtml()` — pure function (exported for testing) that extracts version info from HTML
- `resolveVersion()` / `getVersionAliasEntries()` — now async, with dynamic → fallback chain
- `_resetDynamicAliasCache()` — test helper to reset cached discovery
- Help output shows "Version aliases (dynamically resolved):" with current values
- Log line shows resolved alias when used (e.g. `Resolved alias "alpha" → 8.9`)
- 5 new unit tests for `parseVersionsFromHtml` covering realistic listings, major version transitions, deduplication, and edge cases
- Plugin README updated to document dynamic resolution

### Testing

All 43 cluster plugin tests pass.

Closes the request from https://github.com/camunda/c8ctl/pull/166#issuecomment-4210703786