### PR TITLE
chore: update deps to address vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-semantically-released",
       "license": "MIT",
       "dependencies": {
-        "@camunda8/orchestration-cluster-api": "^8.9.0-alpha.30",
+        "@camunda8/orchestration-cluster-api": "^8.8.4",
         "@modelcontextprotocol/sdk": "^1.29.0"
       },
       "bin": {
@@ -92,24 +92,17 @@
       }
     },
     "node_modules/@camunda8/orchestration-cluster-api": {
-      "version": "8.9.0-alpha.30",
-      "resolved": "https://registry.npmjs.org/@camunda8/orchestration-cluster-api/-/orchestration-cluster-api-8.9.0-alpha.30.tgz",
-      "integrity": "sha512-qAQQW80wHuaxMzSA1kaGFq9XPRn9MD7tI3QhebfPpM3B3bu5dltqH54hc3WxZvIwZy++/Y15TrBnPi6x8bkIQQ==",
+      "version": "8.8.4",
+      "resolved": "https://registry.npmjs.org/@camunda8/orchestration-cluster-api/-/orchestration-cluster-api-8.8.4.tgz",
+      "integrity": "sha512-hrs9pP5dDa2zCeRBAdFj9eMFk5nV9djQkYF6NtX8M1IGiFk8t3gGYd2Y9x3hv8ZetnA4ZNpBf3Q2HuGJ6VZdbQ==",
       "license": "Apache-2.0",
       "dependencies": {
+        "p-retry": "^6.0.1",
         "typed-env": "^2.0.0",
         "zod": "^4"
       },
       "engines": {
-        "node": ">=22"
-      },
-      "peerDependencies": {
-        "fp-ts": "^2.16.11"
-      },
-      "peerDependenciesMeta": {
-        "fp-ts": {
-          "optional": true
-        }
+        "node": ">=18"
       }
     },
     "node_modules/@colors/colors": {
@@ -595,6 +588,12 @@
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
       "license": "MIT"
     },
     "node_modules/accepts": {
@@ -2129,6 +2128,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-network-error": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
+      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "dev": true,
@@ -3324,15 +3335,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/npm/node_modules/encoding": {
-      "version": "0.1.13",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
       "dev": true,
@@ -3341,11 +3343,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/npm/node_modules/err-code": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.3",
@@ -3468,14 +3465,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
       }
     },
     "node_modules/npm/node_modules/ini": {
@@ -4208,18 +4197,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/npm/node_modules/promise-retry": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "err-code": "^2.0.2",
-        "retry": "^0.12.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/npm/node_modules/promzard": {
       "version": "3.0.1",
       "dev": true,
@@ -4259,14 +4236,6 @@
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/retry": {
-      "version": "0.12.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/npm/node_modules/safer-buffer": {
@@ -4497,28 +4466,6 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
-    "node_modules/npm/node_modules/unique-filename": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^6.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/npm/node_modules/unique-slug": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
       "dev": true,
@@ -4713,6 +4660,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
+      "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.2",
+        "is-network-error": "^1.0.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=16.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -5123,6 +5087,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/router": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-semantically-released",
       "license": "MIT",
       "dependencies": {
-        "@camunda8/orchestration-cluster-api": "^8.9.0-alpha.31",
+        "@camunda8/orchestration-cluster-api": "8.9.0-alpha.33",
         "@modelcontextprotocol/sdk": "^1.29.0"
       },
       "bin": {
@@ -92,9 +92,9 @@
       }
     },
     "node_modules/@camunda8/orchestration-cluster-api": {
-      "version": "8.9.0-alpha.32",
-      "resolved": "https://registry.npmjs.org/@camunda8/orchestration-cluster-api/-/orchestration-cluster-api-8.9.0-alpha.32.tgz",
-      "integrity": "sha512-8EOLwUKnHN+YlGvGNkcnfQP9H+A5rRRf/Ka7F5R7oOAebRr6QIKe5mqP1FpJ+E/3rDlRBZFxrzs0oVfWc0IgPA==",
+      "version": "8.9.0-alpha.33",
+      "resolved": "https://registry.npmjs.org/@camunda8/orchestration-cluster-api/-/orchestration-cluster-api-8.9.0-alpha.33.tgz",
+      "integrity": "sha512-29gi+f/SQa9j7QYO3uUv/WR2sFa4rfwgQPuCI4j2xvif8ABbtOJ399OkHmOFj/aBJMFwUNmKRoJrN8/Qy0hQnQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "typed-env": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "@camunda8/cli",
-  "version": "2.0.0-alpha.6",
+  "version": "0.0.0-semantically-released",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@camunda8/cli",
-      "version": "2.0.0-alpha.6",
+      "version": "0.0.0-semantically-released",
       "license": "MIT",
       "dependencies": {
-        "@camunda8/orchestration-cluster-api": "^8.8.4",
-        "@modelcontextprotocol/sdk": "^1.27.1"
+        "@camunda8/orchestration-cluster-api": "^8.9.0-alpha.30",
+        "@modelcontextprotocol/sdk": "^1.29.0"
       },
       "bin": {
         "c8": "dist/index.js",
@@ -56,7 +56,9 @@
       }
     },
     "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "6.23.0",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -90,15 +92,24 @@
       }
     },
     "node_modules/@camunda8/orchestration-cluster-api": {
-      "version": "8.8.4",
+      "version": "8.9.0-alpha.30",
+      "resolved": "https://registry.npmjs.org/@camunda8/orchestration-cluster-api/-/orchestration-cluster-api-8.9.0-alpha.30.tgz",
+      "integrity": "sha512-qAQQW80wHuaxMzSA1kaGFq9XPRn9MD7tI3QhebfPpM3B3bu5dltqH54hc3WxZvIwZy++/Y15TrBnPi6x8bkIQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "p-retry": "^6.0.1",
         "typed-env": "^2.0.0",
         "zod": "^4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "fp-ts": "^2.16.11"
+      },
+      "peerDependenciesMeta": {
+        "fp-ts": {
+          "optional": true
+        }
       }
     },
     "node_modules/@colors/colors": {
@@ -111,9 +122,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.13",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.13.tgz",
+      "integrity": "sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -123,9 +134,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.28.0.tgz",
-      "integrity": "sha512-gmloF+i+flI8ouQK7MWW4mOwuMh4RePBuPFAEPC6+pdqyWOUMDOixb6qZ69owLJpz6XmyllCouc4t8YWO+E2Nw==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -584,10 +595,6 @@
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/retry": {
-      "version": "0.12.2",
       "license": "MIT"
     },
     "node_modules/accepts": {
@@ -1577,10 +1584,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.2.1",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.0.1"
+        "ip-address": "10.1.0"
       },
       "engines": {
         "node": ">= 16"
@@ -1852,7 +1861,9 @@
       "license": "ISC"
     },
     "node_modules/handlebars": {
-      "version": "4.7.8",
+      "version": "4.7.9",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+      "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1908,9 +1919,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "version": "4.12.12",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
+      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2090,7 +2101,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.0.1",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -2114,16 +2127,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-network-error": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -2307,7 +2310,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },
@@ -2569,7 +2574,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.10.1",
+      "version": "11.12.1",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.12.1.tgz",
+      "integrity": "sha512-zcoUuF1kezGSAo0CqtvoLXX3mkRqzuqYdL6Y5tdo8g69NVV3CkjQ6ZBhBgB4d7vGkPcV6TcvLi3GRKPDFX+xTA==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -2648,19 +2655,19 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.3.1",
-        "@npmcli/config": "^10.7.1",
+        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/config": "^10.8.1",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
         "@npmcli/package-json": "^7.0.5",
         "@npmcli/promise-spawn": "^9.0.1",
         "@npmcli/redact": "^4.0.0",
-        "@npmcli/run-script": "^10.0.3",
-        "@sigstore/tuf": "^4.0.1",
+        "@npmcli/run-script": "^10.0.4",
+        "@sigstore/tuf": "^4.0.2",
         "abbrev": "^4.0.0",
         "archy": "~1.0.0",
-        "cacache": "^20.0.3",
+        "cacache": "^20.0.4",
         "chalk": "^5.6.2",
         "ci-info": "^4.4.0",
         "fastest-levenshtein": "^1.0.16",
@@ -2673,17 +2680,17 @@
         "is-cidr": "^6.0.3",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.2",
-        "libnpmexec": "^10.2.2",
-        "libnpmfund": "^7.0.16",
+        "libnpmdiff": "^8.1.5",
+        "libnpmexec": "^10.2.5",
+        "libnpmfund": "^7.0.19",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.2",
+        "libnpmpack": "^9.1.5",
         "libnpmpublish": "^11.1.3",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
         "libnpmversion": "^8.0.3",
-        "make-fetch-happen": "^15.0.3",
-        "minimatch": "^10.2.2",
+        "make-fetch-happen": "^15.0.5",
+        "minimatch": "^10.2.4",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
@@ -2697,7 +2704,7 @@
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
-        "pacote": "^21.3.1",
+        "pacote": "^21.5.0",
         "parse-conflict-json": "^5.0.1",
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
@@ -2706,7 +2713,7 @@
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.9",
+        "tar": "^7.5.11",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -2747,6 +2754,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/npm/node_modules/@gar/promise-retry": {
+      "version": "1.0.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "dev": true,
@@ -2782,11 +2798,12 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.3.1",
+      "version": "9.4.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
         "@isaacs/string-locale-compare": "^1.1.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/installed-package-contents": "^4.0.0",
@@ -2829,7 +2846,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.7.1",
+      "version": "10.8.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -2860,17 +2877,17 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "7.0.1",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
         "@npmcli/promise-spawn": "^9.0.0",
         "ini": "^6.0.0",
         "lru-cache": "^11.2.1",
         "npm-pick-manifest": "^11.0.1",
         "proc-log": "^6.0.0",
-        "promise-retry": "^2.0.1",
         "semver": "^7.3.5",
         "which": "^6.0.0"
       },
@@ -2995,7 +3012,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "10.0.3",
+      "version": "10.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3004,8 +3021,7 @@
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/promise-spawn": "^9.0.0",
         "node-gyp": "^12.1.0",
-        "proc-log": "^6.0.0",
-        "which": "^6.0.0"
+        "proc-log": "^6.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -3024,7 +3040,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/core": {
-      "version": "3.1.0",
+      "version": "3.2.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -3042,24 +3058,24 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
-      "version": "4.1.0",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.2",
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.0",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "make-fetch-happen": "^15.0.3",
-        "proc-log": "^6.1.0",
-        "promise-retry": "^2.0.1"
+        "make-fetch-happen": "^15.0.4",
+        "proc-log": "^6.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "4.0.1",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -3138,12 +3154,12 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/npm/node_modules/bin-links": {
@@ -3175,7 +3191,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.2",
+      "version": "5.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3183,11 +3199,11 @@
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/npm/node_modules/cacache": {
-      "version": "20.0.3",
+      "version": "20.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3201,8 +3217,7 @@
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "p-map": "^7.0.2",
-        "ssri": "^13.0.0",
-        "unique-filename": "^5.0.0"
+        "ssri": "^13.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -3312,7 +3327,6 @@
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3331,7 +3345,6 @@
     "node_modules/npm/node_modules/err-code": {
       "version": "2.0.3",
       "dev": true,
-      "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
@@ -3429,7 +3442,7 @@
       }
     },
     "node_modules/npm/node_modules/iconv-lite": {
-      "version": "0.6.3",
+      "version": "0.7.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3439,6 +3452,10 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/npm/node_modules/ignore-walk": {
@@ -3456,7 +3473,6 @@
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -3571,12 +3587,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.2",
+      "version": "8.1.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.3.1",
+        "@npmcli/arborist": "^9.4.2",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -3590,19 +3606,19 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.2",
+      "version": "10.2.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.3.1",
+        "@gar/promise-retry": "^1.0.0",
+        "@npmcli/arborist": "^9.4.2",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2",
         "proc-log": "^6.0.0",
-        "promise-retry": "^2.0.1",
         "read": "^5.0.1",
         "semver": "^7.3.7",
         "signal-exit": "^4.1.0",
@@ -3613,12 +3629,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.16",
+      "version": "7.0.19",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.3.1"
+        "@npmcli/arborist": "^9.4.2"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -3638,12 +3654,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.2",
+      "version": "9.1.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.3.1",
+        "@npmcli/arborist": "^9.4.2",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -3713,7 +3729,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.2.6",
+      "version": "11.2.7",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -3722,12 +3738,14 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "15.0.3",
+      "version": "15.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
         "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
         "cacache": "^20.0.1",
         "http-cache-semantics": "^4.1.1",
         "minipass": "^7.0.2",
@@ -3736,7 +3754,6 @@
         "minipass-pipeline": "^1.2.4",
         "negotiator": "^1.0.0",
         "proc-log": "^6.0.0",
-        "promise-retry": "^2.0.1",
         "ssri": "^13.0.0"
       },
       "engines": {
@@ -3744,7 +3761,7 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "10.2.2",
+      "version": "10.2.4",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -3780,7 +3797,7 @@
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "5.0.1",
+      "version": "5.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3793,7 +3810,7 @@
         "node": "^20.17.0 || >=22.9.0"
       },
       "optionalDependencies": {
-        "encoding": "^0.1.13"
+        "iconv-lite": "^0.7.2"
       }
     },
     "node_modules/npm/node_modules/minipass-flush": {
@@ -4001,7 +4018,7 @@
       }
     },
     "node_modules/npm/node_modules/npm-packlist": {
-      "version": "10.0.3",
+      "version": "10.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4082,11 +4099,12 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "21.3.1",
+      "version": "21.5.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.0",
         "@npmcli/git": "^7.0.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "@npmcli/package-json": "^7.0.0",
@@ -4100,7 +4118,6 @@
         "npm-pick-manifest": "^11.0.1",
         "npm-registry-fetch": "^19.0.0",
         "proc-log": "^6.0.0",
-        "promise-retry": "^2.0.1",
         "sigstore": "^4.0.0",
         "ssri": "^13.0.0",
         "tar": "^7.4.3"
@@ -4194,7 +4211,6 @@
     "node_modules/npm/node_modules/promise-retry": {
       "version": "2.0.1",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "err-code": "^2.0.2",
@@ -4248,7 +4264,6 @@
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
       "dev": true,
-      "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -4357,7 +4372,7 @@
       }
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.22",
+      "version": "3.0.23",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
@@ -4387,7 +4402,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.9",
+      "version": "7.5.11",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -4485,7 +4500,6 @@
     "node_modules/npm/node_modules/unique-filename": {
       "version": "5.0.0",
       "dev": true,
-      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "unique-slug": "^6.0.0"
@@ -4497,7 +4511,6 @@
     "node_modules/npm/node_modules/unique-slug": {
       "version": "6.0.0",
       "dev": true,
-      "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4"
@@ -4546,12 +4559,11 @@
       }
     },
     "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "7.0.0",
+      "version": "7.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "imurmurhash": "^0.1.4",
         "signal-exit": "^4.0.1"
       },
       "engines": {
@@ -4706,21 +4718,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-retry": {
-      "version": "6.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "@types/retry": "0.12.2",
-        "is-network-error": "^1.0.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-timeout": {
       "version": "6.1.4",
       "dev": true,
@@ -4819,7 +4816,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -4840,7 +4839,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5122,13 +5123,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/router": {
@@ -5840,7 +5834,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5942,7 +5938,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.21.0",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-semantically-released",
       "license": "MIT",
       "dependencies": {
-        "@camunda8/orchestration-cluster-api": "^8.9.0-alpha.30",
+        "@camunda8/orchestration-cluster-api": "^8.9.0-alpha.31",
         "@modelcontextprotocol/sdk": "^1.29.0"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-semantically-released",
       "license": "MIT",
       "dependencies": {
-        "@camunda8/orchestration-cluster-api": "^8.8.4",
+        "@camunda8/orchestration-cluster-api": "^8.9.0-alpha.30",
         "@modelcontextprotocol/sdk": "^1.29.0"
       },
       "bin": {
@@ -92,17 +92,24 @@
       }
     },
     "node_modules/@camunda8/orchestration-cluster-api": {
-      "version": "8.8.4",
-      "resolved": "https://registry.npmjs.org/@camunda8/orchestration-cluster-api/-/orchestration-cluster-api-8.8.4.tgz",
-      "integrity": "sha512-hrs9pP5dDa2zCeRBAdFj9eMFk5nV9djQkYF6NtX8M1IGiFk8t3gGYd2Y9x3hv8ZetnA4ZNpBf3Q2HuGJ6VZdbQ==",
+      "version": "8.9.0-alpha.32",
+      "resolved": "https://registry.npmjs.org/@camunda8/orchestration-cluster-api/-/orchestration-cluster-api-8.9.0-alpha.32.tgz",
+      "integrity": "sha512-8EOLwUKnHN+YlGvGNkcnfQP9H+A5rRRf/Ka7F5R7oOAebRr6QIKe5mqP1FpJ+E/3rDlRBZFxrzs0oVfWc0IgPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "p-retry": "^6.0.1",
         "typed-env": "^2.0.0",
         "zod": "^4"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "fp-ts": "^2.16.11"
+      },
+      "peerDependenciesMeta": {
+        "fp-ts": {
+          "optional": true
+        }
       }
     },
     "node_modules/@colors/colors": {
@@ -588,12 +595,6 @@
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/retry": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
-      "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
       "license": "MIT"
     },
     "node_modules/accepts": {
@@ -2126,18 +2127,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/is-network-error": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.3.1.tgz",
-      "integrity": "sha512-6QCxa49rQbmUWLfk0nuGqzql9U8uaV2H6279bRErPBHe/109hCzsLUBUHfbEtvLIHBd6hyXbgedBSHevm43Edw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -4665,23 +4654,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-retry": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
-      "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/retry": "0.12.2",
-        "is-network-error": "^1.0.0",
-        "retry": "^0.13.1"
-      },
-      "engines": {
-        "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/p-timeout": {
       "version": "6.1.4",
       "dev": true,
@@ -5087,15 +5059,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/router": {

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@camunda8/orchestration-cluster-api": "^8.8.4",
-    "@modelcontextprotocol/sdk": "^1.27.1"
+    "@camunda8/orchestration-cluster-api": "^8.9.0-alpha.30",
+    "@modelcontextprotocol/sdk": "^1.29.0"
   },
   "devDependencies": {
     "@semantic-release/exec": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@camunda8/orchestration-cluster-api": "^8.9.0-alpha.31",
+    "@camunda8/orchestration-cluster-api": "8.9.0-alpha.33",
     "@modelcontextprotocol/sdk": "^1.29.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@camunda8/orchestration-cluster-api": "^8.8.4",
+    "@camunda8/orchestration-cluster-api": "^8.9.0-alpha.30",
     "@modelcontextprotocol/sdk": "^1.29.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@camunda8/orchestration-cluster-api": "^8.9.0-alpha.30",
+    "@camunda8/orchestration-cluster-api": "^8.8.4",
     "@modelcontextprotocol/sdk": "^1.29.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@camunda8/orchestration-cluster-api": "^8.9.0-alpha.30",
+    "@camunda8/orchestration-cluster-api": "^8.9.0-alpha.31",
     "@modelcontextprotocol/sdk": "^1.29.0"
   },
   "devDependencies": {

--- a/tests/integration/forms.test.ts
+++ b/tests/integration/forms.test.ts
@@ -67,7 +67,7 @@ describe('Form Integration Tests', () => {
     rmSync(dataDir, { recursive: true, force: true });
   });
 
-  test('get form for user task after deploying list-pis fixtures', async () => {
+  test('get form for user task after deploying list-pis fixtures', async (t) => {
     await cli('deploy', 'tests/fixtures/list-pis');
 
     // Poll until process definition is indexed
@@ -101,7 +101,7 @@ describe('Form Integration Tests', () => {
     // Retrieve the form via CLI
     const formResult = await cli('get', 'form', userTaskKey!, '--ut');
     assert.strictEqual(formResult.status, 0, `get form should exit 0. stderr: ${formResult.stderr}`);
-    console.log(formResult.stdout) // @DEBUG
+    t.diagnostic('*************', formResult.stdout) // @DEBUG
     const form = parseJson<Record<string, unknown>>(formResult.stdout);
 
     assert.ok(form, 'Form should be retrieved');
@@ -179,7 +179,7 @@ describe('Form Integration Tests', () => {
     assert.ok(form.formKey, 'Retrieved form should have formKey');
   });
 
-  test('getForm finds user task form with user task key', async () => {
+  test('getForm finds user task form with user task key', async (t) => {
     await cli('deploy', 'tests/fixtures/list-pis');
 
     // Poll until process definition is indexed
@@ -199,6 +199,7 @@ describe('Form Integration Tests', () => {
     let userTaskKey: string | undefined;
     const userTaskFound = await pollUntil(async () => {
       const result = await cli('search', 'ut', `--processInstanceKey=${piKey}`);
+      t.diagnostic('****UserTaskRow', result.stdout)
       const items = parseJson<UserTaskRow[]>(result.stdout);
       if (items.length > 0) {
         userTaskKey = String(items[0].Key);

--- a/tests/integration/forms.test.ts
+++ b/tests/integration/forms.test.ts
@@ -101,7 +101,8 @@ describe('Form Integration Tests', () => {
     // Retrieve the form via CLI
     const formResult = await cli('get', 'form', userTaskKey!, '--ut');
     assert.strictEqual(formResult.status, 0, `get form should exit 0. stderr: ${formResult.stderr}`);
-    t.diagnostic('*************', formResult.stdout) // @DEBUG
+    t.diagnostic('*************') // @DEBUG
+    t.diagnostic(formResult.stdout) // @DEBUG
     const form = parseJson<Record<string, unknown>>(formResult.stdout);
 
     assert.ok(form, 'Form should be retrieved');
@@ -199,7 +200,8 @@ describe('Form Integration Tests', () => {
     let userTaskKey: string | undefined;
     const userTaskFound = await pollUntil(async () => {
       const result = await cli('search', 'ut', `--processInstanceKey=${piKey}`);
-      t.diagnostic('****UserTaskRow', result.stdout)
+      t.diagnostic('****UserTaskRow') // @DEBUG
+      t.diagnostic(result.stdout) // @DEBUG
       const items = parseJson<UserTaskRow[]>(result.stdout);
       if (items.length > 0) {
         userTaskKey = String(items[0].Key);

--- a/tests/integration/forms.test.ts
+++ b/tests/integration/forms.test.ts
@@ -101,6 +101,7 @@ describe('Form Integration Tests', () => {
     // Retrieve the form via CLI
     const formResult = await cli('get', 'form', userTaskKey!, '--ut');
     assert.strictEqual(formResult.status, 0, `get form should exit 0. stderr: ${formResult.stderr}`);
+    console.log(formResult.stdout) // @DEBUG
     const form = parseJson<Record<string, unknown>>(formResult.stdout);
 
     assert.ok(form, 'Form should be retrieved');

--- a/tests/integration/forms.test.ts
+++ b/tests/integration/forms.test.ts
@@ -67,7 +67,7 @@ describe('Form Integration Tests', () => {
     rmSync(dataDir, { recursive: true, force: true });
   });
 
-  test('get form for user task after deploying list-pis fixtures', async (t) => {
+  test('get form for user task after deploying list-pis fixtures', async () => {
     await cli('deploy', 'tests/fixtures/list-pis');
 
     // Poll until process definition is indexed
@@ -101,8 +101,6 @@ describe('Form Integration Tests', () => {
     // Retrieve the form via CLI
     const formResult = await cli('get', 'form', userTaskKey!, '--ut');
     assert.strictEqual(formResult.status, 0, `get form should exit 0. stderr: ${formResult.stderr}`);
-    t.diagnostic('*************') // @DEBUG
-    t.diagnostic(formResult.stdout) // @DEBUG
     const form = parseJson<Record<string, unknown>>(formResult.stdout);
 
     assert.ok(form, 'Form should be retrieved');
@@ -180,7 +178,7 @@ describe('Form Integration Tests', () => {
     assert.ok(form.formKey, 'Retrieved form should have formKey');
   });
 
-  test('getForm finds user task form with user task key', async (t) => {
+  test('getForm finds user task form with user task key', async () => {
     await cli('deploy', 'tests/fixtures/list-pis');
 
     // Poll until process definition is indexed
@@ -200,8 +198,6 @@ describe('Form Integration Tests', () => {
     let userTaskKey: string | undefined;
     const userTaskFound = await pollUntil(async () => {
       const result = await cli('search', 'ut', `--processInstanceKey=${piKey}`);
-      t.diagnostic('****UserTaskRow') // @DEBUG
-      t.diagnostic(result.stdout) // @DEBUG
       const items = parseJson<UserTaskRow[]>(result.stdout);
       if (items.length > 0) {
         userTaskKey = String(items[0].Key);


### PR DESCRIPTION
Addresses all vulnerabilities reported by `npm audit --omit=dev`. 

Two reported vulnerabilities remain on my machine when `--omit-dev` is not used: brace-expansion and picomatch. 

These come from npm itself. 

An open question is why these were not detected by Dependabot.

This also pulls in the pre-release of the 9.0 JS SDK, so that we can triage any effects before the release.

Closes #174