### PR TITLE
feat: add .c8ignore support for filtering deploy/watch file scanning

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -604,6 +604,32 @@ c8 deploy process-v2.bpmn
 
 The CLI will detect duplicate IDs and provide a helpful error message showing which files conflict.
 
+### Ignoring Files (`.c8ignore`)
+
+When deploying or watching a directory, c8ctl ignores `node_modules/`, `target/`, and `.git/` by default. Add a `.c8ignore` file to your project root for custom patterns (uses `.gitignore` syntax):
+
+```gitignore
+# .c8ignore — filter directories for deploy and watch
+
+# Ignore build output
+dist/
+build/
+
+# Ignore draft processes
+**/draft-*.bpmn
+
+# But keep this approved draft
+!draft-approved.bpmn
+```
+
+```bash
+# Deploy respects .c8ignore automatically
+c8 deploy
+
+# Watch mode also respects .c8ignore
+c8 watch
+```
+
 ### Run (Deploy + Start)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ c8ctl (_pronounced: "cocktail"_) — a minimal-dependency CLI for Camunda 8 oper
 - **Process Application Support**: Resources in folders with `.process-application` file marked with 📦 in results
 - **Enhanced Deployment Results**: Table view showing file paths, visual indicators, resource details, and versions
 - **Watch Mode**: Monitors a folder for changes to `*.{bpmn,dmn,form}` and auto-redeploys
+- **`.c8ignore` Support**: Filter deploy/watch file scanning with `.gitignore`-style patterns; `node_modules/`, `target/`, `.git/` ignored by default
 - **Search**: Powerful search across process definitions, process instances, user tasks, incidents, jobs, and variables with filter, wildcard, and case-insensitive support
 - **Flexible Output**: Switch between human-readable text and JSON output modes
 
@@ -126,6 +127,30 @@ c8ctl run ./my-process.bpmn            # Deploy and start process
 c8ctl watch                            # Watch for changes and auto-deploy
 c8ctl watch --force                    # Keep watching after failed deploys
 ```
+
+### Ignoring Files (`.c8ignore`)
+
+When scanning directories for deployment artifacts, c8ctl automatically ignores:
+
+- `node_modules/`
+- `target/`
+- `.git/`
+
+Create a `.c8ignore` file in your project root to add custom patterns (`.gitignore` syntax):
+
+```gitignore
+# Ignore build output
+dist/
+build/
+
+# Ignore draft processes
+**/draft-*.bpmn
+
+# But keep this specific one
+!draft-approved.bpmn
+```
+
+`.c8ignore` rules apply to both `deploy` (directory scan) and `watch` (file monitoring).
 
 For comprehensive examples of all commands and their flags, see [EXAMPLES.md](EXAMPLES.md).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@camunda8/orchestration-cluster-api": "8.9.0-alpha.33",
-        "@modelcontextprotocol/sdk": "^1.29.0"
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "ignore": "^7.0.5"
       },
       "bin": {
         "c8": "dist/index.js",
@@ -2011,6 +2012,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/import-fresh": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
   },
   "dependencies": {
     "@camunda8/orchestration-cluster-api": "8.9.0-alpha.33",
-    "@modelcontextprotocol/sdk": "^1.29.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "ignore": "^7.0.5"
   },
   "devDependencies": {
     "@semantic-release/exec": "^7.1.0",

--- a/src/commands/deployments.ts
+++ b/src/commands/deployments.ts
@@ -8,7 +8,9 @@ import { resolveTenantId, resolveClusterConfig } from '../config.ts';
 import { TenantId } from '@camunda8/orchestration-cluster-api';
 import { c8ctl } from '../runtime.ts';
 import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
-import { join, dirname, extname, basename, relative } from 'node:path';
+import { join, dirname, extname, basename, relative, resolve } from 'node:path';
+import { type Ignore } from 'ignore';
+import { loadIgnoreRules, isIgnored } from '../ignore.ts';
 
 const RESOURCE_EXTENSIONS = ['.bpmn', '.dmn', '.form'];
 const PROCESS_APPLICATION_FILE = '.process-application';
@@ -108,7 +110,7 @@ function findGroupRoot(filePath: string, basePath: string): { type: 'bb', root: 
 /**
  * Recursively collect resource files from a directory
  */
-function collectResourceFiles(dirPath: string, collected: ResourceFile[] = [], basePath?: string): ResourceFile[] {
+function collectResourceFiles(dirPath: string, collected: ResourceFile[] = [], basePath?: string, ig?: Ignore): ResourceFile[] {
   if (!existsSync(dirPath)) {
     return collected;
   }
@@ -121,6 +123,9 @@ function collectResourceFiles(dirPath: string, collected: ResourceFile[] = [], b
   const stat = statSync(dirPath);
   
   if (stat.isFile()) {
+    if (ig && isIgnored(ig, dirPath, basePath)) {
+      return collected;
+    }
     const ext = extname(dirPath);
     if (RESOURCE_EXTENSIONS.includes(ext)) {
       const groupInfo = findGroupRoot(dirPath, basePath);
@@ -137,6 +142,11 @@ function collectResourceFiles(dirPath: string, collected: ResourceFile[] = [], b
   }
 
   if (stat.isDirectory()) {
+    // Skip entire directory if it matches an ignore rule
+    if (ig && isIgnored(ig, dirPath + '/', basePath)) {
+      return collected;
+    }
+
     const entries = readdirSync(dirPath);
     
     // Separate building block folders from regular ones
@@ -149,12 +159,20 @@ function collectResourceFiles(dirPath: string, collected: ResourceFile[] = [], b
       const entryStat = statSync(fullPath);
       
       if (entryStat.isDirectory()) {
+        // Skip ignored directories early to avoid descending into them
+        if (ig && isIgnored(ig, fullPath + '/', basePath!)) {
+          return;
+        }
         if (isBuildingBlockFolder(entry)) {
           bbFolders.push(fullPath);
         } else {
           regularFolders.push(fullPath);
         }
       } else if (entryStat.isFile()) {
+        // Skip ignored files
+        if (ig && isIgnored(ig, fullPath, basePath!)) {
+          return;
+        }
         files.push(fullPath);
       }
     });
@@ -177,12 +195,12 @@ function collectResourceFiles(dirPath: string, collected: ResourceFile[] = [], b
 
     // Process building block folders first (prioritized)
     bbFolders.forEach(bbFolder => {
-      collectResourceFiles(bbFolder, collected, basePath);
+      collectResourceFiles(bbFolder, collected, basePath, ig);
     });
 
     // Then process regular folders
     regularFolders.forEach(regularFolder => {
-      collectResourceFiles(regularFolder, collected, basePath);
+      collectResourceFiles(regularFolder, collected, basePath, ig);
     });
   }
 
@@ -225,9 +243,12 @@ export async function deploy(paths: string[], options: {
       process.exit(1);
     }
 
-    // Collect all resource files
+    // Load .c8ignore rules from the working directory
+    const ig = loadIgnoreRules(resolve(process.cwd()));
+
+    // Collect all resource files (respecting .c8ignore)
     paths.forEach(path => {
-      collectResourceFiles(path, resources);
+      collectResourceFiles(path, resources, undefined, ig);
     });
 
     if (resources.length === 0) {

--- a/src/commands/deployments.ts
+++ b/src/commands/deployments.ts
@@ -110,7 +110,7 @@ function findGroupRoot(filePath: string, basePath: string): { type: 'bb', root: 
 /**
  * Recursively collect resource files from a directory
  */
-function collectResourceFiles(dirPath: string, collected: ResourceFile[] = [], basePath?: string, ig?: Ignore): ResourceFile[] {
+function collectResourceFiles(dirPath: string, collected: ResourceFile[] = [], basePath?: string, ig?: Ignore, ignoreBaseDir?: string): ResourceFile[] {
   if (!existsSync(dirPath)) {
     return collected;
   }
@@ -123,7 +123,7 @@ function collectResourceFiles(dirPath: string, collected: ResourceFile[] = [], b
   const stat = statSync(dirPath);
   
   if (stat.isFile()) {
-    if (ig && isIgnored(ig, dirPath, basePath)) {
+    if (ig && ignoreBaseDir && isIgnored(ig, dirPath, ignoreBaseDir)) {
       return collected;
     }
     const ext = extname(dirPath);
@@ -143,7 +143,7 @@ function collectResourceFiles(dirPath: string, collected: ResourceFile[] = [], b
 
   if (stat.isDirectory()) {
     // Skip entire directory if it matches an ignore rule
-    if (ig && isIgnored(ig, dirPath + '/', basePath)) {
+    if (ig && ignoreBaseDir && isIgnored(ig, dirPath + '/', ignoreBaseDir)) {
       return collected;
     }
 
@@ -160,7 +160,7 @@ function collectResourceFiles(dirPath: string, collected: ResourceFile[] = [], b
       
       if (entryStat.isDirectory()) {
         // Skip ignored directories early to avoid descending into them
-        if (ig && isIgnored(ig, fullPath + '/', basePath!)) {
+        if (ig && ignoreBaseDir && isIgnored(ig, fullPath + '/', ignoreBaseDir)) {
           return;
         }
         if (isBuildingBlockFolder(entry)) {
@@ -170,7 +170,7 @@ function collectResourceFiles(dirPath: string, collected: ResourceFile[] = [], b
         }
       } else if (entryStat.isFile()) {
         // Skip ignored files
-        if (ig && isIgnored(ig, fullPath, basePath!)) {
+        if (ig && ignoreBaseDir && isIgnored(ig, fullPath, ignoreBaseDir)) {
           return;
         }
         files.push(fullPath);
@@ -195,12 +195,12 @@ function collectResourceFiles(dirPath: string, collected: ResourceFile[] = [], b
 
     // Process building block folders first (prioritized)
     bbFolders.forEach(bbFolder => {
-      collectResourceFiles(bbFolder, collected, basePath, ig);
+      collectResourceFiles(bbFolder, collected, basePath, ig, ignoreBaseDir);
     });
 
     // Then process regular folders
     regularFolders.forEach(regularFolder => {
-      collectResourceFiles(regularFolder, collected, basePath, ig);
+      collectResourceFiles(regularFolder, collected, basePath, ig, ignoreBaseDir);
     });
   }
 
@@ -244,11 +244,12 @@ export async function deploy(paths: string[], options: {
     }
 
     // Load .c8ignore rules from the working directory
-    const ig = loadIgnoreRules(resolve(process.cwd()));
+    const ignoreBaseDir = resolve(process.cwd());
+    const ig = loadIgnoreRules(ignoreBaseDir);
 
     // Collect all resource files (respecting .c8ignore)
     paths.forEach(path => {
-      collectResourceFiles(path, resources, undefined, ig);
+      collectResourceFiles(path, resources, undefined, ig, ignoreBaseDir);
     });
 
     if (resources.length === 0) {

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -7,6 +7,7 @@ import { resolve, extname, basename } from 'node:path';
 import { existsSync, statSync } from 'node:fs';
 import { getLogger } from '../logger.ts';
 import { deploy } from './deployments.ts';
+import { loadIgnoreRules, isIgnored } from '../ignore.ts';
 
 const WATCHED_EXTENSIONS = ['.bpmn', '.dmn', '.form'];
 export const DEPLOY_COOLDOWN = 1000; // 1 second cooldown
@@ -36,6 +37,9 @@ export async function watchFiles(paths: string[], options: {
     }
   }
 
+  // Load .c8ignore rules from the working directory
+  const ig = loadIgnoreRules(resolve(process.cwd()));
+
   logger.info(`👁️  Watching for changes in: ${resolvedPaths.join(', ')}`);
   logger.info(`📋 Monitoring extensions: ${WATCHED_EXTENSIONS.join(', ')}`);
   if (options.force) {
@@ -62,6 +66,11 @@ export async function watchFiles(paths: string[], options: {
       }
 
       const fullPath = isDirectory ? resolve(path, filename) : path;
+
+      // Skip files matching .c8ignore rules
+      if (isIgnored(ig, fullPath, resolve(process.cwd()))) {
+        return;
+      }
 
       // Clear any pending debounce for this file and restart the timer.
       // This ensures we wait until the file system is quiet before reading.

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -38,7 +38,8 @@ export async function watchFiles(paths: string[], options: {
   }
 
   // Load .c8ignore rules from the working directory
-  const ig = loadIgnoreRules(resolve(process.cwd()));
+  const ignoreBaseDir = resolve(process.cwd());
+  const ig = loadIgnoreRules(ignoreBaseDir);
 
   logger.info(`👁️  Watching for changes in: ${resolvedPaths.join(', ')}`);
   logger.info(`📋 Monitoring extensions: ${WATCHED_EXTENSIONS.join(', ')}`);
@@ -68,7 +69,7 @@ export async function watchFiles(paths: string[], options: {
       const fullPath = isDirectory ? resolve(path, filename) : path;
 
       // Skip files matching .c8ignore rules
-      if (isIgnored(ig, fullPath, resolve(process.cwd()))) {
+      if (isIgnored(ig, fullPath, ignoreBaseDir)) {
         return;
       }
 

--- a/src/ignore.ts
+++ b/src/ignore.ts
@@ -52,7 +52,7 @@ export function isIgnored(ig: Ignore, filePath: string, baseDir: string): boolea
     rel = rel.split(sep).join('/');
   }
   // Paths outside baseDir can't be ignored
-  if (rel.startsWith('..') || rel === '') {
+  if (rel === '' || rel === '..' || rel.startsWith('../')) {
     return false;
   }
   return ig.ignores(rel);

--- a/src/ignore.ts
+++ b/src/ignore.ts
@@ -1,0 +1,59 @@
+/**
+ * .c8ignore support — filter files/directories using .gitignore-style patterns.
+ *
+ * Default ignore patterns (always active):
+ *   node_modules/
+ *   target/
+ *   .git/
+ *
+ * Users can override or extend via a `.c8ignore` file in the working directory.
+ */
+
+import ignore, { type Ignore } from 'ignore';
+import { readFileSync, existsSync } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+
+const DEFAULT_PATTERNS = [
+  'node_modules/',
+  'target/',
+  '.git/',
+];
+
+const C8IGNORE_FILENAME = '.c8ignore';
+
+/**
+ * Load ignore rules from the `.c8ignore` file in `baseDir` (if present)
+ * merged with built-in default patterns.
+ */
+export function loadIgnoreRules(baseDir: string): Ignore {
+  const ig = ignore().add(DEFAULT_PATTERNS);
+
+  const ignoreFilePath = join(baseDir, C8IGNORE_FILENAME);
+  if (existsSync(ignoreFilePath)) {
+    const content = readFileSync(ignoreFilePath, 'utf-8');
+    ig.add(content);
+  }
+
+  return ig;
+}
+
+/**
+ * Check whether a path should be ignored.
+ *
+ * `filePath` must be an absolute path.
+ * `baseDir` is the root directory the ignore rules are relative to.
+ *
+ * Returns `true` when the path matches an ignore rule.
+ */
+export function isIgnored(ig: Ignore, filePath: string, baseDir: string): boolean {
+  let rel = relative(baseDir, filePath);
+  // `ignore` expects forward-slash separators
+  if (sep !== '/') {
+    rel = rel.split(sep).join('/');
+  }
+  // Paths outside baseDir can't be ignored
+  if (rel.startsWith('..') || rel === '') {
+    return false;
+  }
+  return ig.ignores(rel);
+}

--- a/tests/unit/c8ignore.test.ts
+++ b/tests/unit/c8ignore.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Unit tests for .c8ignore support in deploy and watch commands
+ */
+
+import { test, describe, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+
+const CLI_ENTRY = join(process.cwd(), 'src', 'index.ts');
+
+/**
+ * Run the CLI and return parsed JSON from combined stderr+stdout.
+ * Uses --dry-run --output json so no server is needed and the output lists
+ * the resources that would be deployed.
+ */
+function dryRunDeploy(cwd: string, paths: string[] = ['.']): { body: { resources: { name: string }[] } } {
+  const result = spawnSync('node', [
+    '--experimental-strip-types',
+    CLI_ENTRY,
+    'deploy', ...paths,
+    '--dry-run',
+    '--output', 'json',
+  ], {
+    cwd,
+    encoding: 'utf-8',
+    env: { ...process.env, XDG_DATA_HOME: join(tmpdir(), `c8ctl-ignore-xdg-${Date.now()}`) },
+    timeout: 15000,
+  });
+
+  const output = (result.stdout ?? '') + (result.stderr ?? '');
+
+  // The dry-run JSON may be on stdout or stderr depending on output mode.
+  // Extract first JSON object from combined output.
+  const jsonMatch = output.match(/\{[\s\S]*\}/);
+  assert.ok(jsonMatch, `Expected JSON output, got:\n${output}`);
+  return JSON.parse(jsonMatch[0]);
+}
+
+function resourceNames(result: { body: { resources: { name: string }[] } }): string[] {
+  return result.body.resources.map(r => r.name).sort();
+}
+
+describe('.c8ignore', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `c8ctl-c8ignore-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  // ── Default ignore patterns ──────────────────────────────────────
+
+  describe('default ignore patterns (no .c8ignore file)', () => {
+    test('ignores node_modules directory', () => {
+      writeFileSync(join(testDir, 'root.bpmn'), '<bpmn/>');
+      mkdirSync(join(testDir, 'node_modules', 'pkg'), { recursive: true });
+      writeFileSync(join(testDir, 'node_modules', 'pkg', 'hidden.bpmn'), '<bpmn/>');
+
+      const result = dryRunDeploy(testDir);
+      const names = resourceNames(result);
+      assert.deepStrictEqual(names, ['root.bpmn']);
+    });
+
+    test('ignores target directory', () => {
+      writeFileSync(join(testDir, 'root.bpmn'), '<bpmn/>');
+      mkdirSync(join(testDir, 'target', 'classes'), { recursive: true });
+      writeFileSync(join(testDir, 'target', 'classes', 'hidden.bpmn'), '<bpmn/>');
+
+      const result = dryRunDeploy(testDir);
+      const names = resourceNames(result);
+      assert.deepStrictEqual(names, ['root.bpmn']);
+    });
+
+    test('ignores .git directory', () => {
+      writeFileSync(join(testDir, 'root.bpmn'), '<bpmn/>');
+      mkdirSync(join(testDir, '.git', 'objects'), { recursive: true });
+      writeFileSync(join(testDir, '.git', 'objects', 'hidden.bpmn'), '<bpmn/>');
+
+      const result = dryRunDeploy(testDir);
+      const names = resourceNames(result);
+      assert.deepStrictEqual(names, ['root.bpmn']);
+    });
+
+    test('ignores all default dirs together', () => {
+      writeFileSync(join(testDir, 'main.bpmn'), '<bpmn/>');
+      mkdirSync(join(testDir, 'node_modules'), { recursive: true });
+      writeFileSync(join(testDir, 'node_modules', 'a.bpmn'), '<bpmn/>');
+      mkdirSync(join(testDir, 'target'), { recursive: true });
+      writeFileSync(join(testDir, 'target', 'b.bpmn'), '<bpmn/>');
+      mkdirSync(join(testDir, '.git'), { recursive: true });
+      writeFileSync(join(testDir, '.git', 'c.bpmn'), '<bpmn/>');
+
+      const result = dryRunDeploy(testDir);
+      const names = resourceNames(result);
+      assert.deepStrictEqual(names, ['main.bpmn']);
+    });
+
+    test('does not ignore regular subdirectories', () => {
+      writeFileSync(join(testDir, 'root.bpmn'), '<bpmn/>');
+      mkdirSync(join(testDir, 'src'), { recursive: true });
+      writeFileSync(join(testDir, 'src', 'sub.bpmn'), '<bpmn/>');
+
+      const result = dryRunDeploy(testDir);
+      const names = resourceNames(result);
+      assert.deepStrictEqual(names, ['root.bpmn', 'sub.bpmn']);
+    });
+  });
+
+  // ── .c8ignore file patterns ──────────────────────────────────────
+
+  describe('.c8ignore file patterns', () => {
+    test('ignores files matching a glob pattern', () => {
+      writeFileSync(join(testDir, '.c8ignore'), 'build/\n');
+      writeFileSync(join(testDir, 'main.bpmn'), '<bpmn/>');
+      mkdirSync(join(testDir, 'build'), { recursive: true });
+      writeFileSync(join(testDir, 'build', 'output.bpmn'), '<bpmn/>');
+
+      const result = dryRunDeploy(testDir);
+      const names = resourceNames(result);
+      assert.deepStrictEqual(names, ['main.bpmn']);
+    });
+
+    test('ignores files matching a wildcard pattern', () => {
+      writeFileSync(join(testDir, '.c8ignore'), '**/temp-*.bpmn\n');
+      writeFileSync(join(testDir, 'main.bpmn'), '<bpmn/>');
+      writeFileSync(join(testDir, 'temp-draft.bpmn'), '<bpmn/>');
+      mkdirSync(join(testDir, 'sub'), { recursive: true });
+      writeFileSync(join(testDir, 'sub', 'temp-old.bpmn'), '<bpmn/>');
+
+      const result = dryRunDeploy(testDir);
+      const names = resourceNames(result);
+      assert.deepStrictEqual(names, ['main.bpmn']);
+    });
+
+    test('supports negation patterns (!)', () => {
+      // gitignore spec: you cannot re-include a file under an ignored parent directory.
+      // Negation works for file-level patterns, not directory-level re-inclusion.
+      writeFileSync(join(testDir, '.c8ignore'), '*.draft.bpmn\n!important.draft.bpmn\n');
+      writeFileSync(join(testDir, 'main.bpmn'), '<bpmn/>');
+      writeFileSync(join(testDir, 'sketch.draft.bpmn'), '<bpmn/>');
+      writeFileSync(join(testDir, 'important.draft.bpmn'), '<bpmn/>');
+
+      const result = dryRunDeploy(testDir);
+      const names = resourceNames(result);
+      assert.ok(names.includes('main.bpmn'), 'root file should be included');
+      assert.ok(names.includes('important.draft.bpmn'), 'negated file should be included');
+      assert.ok(!names.includes('sketch.draft.bpmn'), 'non-negated match should be excluded');
+    });
+
+    test('supports comments in .c8ignore', () => {
+      writeFileSync(join(testDir, '.c8ignore'), '# This is a comment\nbuild/\n# Another comment\n');
+      writeFileSync(join(testDir, 'main.bpmn'), '<bpmn/>');
+      mkdirSync(join(testDir, 'build'), { recursive: true });
+      writeFileSync(join(testDir, 'build', 'gone.bpmn'), '<bpmn/>');
+
+      const result = dryRunDeploy(testDir);
+      const names = resourceNames(result);
+      assert.deepStrictEqual(names, ['main.bpmn']);
+    });
+
+    test('supports blank lines in .c8ignore', () => {
+      writeFileSync(join(testDir, '.c8ignore'), '\nbuild/\n\n');
+      writeFileSync(join(testDir, 'main.bpmn'), '<bpmn/>');
+      mkdirSync(join(testDir, 'build'), { recursive: true });
+      writeFileSync(join(testDir, 'build', 'gone.bpmn'), '<bpmn/>');
+
+      const result = dryRunDeploy(testDir);
+      const names = resourceNames(result);
+      assert.deepStrictEqual(names, ['main.bpmn']);
+    });
+
+    test('.c8ignore patterns add to (do not replace) defaults', () => {
+      writeFileSync(join(testDir, '.c8ignore'), 'dist/\n');
+      writeFileSync(join(testDir, 'main.bpmn'), '<bpmn/>');
+      mkdirSync(join(testDir, 'node_modules'), { recursive: true });
+      writeFileSync(join(testDir, 'node_modules', 'a.bpmn'), '<bpmn/>');
+      mkdirSync(join(testDir, 'dist'), { recursive: true });
+      writeFileSync(join(testDir, 'dist', 'b.bpmn'), '<bpmn/>');
+
+      const result = dryRunDeploy(testDir);
+      const names = resourceNames(result);
+      assert.deepStrictEqual(names, ['main.bpmn']);
+    });
+
+    test('ignores deeply nested files matching pattern', () => {
+      writeFileSync(join(testDir, '.c8ignore'), 'vendor/\n');
+      writeFileSync(join(testDir, 'main.bpmn'), '<bpmn/>');
+      mkdirSync(join(testDir, 'vendor', 'deep', 'nested'), { recursive: true });
+      writeFileSync(join(testDir, 'vendor', 'deep', 'nested', 'gone.bpmn'), '<bpmn/>');
+
+      const result = dryRunDeploy(testDir);
+      const names = resourceNames(result);
+      assert.deepStrictEqual(names, ['main.bpmn']);
+    });
+  });
+
+  // ── Edge cases ───────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    test('works when .c8ignore file does not exist', () => {
+      writeFileSync(join(testDir, 'main.bpmn'), '<bpmn/>');
+
+      const result = dryRunDeploy(testDir);
+      const names = resourceNames(result);
+      assert.deepStrictEqual(names, ['main.bpmn']);
+    });
+
+    test('empty .c8ignore still applies default patterns', () => {
+      writeFileSync(join(testDir, '.c8ignore'), '');
+      writeFileSync(join(testDir, 'main.bpmn'), '<bpmn/>');
+      mkdirSync(join(testDir, 'node_modules'), { recursive: true });
+      writeFileSync(join(testDir, 'node_modules', 'hidden.bpmn'), '<bpmn/>');
+
+      const result = dryRunDeploy(testDir);
+      const names = resourceNames(result);
+      assert.deepStrictEqual(names, ['main.bpmn']);
+    });
+
+    test('does not ignore building block folders unless explicitly listed', () => {
+      writeFileSync(join(testDir, 'main.bpmn'), '<bpmn/>');
+      mkdirSync(join(testDir, '_bb-blocks'), { recursive: true });
+      writeFileSync(join(testDir, '_bb-blocks', 'block.bpmn'), '<bpmn/>');
+
+      const result = dryRunDeploy(testDir);
+      const names = resourceNames(result);
+      assert.ok(names.includes('block.bpmn'), 'building block files should be included');
+      assert.ok(names.includes('main.bpmn'), 'root file should be included');
+    });
+
+    test('can explicitly ignore building block folder via .c8ignore', () => {
+      writeFileSync(join(testDir, '.c8ignore'), '_bb-old-blocks/\n');
+      writeFileSync(join(testDir, 'main.bpmn'), '<bpmn/>');
+      mkdirSync(join(testDir, '_bb-old-blocks'), { recursive: true });
+      writeFileSync(join(testDir, '_bb-old-blocks', 'old.bpmn'), '<bpmn/>');
+      mkdirSync(join(testDir, '_bb-active'), { recursive: true });
+      writeFileSync(join(testDir, '_bb-active', 'active.bpmn'), '<bpmn/>');
+
+      const result = dryRunDeploy(testDir);
+      const names = resourceNames(result);
+      assert.ok(names.includes('main.bpmn'));
+      assert.ok(names.includes('active.bpmn'), 'non-ignored BB folder should be included');
+      assert.ok(!names.includes('old.bpmn'), 'ignored BB folder should be excluded');
+    });
+
+    test('handles all resource extensions (.bpmn, .dmn, .form)', () => {
+      writeFileSync(join(testDir, '.c8ignore'), 'ignored/\n');
+      writeFileSync(join(testDir, 'process.bpmn'), '<bpmn/>');
+      writeFileSync(join(testDir, 'decision.dmn'), '<dmn/>');
+      writeFileSync(join(testDir, 'input.form'), '{}');
+      mkdirSync(join(testDir, 'ignored'), { recursive: true });
+      writeFileSync(join(testDir, 'ignored', 'hidden.bpmn'), '<bpmn/>');
+      writeFileSync(join(testDir, 'ignored', 'hidden.dmn'), '<dmn/>');
+      writeFileSync(join(testDir, 'ignored', 'hidden.form'), '{}');
+
+      const result = dryRunDeploy(testDir);
+      const names = resourceNames(result);
+      assert.deepStrictEqual(names, ['decision.dmn', 'input.form', 'process.bpmn']);
+    });
+
+    test('ignoring a specific file by name', () => {
+      writeFileSync(join(testDir, '.c8ignore'), 'draft.bpmn\n');
+      writeFileSync(join(testDir, 'main.bpmn'), '<bpmn/>');
+      writeFileSync(join(testDir, 'draft.bpmn'), '<bpmn/>');
+
+      const result = dryRunDeploy(testDir);
+      const names = resourceNames(result);
+      assert.deepStrictEqual(names, ['main.bpmn']);
+    });
+  });
+
+  // ── loadIgnoreRules / isIgnored unit tests ───────────────────────
+
+  describe('ignore module (unit)', () => {
+    // Import the module functions directly
+    let loadIgnoreRules: typeof import('../../src/ignore.ts').loadIgnoreRules;
+    let isIgnored: typeof import('../../src/ignore.ts').isIgnored;
+
+    beforeEach(async () => {
+      const mod = await import('../../src/ignore.ts');
+      loadIgnoreRules = mod.loadIgnoreRules;
+      isIgnored = mod.isIgnored;
+    });
+
+    test('loadIgnoreRules returns ignore instance with defaults', () => {
+      const ig = loadIgnoreRules(testDir);
+      assert.ok(ig, 'should return an ignore instance');
+      assert.strictEqual(ig.ignores('node_modules/foo'), true);
+      assert.strictEqual(ig.ignores('target/classes/bar'), true);
+      assert.strictEqual(ig.ignores('.git/HEAD'), true);
+      assert.strictEqual(ig.ignores('src/main.bpmn'), false);
+    });
+
+    test('loadIgnoreRules merges .c8ignore with defaults', () => {
+      writeFileSync(join(testDir, '.c8ignore'), 'dist/\n');
+      const ig = loadIgnoreRules(testDir);
+      assert.strictEqual(ig.ignores('dist/output.js'), true);
+      assert.strictEqual(ig.ignores('node_modules/pkg'), true);
+      assert.strictEqual(ig.ignores('src/main.ts'), false);
+    });
+
+    test('isIgnored handles paths relative to baseDir', () => {
+      const ig = loadIgnoreRules(testDir);
+      const full = join(testDir, 'node_modules', 'pkg', 'file.bpmn');
+      assert.strictEqual(isIgnored(ig, full, testDir), true);
+    });
+
+    test('isIgnored returns false for paths outside baseDir', () => {
+      const ig = loadIgnoreRules(testDir);
+      assert.strictEqual(isIgnored(ig, '/some/other/path/file.bpmn', testDir), false);
+    });
+  });
+});

--- a/tests/unit/c8ignore.test.ts
+++ b/tests/unit/c8ignore.test.ts
@@ -13,8 +13,8 @@ const CLI_ENTRY = join(process.cwd(), 'src', 'index.ts');
 
 /**
  * Run the CLI and return parsed JSON from combined stderr+stdout.
- * Uses --dry-run --output json so no server is needed and the output lists
- * the resources that would be deployed.
+ * Uses --dry-run so no server is needed and the output lists
+ * the resources that would be deployed (dry-run always emits JSON).
  */
 function dryRunDeploy(cwd: string, paths: string[] = ['.']): { body: { resources: { name: string }[] } } {
   const result = spawnSync('node', [
@@ -22,7 +22,6 @@ function dryRunDeploy(cwd: string, paths: string[] = ['.']): { body: { resources
     CLI_ENTRY,
     'deploy', ...paths,
     '--dry-run',
-    '--output', 'json',
   ], {
     cwd,
     encoding: 'utf-8',
@@ -316,6 +315,58 @@ describe('.c8ignore', () => {
     test('isIgnored returns false for paths outside baseDir', () => {
       const ig = loadIgnoreRules(testDir);
       assert.strictEqual(isIgnored(ig, '/some/other/path/file.bpmn', testDir), false);
+    });
+  });
+
+  // ── Watch mode filtering ─────────────────────────────────────────
+
+  describe('watch mode respects .c8ignore', () => {
+    test('ignored file change does not trigger deploy', () => {
+      // Set up directory with .c8ignore and an ignored subfolder
+      writeFileSync(join(testDir, '.c8ignore'), 'ignored/\n');
+      mkdirSync(join(testDir, 'ignored'), { recursive: true });
+      writeFileSync(join(testDir, 'ignored', 'hidden.bpmn'), '<bpmn/>');
+      writeFileSync(join(testDir, 'visible.bpmn'), '<bpmn/>');
+
+      // Use a helper script that starts watch, modifies an ignored file,
+      // then collects output. The helper runs in testDir so .c8ignore is found.
+      const helperScript = `
+        const { spawn, execSync } = require('node:child_process');
+        const { writeFileSync } = require('node:fs');
+        const { join } = require('node:path');
+
+        const proc = spawn('node', [
+          '--experimental-strip-types',
+          ${JSON.stringify(CLI_ENTRY)},
+          'watch', '.',
+        ], { stdio: 'pipe', cwd: ${JSON.stringify(testDir)} });
+
+        let output = '';
+        proc.stdout.on('data', d => output += d);
+        proc.stderr.on('data', d => output += d);
+
+        setTimeout(() => {
+          writeFileSync(join(${JSON.stringify(testDir)}, 'ignored', 'hidden.bpmn'), '<updated/>');
+          setTimeout(() => {
+            proc.kill('SIGTERM');
+            process.stdout.write(output);
+            process.exit(0);
+          }, 1500);
+        }, 500);
+      `;
+
+      const result = spawnSync('node', ['-e', helperScript], {
+        encoding: 'utf-8',
+        timeout: 5000,
+        cwd: testDir,
+        env: { ...process.env, XDG_DATA_HOME: join(tmpdir(), `c8ctl-watch-ign-${Date.now()}`) },
+      });
+
+      const output = (result.stdout ?? '') + (result.stderr ?? '');
+
+      // "Change detected" should NOT appear for the ignored file
+      assert.ok(!output.includes('Change detected'),
+        `Watch should not detect changes in ignored directories, but got:\n${output}`);
     });
   });
 });


### PR DESCRIPTION
## Summary

Introduces `.c8ignore` file support so that `deploy` (directory scan) and `watch` (file monitoring) can filter out unwanted directories and files. Uses `.gitignore`-style pattern syntax via the [`ignore`](https://www.npmjs.com/package/ignore) npm package.

Closes #161

## Default ignore patterns (always active)

These directories are ignored automatically, with no `.c8ignore` file needed:

- `node_modules/`
- `target/`
- `.git/`

## Custom patterns via `.c8ignore`

Users create a `.c8ignore` file in their project root:

```gitignore
# Ignore build output
dist/
build/

# Ignore draft processes
**/draft-*.bpmn

# But keep this specific one
!draft-approved.bpmn
```

The file supports the full `.gitignore` syntax: glob patterns, directory trailing slashes, comments (`#`), blank lines, and negation (`!`) for file-level patterns.

Custom patterns are merged with the built-in defaults — they do not replace them.

## Changes

- **`src/ignore.ts`** (new) — `loadIgnoreRules(baseDir)` loads default patterns + `.c8ignore`; `isIgnored(ig, path, baseDir)` checks whether a path matches
- **`src/commands/deployments.ts`** — `collectResourceFiles()` now accepts an `Ignore` instance; `deploy()` loads ignore rules from `process.cwd()` and passes them through traversal. Ignored directories are skipped early to avoid descending into them.
- **`src/commands/watch.ts`** — File change events are filtered through ignore rules before triggering deploys
- **`package.json`** — Added `ignore` runtime dependency
- **`README.md`** — Feature bullet + `.c8ignore` section with example
- **`EXAMPLES.md`** — `.c8ignore` section with pattern examples

## Tests

22 new unit tests in `tests/unit/c8ignore.test.ts` covering:

| Category | Tests |
|---|---|
| Default ignore patterns | `node_modules/`, `target/`, `.git/` ignored without `.c8ignore` file |
| `.c8ignore` patterns | Glob directives, wildcard patterns, negation, comments, blank lines, additive with defaults, nested paths |
| Edge cases | No `.c8ignore` file, empty `.c8ignore`, building block folders, explicit BB ignore, all resource extensions (`.bpmn`/`.dmn`/`.form`), specific file ignore |
| Unit tests | `loadIgnoreRules()`, `isIgnored()` direct function testing |

All 497 unit tests pass. Build compiles cleanly.