### PR TITLE
feat: add feedback command to open issue tracker

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1259,3 +1259,12 @@ c8 help          # → structured JSON command reference
 c8 help list     # → JSON for list command
 c8 help search   # → JSON for search command
 ```
+
+---
+
+## Feedback
+
+```bash
+# Open the issue tracker to report bugs or request features
+c8 feedback
+```

--- a/README.md
+++ b/README.md
@@ -592,6 +592,7 @@ c8ctl <verb> <resource> [arguments] [flags]
 - `use` - Set active profile or tenant
 - `output` - Set output format
 - `completion` - Generate shell completion script
+- `feedback` - Open the feedback page to report issues or request features
 
 **Resources**: process-instance (pi), process-definition (pd), user-task (ut), incident (inc), job, jobs, variables (vars), message (msg), topology, profile, tenant, plugin
 

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -50,7 +50,7 @@ _c8ctl_completions() {
   local completion_resources="bash zsh fish"
   local cluster_resources="start stop status list list-remote install delete log logs"
   local open_resources="operate tasklist modeler optimize"
-  local help_resources="list get create complete await search deploy run watch open cancel resolve fail activate publish correlate upgrade downgrade init profiles profile plugin plugins cluster"
+  local help_resources="list get create complete await search deploy run watch open cancel resolve fail activate publish correlate upgrade downgrade init profiles profile plugin plugins cluster feedback"
 
   # Global flags
   local flags="--help --version --profile --from --all --bpmnProcessId --id --processInstanceKey --processDefinitionKey --parentProcessInstanceKey --variables --state --assignee --type --correlationKey --timeToLive --maxJobsToActivate --timeout --worker --retries --errorMessage --baseUrl --clientId --clientSecret --audience --oAuthUrl --defaultTenantId --awaitCompletion --fetchVariables --requestTimeout --sortBy --asc --desc --limit --between --dateField --name --key --elementId --errorType --value --scopeKey --fullValue --userTask --ut --processDefinition --pd --iname --iid --iassignee --ierrorMessage --itype --ivalue --fields --dry-run --verbose --force --none --from-file --from-env"
@@ -502,6 +502,7 @@ _c8ctl() {
             'plugin:Show plugin management help'
             'plugins:Alias for plugin management help'
             'cluster:No detailed help; use c8ctl help for general usage'
+            'feedback:Show feedback command help'
           )
           _describe 'resource' resources
           ;;
@@ -979,6 +980,8 @@ complete -c c8ctl -n '__fish_seen_subcommand_from help' -a 'plugins' -d 'Alias f
 complete -c c8 -n '__fish_seen_subcommand_from help' -a 'plugins' -d 'Alias for plugin management help'
 complete -c c8ctl -n '__fish_seen_subcommand_from help' -a 'cluster' -d 'No detailed help; use c8ctl help for general usage'
 complete -c c8 -n '__fish_seen_subcommand_from help' -a 'cluster' -d 'No detailed help; use c8ctl help for general usage'
+complete -c c8ctl -n '__fish_seen_subcommand_from help' -a 'feedback' -d 'Show feedback command help'
+complete -c c8 -n '__fish_seen_subcommand_from help' -a 'feedback' -d 'Show feedback command help'
 
 # Resources for 'cluster' command
 complete -c c8ctl -n '__fish_seen_subcommand_from cluster' -a 'start' -d 'Start local Camunda 8 cluster'

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -21,7 +21,7 @@ _c8ctl_completions() {
   cword=\${COMP_CWORD}
 
   # Commands (verbs)
-  local verbs="list search get create cancel await complete fail activate resolve publish correlate deploy run watch open add remove rm load unload sync upgrade downgrade init use which output completion help cluster"
+  local verbs="list search get create cancel await complete fail activate resolve publish correlate deploy run watch open add remove rm load unload sync upgrade downgrade init use which output completion help cluster feedback"
   
   # Resources by verb
   local list_resources="process-instances process-instance pi user-tasks user-task ut incidents incident inc jobs profiles profile plugins plugin"
@@ -209,6 +209,7 @@ _c8ctl() {
     'completion:Generate shell completion script'
     'help:Show help or detailed help for a command'
     'cluster:Manage local Camunda 8 cluster'
+    'feedback:Open the feedback page to report issues or request features'
   )
 
   flags=(
@@ -732,6 +733,8 @@ complete -c c8ctl -n '__fish_use_subcommand' -a 'completion' -d 'Generate shell 
 complete -c c8 -n '__fish_use_subcommand' -a 'completion' -d 'Generate shell completion script'
 complete -c c8ctl -n '__fish_use_subcommand' -a 'cluster' -d 'Manage local Camunda 8 cluster'
 complete -c c8 -n '__fish_use_subcommand' -a 'cluster' -d 'Manage local Camunda 8 cluster'
+complete -c c8ctl -n '__fish_use_subcommand' -a 'feedback' -d 'Open the feedback page to report issues or request features'
+complete -c c8 -n '__fish_use_subcommand' -a 'feedback' -d 'Open the feedback page to report issues or request features'
 
 # Resources for 'list' command
 complete -c c8ctl -n '__fish_seen_subcommand_from list' -a 'process-instances' -d 'List process instances'

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -48,6 +48,7 @@ function buildHelpJson(version: string, pluginCommandsInfo: PluginCommandInfo[])
       { verb: 'output',    resource: 'json|text',        resources: ['json','text'], description: 'Set output format', mutating: false },
       { verb: 'completion',resource: 'bash|zsh|fish',    resources: ['bash','zsh','fish'], description: 'Generate shell completion script', mutating: false },
       { verb: 'mcp-proxy', resource: '[mcp-path]',       resources: [], description: 'Start a STDIO to remote HTTP MCP proxy server', mutating: false },
+      { verb: 'feedback', resource: '',                resources: [], description: 'Open the feedback page to report issues or request features', mutating: false },
       { verb: 'help',      resource: '[command]',        resources: [], description: 'Show help', mutating: false },
       ...pluginCommandsInfo.map(cmd => ({
         verb: cmd.commandName, resource: '', resources: [], description: cmd.description || '', mutating: false,
@@ -197,6 +198,7 @@ Commands:
   output    json|text        Set output format
   completion bash|zsh|fish   Generate shell completion script
   mcp-proxy [mcp-path]       Start a STDIO to remote HTTP MCP proxy server
+  feedback                   Open the feedback page to report issues or request features
   help      [command]        Show help (detailed help for list, get, create, complete, await)${pluginSection}
 
 Flags:
@@ -340,6 +342,10 @@ For detailed help on specific commands with all available flags:
   c8ctl help profiles                Show profile management help
   c8ctl help plugin                  Show plugin management help
   c8ctl help plugins                 Alias for plugin management help
+
+Feedback & Issues:
+  https://github.com/camunda/c8ctl/issues
+  Or run: c8ctl feedback
 `.trim());
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ import {
   executePluginCommand
 } from './plugin-loader.ts';
 import { mcpProxy } from './commands/mcp-proxy.ts';
-import { openApp } from './commands/open.ts';
+import { openApp, openUrl } from './commands/open.ts';
 
 /**
  * Normalize resource aliases
@@ -704,6 +704,15 @@ async function main() {
       profile: values.profile as string | undefined,
       dryRun: values['dry-run'] as boolean | undefined,
     });
+    return;
+  }
+
+  // Handle feedback command
+  if (verb === 'feedback') {
+    const logger = getLogger();
+    const url = 'https://github.com/camunda/c8ctl/issues';
+    logger.info(`Opening feedback page: ${url}`);
+    openUrl(url);
     return;
   }
 

--- a/tests/unit/completion.test.ts
+++ b/tests/unit/completion.test.ts
@@ -80,6 +80,9 @@ describe('Completion Module', () => {
     // Check for open command
     assert.ok(output.includes('open'), 'Should include open verb');
     assert.ok(output.includes('"operate tasklist modeler optimize"'), 'Should include open resources');
+
+    // Check for feedback command
+    assert.ok(output.includes('feedback'), 'Should include feedback verb');
   });
 
   test('generates zsh completion script', () => {
@@ -116,6 +119,9 @@ describe('Completion Module', () => {
     assert.ok(output.includes("'tasklist:Open Camunda Tasklist'"), 'Should include tasklist resource');
     assert.ok(output.includes("'modeler:Open Camunda Web Modeler'"), 'Should include modeler resource');
     assert.ok(output.includes("'optimize:Open Camunda Optimize'"), 'Should include optimize resource');
+
+    // Check for feedback command
+    assert.ok(output.includes("'feedback:Open the feedback page to report issues or request features'"), 'Should include feedback verb');
   });
 
   test('generates fish completion script', () => {
@@ -147,6 +153,9 @@ describe('Completion Module', () => {
     assert.ok(output.includes("'open' -d 'Open Camunda web application in browser'"), 'Should include open verb');
     assert.ok(output.includes("'operate' -d 'Open Camunda Operate'"), 'Should include operate resource');
     assert.ok(output.includes("'tasklist' -d 'Open Camunda Tasklist'"), 'Should include tasklist resource');
+
+    // Check for feedback command
+    assert.ok(output.includes("'feedback' -d 'Open the feedback page to report issues or request features'"), 'Should include feedback verb');
   });
 
   test('handles missing shell argument', () => {

--- a/tests/unit/help.test.ts
+++ b/tests/unit/help.test.ts
@@ -381,6 +381,24 @@ describe('Help Module', () => {
     assert.ok(output.includes('c8ctl help open'), 'help should include c8ctl help open link');
   });
 
+  test('showHelp includes feedback command and URL', () => {
+    showHelp();
+
+    const output = consoleLogSpy.join('\n');
+    assert.ok(output.includes('feedback'), 'help should include feedback command');
+    assert.ok(output.includes('https://github.com/camunda/c8ctl/issues'), 'help should include feedback URL');
+    assert.ok(output.includes('c8ctl feedback'), 'help should include c8ctl feedback hint');
+  });
+
+  test('showHelp includes feedback command and URL', () => {
+    showHelp();
+
+    const output = consoleLogSpy.join('\n');
+    assert.ok(output.includes('feedback'), 'help should include feedback command');
+    assert.ok(output.includes('https://github.com/camunda/c8ctl/issues'), 'help should include feedback URL');
+    assert.ok(output.includes('c8ctl feedback'), 'help should include c8ctl feedback hint');
+  });
+
   test('showCommandHelp shows cancel help', () => {
     showCommandHelp('cancel');
     

--- a/tests/unit/help.test.ts
+++ b/tests/unit/help.test.ts
@@ -390,15 +390,6 @@ describe('Help Module', () => {
     assert.ok(output.includes('c8ctl feedback'), 'help should include c8ctl feedback hint');
   });
 
-  test('showHelp includes feedback command and URL', () => {
-    showHelp();
-
-    const output = consoleLogSpy.join('\n');
-    assert.ok(output.includes('feedback'), 'help should include feedback command');
-    assert.ok(output.includes('https://github.com/camunda/c8ctl/issues'), 'help should include feedback URL');
-    assert.ok(output.includes('c8ctl feedback'), 'help should include c8ctl feedback hint');
-  });
-
   test('showCommandHelp shows cancel help', () => {
     showCommandHelp('cancel');
     


### PR DESCRIPTION
## Summary

Adds a `c8ctl feedback` command that opens the GitHub issues page (`https://github.com/camunda/c8ctl/issues`) in the user's default browser.

Also adds a "Feedback & Issues" footer to the main help output with the URL and a hint to run `c8ctl feedback`.

## Changes

- **`src/index.ts`**: Added `feedback` verb handler that calls `openUrl()` with the issues URL
- **`src/commands/help.ts`**: Added feedback to verb registry, commands table, and help footer
- **`src/commands/completion.ts`**: Added feedback to bash, zsh, and fish completions
- **`README.md`**: Added feedback to commands list
- **`EXAMPLES.md`**: Added feedback examples section
- **Tests**: Added assertions for feedback in help and completion tests

## Testing

- 567 unit tests pass
- Build succeeds

Closes #170