### PR TITLE
feat: show current output mode when `c8 output` invoked with no args

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,9 @@ c8 list pi --profile=modeler:Cloud Cluster
 ### Session Management
 
 ```bash
+# Show current output mode
+c8ctl output
+
 # Switch to JSON output
 c8ctl output json
 
@@ -590,7 +593,7 @@ c8ctl <verb> <resource> [arguments] [flags]
 - `unload` - Unload a plugin
 - `sync` - Synchronize plugins
 - `use` - Set active profile or tenant
-- `output` - Set output format
+- `output` - Show or set output format
 - `completion` - Generate shell completion script
 - `feedback` - Open the feedback page to report issues or request features
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -48,7 +48,7 @@ function buildHelpJson(version: string, pluginCommandsInfo: PluginCommandInfo[])
       { verb: 'sync',      resource: 'plugin',           resources: ['plugin'], description: 'Synchronize plugins', mutating: false },
       { verb: 'init',      resource: 'plugin [name]', resources: ['plugin'], description: 'Create a new plugin from TypeScript template', mutating: false },
       { verb: 'use',       resource: 'profile|tenant',   resources: ['profile','tenant'], description: 'Set active profile or tenant', mutating: false },
-      { verb: 'output',    resource: 'json|text',        resources: ['json','text'], description: 'Set output format', mutating: false },
+      { verb: 'output',    resource: '[json|text]',      resources: ['json','text'], description: 'Show or set output format', mutating: false },
       { verb: 'completion',resource: 'bash|zsh|fish',    resources: ['bash','zsh','fish'], description: 'Generate shell completion script', mutating: false },
       { verb: 'mcp-proxy', resource: '[mcp-path]',       resources: [], description: 'Start a STDIO to remote HTTP MCP proxy server', mutating: false },
       { verb: 'feedback', resource: '',                resources: [], description: 'Open the feedback page to report issues or request features', mutating: false },
@@ -214,7 +214,7 @@ Commands:
   sync      plugin           Synchronize plugins from registry (rebuild/reinstall)
   init      plugin [name]    Create a new plugin from TypeScript template
   use       profile|tenant   Set active profile or tenant
-  output    json|text        Set output format
+  output    [json|text]      Show or set output format
   completion bash|zsh|fish   Generate shell completion script
   mcp-proxy [mcp-path]       Start a STDIO to remote HTTP MCP proxy server
   feedback                   Open the feedback page to report issues or request features

--- a/src/index.ts
+++ b/src/index.ts
@@ -325,7 +325,9 @@ async function main() {
   if (verb === 'output') {
     if (!resource) {
       logger.info(`Current output mode: ${c8ctl.outputMode}`);
-      logger.info('');
+      if (c8ctl.outputMode === 'text') {
+        logger.info('');
+      }
       logger.info('Available modes: json|text');
       return;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -324,8 +324,10 @@ async function main() {
 
   if (verb === 'output') {
     if (!resource) {
-      logger.error('Output mode required. Usage: c8 output json|text');
-      process.exit(1);
+      logger.info(`Current output mode: ${c8ctl.outputMode}`);
+      logger.info('');
+      logger.info('Available modes: json|text');
+      return;
     }
     setOutputFormat(resource);
     return;

--- a/tests/unit/output-mode.test.ts
+++ b/tests/unit/output-mode.test.ts
@@ -4,7 +4,7 @@
  * Exercises the CLI as a subprocess to match DEVELOPMENT.md conventions.
  */
 
-import { test, describe, before, after } from 'node:test';
+import { test, describe, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -24,11 +24,11 @@ function cli(...args: string[]) {
 }
 
 describe('c8 output', () => {
-  before(() => {
+  beforeEach(() => {
     dataDir = mkdtempSync(join(tmpdir(), 'c8ctl-output-mode-test-'));
   });
 
-  after(() => {
+  afterEach(() => {
     rmSync(dataDir, { recursive: true, force: true });
   });
   test('shows current output mode when invoked with no arguments', async () => {
@@ -47,9 +47,6 @@ describe('c8 output', () => {
     // In json mode, success goes to stderr per unix convention
     const output = result.stdout + result.stderr;
     assert.ok(output.includes('Output mode set to: json'), `Expected confirmation, got stdout: ${result.stdout}, stderr: ${result.stderr}`);
-
-    // Reset to text mode
-    await cli('output', 'text');
   });
 
   test('sets output mode to text', async () => {

--- a/tests/unit/output-mode.test.ts
+++ b/tests/unit/output-mode.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for `c8 output` command
+ *
+ * Exercises the CLI as a subprocess to match DEVELOPMENT.md conventions.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { resolve, join } from 'node:path';
+import { asyncSpawn } from '../utils/spawn.ts';
+
+const PROJECT_ROOT = resolve(import.meta.dirname, '..', '..');
+const CLI = join(PROJECT_ROOT, 'src', 'index.ts');
+
+function cli(...args: string[]) {
+  return asyncSpawn('node', ['--experimental-strip-types', CLI, ...args], {
+    cwd: PROJECT_ROOT,
+  });
+}
+
+describe('c8 output', () => {
+  test('shows current output mode when invoked with no arguments', async () => {
+    const result = await cli('output');
+    const output = result.stdout + result.stderr;
+
+    assert.strictEqual(result.status, 0, `Expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+    assert.ok(output.includes('Current output mode:'), `Expected current mode in output, got stdout: ${result.stdout}, stderr: ${result.stderr}`);
+    assert.ok(output.includes('Available modes: json|text'), `Expected available modes in output, got stdout: ${result.stdout}, stderr: ${result.stderr}`);
+  });
+
+  test('sets output mode to json', async () => {
+    const result = await cli('output', 'json');
+
+    assert.strictEqual(result.status, 0, `Expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+    // In json mode, success goes to stderr per unix convention
+    const output = result.stdout + result.stderr;
+    assert.ok(output.includes('Output mode set to: json'), `Expected confirmation, got stdout: ${result.stdout}, stderr: ${result.stderr}`);
+
+    // Reset to text mode
+    await cli('output', 'text');
+  });
+
+  test('sets output mode to text', async () => {
+    const result = await cli('output', 'text');
+
+    assert.strictEqual(result.status, 0, `Expected exit 0, got ${result.status}. stderr: ${result.stderr}`);
+    assert.ok(result.stdout.includes('Output mode set to: text'), `Expected confirmation, got: ${result.stdout}`);
+  });
+
+  test('rejects invalid output mode', async () => {
+    const result = await cli('output', 'yaml');
+
+    assert.notStrictEqual(result.status, 0, 'Expected non-zero exit for invalid mode');
+  });
+});

--- a/tests/unit/output-mode.test.ts
+++ b/tests/unit/output-mode.test.ts
@@ -4,21 +4,33 @@
  * Exercises the CLI as a subprocess to match DEVELOPMENT.md conventions.
  */
 
-import { test, describe } from 'node:test';
+import { test, describe, before, after } from 'node:test';
 import assert from 'node:assert';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { resolve, join } from 'node:path';
 import { asyncSpawn } from '../utils/spawn.ts';
 
 const PROJECT_ROOT = resolve(import.meta.dirname, '..', '..');
 const CLI = join(PROJECT_ROOT, 'src', 'index.ts');
 
+let dataDir = '';
+
 function cli(...args: string[]) {
   return asyncSpawn('node', ['--experimental-strip-types', CLI, ...args], {
     cwd: PROJECT_ROOT,
+    env: { ...process.env, C8CTL_DATA_DIR: dataDir } as NodeJS.ProcessEnv,
   });
 }
 
 describe('c8 output', () => {
+  before(() => {
+    dataDir = mkdtempSync(join(tmpdir(), 'c8ctl-output-mode-test-'));
+  });
+
+  after(() => {
+    rmSync(dataDir, { recursive: true, force: true });
+  });
   test('shows current output mode when invoked with no arguments', async () => {
     const result = await cli('output');
     const output = result.stdout + result.stderr;


### PR DESCRIPTION
When `c8 output` is invoked without specifying a mode, display the current output mode and available options instead of erroring with "Output mode required".

**Before:**
```
$ c8 output
✖ Output mode required. Usage: c8 output json|text
(exit 1)
```

**After:**
```
$ c8 output
Current output mode: text

Available modes: json|text
```

Closes #211