### PR TITLE
fix: eliminate all any types, add Biome + GritQL enforcement, fix security issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,10 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Setup Node.js 22
         uses: actions/setup-node@v6
@@ -27,13 +25,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Lint fix
-        run: npx biome check src/ --fix
-
-      - name: Commit lint fixes
-        uses: stefanzweifel/git-auto-commit-action@v5
-        with:
-          commit_message: "fix: auto-fix lint issues"
+      - name: Lint
+        run: npm run lint
 
   unit-test:
     name: Unit Test (Node ${{ matrix.node }} / ${{ matrix.os }})

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
       - name: Run unit tests
         run: npm run test:unit
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,37 @@ on:
   workflow_dispatch:
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.head_ref }}
+
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint fix
+        run: npx biome check src/ --fix
+
+      - name: Commit lint fixes
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "fix: auto-fix lint issues"
+
   unit-test:
     name: Unit Test (Node ${{ matrix.node }} / ${{ matrix.os }})
+    needs: lint
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -30,9 +59,6 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-
-      - name: Lint
-        run: npm run lint
 
       - name: Run unit tests
         run: npm run test:unit

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -59,6 +59,9 @@ Follow conventions in [COMMIT-MESSAGE-GUIDELINE.md](COMMIT-MESSAGE-GUIDELINE.md)
 - when outputting errors, provide clear, concise and actionable hints to the user
 
 - use modern TypeScript syntax and features
+- **never use `any`** — use `unknown` and narrow with type guards. Enforced by Biome (`noExplicitAny`, `noImplicitAnyLet`, `noEvolvingTypes` — all set to `error`)
+- **never use `as T` type assertions** — use type guards, narrowing, or `satisfies` instead. Enforced by a GritQL plugin (`plugins/no-unsafe-type-assertion.grit`). Exceptions: `as const` and import renames are allowed. If a cast is genuinely unavoidable, add a `// biome-ignore lint/plugin:` comment with a justification and a tracking issue reference
+- run `npx biome check src/` to verify — this runs as part of `npm run build` and CI. Zero diagnostics required
 - use modern Getter and Setter syntax for class properties. Examples:
 
 ```typescript

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+  "files": {
+    "includes": ["src/**/*.ts", "!src/templates/**"]
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noExplicitAny": "error",
+        "noImplicitAnyLet": "error",
+        "noEvolvingTypes": "error"
+      }
+    },
+    "domains": {
+      "react": "none",
+      "solid": "none",
+      "next": "none",
+      "qwik": "none",
+      "vue": "none"
+    }
+  },
+  "plugins": ["./plugins/no-unsafe-type-assertion.grit"]
+}

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
   "files": {
-    "includes": ["src/**/*.ts", "!src/templates/**"]
+    "includes": ["src/**/*.ts", "!src/templates"]
   },
   "linter": {
     "enabled": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "c8ctl": "dist/index.js"
       },
       "devDependencies": {
+        "@biomejs/biome": "^2.4.11",
         "@semantic-release/exec": "^7.1.0",
         "@semantic-release/github": "^12.0.6",
         "@semantic-release/npm": "^13.1.5",
@@ -90,6 +91,181 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@biomejs/biome": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@biomejs/biome/-/biome-2.4.11.tgz",
+      "integrity": "sha512-nWxHX8tf3Opb/qRgZpBbsTOqOodkbrkJ7S+JxJAruxOReaDPPmPuLBAGQ8vigyUgo0QBB+oQltNEAvalLcjggA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "bin": {
+        "biome": "bin/biome"
+      },
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/biome"
+      },
+      "optionalDependencies": {
+        "@biomejs/cli-darwin-arm64": "2.4.11",
+        "@biomejs/cli-darwin-x64": "2.4.11",
+        "@biomejs/cli-linux-arm64": "2.4.11",
+        "@biomejs/cli-linux-arm64-musl": "2.4.11",
+        "@biomejs/cli-linux-x64": "2.4.11",
+        "@biomejs/cli-linux-x64-musl": "2.4.11",
+        "@biomejs/cli-win32-arm64": "2.4.11",
+        "@biomejs/cli-win32-x64": "2.4.11"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-arm64": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-arm64/-/cli-darwin-arm64-2.4.11.tgz",
+      "integrity": "sha512-wOt+ed+L2dgZanWyL6i29qlXMc088N11optzpo10peayObBaAshbTcxKUchzEMp9QSY8rh5h6VfAFE3WTS1rqg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-darwin-x64": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-darwin-x64/-/cli-darwin-x64-2.4.11.tgz",
+      "integrity": "sha512-gZ6zR8XmZlExfi/Pz/PffmdpWOQ8Qhy7oBztgkR8/ylSRyLwfRPSadmiVCV8WQ8PoJ2MWUy2fgID9zmtgUUJmw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64/-/cli-linux-arm64-2.4.11.tgz",
+      "integrity": "sha512-avdJaEElXrKceK0va9FkJ4P5ci3N01TGkc6ni3P8l3BElqbOz42Wg2IyX3gbh0ZLEd4HVKEIrmuVu/AMuSeFFA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-arm64-musl": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-arm64-musl/-/cli-linux-arm64-musl-2.4.11.tgz",
+      "integrity": "sha512-+Sbo1OAmlegtdwqFE8iOxFIWLh1B3OEgsuZfBpyyN/kWuqZ8dx9ZEes6zVnDMo+zRHF2wLynRVhoQmV7ohxl2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64/-/cli-linux-x64-2.4.11.tgz",
+      "integrity": "sha512-TagWV0iomp5LnEnxWFg4nQO+e52Fow349vaX0Q/PIcX6Zhk4GGBgp3qqZ8PVkpC+cuehRctMf3+6+FgQ8jCEFQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-linux-x64-musl": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-linux-x64-musl/-/cli-linux-x64-musl-2.4.11.tgz",
+      "integrity": "sha512-bexd2IklK7ZgPhrz6jXzpIL6dEAH9MlJU1xGTrypx+FICxrXUp4CqtwfiuoDKse+UlgAlWtzML3jrMqeEAHEhA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-arm64": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-arm64/-/cli-win32-arm64-2.4.11.tgz",
+      "integrity": "sha512-RJhaTnY8byzxDt4bDVb7AFPHkPcjOPK3xBip4ZRTrN3TEfyhjLRm3r3mqknqydgVTB74XG8l4jMLwEACEeihVg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
+      }
+    },
+    "node_modules/@biomejs/cli-win32-x64": {
+      "version": "2.4.11",
+      "resolved": "https://registry.npmjs.org/@biomejs/cli-win32-x64/-/cli-win32-x64-2.4.11.tgz",
+      "integrity": "sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.21.3"
       }
     },
     "node_modules/@camunda8/orchestration-cluster-api": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "build": "npm run clean && tsc && npm run copy-plugins && npm run copy-templates",
+    "build": "npm run lint && npm run clean && tsc && npm run copy-plugins && npm run copy-templates",
+    "lint": "biome check src/",
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
     "copy-plugins": "node -e \"const fs=require('fs');const path=require('path');const src='default-plugins';const dest='dist/default-plugins';if(fs.existsSync(src)){fs.cpSync(src,dest,{recursive:true})}\"",
     "copy-templates": "node -e \"const fs=require('fs');const src='src/templates';const dest='dist/templates';if(fs.existsSync(src)){fs.cpSync(src,dest,{recursive:true})}\"",
@@ -63,6 +64,7 @@
     "ignore": "^7.0.5"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.11",
     "@semantic-release/exec": "^7.1.0",
     "@semantic-release/github": "^12.0.6",
     "@semantic-release/npm": "^13.1.5",

--- a/plugins/no-unsafe-type-assertion.grit
+++ b/plugins/no-unsafe-type-assertion.grit
@@ -1,0 +1,12 @@
+engine biome(1.0)
+language js(typescript)
+
+`$expr as $type` as $assertion where {
+    $type <: not r"const",
+    $assertion <: not within JsImport(),
+    register_diagnostic(
+        span = $assertion,
+        message = "Type assertions (`as T`) bypass the type system. Use a type guard, `.assumeExists()`, or `satisfies` instead. If unavoidable, add `// biome-ignore lint/plugin: <reason>` above.",
+        severity = "error"
+    )
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -2,53 +2,57 @@
  * SDK client factory using resolved configuration
  */
 
-import { createCamundaClient, type CamundaClient, type CamundaOptions } from '@camunda8/orchestration-cluster-api';
-import { resolveClusterConfig } from './config.ts';
-import { c8ctl } from './runtime.ts';
+import {
+	type CamundaClient,
+	type CamundaOptions,
+	createCamundaClient,
+} from "@camunda8/orchestration-cluster-api";
+import { resolveClusterConfig } from "./config.ts";
+import { c8ctl } from "./runtime.ts";
 
 /**
  * Create a Camunda 8 cluster client with resolved configuration
  */
 export function createClient(
-  profileFlag?: string,
-  additionalSdkConfig: Partial<CamundaOptions> = {},
+	profileFlag?: string,
+	additionalSdkConfig: Partial<CamundaOptions> = {},
 ): CamundaClient {
-  const config = resolveClusterConfig(profileFlag);
+	const config = resolveClusterConfig(profileFlag);
 
-  // Build config object for the SDK
-  const sdkConfig: Partial<CamundaOptions["config"]> = {
-    CAMUNDA_REST_ADDRESS: config.baseUrl,
-  };
+	// Build config object for the SDK
+	const sdkConfig: Partial<CamundaOptions["config"]> = {
+		CAMUNDA_REST_ADDRESS: config.baseUrl,
+	};
 
-  // Add OAuth configuration if present
-  if (config.clientId && config.clientSecret) {
-    sdkConfig.CAMUNDA_AUTH_STRATEGY = 'OAUTH';
-    sdkConfig.CAMUNDA_CLIENT_ID = config.clientId;
-    sdkConfig.CAMUNDA_CLIENT_SECRET = config.clientSecret;
-    if (config.audience) {
-      sdkConfig.CAMUNDA_TOKEN_AUDIENCE = config.audience;
-    }
-    if (config.oAuthUrl) {
-      sdkConfig.CAMUNDA_OAUTH_URL = config.oAuthUrl;
-    }
-  }
-  // Add Basic auth configuration if present
-  else if (config.username && config.password) {
-    sdkConfig.CAMUNDA_AUTH_STRATEGY = 'BASIC';
-    sdkConfig.CAMUNDA_BASIC_AUTH_USERNAME = config.username;
-    sdkConfig.CAMUNDA_BASIC_AUTH_PASSWORD = config.password;
-  }
-  // No authentication
-  else {
-    sdkConfig.CAMUNDA_AUTH_STRATEGY = 'NONE';
-  }
+	// Add OAuth configuration if present
+	if (config.clientId && config.clientSecret) {
+		sdkConfig.CAMUNDA_AUTH_STRATEGY = "OAUTH";
+		sdkConfig.CAMUNDA_CLIENT_ID = config.clientId;
+		sdkConfig.CAMUNDA_CLIENT_SECRET = config.clientSecret;
+		if (config.audience) {
+			sdkConfig.CAMUNDA_TOKEN_AUDIENCE = config.audience;
+		}
+		if (config.oAuthUrl) {
+			sdkConfig.CAMUNDA_OAUTH_URL = config.oAuthUrl;
+		}
+	}
+	// Add Basic auth configuration if present
+	else if (config.username && config.password) {
+		sdkConfig.CAMUNDA_AUTH_STRATEGY = "BASIC";
+		sdkConfig.CAMUNDA_BASIC_AUTH_USERNAME = config.username;
+		sdkConfig.CAMUNDA_BASIC_AUTH_PASSWORD = config.password;
+	}
+	// No authentication
+	else {
+		sdkConfig.CAMUNDA_AUTH_STRATEGY = "NONE";
+	}
 
-  // Add verbose/trace logging when --verbose flag is set
-  if (c8ctl.verbose) {
-    sdkConfig.CAMUNDA_SDK_LOG_LEVEL = 'trace';
-  }
+	// Add verbose/trace logging when --verbose flag is set
+	if (c8ctl.verbose) {
+		sdkConfig.CAMUNDA_SDK_LOG_LEVEL = "trace";
+	}
 
-  return createCamundaClient({ config: sdkConfig, ...additionalSdkConfig });
+	return createCamundaClient({ config: sdkConfig, ...additionalSdkConfig });
 }
 
 /**
@@ -68,13 +72,13 @@ export const DEFAULT_MAX_ITEMS = 1_000_000;
  * required but cursors are nullable.
  */
 type PagedResponse<T> = {
-  items: T[];
-  page: {
-    totalItems: number | bigint;
-    endCursor: string | null;
-    startCursor: string | null;
-    hasMoreTotalItems: boolean;
-  };
+	items: T[];
+	page: {
+		totalItems: number | bigint;
+		endCursor: string | null;
+		startCursor: string | null;
+		hasMoreTotalItems: boolean;
+	};
 };
 
 /**
@@ -88,47 +92,57 @@ type PagedResponse<T> = {
  * @param maxItems  – stop after collecting this many items (default 1 000 000)
  * @returns all collected items across every page (up to maxItems)
  */
-export async function fetchAllPages<T>(
-  searchFn: (filter: any, opts?: any) => Promise<PagedResponse<T>>,
-  filter: Record<string, unknown> = {},
-  pageSize = DEFAULT_PAGE_SIZE,
-  maxItems = DEFAULT_MAX_ITEMS,
+/** Consistency options passed to every search call in fetchAllPages */
+type SearchConsistencyOpts = { consistency: { waitUpToMs: number } };
+
+export async function fetchAllPages<
+	T,
+	F extends Record<string, unknown> = Record<string, unknown>,
+>(
+	searchFn: (
+		filter: F & { page?: Record<string, unknown> },
+		opts: SearchConsistencyOpts,
+	) => Promise<PagedResponse<T>>,
+	filter: F,
+	pageSize = DEFAULT_PAGE_SIZE,
+	maxItems = DEFAULT_MAX_ITEMS,
 ): Promise<T[]> {
-  const allItems: T[] = [];
-  let cursor: string | undefined;
-  const seenCursors = new Set<string>();
-  const consistencyOpts = { consistency: { waitUpToMs: 0 } };
+	const allItems: T[] = [];
+	let cursor: string | undefined;
+	const seenCursors = new Set<string>();
+	const consistencyOpts = { consistency: { waitUpToMs: 0 } };
 
-  do {
-    const pageFilter = {
-      ...filter,
-      page: {
-        limit: pageSize,
-        ...(cursor ? { after: cursor } : {}),
-      },
-    };
+	do {
+		const pageFilter = {
+			...filter,
+			page: {
+				limit: pageSize,
+				...(cursor ? { after: cursor } : {}),
+			},
+		};
 
-    const result = await searchFn(pageFilter, consistencyOpts);
+		const result = await searchFn(pageFilter, consistencyOpts);
 
-    if (result.items.length) {
-      allItems.push(...result.items);
-    }
+		if (result.items.length) {
+			allItems.push(...result.items);
+		}
 
-    if (allItems.length >= maxItems) {
-      allItems.length = maxItems;
-      break;
-    }
+		if (allItems.length >= maxItems) {
+			allItems.length = maxItems;
+			break;
+		}
 
-    const endCursor = result.page.endCursor;
-    const totalItems = Number(result.page.totalItems);
+		const endCursor = result.page.endCursor;
+		const totalItems = Number(result.page.totalItems);
 
-    if (!endCursor || seenCursors.has(endCursor)) break;
-    if (allItems.length >= totalItems) break;
-    if (!result.items.length) break;
+		if (!endCursor || seenCursors.has(endCursor)) break;
+		if (allItems.length >= totalItems) break;
+		if (!result.items.length) break;
 
-    seenCursors.add(endCursor);
-    cursor = endCursor;
-  } while (true);
+		seenCursors.add(endCursor);
+		cursor = endCursor;
+		// biome-ignore lint/correctness/noConstantCondition: intentional infinite loop with multiple break conditions
+	} while (true);
 
-  return allItems;
+	return allItems;
 }

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -2,14 +2,13 @@
  * Shell completion commands
  */
 
-import { getLogger } from '../logger.ts';
+import { getLogger } from "../logger.ts";
 
 /**
  * Generate bash completion script
  */
 function generateBashCompletion(): string {
-
-  return `# c8ctl bash completion
+	return `# c8ctl bash completion
 _c8ctl_completions() {
   local cur prev words cword
   
@@ -61,114 +60,114 @@ _c8ctl_completions() {
   case \${cword} in
     1)
       # Complete verbs
-      COMPREPLY=( \$(compgen -W "\${verbs}" -- "\${cur}") )
+      COMPREPLY=( $(compgen -W "\${verbs}" -- "\${cur}") )
       ;;
     2)
       # Complete resources based on verb
       local verb="\${words[1]}"
       case "\${verb}" in
         list)
-          COMPREPLY=( \$(compgen -W "\${list_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${list_resources}" -- "\${cur}") )
           ;;
         search)
-          COMPREPLY=( \$(compgen -W "\${search_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${search_resources}" -- "\${cur}") )
           ;;
         get)
-          COMPREPLY=( \$(compgen -W "\${get_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${get_resources}" -- "\${cur}") )
           ;;
         create)
-          COMPREPLY=( \$(compgen -W "\${create_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${create_resources}" -- "\${cur}") )
           ;;
         cancel)
-          COMPREPLY=( \$(compgen -W "\${cancel_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${cancel_resources}" -- "\${cur}") )
           ;;
         await)
-          COMPREPLY=( \$(compgen -W "\${await_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${await_resources}" -- "\${cur}") )
           ;;
         complete)
-          COMPREPLY=( \$(compgen -W "\${complete_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${complete_resources}" -- "\${cur}") )
           ;;
         fail)
-          COMPREPLY=( \$(compgen -W "\${fail_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${fail_resources}" -- "\${cur}") )
           ;;
         activate)
-          COMPREPLY=( \$(compgen -W "\${activate_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${activate_resources}" -- "\${cur}") )
           ;;
         resolve)
-          COMPREPLY=( \$(compgen -W "\${resolve_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${resolve_resources}" -- "\${cur}") )
           ;;
         publish)
-          COMPREPLY=( \$(compgen -W "\${publish_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${publish_resources}" -- "\${cur}") )
           ;;
         correlate)
-          COMPREPLY=( \$(compgen -W "\${correlate_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${correlate_resources}" -- "\${cur}") )
           ;;
         delete)
-          COMPREPLY=( \$(compgen -W "\${delete_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${delete_resources}" -- "\${cur}") )
           ;;
         assign)
-          COMPREPLY=( \$(compgen -W "\${assign_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${assign_resources}" -- "\${cur}") )
           ;;
         unassign)
-          COMPREPLY=( \$(compgen -W "\${unassign_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${unassign_resources}" -- "\${cur}") )
           ;;
         add)
-          COMPREPLY=( \$(compgen -W "\${add_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${add_resources}" -- "\${cur}") )
           ;;
         remove|rm)
-          COMPREPLY=( \$(compgen -W "\${remove_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${remove_resources}" -- "\${cur}") )
           ;;
         load)
-          COMPREPLY=( \$(compgen -W "\${load_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${load_resources}" -- "\${cur}") )
           ;;
         unload)
-          COMPREPLY=( \$(compgen -W "\${unload_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${unload_resources}" -- "\${cur}") )
           ;;
         sync)
-          COMPREPLY=( \$(compgen -W "\${sync_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${sync_resources}" -- "\${cur}") )
           ;;
         upgrade)
-          COMPREPLY=( \$(compgen -W "\${upgrade_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${upgrade_resources}" -- "\${cur}") )
           ;;
         downgrade)
-          COMPREPLY=( \$(compgen -W "\${downgrade_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${downgrade_resources}" -- "\${cur}") )
           ;;
         init)
-          COMPREPLY=( \$(compgen -W "\${init_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${init_resources}" -- "\${cur}") )
           ;;
         use)
-          COMPREPLY=( \$(compgen -W "\${use_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${use_resources}" -- "\${cur}") )
           ;;
         which)
-          COMPREPLY=( \$(compgen -W "\${which_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${which_resources}" -- "\${cur}") )
           ;;
         output)
-          COMPREPLY=( \$(compgen -W "\${output_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${output_resources}" -- "\${cur}") )
           ;;
         completion)
-          COMPREPLY=( \$(compgen -W "\${completion_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${completion_resources}" -- "\${cur}") )
           ;;
         help)
-          COMPREPLY=( \$(compgen -W "\${help_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${help_resources}" -- "\${cur}") )
           ;;
         cluster)
-          COMPREPLY=( \$(compgen -W "\${cluster_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${cluster_resources}" -- "\${cur}") )
           ;;
         open)
-          COMPREPLY=( \$(compgen -W "\${open_resources}" -- "\${cur}") )
+          COMPREPLY=( $(compgen -W "\${open_resources}" -- "\${cur}") )
           ;;
         deploy|run|watch)
           # Complete with files
-          COMPREPLY=( \$(compgen -f -- "\${cur}") )
+          COMPREPLY=( $(compgen -f -- "\${cur}") )
           ;;
       esac
       ;;
     *)
       # Complete flags or files
       if [[ \${cur} == -* ]]; then
-        COMPREPLY=( \$(compgen -W "\${flags}" -- "\${cur}") )
+        COMPREPLY=( $(compgen -W "\${flags}" -- "\${cur}") )
       else
-        COMPREPLY=( \$(compgen -f -- "\${cur}") )
+        COMPREPLY=( $(compgen -f -- "\${cur}") )
       fi
       ;;
   esac
@@ -183,8 +182,7 @@ complete -F _c8ctl_completions c8
  * Generate zsh completion script
  */
 function generateZshCompletion(): string {
-
-  return `#compdef c8ctl c8
+	return `#compdef c8ctl c8
 
 _c8ctl() {
   local -a verbs resources flags
@@ -315,7 +313,7 @@ _c8ctl() {
     '--from-mapping-rule[Source mapping rule for unassignment]:mappingRule:'
   )
 
-  case \$CURRENT in
+  case $CURRENT in
     2)
       _describe 'command' verbs
       ;;
@@ -658,7 +656,7 @@ _c8ctl() {
  * Generate fish completion script
  */
 function generateFishCompletion(): string {
-  return `# c8ctl fish completion
+	return `# c8ctl fish completion
 
 # Remove all existing completions for c8ctl and c8
 complete -c c8ctl -e
@@ -1308,29 +1306,29 @@ complete -c c8 -n '__fish_seen_subcommand_from open' -a 'optimize' -d 'Open Camu
  * Show completion command
  */
 export function showCompletion(shell?: string): void {
-  const logger = getLogger();
+	const logger = getLogger();
 
-  if (!shell) {
-    logger.error('Shell type required. Usage: c8 completion <bash|zsh|fish>');
-    process.exit(1);
-  }
+	if (!shell) {
+		logger.error("Shell type required. Usage: c8 completion <bash|zsh|fish>");
+		process.exit(1);
+	}
 
-  const normalizedShell = shell.toLowerCase();
+	const normalizedShell = shell.toLowerCase();
 
-  switch (normalizedShell) {
-    case 'bash':
-      console.log(generateBashCompletion());
-      break;
-    case 'zsh':
-      console.log(generateZshCompletion());
-      break;
-    case 'fish':
-      console.log(generateFishCompletion());
-      break;
-    default:
-      logger.error(`Unknown shell: ${shell}`);
-      logger.info('Supported shells: bash, zsh, fish');
-      logger.info('Usage: c8 completion <bash|zsh|fish>');
-      process.exit(1);
-  }
+	switch (normalizedShell) {
+		case "bash":
+			console.log(generateBashCompletion());
+			break;
+		case "zsh":
+			console.log(generateZshCompletion());
+			break;
+		case "fish":
+			console.log(generateFishCompletion());
+			break;
+		default:
+			logger.error(`Unknown shell: ${shell}`);
+			logger.info("Supported shells: bash, zsh, fish");
+			logger.info("Usage: c8 completion <bash|zsh|fish>");
+			process.exit(1);
+	}
 }

--- a/src/commands/deployments.ts
+++ b/src/commands/deployments.ts
@@ -2,594 +2,707 @@
  * Deployment commands with building-block folder prioritization
  */
 
-import { getLogger } from '../logger.ts';
-import { createClient } from '../client.ts';
-import { resolveTenantId, resolveClusterConfig } from '../config.ts';
-import { TenantId } from '@camunda8/orchestration-cluster-api';
-import { c8ctl } from '../runtime.ts';
-import { readFileSync, readdirSync, statSync, existsSync } from 'node:fs';
-import { join, dirname, extname, basename, relative, resolve } from 'node:path';
-import { type Ignore } from 'ignore';
-import { loadIgnoreRules, isIgnored } from '../ignore.ts';
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { basename, dirname, extname, join, relative, resolve } from "node:path";
+import { TenantId } from "@camunda8/orchestration-cluster-api";
+import type { Ignore } from "ignore";
+import { createClient } from "../client.ts";
+import { resolveClusterConfig, resolveTenantId } from "../config.ts";
+import { isIgnored, loadIgnoreRules } from "../ignore.ts";
+import { isRecord } from "../index.ts";
+import { getLogger } from "../logger.ts";
+import { c8ctl } from "../runtime.ts";
 
-const RESOURCE_EXTENSIONS = ['.bpmn', '.dmn', '.form'];
-const PROCESS_APPLICATION_FILE = '.process-application';
+const RESOURCE_EXTENSIONS = [".bpmn", ".dmn", ".form"];
+const PROCESS_APPLICATION_FILE = ".process-application";
 
 /**
  * Helper to output messages that respect JSON mode for Unix pipe compatibility
  */
 function logMessage(message: string): void {
-  if (c8ctl.outputMode === 'json') {
-    console.error(JSON.stringify({ type: 'message', message }));
-  } else {
-    console.error(message);
-  }
+	if (c8ctl.outputMode === "json") {
+		console.error(JSON.stringify({ type: "message", message }));
+	} else {
+		console.error(message);
+	}
 }
 
 /**
  * Extract process/decision IDs from BPMN/DMN files to detect duplicates
  */
-function extractDefinitionId(content: Buffer, extension: string): string | null {
-  const text = content.toString('utf-8');
-  
-  if (extension === '.bpmn') {
-    // Extract bpmn:process id attribute
-    const match = text.match(/<bpmn\d?:process[^>]+id="([^"]+)"/);
-    return match ? match[1] : null;
-  } else if (extension === '.dmn') {
-    // Extract decision id attribute
-    const match = text.match(/<decision[^>]+id="([^"]+)"/);
-    return match ? match[1] : null;
-  } else if (extension === '.form') {
-    // Forms are identified by filename, not internal ID
-    return null;
-  }
-  
-  return null;
+function extractDefinitionId(
+	content: Buffer,
+	extension: string,
+): string | null {
+	const text = content.toString("utf-8");
+
+	if (extension === ".bpmn") {
+		// Extract bpmn:process id attribute
+		const match = text.match(/<bpmn\d?:process[^>]+id="([^"]+)"/);
+		return match ? match[1] : null;
+	} else if (extension === ".dmn") {
+		// Extract decision id attribute
+		const match = text.match(/<decision[^>]+id="([^"]+)"/);
+		return match ? match[1] : null;
+	} else if (extension === ".form") {
+		// Forms are identified by filename, not internal ID
+		return null;
+	}
+
+	return null;
 }
 
 interface ResourceFile {
-  path: string;
-  name: string;
-  content: Buffer;
-  isBuildingBlock: boolean;
-  isProcessApplication: boolean;
-  groupPath?: string; // Path to the root of the group (BB or PA folder)
-  relativePath?: string;
+	path: string;
+	name: string;
+	content: Buffer;
+	isBuildingBlock: boolean;
+	isProcessApplication: boolean;
+	groupPath?: string; // Path to the root of the group (BB or PA folder)
+	relativePath?: string;
 }
 
 /**
  * Check if a path is a building block folder (contains _bb- in name)
  */
 function isBuildingBlockFolder(path: string): boolean {
-  return basename(path).includes('_bb-');
+	return basename(path).includes("_bb-");
 }
 
 /**
  * Check if a directory contains a .process-application file
  */
 function hasProcessApplicationFile(dirPath: string): boolean {
-  const paFilePath = join(dirPath, PROCESS_APPLICATION_FILE);
-  return existsSync(paFilePath);
+	const paFilePath = join(dirPath, PROCESS_APPLICATION_FILE);
+	return existsSync(paFilePath);
 }
 
 /**
  * Find the root building block or process application folder by traversing up the path
  * Returns the path to the group root, or null if not in a group
  */
-function findGroupRoot(filePath: string, basePath: string): { type: 'bb', root: string } | { type: 'pa', root: string } | { type: null, root: null } {
-  let currentDir = dirname(filePath);
-  
-  // Traverse up the directory tree until we reach or go outside basePath
-  while (true) {
-    // Check if we've gone outside the basePath
-    const rel = relative(basePath, currentDir);
-    if (rel.startsWith('..') || rel === '') {
-      break;
-    }
-    
-    // Check if this directory is a building block
-    if (isBuildingBlockFolder(currentDir)) {
-      return { type: 'bb', root: currentDir };
-    }
-    
-    // Check if this directory has a .process-application file
-    if (hasProcessApplicationFile(currentDir)) {
-      return { type: 'pa', root: currentDir };
-    }
-    
-    // Move up one level
-    const parentDir = dirname(currentDir);
-    if (parentDir === currentDir) break; // Reached filesystem root
-    currentDir = parentDir;
-  }
-  
-  return { type: null, root: null };
+function findGroupRoot(
+	filePath: string,
+	basePath: string,
+):
+	| { type: "bb"; root: string }
+	| { type: "pa"; root: string }
+	| { type: null; root: null } {
+	let currentDir = dirname(filePath);
+
+	// Traverse up the directory tree until we reach or go outside basePath
+	while (true) {
+		// Check if we've gone outside the basePath
+		const rel = relative(basePath, currentDir);
+		if (rel.startsWith("..") || rel === "") {
+			break;
+		}
+
+		// Check if this directory is a building block
+		if (isBuildingBlockFolder(currentDir)) {
+			return { type: "bb", root: currentDir };
+		}
+
+		// Check if this directory has a .process-application file
+		if (hasProcessApplicationFile(currentDir)) {
+			return { type: "pa", root: currentDir };
+		}
+
+		// Move up one level
+		const parentDir = dirname(currentDir);
+		if (parentDir === currentDir) break; // Reached filesystem root
+		currentDir = parentDir;
+	}
+
+	return { type: null, root: null };
 }
 
 /**
  * Recursively collect resource files from a directory
  */
-function collectResourceFiles(dirPath: string, collected: ResourceFile[] = [], basePath?: string, ig?: Ignore, ignoreBaseDir?: string): ResourceFile[] {
-  if (!existsSync(dirPath)) {
-    return collected;
-  }
+function collectResourceFiles(
+	dirPath: string,
+	collected: ResourceFile[] = [],
+	basePath?: string,
+	ig?: Ignore,
+	ignoreBaseDir?: string,
+): ResourceFile[] {
+	if (!existsSync(dirPath)) {
+		return collected;
+	}
 
-  // Set basePath to dirPath on first call
-  if (!basePath) {
-    basePath = dirPath;
-  }
+	// Set basePath to dirPath on first call
+	if (!basePath) {
+		basePath = dirPath;
+	}
 
-  const stat = statSync(dirPath);
-  
-  if (stat.isFile()) {
-    if (ig && ignoreBaseDir && isIgnored(ig, dirPath, ignoreBaseDir)) {
-      return collected;
-    }
-    const ext = extname(dirPath);
-    if (RESOURCE_EXTENSIONS.includes(ext)) {
-      const groupInfo = findGroupRoot(dirPath, basePath);
-      collected.push({
-        path: dirPath,
-        name: basename(dirPath),
-        content: readFileSync(dirPath),
-        isBuildingBlock: groupInfo.type === 'bb',
-        isProcessApplication: groupInfo.type === 'pa',
-        groupPath: groupInfo.root || undefined,
-      });
-    }
-    return collected;
-  }
+	const stat = statSync(dirPath);
 
-  if (stat.isDirectory()) {
-    // Skip entire directory if it matches an ignore rule
-    if (ig && ignoreBaseDir && isIgnored(ig, dirPath + '/', ignoreBaseDir)) {
-      return collected;
-    }
+	if (stat.isFile()) {
+		if (ig && ignoreBaseDir && isIgnored(ig, dirPath, ignoreBaseDir)) {
+			return collected;
+		}
+		const ext = extname(dirPath);
+		if (RESOURCE_EXTENSIONS.includes(ext)) {
+			const groupInfo = findGroupRoot(dirPath, basePath);
+			collected.push({
+				path: dirPath,
+				name: basename(dirPath),
+				content: readFileSync(dirPath),
+				isBuildingBlock: groupInfo.type === "bb",
+				isProcessApplication: groupInfo.type === "pa",
+				groupPath: groupInfo.root || undefined,
+			});
+		}
+		return collected;
+	}
 
-    const entries = readdirSync(dirPath);
-    
-    // Separate building block folders from regular ones
-    const bbFolders: string[] = [];
-    const regularFolders: string[] = [];
-    const files: string[] = [];
+	if (stat.isDirectory()) {
+		// Skip entire directory if it matches an ignore rule
+		if (ig && ignoreBaseDir && isIgnored(ig, `${dirPath}/`, ignoreBaseDir)) {
+			return collected;
+		}
 
-    entries.forEach(entry => {
-      const fullPath = join(dirPath, entry);
-      const entryStat = statSync(fullPath);
-      
-      if (entryStat.isDirectory()) {
-        // Skip ignored directories early to avoid descending into them
-        if (ig && ignoreBaseDir && isIgnored(ig, fullPath + '/', ignoreBaseDir)) {
-          return;
-        }
-        if (isBuildingBlockFolder(entry)) {
-          bbFolders.push(fullPath);
-        } else {
-          regularFolders.push(fullPath);
-        }
-      } else if (entryStat.isFile()) {
-        // Skip ignored files
-        if (ig && ignoreBaseDir && isIgnored(ig, fullPath, ignoreBaseDir)) {
-          return;
-        }
-        files.push(fullPath);
-      }
-    });
+		const entries = readdirSync(dirPath);
 
-    // Process files in current directory first
-    files.forEach(file => {
-      const ext = extname(file);
-      if (RESOURCE_EXTENSIONS.includes(ext)) {
-        const groupInfo = findGroupRoot(file, basePath);
-        collected.push({
-          path: file,
-          name: basename(file),
-          content: readFileSync(file),
-          isBuildingBlock: groupInfo.type === 'bb',
-          isProcessApplication: groupInfo.type === 'pa',
-          groupPath: groupInfo.root || undefined,
-        });
-      }
-    });
+		// Separate building block folders from regular ones
+		const bbFolders: string[] = [];
+		const regularFolders: string[] = [];
+		const files: string[] = [];
 
-    // Process building block folders first (prioritized)
-    bbFolders.forEach(bbFolder => {
-      collectResourceFiles(bbFolder, collected, basePath, ig, ignoreBaseDir);
-    });
+		entries.forEach((entry) => {
+			const fullPath = join(dirPath, entry);
+			const entryStat = statSync(fullPath);
 
-    // Then process regular folders
-    regularFolders.forEach(regularFolder => {
-      collectResourceFiles(regularFolder, collected, basePath, ig, ignoreBaseDir);
-    });
-  }
+			if (entryStat.isDirectory()) {
+				// Skip ignored directories early to avoid descending into them
+				if (
+					ig &&
+					ignoreBaseDir &&
+					isIgnored(ig, `${fullPath}/`, ignoreBaseDir)
+				) {
+					return;
+				}
+				if (isBuildingBlockFolder(entry)) {
+					bbFolders.push(fullPath);
+				} else {
+					regularFolders.push(fullPath);
+				}
+			} else if (entryStat.isFile()) {
+				// Skip ignored files
+				if (ig && ignoreBaseDir && isIgnored(ig, fullPath, ignoreBaseDir)) {
+					return;
+				}
+				files.push(fullPath);
+			}
+		});
 
-  return collected;
+		// Process files in current directory first
+		files.forEach((file) => {
+			const ext = extname(file);
+			if (RESOURCE_EXTENSIONS.includes(ext)) {
+				const groupInfo = findGroupRoot(file, basePath);
+				collected.push({
+					path: file,
+					name: basename(file),
+					content: readFileSync(file),
+					isBuildingBlock: groupInfo.type === "bb",
+					isProcessApplication: groupInfo.type === "pa",
+					groupPath: groupInfo.root || undefined,
+				});
+			}
+		});
+
+		// Process building block folders first (prioritized)
+		bbFolders.forEach((bbFolder) => {
+			collectResourceFiles(bbFolder, collected, basePath, ig, ignoreBaseDir);
+		});
+
+		// Then process regular folders
+		regularFolders.forEach((regularFolder) => {
+			collectResourceFiles(
+				regularFolder,
+				collected,
+				basePath,
+				ig,
+				ignoreBaseDir,
+			);
+		});
+	}
+
+	return collected;
 }
 
 /**
  * Find duplicate process/decision IDs across resources
  */
-function findDuplicateDefinitionIds(resources: ResourceFile[]): Map<string, string[]> {
-  const idMap = resources.reduce((map, r) => {
-    const ext = extname(r.path);
-    if (ext === '.bpmn' || ext === '.dmn') {
-      const defId = extractDefinitionId(r.content, ext);
-      if (defId) map.set(defId, [...(map.get(defId) ?? []), r.path]);
-    }
-    return map;
-  }, new Map<string, string[]>());
+function findDuplicateDefinitionIds(
+	resources: ResourceFile[],
+): Map<string, string[]> {
+	const idMap = resources.reduce((map, r) => {
+		const ext = extname(r.path);
+		if (ext === ".bpmn" || ext === ".dmn") {
+			const defId = extractDefinitionId(r.content, ext);
+			if (defId) map.set(defId, [...(map.get(defId) ?? []), r.path]);
+		}
+		return map;
+	}, new Map<string, string[]>());
 
-  return new Map([...idMap].filter(([, paths]) => paths.length > 1));
+	return new Map([...idMap].filter(([, paths]) => paths.length > 1));
 }
 
 /**
  * Deploy resources
  */
-export async function deploy(paths: string[], options: {
-  profile?: string;
-  continueOnError?: boolean;
-  continueOnUserError?: boolean;
-}): Promise<void> {
-  const logger = getLogger();
-  const tenantId = resolveTenantId(options.profile);
-  const resources: ResourceFile[] = [];
+export async function deploy(
+	paths: string[],
+	options: {
+		profile?: string;
+		continueOnError?: boolean;
+		continueOnUserError?: boolean;
+	},
+): Promise<void> {
+	const logger = getLogger();
+	const tenantId = resolveTenantId(options.profile);
+	const resources: ResourceFile[] = [];
 
-  try {
-    // Store the base paths for relative path calculation
-    const basePaths = paths.length === 0 ? [process.cwd()] : paths;
+	try {
+		// Store the base paths for relative path calculation
+		const basePaths = paths.length === 0 ? [process.cwd()] : paths;
 
-    if (paths.length === 0) {
-      logger.error('No paths provided. Use: c8 deploy <path> or c8 deploy (for current directory)');
-      process.exit(1);
-    }
+		if (paths.length === 0) {
+			logger.error(
+				"No paths provided. Use: c8 deploy <path> or c8 deploy (for current directory)",
+			);
+			process.exit(1);
+		}
 
-    // Load .c8ignore rules from the working directory
-    const ignoreBaseDir = resolve(process.cwd());
-    const ig = loadIgnoreRules(ignoreBaseDir);
+		// Load .c8ignore rules from the working directory
+		const ignoreBaseDir = resolve(process.cwd());
+		const ig = loadIgnoreRules(ignoreBaseDir);
 
-    // Collect all resource files (respecting .c8ignore)
-    paths.forEach(path => {
-      collectResourceFiles(path, resources, undefined, ig, ignoreBaseDir);
-    });
+		// Collect all resource files (respecting .c8ignore)
+		paths.forEach((path) => {
+			collectResourceFiles(path, resources, undefined, ig, ignoreBaseDir);
+		});
 
-    if (resources.length === 0) {
-      logger.error('No BPMN/DMN/Form files found in the specified paths');
-      process.exit(1);
-    }
+		if (resources.length === 0) {
+			logger.error("No BPMN/DMN/Form files found in the specified paths");
+			process.exit(1);
+		}
 
-    // Dry-run: emit the would-be API request without executing
-    if (c8ctl.dryRun) {
-      const config = resolveClusterConfig(options.profile);
-      logger.json({
-        dryRun: true,
-        command: 'deploy',
-        method: 'POST',
-        url: `${config.baseUrl}/deployments`,
-        body: {
-          tenantId,
-          resources: resources.map(r => ({ name: r.name })),
-        },
-      });
-      return;
-    }
+		// Dry-run: emit the would-be API request without executing
+		if (c8ctl.dryRun) {
+			const config = resolveClusterConfig(options.profile);
+			logger.json({
+				dryRun: true,
+				command: "deploy",
+				method: "POST",
+				url: `${config.baseUrl}/deployments`,
+				body: {
+					tenantId,
+					resources: resources.map((r) => ({ name: r.name })),
+				},
+			});
+			return;
+		}
 
-    const client = createClient(options.profile);
+		const client = createClient(options.profile);
 
-    // Calculate relative paths for display
-    const basePath = basePaths.length === 1 ? basePaths[0] : process.cwd();
-    resources.forEach(r => {
-      r.relativePath = relative(basePath, r.path) || r.name;
-    });
+		// Calculate relative paths for display
+		const basePath = basePaths.length === 1 ? basePaths[0] : process.cwd();
+		resources.forEach((r) => {
+			r.relativePath = relative(basePath, r.path) || r.name;
+		});
 
-    // Sort: group resources by their group, with building blocks first, then process applications, then standalone
-    resources.sort((a, b) => {
-      // Building blocks have highest priority
-      if (a.isBuildingBlock && !b.isBuildingBlock) return -1;
-      if (!a.isBuildingBlock && b.isBuildingBlock) return 1;
-      
-      // Within building blocks, group by groupPath
-      if (a.isBuildingBlock && b.isBuildingBlock) {
-        if (a.groupPath && b.groupPath) {
-          const groupCompare = a.groupPath.localeCompare(b.groupPath);
-          if (groupCompare !== 0) return groupCompare;
-        }
-        return a.path.localeCompare(b.path);
-      }
-      
-      // Process applications come next
-      if (a.isProcessApplication && !b.isProcessApplication) return -1;
-      if (!a.isProcessApplication && b.isProcessApplication) return 1;
-      
-      // Within process applications, group by groupPath
-      if (a.isProcessApplication && b.isProcessApplication) {
-        if (a.groupPath && b.groupPath) {
-          const groupCompare = a.groupPath.localeCompare(b.groupPath);
-          if (groupCompare !== 0) return groupCompare;
-        }
-        return a.path.localeCompare(b.path);
-      }
-      
-      // Finally, standalone resources sorted by path
-      return a.path.localeCompare(b.path);
-    });
+		// Sort: group resources by their group, with building blocks first, then process applications, then standalone
+		resources.sort((a, b) => {
+			// Building blocks have highest priority
+			if (a.isBuildingBlock && !b.isBuildingBlock) return -1;
+			if (!a.isBuildingBlock && b.isBuildingBlock) return 1;
 
-    // Validate for duplicate process/decision IDs
-    const duplicates = findDuplicateDefinitionIds(resources);
-    if (duplicates.size > 0) {
-      logger.error('Cannot deploy: Multiple files with the same process/decision ID in one deployment');
-      duplicates.forEach((paths, id) => logMessage(`  Process/Decision ID "${id}" found in: ${paths.join(', ')}`));
-      logMessage('\nCamunda does not allow deploying multiple resources with the same definition ID in a single deployment.');
-      logMessage('Please deploy these files separately or ensure each process/decision has a unique ID.');
-      process.exit(1);
-    }
+			// Within building blocks, group by groupPath
+			if (a.isBuildingBlock && b.isBuildingBlock) {
+				if (a.groupPath && b.groupPath) {
+					const groupCompare = a.groupPath.localeCompare(b.groupPath);
+					if (groupCompare !== 0) return groupCompare;
+				}
+				return a.path.localeCompare(b.path);
+			}
 
-    logger.info(`Deploying ${resources.length} resource(s)...`);
+			// Process applications come next
+			if (a.isProcessApplication && !b.isProcessApplication) return -1;
+			if (!a.isProcessApplication && b.isProcessApplication) return 1;
 
-    // Create a mapping from definition ID to resource file for later reference
-    const definitionIdToResource = new Map<string, ResourceFile>();
-    const formNameToResource = new Map<string, ResourceFile>();
-    
-    resources.forEach(r => {
-      const ext = extname(r.path);
-      if (ext === '.bpmn' || ext === '.dmn') {
-        const defId = extractDefinitionId(r.content, ext);
-        if (defId) {
-          definitionIdToResource.set(defId, r);
-        }
-      } else if (ext === '.form') {
-        // Forms are matched by filename (without extension)
-        const formId = basename(r.name, '.form');
-        formNameToResource.set(formId, r);
-      }
-    });
+			// Within process applications, group by groupPath
+			if (a.isProcessApplication && b.isProcessApplication) {
+				if (a.groupPath && b.groupPath) {
+					const groupCompare = a.groupPath.localeCompare(b.groupPath);
+					if (groupCompare !== 0) return groupCompare;
+				}
+				return a.path.localeCompare(b.path);
+			}
 
-    // Create deployment request - convert buffers to File objects with proper MIME types
-    const result = await client.createDeployment({
-      tenantId: TenantId.assumeExists(tenantId),
-      resources: resources.map(r => {
-        // Determine MIME type based on extension
-        const ext = r.name.split('.').pop()?.toLowerCase();
-        const mimeType = ext === 'bpmn' ? 'application/xml' :
-                        ext === 'dmn' ? 'application/xml' :
-                        ext === 'form' ? 'application/json' :
-                        'application/octet-stream';
-        // Convert Buffer to Uint8Array for File constructor
-        return new File([new Uint8Array(r.content)], r.name, { type: mimeType });
-      }),
-    });
-    
-    logger.success('Deployment successful', result.deploymentKey.toString());
-    
-    // Group resources by their directory (building block or process application)
-    type ResourceRow = {File: string, Type: string, ID: string, Version: string | number, Key: string, sortKey: string};
-    
-    // Normalize all deployed resources into a common structure
-    const allResources = [
-      ...result.processes.map(proc => ({
-        type: 'Process' as const,
-        id: proc.processDefinitionId,
-        version: proc.processDefinitionVersion,
-        key: proc.processDefinitionKey.toString(),
-        resource: definitionIdToResource.get(proc.processDefinitionId),
-      })),
-      ...result.decisions.map(dec => ({
-        type: 'Decision' as const,
-        id: dec.decisionDefinitionId || '-',
-        version: dec.version ?? '-',
-        key: dec.decisionDefinitionKey?.toString() || '-',
-        resource: definitionIdToResource.get(dec.decisionDefinitionId || ''),
-      })),
-      ...result.forms.map(form => ({
-        type: 'Form' as const,
-        id: form.formId || '-',
-        version: form.version ?? '-',
-        key: form.formKey?.toString() || '-',
-        resource: formNameToResource.get(form.formId || ''),
-      })),
-    ];
-    
-    const tableData: ResourceRow[] = allResources.map(({type, id, version, key, resource}) => {
-      const fileDisplay = resource 
-        ? `${resource.isBuildingBlock ? '🧱 ' : ''}${resource.isProcessApplication ? '📦 ' : ''}${resource.relativePath || resource.name}`
-        : '-';
-      
-      // Extract directory path for grouping (e.g., "bla/_bb-building-block" or "pa")
-      const sortKey = resource?.relativePath 
-        ? resource.relativePath.substring(0, resource.relativePath.lastIndexOf('/') + 1) || resource.relativePath
-        : 'zzz'; // Resources without paths go last
-      
-      return {
-        File: fileDisplay,
-        Type: type,
-        ID: id,
-        Version: version,
-        Key: key,
-        sortKey,
-      };
-    });
-    
-    // Sort by directory path (grouping), then by file name
-    tableData.sort((a, b) => {
-      if (a.sortKey !== b.sortKey) {
-        return a.sortKey.localeCompare(b.sortKey);
-      }
-      return a.File.localeCompare(b.File);
-    });
-    
-    // Remove sortKey before displaying
-    const displayData = tableData.map(({File, Type, ID, Version, Key}) => ({File, Type, ID, Version, Key}));
-    
-    if (displayData.length > 0) {
-      logger.table(displayData);
-    }
-  } catch (error) {
-    handleDeploymentError(error, resources, logger, options.continueOnError, options.continueOnUserError);
-  }
+			// Finally, standalone resources sorted by path
+			return a.path.localeCompare(b.path);
+		});
+
+		// Validate for duplicate process/decision IDs
+		const duplicates = findDuplicateDefinitionIds(resources);
+		if (duplicates.size > 0) {
+			logger.error(
+				"Cannot deploy: Multiple files with the same process/decision ID in one deployment",
+			);
+			duplicates.forEach((paths, id) => {
+				logMessage(
+					`  Process/Decision ID "${id}" found in: ${paths.join(", ")}`,
+				);
+			});
+			logMessage(
+				"\nCamunda does not allow deploying multiple resources with the same definition ID in a single deployment.",
+			);
+			logMessage(
+				"Please deploy these files separately or ensure each process/decision has a unique ID.",
+			);
+			process.exit(1);
+		}
+
+		logger.info(`Deploying ${resources.length} resource(s)...`);
+
+		// Create a mapping from definition ID to resource file for later reference
+		const definitionIdToResource = new Map<string, ResourceFile>();
+		const formNameToResource = new Map<string, ResourceFile>();
+
+		resources.forEach((r) => {
+			const ext = extname(r.path);
+			if (ext === ".bpmn" || ext === ".dmn") {
+				const defId = extractDefinitionId(r.content, ext);
+				if (defId) {
+					definitionIdToResource.set(defId, r);
+				}
+			} else if (ext === ".form") {
+				// Forms are matched by filename (without extension)
+				const formId = basename(r.name, ".form");
+				formNameToResource.set(formId, r);
+			}
+		});
+
+		// Create deployment request - convert buffers to File objects with proper MIME types
+		const result = await client.createDeployment({
+			tenantId: TenantId.assumeExists(tenantId),
+			resources: resources.map((r) => {
+				// Determine MIME type based on extension
+				const ext = r.name.split(".").pop()?.toLowerCase();
+				const mimeType =
+					ext === "bpmn"
+						? "application/xml"
+						: ext === "dmn"
+							? "application/xml"
+							: ext === "form"
+								? "application/json"
+								: "application/octet-stream";
+				// Convert Buffer to Uint8Array for File constructor
+				return new File([new Uint8Array(r.content)], r.name, {
+					type: mimeType,
+				});
+			}),
+		});
+
+		logger.success("Deployment successful", result.deploymentKey.toString());
+
+		// Group resources by their directory (building block or process application)
+		type ResourceRow = {
+			File: string;
+			Type: string;
+			ID: string;
+			Version: string | number;
+			Key: string;
+			sortKey: string;
+		};
+
+		// Normalize all deployed resources into a common structure
+		const allResources = [
+			...result.processes.map((proc) => ({
+				type: "Process" as const,
+				id: proc.processDefinitionId,
+				version: proc.processDefinitionVersion,
+				key: proc.processDefinitionKey.toString(),
+				resource: definitionIdToResource.get(proc.processDefinitionId),
+			})),
+			...result.decisions.map((dec) => ({
+				type: "Decision" as const,
+				id: dec.decisionDefinitionId || "-",
+				version: dec.version ?? "-",
+				key: dec.decisionDefinitionKey?.toString() || "-",
+				resource: definitionIdToResource.get(dec.decisionDefinitionId || ""),
+			})),
+			...result.forms.map((form) => ({
+				type: "Form" as const,
+				id: form.formId || "-",
+				version: form.version ?? "-",
+				key: form.formKey?.toString() || "-",
+				resource: formNameToResource.get(form.formId || ""),
+			})),
+		];
+
+		const tableData: ResourceRow[] = allResources.map(
+			({ type, id, version, key, resource }) => {
+				const fileDisplay = resource
+					? `${resource.isBuildingBlock ? "🧱 " : ""}${resource.isProcessApplication ? "📦 " : ""}${resource.relativePath || resource.name}`
+					: "-";
+
+				// Extract directory path for grouping (e.g., "bla/_bb-building-block" or "pa")
+				const sortKey = resource?.relativePath
+					? resource.relativePath.substring(
+							0,
+							resource.relativePath.lastIndexOf("/") + 1,
+						) || resource.relativePath
+					: "zzz"; // Resources without paths go last
+
+				return {
+					File: fileDisplay,
+					Type: type,
+					ID: id,
+					Version: version,
+					Key: key,
+					sortKey,
+				};
+			},
+		);
+
+		// Sort by directory path (grouping), then by file name
+		tableData.sort((a, b) => {
+			if (a.sortKey !== b.sortKey) {
+				return a.sortKey.localeCompare(b.sortKey);
+			}
+			return a.File.localeCompare(b.File);
+		});
+
+		// Remove sortKey before displaying
+		const displayData = tableData.map(({ File, Type, ID, Version, Key }) => ({
+			File,
+			Type,
+			ID,
+			Version,
+			Key,
+		}));
+
+		if (displayData.length > 0) {
+			logger.table(displayData);
+		}
+	} catch (error) {
+		handleDeploymentError(
+			error,
+			resources,
+			logger,
+			options.continueOnError,
+			options.continueOnUserError,
+		);
+	}
 }
 
 /**
  * Format and display deployment errors with actionable guidance
  */
-function handleDeploymentError(error: unknown, resources: ResourceFile[], logger: ReturnType<typeof getLogger>, continueOnError?: boolean, continueOnUserError?: boolean): void {
-  // Extract problem title early to determine whether this is a user-fixable error
-  const raw = (error && typeof error === 'object') ? (error as Record<string, unknown>) : {};
-  const problemTitle = typeof raw.title === 'string' ? (raw.title as string) : undefined;
-  const isUserFixable = problemTitle === 'INVALID_ARGUMENT';
-  const shouldContinue = continueOnError || (continueOnUserError && isUserFixable);
+function handleDeploymentError(
+	error: unknown,
+	resources: ResourceFile[],
+	logger: ReturnType<typeof getLogger>,
+	continueOnError?: boolean,
+	continueOnUserError?: boolean,
+): void {
+	// Extract problem title early to determine whether this is a user-fixable error
+	const raw: Record<string, unknown> = isRecord(error) ? error : {};
+	const problemTitle = typeof raw.title === "string" ? raw.title : undefined;
+	const isUserFixable = problemTitle === "INVALID_ARGUMENT";
+	const shouldContinue =
+		continueOnError || (continueOnUserError && isUserFixable);
 
-  if (c8ctl.verbose) {
-    if (shouldContinue) {
-      throw error;
-    }
-    const normalizedError = error instanceof Error ? error : new Error(String(error));
-    console.error(normalizedError);
-    process.exit(1);
-  }
+	if (c8ctl.verbose) {
+		if (shouldContinue) {
+			throw error;
+		}
+		const normalizedError =
+			error instanceof Error ? error : new Error(String(error));
+		console.error(normalizedError);
+		process.exit(1);
+	}
 
-  // Try to interpret common transport/network issues first for actionable guidance
-  const deriveNetworkErrorTitle = (err: unknown): string | undefined => {
-    const anyErr = err as { code?: unknown; name?: unknown; message?: unknown; cause?: unknown };
-    const code = typeof anyErr?.code === 'string'
-      ? anyErr.code
-      : (typeof (anyErr?.cause as Record<string, unknown> | undefined)?.code === 'string'
-          ? ((anyErr.cause as Record<string, unknown>).code as string)
-          : undefined);
+	// Try to interpret common transport/network issues first for actionable guidance
+	const deriveNetworkErrorTitle = (err: unknown): string | undefined => {
+		const anyErr = isRecord(err) ? err : {};
+		const code =
+			typeof anyErr.code === "string"
+				? anyErr.code
+				: isRecord(anyErr.cause) && typeof anyErr.cause.code === "string"
+					? anyErr.cause.code
+					: undefined;
 
-    if (!code && typeof anyErr?.name === 'string') {
-      // Handle fetch/abort style errors
-      if (anyErr.name === 'AbortError') {
-        return 'Request to Camunda cluster timed out or was aborted. Please check your network connection and try again.';
-      }
-    }
+		if (!code && typeof anyErr?.name === "string") {
+			// Handle fetch/abort style errors
+			if (anyErr.name === "AbortError") {
+				return "Request to Camunda cluster timed out or was aborted. Please check your network connection and try again.";
+			}
+		}
 
-    switch (code) {
-      case 'ECONNREFUSED':
-        return 'Cannot connect to Camunda cluster (connection refused). Verify the endpoint URL and that the cluster is reachable.';
-      case 'ENOTFOUND':
-        return 'Cannot resolve Camunda cluster host. Check the cluster URL and your DNS/network configuration.';
-      case 'EHOSTUNREACH':
-        return 'Camunda cluster host is unreachable. Check VPN/proxy settings and your network connectivity.';
-      case 'ECONNRESET':
-        return 'Connection to Camunda cluster was reset. Retry the operation and check for intermittent network issues.';
-      case 'ETIMEDOUT':
-        return 'Request to Camunda cluster timed out. Check your network connection and consider retrying.';
-      default:
-        return undefined;
-    }
-  };
+		switch (code) {
+			case "ECONNREFUSED":
+				return "Cannot connect to Camunda cluster (connection refused). Verify the endpoint URL and that the cluster is reachable.";
+			case "ENOTFOUND":
+				return "Cannot resolve Camunda cluster host. Check the cluster URL and your DNS/network configuration.";
+			case "EHOSTUNREACH":
+				return "Camunda cluster host is unreachable. Check VPN/proxy settings and your network connectivity.";
+			case "ECONNRESET":
+				return "Connection to Camunda cluster was reset. Retry the operation and check for intermittent network issues.";
+			case "ETIMEDOUT":
+				return "Request to Camunda cluster timed out. Check your network connection and consider retrying.";
+			default:
+				return undefined;
+		}
+	};
 
-  // Extract RFC 9457 Problem Detail fields and other useful signals
-  const networkTitle = deriveNetworkErrorTitle(error);
-  const errorInstanceTitle =
-    error instanceof Error && typeof error.message === 'string' && error.message
-      ? error.message
-      : undefined;
-  const messageFieldTitle = typeof raw.message === 'string' ? (raw.message as string) : undefined;
-  const title =
-    problemTitle ??
-    networkTitle ??
-    errorInstanceTitle ??
-    messageFieldTitle ??
-    'Unknown error (unexpected error format; re-run with increased logging or check network configuration).';
+	// Extract RFC 9457 Problem Detail fields and other useful signals
+	const networkTitle = deriveNetworkErrorTitle(error);
+	const errorInstanceTitle =
+		error instanceof Error && typeof error.message === "string" && error.message
+			? error.message
+			: undefined;
+	const messageFieldTitle =
+		typeof raw.message === "string" ? raw.message : undefined;
+	const title =
+		problemTitle ??
+		networkTitle ??
+		errorInstanceTitle ??
+		messageFieldTitle ??
+		"Unknown error (unexpected error format; re-run with increased logging or check network configuration).";
 
-  const detail = typeof raw.detail === 'string' ? (raw.detail as string) : undefined;
-  const status = typeof raw.status === 'number' ? (raw.status as number) : undefined;
+	const detail = typeof raw.detail === "string" ? raw.detail : undefined;
+	const status = typeof raw.status === "number" ? raw.status : undefined;
 
-  // Display the main error
-  logger.error('Deployment failed', new Error(title));
+	// Display the main error
+	logger.error("Deployment failed", new Error(title));
 
-  // Display the detailed error message if available
-  if (detail) {
-    logMessage('\n' + formatDeploymentErrorDetail(detail));
-  }
+	// Display the detailed error message if available
+	if (detail) {
+		logMessage(`\n${formatDeploymentErrorDetail(detail)}`);
+	}
 
-  // Provide actionable hints based on error type
-  logMessage('');
-  printDeploymentHints(title, detail, status, resources);
-  logMessage('For more details on the error, run with the --verbose flag');
+	// Provide actionable hints based on error type
+	logMessage("");
+	printDeploymentHints(title, detail, status, resources);
+	logMessage("For more details on the error, run with the --verbose flag");
 
-  if (shouldContinue) {
-    return;
-  }
-  process.exit(1);
+	if (shouldContinue) {
+		return;
+	}
+	process.exit(1);
 }
 
 /**
  * Format the error detail for better readability
  */
 function formatDeploymentErrorDetail(detail: string): string {
-  // The detail often contains embedded newlines, format them nicely
-  const lines = detail.split('\n').map(line => line.trim()).filter(Boolean);
-  
-  // Find the main message and the file-specific errors
-  const result: string[] = [];
-  let inFileError = false;
-  
-  for (const line of lines) {
-    if (line.startsWith("'") && (line.includes('.bpmn') || line.includes('.dmn') || line.includes('.form'))) {
-      // This is a file-specific error
-      inFileError = true;
-      result.push(`  📄 ${line}`);
-    } else if (line.startsWith('- Element:')) {
-      result.push(`     ${line}`);
-    } else if (line.startsWith('- ERROR:') || line.startsWith('- WARNING:')) {
-      const icon = line.startsWith('- ERROR:') ? '❌' : '⚠️';
-      result.push(`     ${icon} ${line.substring(2)}`);
-    } else if (inFileError && line.startsWith('-')) {
-      result.push(`     ${line}`);
-    } else {
-      result.push(`  ${line}`);
-    }
-  }
-  
-  return result.join('\n');
+	// The detail often contains embedded newlines, format them nicely
+	const lines = detail
+		.split("\n")
+		.map((line) => line.trim())
+		.filter(Boolean);
+
+	// Find the main message and the file-specific errors
+	const result: string[] = [];
+	let inFileError = false;
+
+	for (const line of lines) {
+		if (
+			line.startsWith("'") &&
+			(line.includes(".bpmn") ||
+				line.includes(".dmn") ||
+				line.includes(".form"))
+		) {
+			// This is a file-specific error
+			inFileError = true;
+			result.push(`  📄 ${line}`);
+		} else if (line.startsWith("- Element:")) {
+			result.push(`     ${line}`);
+		} else if (line.startsWith("- ERROR:") || line.startsWith("- WARNING:")) {
+			const icon = line.startsWith("- ERROR:") ? "❌" : "⚠️";
+			result.push(`     ${icon} ${line.substring(2)}`);
+		} else if (inFileError && line.startsWith("-")) {
+			result.push(`     ${line}`);
+		} else {
+			result.push(`  ${line}`);
+		}
+	}
+
+	return result.join("\n");
 }
 
 /**
  * Print actionable hints based on the error type
  */
-function printDeploymentHints(title: string, detail: string | undefined, status: number | undefined, resources: ResourceFile[]): void {
-  const hints: string[] = [];
-  
-  if (title === 'INVALID_ARGUMENT') {
-    if (detail?.includes('Must reference a message')) {
-      hints.push('💡 A message start event or intermediate catch event is missing a message reference.');
-      hints.push('   Open the BPMN file in Camunda Modeler and configure the message name.');
-    }
-    if (detail?.includes('duplicate')) {
-      hints.push('💡 Resource IDs must be unique within a deployment.');
-      hints.push('   Check for duplicate process/decision IDs in your files.');
-    }
-    if (detail?.includes('parsing') || detail?.includes('syntax')) {
-      hints.push('💡 The resource file contains syntax errors.');
-      hints.push('   Validate the file in Camunda Modeler or check the XML/JSON structure.');
-    }
-  } else if (title === 'RESOURCE_EXHAUSTED') {
-    hints.push('💡 The server is under heavy load (backpressure).');
-    hints.push('   Wait a moment and retry the deployment.');
-  } else if (title === 'NOT_FOUND' || status === 404) {
-    hints.push('💡 The Camunda server could not be reached or the endpoint was not found.');
-    hints.push('   Check your connection settings with: c8 list profiles');
-  } else if (title === 'UNAUTHENTICATED' || title === 'PERMISSION_DENIED' || status === 401 || status === 403) {
-    hints.push('💡 Authentication or authorization failed.');
-    hints.push('   Check your credentials and permissions for the current profile.');
-  } else {
-    hints.push('💡 Review the error message above for specific issues.');
-    hints.push('   You may need to fix the resource files before deploying.');
-  }
-  
-  // Show which files were being deployed
-  if (resources.length > 0) {
-    hints.push('');
-    hints.push(`📁 Resources attempted (${resources.length}):`);
-    resources.slice(0, 5).forEach(r => {
-      hints.push(`   - ${r.relativePath || r.name}`);
-    });
-    if (resources.length > 5) {
-      hints.push(`   ... and ${resources.length - 5} more`);
-    }
-  }
-  
-  hints.forEach(h => logMessage(h));
+function printDeploymentHints(
+	title: string,
+	detail: string | undefined,
+	status: number | undefined,
+	resources: ResourceFile[],
+): void {
+	const hints: string[] = [];
+
+	if (title === "INVALID_ARGUMENT") {
+		if (detail?.includes("Must reference a message")) {
+			hints.push(
+				"💡 A message start event or intermediate catch event is missing a message reference.",
+			);
+			hints.push(
+				"   Open the BPMN file in Camunda Modeler and configure the message name.",
+			);
+		}
+		if (detail?.includes("duplicate")) {
+			hints.push("💡 Resource IDs must be unique within a deployment.");
+			hints.push("   Check for duplicate process/decision IDs in your files.");
+		}
+		if (detail?.includes("parsing") || detail?.includes("syntax")) {
+			hints.push("💡 The resource file contains syntax errors.");
+			hints.push(
+				"   Validate the file in Camunda Modeler or check the XML/JSON structure.",
+			);
+		}
+	} else if (title === "RESOURCE_EXHAUSTED") {
+		hints.push("💡 The server is under heavy load (backpressure).");
+		hints.push("   Wait a moment and retry the deployment.");
+	} else if (title === "NOT_FOUND" || status === 404) {
+		hints.push(
+			"💡 The Camunda server could not be reached or the endpoint was not found.",
+		);
+		hints.push("   Check your connection settings with: c8 list profiles");
+	} else if (
+		title === "UNAUTHENTICATED" ||
+		title === "PERMISSION_DENIED" ||
+		status === 401 ||
+		status === 403
+	) {
+		hints.push("💡 Authentication or authorization failed.");
+		hints.push(
+			"   Check your credentials and permissions for the current profile.",
+		);
+	} else {
+		hints.push("💡 Review the error message above for specific issues.");
+		hints.push("   You may need to fix the resource files before deploying.");
+	}
+
+	// Show which files were being deployed
+	if (resources.length > 0) {
+		hints.push("");
+		hints.push(`📁 Resources attempted (${resources.length}):`);
+		resources.slice(0, 5).forEach((r) => {
+			hints.push(`   - ${r.relativePath || r.name}`);
+		});
+		if (resources.length > 5) {
+			hints.push(`   ... and ${resources.length - 5} more`);
+		}
+	}
+
+	hints.forEach((h) => {
+		logMessage(h);
+	});
 }

--- a/src/commands/forms.ts
+++ b/src/commands/forms.ts
@@ -4,6 +4,7 @@
 
 import { getLogger } from '../logger.ts';
 import { createClient } from '../client.ts';
+import { UserTaskKey, ProcessDefinitionKey } from '@camunda8/orchestration-cluster-api';
 
 /**
  * Get form for a user task
@@ -16,7 +17,7 @@ export async function getUserTaskForm(userTaskKey: string, options: {
 
   try {
     const result = await client.getUserTaskForm(
-      { userTaskKey: userTaskKey as any },
+      { userTaskKey: UserTaskKey.assumeExists(userTaskKey) },
       { consistency: { waitUpToMs: 0 } }
     );
     // API returns null when user task exists but has no form
@@ -48,7 +49,7 @@ export async function getStartForm(processDefinitionKey: string, options: {
 
   try {
     const result = await client.getStartProcessForm(
-      { processDefinitionKey: processDefinitionKey as any },
+      { processDefinitionKey: ProcessDefinitionKey.assumeExists(processDefinitionKey) },
       { consistency: { waitUpToMs: 0 } }
     );
     // API returns null when process definition exists but has no start form
@@ -84,7 +85,7 @@ export async function getForm(key: string, options: {
   // Try user task form
   try {
     const result = await client.getUserTaskForm(
-      { userTaskKey: key as any },
+      { userTaskKey: UserTaskKey.assumeExists(key) },
       { consistency: { waitUpToMs: 0 } }
     );
     if (result !== null && result !== undefined) {
@@ -100,7 +101,7 @@ export async function getForm(key: string, options: {
   // Try process definition form
   try {
     const result = await client.getStartProcessForm(
-      { processDefinitionKey: key as any },
+      { processDefinitionKey: ProcessDefinitionKey.assumeExists(key) },
       { consistency: { waitUpToMs: 0 } }
     );
     if (result !== null && result !== undefined) {

--- a/src/commands/forms.ts
+++ b/src/commands/forms.ts
@@ -2,144 +2,200 @@
  * Form commands
  */
 
-import { getLogger } from '../logger.ts';
-import { createClient } from '../client.ts';
-import { UserTaskKey, ProcessDefinitionKey } from '@camunda8/orchestration-cluster-api';
+import {
+	ProcessDefinitionKey,
+	UserTaskKey,
+} from "@camunda8/orchestration-cluster-api";
+import { createClient } from "../client.ts";
+import { isRecord } from "../index.ts";
+import { getLogger } from "../logger.ts";
+
+/** Extract HTTP status code from an unknown error (SDK errors expose statusCode or status). */
+function getErrorStatus(error: unknown): number | undefined {
+	if (isRecord(error)) {
+		if (typeof error.statusCode === "number") return error.statusCode;
+		if (typeof error.status === "number") return error.status;
+	}
+	return undefined;
+}
 
 /**
  * Get form for a user task
  */
-export async function getUserTaskForm(userTaskKey: string, options: {
-  profile?: string;
-}): Promise<Record<string, unknown> | undefined> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+export async function getUserTaskForm(
+	userTaskKey: string,
+	options: {
+		profile?: string;
+	},
+): Promise<Record<string, unknown> | undefined> {
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const result = await client.getUserTaskForm(
-      { userTaskKey: UserTaskKey.assumeExists(userTaskKey) },
-      { consistency: { waitUpToMs: 0 } }
-    );
-    // API returns null when user task exists but has no form
-    if (result === null || result === undefined) {
-      logger.info('User task found but has no associated form');
-      return undefined;
-    }
-    logger.json(result);
-    return result as Record<string, unknown>;
-  } catch (error: any) {
-    // Handle 204 No Content (user task exists but has no form)
-    if (error.statusCode === 204 || error.status === 204) {
-      logger.info('User task found but has no associated form');
-      return undefined;
-    }
-    logger.error(`Failed to get form for user task ${userTaskKey}`, error as Error);
-    process.exit(1);
-  }
+	try {
+		const result = await client.getUserTaskForm(
+			{ userTaskKey: UserTaskKey.assumeExists(userTaskKey) },
+			{ consistency: { waitUpToMs: 0 } },
+		);
+		// API returns null when user task exists but has no form
+		if (result === null || result === undefined) {
+			logger.info("User task found but has no associated form");
+			return undefined;
+		}
+		logger.json(result);
+		
+		return;
+	} catch (error: unknown) {
+		// Handle 204 No Content (user task exists but has no form)
+		if (getErrorStatus(error) === 204) {
+			logger.info("User task found but has no associated form");
+			return undefined;
+		}
+		logger.error(
+			`Failed to get form for user task ${userTaskKey}`,
+			error instanceof Error ? error : new Error(String(error)),
+		);
+		process.exit(1);
+	}
 }
 
 /**
  * Get start form for a process definition
  */
-export async function getStartForm(processDefinitionKey: string, options: {
-  profile?: string;
-}): Promise<Record<string, unknown> | undefined> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+export async function getStartForm(
+	processDefinitionKey: string,
+	options: {
+		profile?: string;
+	},
+): Promise<Record<string, unknown> | undefined> {
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const result = await client.getStartProcessForm(
-      { processDefinitionKey: ProcessDefinitionKey.assumeExists(processDefinitionKey) },
-      { consistency: { waitUpToMs: 0 } }
-    );
-    // API returns null when process definition exists but has no start form
-    if (result === null || result === undefined) {
-      logger.info('Process definition found but has no associated start form');
-      return undefined;
-    }
-    logger.json(result);
-    return result as Record<string, unknown>;
-  } catch (error: any) {
-    // Handle 204 No Content (process definition exists but has no form)
-    if (error.statusCode === 204 || error.status === 204) {
-      logger.info('Process definition found but has no associated start form');
-      return undefined;
-    }
-    logger.error(`Failed to get start form for process definition ${processDefinitionKey}`, error as Error);
-    process.exit(1);
-  }
+	try {
+		const result = await client.getStartProcessForm(
+			{
+				processDefinitionKey:
+					ProcessDefinitionKey.assumeExists(processDefinitionKey),
+			},
+			{ consistency: { waitUpToMs: 0 } },
+		);
+		// API returns null when process definition exists but has no start form
+		if (result === null || result === undefined) {
+			logger.info("Process definition found but has no associated start form");
+			return undefined;
+		}
+		logger.json(result);
+		// biome-ignore lint/plugin: safe widening — SDK result to generic Record return type
+		return result as Record<string, unknown>;
+	} catch (error: unknown) {
+		// Handle 204 No Content (process definition exists but has no form)
+		if (getErrorStatus(error) === 204) {
+			logger.info("Process definition found but has no associated start form");
+			return undefined;
+		}
+		logger.error(
+			`Failed to get start form for process definition ${processDefinitionKey}`,
+			error instanceof Error ? error : new Error(String(error)),
+		);
+		process.exit(1);
+	}
 }
 
 /**
  * Get form by trying both user task and process definition APIs
  */
-export async function getForm(key: string, options: {
-  profile?: string;
-}): Promise<{ type: string; key: string; form: Record<string, unknown> } | undefined> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+export async function getForm(
+	key: string,
+	options: {
+		profile?: string;
+	},
+): Promise<
+	{ type: string; key: string; form: Record<string, unknown> } | undefined
+> {
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  const results: { type: string; key: string; form: any }[] = [];
-  const errors: { type: string; error: any }[] = [];
+	const results: {
+		type: string;
+		key: string;
+		form: Record<string, unknown>;
+	}[] = [];
+	const errors: { type: string; error: unknown }[] = [];
 
-  // Try user task form
-  try {
-    const result = await client.getUserTaskForm(
-      { userTaskKey: UserTaskKey.assumeExists(key) },
-      { consistency: { waitUpToMs: 0 } }
-    );
-    if (result !== null && result !== undefined) {
-      results.push({ type: 'user task', key, form: result });
-    }
-  } catch (error: any) {
-    // 204 means resource exists but no form - not an error
-    if (error.statusCode !== 204 && error.status !== 204) {
-      errors.push({ type: 'user task', error });
-    }
-  }
+	// Try user task form
+	try {
+		const result = await client.getUserTaskForm(
+			{ userTaskKey: UserTaskKey.assumeExists(key) },
+			{ consistency: { waitUpToMs: 0 } },
+		);
+		if (result !== null && result !== undefined) {
+			results.push({ type: "user task", key, form: result });
+		}
+	} catch (error: unknown) {
+		// 204 means resource exists but no form - not an error
+		if (getErrorStatus(error) !== 204) {
+			errors.push({ type: "user task", error });
+		}
+	}
 
-  // Try process definition form
-  try {
-    const result = await client.getStartProcessForm(
-      { processDefinitionKey: ProcessDefinitionKey.assumeExists(key) },
-      { consistency: { waitUpToMs: 0 } }
-    );
-    if (result !== null && result !== undefined) {
-      results.push({ type: 'process definition', key, form: result });
-    }
-  } catch (error: any) {
-    // 204 means resource exists but no form - not an error
-    if (error.statusCode !== 204 && error.status !== 204) {
-      errors.push({ type: 'process definition', error });
-    }
-  }
+	// Try process definition form
+	try {
+		const result = await client.getStartProcessForm(
+			{ processDefinitionKey: ProcessDefinitionKey.assumeExists(key) },
+			{ consistency: { waitUpToMs: 0 } },
+		);
+		if (result !== null && result !== undefined) {
+			results.push({ type: "process definition", key, form: result });
+		}
+	} catch (error: unknown) {
+		// 204 means resource exists but no form - not an error
+		if (getErrorStatus(error) !== 204) {
+			errors.push({ type: "process definition", error });
+		}
+	}
 
-  // Report results
-  if (results.length === 0) {
-    if (errors.length === 0) {
-      logger.info('No form found for user task or process definition');
-      return undefined;
-    } else if (errors.length === 1) {
-      logger.error(`Failed to get form: not found as ${errors[0].type}`, errors[0].error as Error);
-      process.exit(1);
-    } else {
-      logger.error('Failed to get form: not found as user task or process definition');
-      process.exit(1);
-    }
-  } else if (results.length === 1) {
-    const keyType = results[0].type === 'user task' ? 'userTaskKey' : 'processDefinitionKey';
-    logger.info(`Form found for ${results[0].type} (${keyType}: ${key}):`);
-    logger.json(results[0].form);
-    return { type: results[0].type, key, form: results[0].form as Record<string, unknown> };
-  } else {
-    logger.info(`Form found in both user task and process definition (key: ${key}):`);
-    const combined = {
-      userTaskKey: key,
-      userTask: results.find(r => r.type === 'user task')?.form,
-      processDefinitionKey: key,
-      processDefinition: results.find(r => r.type === 'process definition')?.form,
-    };
-    logger.json(combined);
-    return { type: 'both', key, form: combined as Record<string, unknown> };
-  }
+	// Report results
+	if (results.length === 0) {
+		if (errors.length === 0) {
+			logger.info("No form found for user task or process definition");
+			return undefined;
+		} else if (errors.length === 1) {
+			logger.error(
+				`Failed to get form: not found as ${errors[0].type}`,
+				errors[0].error instanceof Error
+					? errors[0].error
+					: new Error(String(errors[0].error)),
+			);
+			process.exit(1);
+		} else {
+			logger.error(
+				"Failed to get form: not found as user task or process definition",
+			);
+			process.exit(1);
+		}
+	} else if (results.length === 1) {
+		const keyType =
+			results[0].type === "user task" ? "userTaskKey" : "processDefinitionKey";
+		logger.info(`Form found for ${results[0].type} (${keyType}: ${key}):`);
+		logger.json(results[0].form);
+		return {
+			type: results[0].type,
+			key,
+			// biome-ignore lint/plugin: safe widening — SDK result to generic Record return type
+			form: results[0].form as Record<string, unknown>,
+		};
+	} else {
+		logger.info(
+			`Form found in both user task and process definition (key: ${key}):`,
+		);
+		const combined = {
+			userTaskKey: key,
+			userTask: results.find((r) => r.type === "user task")?.form,
+			processDefinitionKey: key,
+			processDefinition: results.find((r) => r.type === "process definition")
+				?.form,
+		};
+		logger.json(combined);
+		// biome-ignore lint/plugin: safe widening — combined object to generic Record return type
+		return { type: "both", key, form: combined as Record<string, unknown> };
+	}
 }

--- a/src/commands/forms.ts
+++ b/src/commands/forms.ts
@@ -42,7 +42,7 @@ export async function getUserTaskForm(
 			return undefined;
 		}
 		logger.json(result);
-		
+
 		return;
 	} catch (error: unknown) {
 		// Handle 204 No Content (user task exists but has no form)

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -1593,8 +1593,9 @@ export function showCommandHelp(command: string): void {
   if (logger.mode === 'json') {
     const version = getVersion();
     const pluginCommandsInfo = getPluginCommandsInfo();
-    const allHelp = buildHelpJson(version, pluginCommandsInfo) as any;
-    const commandEntry = allHelp.commands?.find((c: any) => c.verb === command);
+    const allHelp = buildHelpJson(version, pluginCommandsInfo) as Record<string, unknown>;
+    const commands = allHelp.commands as Array<Record<string, unknown>> | undefined;
+    const commandEntry = commands?.find((c) => c.verb === command);
     logger.json({
       command,
       ...(commandEntry ?? { verb: command, description: `No detailed help available for: ${command}` }),

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -15,7 +15,35 @@ const __dirname = dirname(__filename);
  * Build structured JSON help data for machine/agent consumption.
  * Returned by showHelp() and showCommandHelp() in JSON output mode.
  */
-function buildHelpJson(version: string, pluginCommandsInfo: PluginCommandInfo[]): object {
+
+interface HelpFlag {
+  flag: string;
+  type: string;
+  description: string;
+  short?: string;
+  appliesTo?: string;
+}
+
+interface HelpCommand {
+  verb: string;
+  resource: string;
+  resources: string[];
+  description: string;
+  mutating: boolean;
+  examples?: string[];
+}
+
+interface HelpJson {
+  version: string;
+  usage: string;
+  commands: HelpCommand[];
+  resourceAliases: Record<string, string>;
+  globalFlags: HelpFlag[];
+  searchFlags: HelpFlag[];
+  agentFlags: HelpFlag[];
+}
+
+function buildHelpJson(version: string, pluginCommandsInfo: PluginCommandInfo[]): HelpJson {
   return {
     version,
     usage: 'c8ctl <command> [resource] [options]',
@@ -1593,9 +1621,8 @@ export function showCommandHelp(command: string): void {
   if (logger.mode === 'json') {
     const version = getVersion();
     const pluginCommandsInfo = getPluginCommandsInfo();
-    const allHelp = buildHelpJson(version, pluginCommandsInfo) as Record<string, unknown>;
-    const commands = allHelp.commands as Array<Record<string, unknown>> | undefined;
-    const commandEntry = commands?.find((c) => c.verb === command);
+    const allHelp = buildHelpJson(version, pluginCommandsInfo);
+    const commandEntry = allHelp.commands.find((c) => c.verb === command);
     logger.json({
       command,
       ...(commandEntry ?? { verb: command, description: `No detailed help available for: ${command}` }),

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -2,11 +2,14 @@
  * Help and version commands
  */
 
-import { readFileSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { getLogger } from '../logger.ts';
-import { getPluginCommandsInfo, type PluginCommandInfo } from '../plugin-loader.ts';
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { getLogger } from "../logger.ts";
+import {
+	getPluginCommandsInfo,
+	type PluginCommandInfo,
+} from "../plugin-loader.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -17,197 +20,628 @@ const __dirname = dirname(__filename);
  */
 
 interface HelpFlag {
-  flag: string;
-  type: string;
-  description: string;
-  short?: string;
-  appliesTo?: string;
+	flag: string;
+	type: string;
+	description: string;
+	short?: string;
+	appliesTo?: string;
 }
 
 interface HelpCommand {
-  verb: string;
-  resource: string;
-  resources: string[];
-  description: string;
-  mutating: boolean;
-  examples?: Array<{ command: string; description: string }> | string[];
+	verb: string;
+	resource: string;
+	resources: string[];
+	description: string;
+	mutating: boolean;
+	examples?: Array<{ command: string; description: string }> | string[];
 }
 
 interface HelpJson {
-  version: string;
-  usage: string;
-  commands: HelpCommand[];
-  resourceAliases: Record<string, string>;
-  globalFlags: HelpFlag[];
-  searchFlags: HelpFlag[];
-  agentFlags: HelpFlag[];
+	version: string;
+	usage: string;
+	commands: HelpCommand[];
+	resourceAliases: Record<string, string>;
+	globalFlags: HelpFlag[];
+	searchFlags: HelpFlag[];
+	agentFlags: HelpFlag[];
 }
 
-function buildHelpJson(version: string, pluginCommandsInfo: PluginCommandInfo[]): HelpJson {
-  return {
-    version,
-    usage: 'c8ctl <command> [resource] [options]',
-    commands: [
-      { verb: 'list',      resource: '<resource>',       resources: ['pi','pd','ut','inc','jobs','profiles','plugins','users','roles','groups','tenants','auth','mapping-rules'], description: 'List resources (process, identity)', mutating: false },
-      { verb: 'search',    resource: '<resource>',       resources: ['pi','pd','ut','inc','jobs','vars','users','roles','groups','tenants','auth','mapping-rules'], description: 'Search resources with filters', mutating: false },
-      { verb: 'get',       resource: '<resource> <key>', resources: ['pi','pd','inc','topology','form','user','role','group','tenant','auth','mapping-rule'],  description: 'Get resource by key', mutating: false },
-      { verb: 'create',    resource: '<resource>',       resources: ['pi','user','role','group','tenant','auth','mapping-rule'], description: 'Create resource', mutating: true },
-      { verb: 'delete',    resource: '<resource> <key>', resources: ['user','role','group','tenant','auth','mapping-rule'], description: 'Delete resource', mutating: true },
-      { verb: 'assign',    resource: '<resource> <id> --to-<target>=<id>', resources: ['role','user','group','mapping-rule'], description: 'Assign resource to target', mutating: true },
-      { verb: 'unassign',  resource: '<resource> <id> --from-<target>=<id>', resources: ['role','user','group','mapping-rule'], description: 'Unassign resource from target', mutating: true },
-      { verb: 'cancel',    resource: '<resource> <key>', resources: ['pi'], description: 'Cancel resource', mutating: true },
-      { verb: 'await',     resource: '<resource>',       resources: ['pi'], description: 'Create and await completion (alias for create --awaitCompletion)', mutating: true },
-      { verb: 'complete',  resource: '<resource> <key>', resources: ['ut','job'], description: 'Complete resource', mutating: true },
-      { verb: 'fail',      resource: 'job <key>',        resources: ['job'], description: 'Fail a job', mutating: true },
-      { verb: 'activate',  resource: 'jobs <type>',      resources: ['jobs'], description: 'Activate jobs by type', mutating: true },
-      { verb: 'resolve',   resource: 'inc <key>',        resources: ['inc'], description: 'Resolve incident', mutating: true },
-      { verb: 'publish',   resource: 'msg <name>',       resources: ['msg'], description: 'Publish message', mutating: true },
-      { verb: 'correlate', resource: 'msg <name>',       resources: ['msg'], description: 'Correlate message', mutating: true },
-      { verb: 'deploy',    resource: '[path...]',        resources: [], description: 'Deploy BPMN/DMN/forms', mutating: true },
-      { verb: 'run',       resource: '<path>',           resources: [], description: 'Deploy and start process', mutating: true },
-      { verb: 'watch',     resource: '[path...]',        resources: [], description: 'Watch files for changes and auto-deploy', mutating: false },
-      { verb: 'open',      resource: '<app>',            resources: ['operate','tasklist','modeler','optimize'], description: 'Open Camunda web application in browser', mutating: false },
-      { verb: 'add',       resource: 'profile <name>',   resources: ['profile'], description: 'Add a profile', mutating: false },
-      { verb: 'remove',    resource: 'profile <name>',   resources: ['profile'], description: 'Remove a profile (alias: rm)', mutating: false },
-      { verb: 'load',      resource: 'plugin <name>',    resources: ['plugin'], description: 'Load a c8ctl plugin', mutating: false },
-      { verb: 'unload',    resource: 'plugin <name>',    resources: ['plugin'], description: 'Unload a c8ctl plugin', mutating: false },
-      { verb: 'upgrade',   resource: 'plugin <name>',    resources: ['plugin'], description: 'Upgrade a plugin', mutating: false },
-      { verb: 'downgrade', resource: 'plugin <name> <version>', resources: ['plugin'], description: 'Downgrade a plugin to a specific version', mutating: false },
-      { verb: 'sync',      resource: 'plugin',           resources: ['plugin'], description: 'Synchronize plugins', mutating: false },
-      { verb: 'init',      resource: 'plugin [name]', resources: ['plugin'], description: 'Create a new plugin from TypeScript template', mutating: false },
-      { verb: 'use',       resource: 'profile|tenant',   resources: ['profile','tenant'], description: 'Set active profile or tenant', mutating: false },
-      { verb: 'output',    resource: '[json|text]',      resources: ['json','text'], description: 'Show or set output format', mutating: false },
-      { verb: 'completion',resource: 'bash|zsh|fish',    resources: ['bash','zsh','fish'], description: 'Generate shell completion script', mutating: false },
-      { verb: 'mcp-proxy', resource: '[mcp-path]',       resources: [], description: 'Start a STDIO to remote HTTP MCP proxy server', mutating: false },
-      { verb: 'feedback', resource: '',                resources: [], description: 'Open the feedback page to report issues or request features', mutating: false },
-      { verb: 'help',      resource: '[command]',        resources: [], description: 'Show help', mutating: false },
-      ...pluginCommandsInfo.map(cmd => ({
-        verb: cmd.commandName, resource: '', resources: [], description: cmd.description || '', mutating: false,
-        examples: cmd.examples || [],
-      })),
-    ],
-    resourceAliases: {
-      pi: 'process-instance(s)',
-      pd: 'process-definition(s)',
-      ut: 'user-task(s)',
-      inc: 'incident(s)',
-      msg: 'message',
-      vars: 'variable(s)',
-      auth: 'authorization(s)',
-      mr: 'mapping-rule(s)',
-    },
-    globalFlags: [
-      { flag: '--profile', type: 'string', description: 'Use specific profile for this command' },
-      { flag: '--sortBy',  type: 'string', description: 'Sort list/search output by column name' },
-      { flag: '--asc',     type: 'boolean', description: 'Sort in ascending order (default)' },
-      { flag: '--desc',    type: 'boolean', description: 'Sort in descending order' },
-      { flag: '--limit',   type: 'string', description: 'Maximum number of items to fetch (default: 1000000)' },
-      { flag: '--between', type: 'string', description: 'Filter by date range: <from>..<to> (YYYY-MM-DD or ISO 8601; open-ended: ..to or from..)' },
-      { flag: '--dateField', type: 'string', description: 'Date field to filter on with --between (default depends on resource)' },
-      { flag: '--state',   type: 'string', description: 'Filter by state (ACTIVE, COMPLETED, etc.)' },
-      { flag: '--id',      type: 'string', description: 'Process definition ID (alias for --bpmnProcessId)' },
-      { flag: '--verbose', type: 'boolean', description: 'Enable SDK trace logging and show full error details' },
-      { flag: '--version', type: 'string', short: '-v', description: 'Show version' },
-      { flag: '--help',    type: 'boolean', short: '-h', description: 'Show help' },
-    ],
-    searchFlags: [
-      { flag: '--bpmnProcessId',           type: 'string',  description: 'Filter by process definition ID' },
-      { flag: '--processDefinitionKey',    type: 'string',  description: 'Filter by process definition key' },
-      { flag: '--processInstanceKey',      type: 'string',  description: 'Filter by process instance key' },
-      { flag: '--parentProcessInstanceKey',type: 'string',  description: 'Filter by parent process instance key' },
-      { flag: '--name',                    type: 'string',  description: 'Filter by name (variables, process definitions); supports wildcards * and ?' },
-      { flag: '--key',                     type: 'string',  description: 'Filter by key' },
-      { flag: '--assignee',                type: 'string',  description: 'Filter by assignee (user tasks)' },
-      { flag: '--elementId',               type: 'string',  description: 'Filter by element ID (user tasks)' },
-      { flag: '--errorType',               type: 'string',  description: 'Filter by error type (incidents)' },
-      { flag: '--errorMessage',            type: 'string',  description: 'Filter by error message (incidents); supports wildcards' },
-      { flag: '--type',                    type: 'string',  description: 'Filter by type (jobs); supports wildcards' },
-      { flag: '--value',                   type: 'string',  description: 'Filter by variable value' },
-      { flag: '--scopeKey',                type: 'string',  description: 'Filter by scope key (variables)' },
-      { flag: '--fullValue',               type: 'boolean', description: 'Return full variable values (default: truncated)' },
-      { flag: '--iname',                   type: 'string',  description: 'Case-insensitive --name filter (supports wildcards)' },
-      { flag: '--iid',                     type: 'string',  description: 'Case-insensitive --bpmnProcessId filter' },
-      { flag: '--iassignee',               type: 'string',  description: 'Case-insensitive --assignee filter' },
-      { flag: '--ierrorMessage',           type: 'string',  description: 'Case-insensitive --errorMessage filter' },
-      { flag: '--itype',                   type: 'string',  description: 'Case-insensitive --type filter' },
-      { flag: '--ivalue',                  type: 'string',  description: 'Case-insensitive --value filter' },
-      { flag: '--username',                type: 'string',  description: 'Filter by username (users)' },
-      { flag: '--email',                   type: 'string',  description: 'Filter by email (users)' },
-      { flag: '--roleId',                  type: 'string',  description: 'Filter by role ID (roles)' },
-      { flag: '--groupId',                 type: 'string',  description: 'Filter by group ID (groups)' },
-      { flag: '--ownerId',                 type: 'string',  description: 'Filter by owner ID (authorizations)' },
-      { flag: '--ownerType',               type: 'string',  description: 'Filter by owner type (authorizations)' },
-      { flag: '--resourceType',            type: 'string',  description: 'Filter by resource type (authorizations)' },
-      { flag: '--resourceId',              type: 'string',  description: 'Filter by resource ID (authorizations)' },
-      { flag: '--claimName',               type: 'string',  description: 'Filter by claim name (mapping rules)' },
-      { flag: '--claimValue',              type: 'string',  description: 'Filter by claim value (mapping rules)' },
-      { flag: '--mappingRuleId',           type: 'string',  description: 'Filter by mapping rule ID (mapping rules)' },
-    ],
-    agentFlags: [
-      {
-        flag: '--fields',
-        type: 'string',
-        description: 'Comma-separated list of output fields to include. Reduces context window size. Case-insensitive. Example: --fields Key,State,processDefinitionId',
-        appliesTo: 'all list/search/get commands',
-      },
-      {
-        flag: '--dry-run',
-        type: 'boolean',
-        description: 'Preview the API request that would be sent without executing it. Emits { dryRun, command, method, url, body } as JSON. Always exits 0.',
-        appliesTo: 'mutating commands: create, cancel, deploy, complete, fail, activate, resolve, publish, correlate, delete, assign, unassign',
-      },
-    ],
-  };
+function buildHelpJson(
+	version: string,
+	pluginCommandsInfo: PluginCommandInfo[],
+): HelpJson {
+	return {
+		version,
+		usage: "c8ctl <command> [resource] [options]",
+		commands: [
+			{
+				verb: "list",
+				resource: "<resource>",
+				resources: [
+					"pi",
+					"pd",
+					"ut",
+					"inc",
+					"jobs",
+					"profiles",
+					"plugins",
+					"users",
+					"roles",
+					"groups",
+					"tenants",
+					"auth",
+					"mapping-rules",
+				],
+				description: "List resources (process, identity)",
+				mutating: false,
+			},
+			{
+				verb: "search",
+				resource: "<resource>",
+				resources: [
+					"pi",
+					"pd",
+					"ut",
+					"inc",
+					"jobs",
+					"vars",
+					"users",
+					"roles",
+					"groups",
+					"tenants",
+					"auth",
+					"mapping-rules",
+				],
+				description: "Search resources with filters",
+				mutating: false,
+			},
+			{
+				verb: "get",
+				resource: "<resource> <key>",
+				resources: [
+					"pi",
+					"pd",
+					"inc",
+					"topology",
+					"form",
+					"user",
+					"role",
+					"group",
+					"tenant",
+					"auth",
+					"mapping-rule",
+				],
+				description: "Get resource by key",
+				mutating: false,
+			},
+			{
+				verb: "create",
+				resource: "<resource>",
+				resources: [
+					"pi",
+					"user",
+					"role",
+					"group",
+					"tenant",
+					"auth",
+					"mapping-rule",
+				],
+				description: "Create resource",
+				mutating: true,
+			},
+			{
+				verb: "delete",
+				resource: "<resource> <key>",
+				resources: ["user", "role", "group", "tenant", "auth", "mapping-rule"],
+				description: "Delete resource",
+				mutating: true,
+			},
+			{
+				verb: "assign",
+				resource: "<resource> <id> --to-<target>=<id>",
+				resources: ["role", "user", "group", "mapping-rule"],
+				description: "Assign resource to target",
+				mutating: true,
+			},
+			{
+				verb: "unassign",
+				resource: "<resource> <id> --from-<target>=<id>",
+				resources: ["role", "user", "group", "mapping-rule"],
+				description: "Unassign resource from target",
+				mutating: true,
+			},
+			{
+				verb: "cancel",
+				resource: "<resource> <key>",
+				resources: ["pi"],
+				description: "Cancel resource",
+				mutating: true,
+			},
+			{
+				verb: "await",
+				resource: "<resource>",
+				resources: ["pi"],
+				description:
+					"Create and await completion (alias for create --awaitCompletion)",
+				mutating: true,
+			},
+			{
+				verb: "complete",
+				resource: "<resource> <key>",
+				resources: ["ut", "job"],
+				description: "Complete resource",
+				mutating: true,
+			},
+			{
+				verb: "fail",
+				resource: "job <key>",
+				resources: ["job"],
+				description: "Fail a job",
+				mutating: true,
+			},
+			{
+				verb: "activate",
+				resource: "jobs <type>",
+				resources: ["jobs"],
+				description: "Activate jobs by type",
+				mutating: true,
+			},
+			{
+				verb: "resolve",
+				resource: "inc <key>",
+				resources: ["inc"],
+				description: "Resolve incident",
+				mutating: true,
+			},
+			{
+				verb: "publish",
+				resource: "msg <name>",
+				resources: ["msg"],
+				description: "Publish message",
+				mutating: true,
+			},
+			{
+				verb: "correlate",
+				resource: "msg <name>",
+				resources: ["msg"],
+				description: "Correlate message",
+				mutating: true,
+			},
+			{
+				verb: "deploy",
+				resource: "[path...]",
+				resources: [],
+				description: "Deploy BPMN/DMN/forms",
+				mutating: true,
+			},
+			{
+				verb: "run",
+				resource: "<path>",
+				resources: [],
+				description: "Deploy and start process",
+				mutating: true,
+			},
+			{
+				verb: "watch",
+				resource: "[path...]",
+				resources: [],
+				description: "Watch files for changes and auto-deploy",
+				mutating: false,
+			},
+			{
+				verb: "open",
+				resource: "<app>",
+				resources: ["operate", "tasklist", "modeler", "optimize"],
+				description: "Open Camunda web application in browser",
+				mutating: false,
+			},
+			{
+				verb: "add",
+				resource: "profile <name>",
+				resources: ["profile"],
+				description: "Add a profile",
+				mutating: false,
+			},
+			{
+				verb: "remove",
+				resource: "profile <name>",
+				resources: ["profile"],
+				description: "Remove a profile (alias: rm)",
+				mutating: false,
+			},
+			{
+				verb: "load",
+				resource: "plugin <name>",
+				resources: ["plugin"],
+				description: "Load a c8ctl plugin",
+				mutating: false,
+			},
+			{
+				verb: "unload",
+				resource: "plugin <name>",
+				resources: ["plugin"],
+				description: "Unload a c8ctl plugin",
+				mutating: false,
+			},
+			{
+				verb: "upgrade",
+				resource: "plugin <name>",
+				resources: ["plugin"],
+				description: "Upgrade a plugin",
+				mutating: false,
+			},
+			{
+				verb: "downgrade",
+				resource: "plugin <name> <version>",
+				resources: ["plugin"],
+				description: "Downgrade a plugin to a specific version",
+				mutating: false,
+			},
+			{
+				verb: "sync",
+				resource: "plugin",
+				resources: ["plugin"],
+				description: "Synchronize plugins",
+				mutating: false,
+			},
+			{
+				verb: "init",
+				resource: "plugin [name]",
+				resources: ["plugin"],
+				description: "Create a new plugin from TypeScript template",
+				mutating: false,
+			},
+			{
+				verb: "use",
+				resource: "profile|tenant",
+				resources: ["profile", "tenant"],
+				description: "Set active profile or tenant",
+				mutating: false,
+			},
+			{
+				verb: "output",
+				resource: "[json|text]",
+				resources: ["json", "text"],
+				description: "Show or set output format",
+				mutating: false,
+			},
+			{
+				verb: "completion",
+				resource: "bash|zsh|fish",
+				resources: ["bash", "zsh", "fish"],
+				description: "Generate shell completion script",
+				mutating: false,
+			},
+			{
+				verb: "mcp-proxy",
+				resource: "[mcp-path]",
+				resources: [],
+				description: "Start a STDIO to remote HTTP MCP proxy server",
+				mutating: false,
+			},
+			{
+				verb: "feedback",
+				resource: "",
+				resources: [],
+				description:
+					"Open the feedback page to report issues or request features",
+				mutating: false,
+			},
+			{
+				verb: "help",
+				resource: "[command]",
+				resources: [],
+				description: "Show help",
+				mutating: false,
+			},
+			...pluginCommandsInfo.map((cmd) => ({
+				verb: cmd.commandName,
+				resource: "",
+				resources: [],
+				description: cmd.description || "",
+				mutating: false,
+				examples: cmd.examples || [],
+			})),
+		],
+		resourceAliases: {
+			pi: "process-instance(s)",
+			pd: "process-definition(s)",
+			ut: "user-task(s)",
+			inc: "incident(s)",
+			msg: "message",
+			vars: "variable(s)",
+			auth: "authorization(s)",
+			mr: "mapping-rule(s)",
+		},
+		globalFlags: [
+			{
+				flag: "--profile",
+				type: "string",
+				description: "Use specific profile for this command",
+			},
+			{
+				flag: "--sortBy",
+				type: "string",
+				description: "Sort list/search output by column name",
+			},
+			{
+				flag: "--asc",
+				type: "boolean",
+				description: "Sort in ascending order (default)",
+			},
+			{
+				flag: "--desc",
+				type: "boolean",
+				description: "Sort in descending order",
+			},
+			{
+				flag: "--limit",
+				type: "string",
+				description: "Maximum number of items to fetch (default: 1000000)",
+			},
+			{
+				flag: "--between",
+				type: "string",
+				description:
+					"Filter by date range: <from>..<to> (YYYY-MM-DD or ISO 8601; open-ended: ..to or from..)",
+			},
+			{
+				flag: "--dateField",
+				type: "string",
+				description:
+					"Date field to filter on with --between (default depends on resource)",
+			},
+			{
+				flag: "--state",
+				type: "string",
+				description: "Filter by state (ACTIVE, COMPLETED, etc.)",
+			},
+			{
+				flag: "--id",
+				type: "string",
+				description: "Process definition ID (alias for --bpmnProcessId)",
+			},
+			{
+				flag: "--verbose",
+				type: "boolean",
+				description: "Enable SDK trace logging and show full error details",
+			},
+			{
+				flag: "--version",
+				type: "string",
+				short: "-v",
+				description: "Show version",
+			},
+			{
+				flag: "--help",
+				type: "boolean",
+				short: "-h",
+				description: "Show help",
+			},
+		],
+		searchFlags: [
+			{
+				flag: "--bpmnProcessId",
+				type: "string",
+				description: "Filter by process definition ID",
+			},
+			{
+				flag: "--processDefinitionKey",
+				type: "string",
+				description: "Filter by process definition key",
+			},
+			{
+				flag: "--processInstanceKey",
+				type: "string",
+				description: "Filter by process instance key",
+			},
+			{
+				flag: "--parentProcessInstanceKey",
+				type: "string",
+				description: "Filter by parent process instance key",
+			},
+			{
+				flag: "--name",
+				type: "string",
+				description:
+					"Filter by name (variables, process definitions); supports wildcards * and ?",
+			},
+			{ flag: "--key", type: "string", description: "Filter by key" },
+			{
+				flag: "--assignee",
+				type: "string",
+				description: "Filter by assignee (user tasks)",
+			},
+			{
+				flag: "--elementId",
+				type: "string",
+				description: "Filter by element ID (user tasks)",
+			},
+			{
+				flag: "--errorType",
+				type: "string",
+				description: "Filter by error type (incidents)",
+			},
+			{
+				flag: "--errorMessage",
+				type: "string",
+				description: "Filter by error message (incidents); supports wildcards",
+			},
+			{
+				flag: "--type",
+				type: "string",
+				description: "Filter by type (jobs); supports wildcards",
+			},
+			{
+				flag: "--value",
+				type: "string",
+				description: "Filter by variable value",
+			},
+			{
+				flag: "--scopeKey",
+				type: "string",
+				description: "Filter by scope key (variables)",
+			},
+			{
+				flag: "--fullValue",
+				type: "boolean",
+				description: "Return full variable values (default: truncated)",
+			},
+			{
+				flag: "--iname",
+				type: "string",
+				description: "Case-insensitive --name filter (supports wildcards)",
+			},
+			{
+				flag: "--iid",
+				type: "string",
+				description: "Case-insensitive --bpmnProcessId filter",
+			},
+			{
+				flag: "--iassignee",
+				type: "string",
+				description: "Case-insensitive --assignee filter",
+			},
+			{
+				flag: "--ierrorMessage",
+				type: "string",
+				description: "Case-insensitive --errorMessage filter",
+			},
+			{
+				flag: "--itype",
+				type: "string",
+				description: "Case-insensitive --type filter",
+			},
+			{
+				flag: "--ivalue",
+				type: "string",
+				description: "Case-insensitive --value filter",
+			},
+			{
+				flag: "--username",
+				type: "string",
+				description: "Filter by username (users)",
+			},
+			{
+				flag: "--email",
+				type: "string",
+				description: "Filter by email (users)",
+			},
+			{
+				flag: "--roleId",
+				type: "string",
+				description: "Filter by role ID (roles)",
+			},
+			{
+				flag: "--groupId",
+				type: "string",
+				description: "Filter by group ID (groups)",
+			},
+			{
+				flag: "--ownerId",
+				type: "string",
+				description: "Filter by owner ID (authorizations)",
+			},
+			{
+				flag: "--ownerType",
+				type: "string",
+				description: "Filter by owner type (authorizations)",
+			},
+			{
+				flag: "--resourceType",
+				type: "string",
+				description: "Filter by resource type (authorizations)",
+			},
+			{
+				flag: "--resourceId",
+				type: "string",
+				description: "Filter by resource ID (authorizations)",
+			},
+			{
+				flag: "--claimName",
+				type: "string",
+				description: "Filter by claim name (mapping rules)",
+			},
+			{
+				flag: "--claimValue",
+				type: "string",
+				description: "Filter by claim value (mapping rules)",
+			},
+			{
+				flag: "--mappingRuleId",
+				type: "string",
+				description: "Filter by mapping rule ID (mapping rules)",
+			},
+		],
+		agentFlags: [
+			{
+				flag: "--fields",
+				type: "string",
+				description:
+					"Comma-separated list of output fields to include. Reduces context window size. Case-insensitive. Example: --fields Key,State,processDefinitionId",
+				appliesTo: "all list/search/get commands",
+			},
+			{
+				flag: "--dry-run",
+				type: "boolean",
+				description:
+					"Preview the API request that would be sent without executing it. Emits { dryRun, command, method, url, body } as JSON. Always exits 0.",
+				appliesTo:
+					"mutating commands: create, cancel, deploy, complete, fail, activate, resolve, publish, correlate, delete, assign, unassign",
+			},
+		],
+	};
 }
 
 /**
  * Get package version
  */
 export function getVersion(): string {
-  const packagePath = join(__dirname, '../../package.json');
-  const packageJson = JSON.parse(readFileSync(packagePath, 'utf-8'));
-  return packageJson.version;
+	const packagePath = join(__dirname, "../../package.json");
+	const packageJson = JSON.parse(readFileSync(packagePath, "utf-8"));
+	return packageJson.version;
 }
 
 /**
  * Display version
  */
 export function showVersion(): void {
-  const logger = getLogger();
-  logger.info(`c8ctl v${getVersion()}`);
+	const logger = getLogger();
+	logger.info(`c8ctl v${getVersion()}`);
 }
 
 /**
  * Display full help
  */
 export function showHelp(): void {
-  const logger = getLogger();
-  const version = getVersion();
-  const pluginCommandsInfo = getPluginCommandsInfo();
+	const logger = getLogger();
+	const version = getVersion();
+	const pluginCommandsInfo = getPluginCommandsInfo();
 
-  // JSON mode: emit structured command tree for machine consumption
-  if (logger.mode === 'json') {
-    logger.json(buildHelpJson(version, pluginCommandsInfo));
-    return;
-  }
-  
-  let pluginSection = '';
-  if (pluginCommandsInfo.length > 0) {
-    pluginSection = '\n\nPlugin Commands:';
-    for (const cmd of pluginCommandsInfo) {
-      const desc = cmd.description ? `  ${cmd.description}` : '';
-      pluginSection += `\n  ${cmd.commandName.padEnd(20)}${desc}`;
-    }
-  }
+	// JSON mode: emit structured command tree for machine consumption
+	if (logger.mode === "json") {
+		logger.json(buildHelpJson(version, pluginCommandsInfo));
+		return;
+	}
 
-  let pluginExamples = '';
-  for (const cmd of pluginCommandsInfo) {
-    for (const ex of cmd.examples ?? []) {
-      pluginExamples += `\n  ${ex.command.padEnd(35)}${ex.description}`;
-    }
-  }
-  
-  console.log(`
+	let pluginSection = "";
+	if (pluginCommandsInfo.length > 0) {
+		pluginSection = "\n\nPlugin Commands:";
+		for (const cmd of pluginCommandsInfo) {
+			const desc = cmd.description ? `  ${cmd.description}` : "";
+			pluginSection += `\n  ${cmd.commandName.padEnd(20)}${desc}`;
+		}
+	}
+
+	let pluginExamples = "";
+	for (const cmd of pluginCommandsInfo) {
+		for (const ex of cmd.examples ?? []) {
+			pluginExamples += `\n  ${ex.command.padEnd(35)}${ex.description}`;
+		}
+	}
+
+	console.log(
+		`
 c8ctl - Camunda 8 CLI v${version}
 
 Usage: c8ctl <command> [resource] [options]
@@ -404,61 +838,66 @@ For detailed help on specific commands with all available flags:
 Feedback & Issues:
   https://github.com/camunda/c8ctl/issues
   Or run: c8ctl feedback
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show available resources for a verb
  */
 export function showVerbResources(verb: string): void {
-  const resources: Record<string, string> = {
-    list: 'process-instances (pi), process-definitions (pd), user-tasks (ut), incidents (inc), jobs, profiles, plugins, users, roles, groups, tenants, authorizations (auth), mapping-rules (mr)',
-    search: 'process-instances (pi), process-definitions (pd), user-tasks (ut), incidents (inc), jobs, variables (vars), users, roles, groups, tenants, authorizations (auth), mapping-rules (mr)',
-    get: 'process-instance (pi), process-definition (pd), incident (inc), topology, form, user, role, group, tenant, authorization (auth), mapping-rule (mr)',
-    create: 'process-instance (pi), user, role, group, tenant, authorization (auth), mapping-rule (mr)',
-    delete: 'user, role, group, tenant, authorization (auth), mapping-rule (mr)',
-    assign: 'role, user, group, mapping-rule',
-    unassign: 'role, user, group, mapping-rule',
-    complete: 'user-task (ut), job',
-    cancel: 'process-instance (pi)',
-    await: 'process-instance (pi)',
-    resolve: 'incident (inc)',
-    activate: 'jobs',
-    fail: 'job',
-    publish: 'message (msg)',
-    correlate: 'message (msg)',
-    add: 'profile',
-    remove: 'profile',
-    rm: 'profile',
-    load: 'plugin',
-    unload: 'plugin',
-    sync: 'plugin',
-    upgrade: 'plugin',
-    downgrade: 'plugin',
-    init: 'plugin',
-    use: 'profile, tenant',
-    which: 'profile',
-    output: 'json, text',
-    open: 'operate, tasklist, modeler, optimize',
-    completion: 'bash, zsh, fish',
-    help: 'list, get, create, complete, await, search, deploy, run, watch, open, cancel, resolve, fail, activate, publish, correlate, delete, assign, unassign, upgrade, downgrade, init, profiles, profile, plugin, plugins',
-  };
+	const resources: Record<string, string> = {
+		list: "process-instances (pi), process-definitions (pd), user-tasks (ut), incidents (inc), jobs, profiles, plugins, users, roles, groups, tenants, authorizations (auth), mapping-rules (mr)",
+		search:
+			"process-instances (pi), process-definitions (pd), user-tasks (ut), incidents (inc), jobs, variables (vars), users, roles, groups, tenants, authorizations (auth), mapping-rules (mr)",
+		get: "process-instance (pi), process-definition (pd), incident (inc), topology, form, user, role, group, tenant, authorization (auth), mapping-rule (mr)",
+		create:
+			"process-instance (pi), user, role, group, tenant, authorization (auth), mapping-rule (mr)",
+		delete:
+			"user, role, group, tenant, authorization (auth), mapping-rule (mr)",
+		assign: "role, user, group, mapping-rule",
+		unassign: "role, user, group, mapping-rule",
+		complete: "user-task (ut), job",
+		cancel: "process-instance (pi)",
+		await: "process-instance (pi)",
+		resolve: "incident (inc)",
+		activate: "jobs",
+		fail: "job",
+		publish: "message (msg)",
+		correlate: "message (msg)",
+		add: "profile",
+		remove: "profile",
+		rm: "profile",
+		load: "plugin",
+		unload: "plugin",
+		sync: "plugin",
+		upgrade: "plugin",
+		downgrade: "plugin",
+		init: "plugin",
+		use: "profile, tenant",
+		which: "profile",
+		output: "json, text",
+		open: "operate, tasklist, modeler, optimize",
+		completion: "bash, zsh, fish",
+		help: "list, get, create, complete, await, search, deploy, run, watch, open, cancel, resolve, fail, activate, publish, correlate, delete, assign, unassign, upgrade, downgrade, init, profiles, profile, plugin, plugins",
+	};
 
-  const available = resources[verb];
-  if (available) {
-    console.log(`\nUsage: c8ctl ${verb} <resource>\n`);
-    console.log(`Available resources:\n  ${available}`);
-  } else {
-    console.log(`\nUnknown command: ${verb}`);
-    console.log('Run "c8ctl help" for usage information.');
-  }
+	const available = resources[verb];
+	if (available) {
+		console.log(`\nUsage: c8ctl ${verb} <resource>\n`);
+		console.log(`Available resources:\n  ${available}`);
+	} else {
+		console.log(`\nUnknown command: ${verb}`);
+		console.log('Run "c8ctl help" for usage information.');
+	}
 }
 
 /**
  * Show detailed help for list command with all resources and their flags
  */
 export function showListHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl list - List resources
 
 Usage: c8ctl list <resource> [flags]
@@ -591,10 +1030,12 @@ Examples:
   c8ctl list tenants
   c8ctl list auth
   c8ctl list mapping-rules
-`.trim());
+`.trim(),
+	);
 }
 export function showGetHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl get - Get resource by key
 
 Usage: c8ctl get <resource> <key> [flags]
@@ -656,14 +1097,16 @@ Examples:
   c8ctl get tenant prod
   c8ctl get auth 123456
   c8ctl get mapping-rule abc123
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show detailed help for create command
  */
 export function showCreateHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl create - Create a resource
 
 Usage: c8ctl create <resource> [flags]
@@ -726,14 +1169,16 @@ Examples:
   c8ctl create tenant --tenantId=prod --name='Production'
   c8ctl create auth --ownerId=john --ownerType=USER --resourceType=process-definition --resourceId='*' --permissions=READ,CREATE
   c8ctl create mapping-rule --mappingRuleId=my-rule --name=my-rule --claimName=department --claimValue=engineering
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show detailed help for complete command
  */
 export function showCompleteHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl complete - Complete a resource
 
 Usage: c8ctl complete <resource> <key> [flags]
@@ -752,14 +1197,16 @@ Examples:
   c8ctl complete ut 2251799813685250
   c8ctl complete ut 2251799813685250 --variables='{"approved":true}'
   c8ctl complete job 2251799813685252 --variables='{"result":"success"}'
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show detailed help for await command
  */
 export function showAwaitHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl await - Create and await process instance completion
 
 Usage: c8ctl await <resource> [flags]
@@ -788,14 +1235,16 @@ Examples:
   
   # Equivalent to:
   c8ctl create pi --id=order-process --awaitCompletion
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show detailed help for mcp-proxy command
  */
 export function showMcpProxyHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl mcp-proxy - Start MCP proxy server
 
 Usage: c8ctl mcp-proxy [mcp-path] [flags]
@@ -847,14 +1296,16 @@ Examples:
 Note:
   The mcp-proxy command runs in the foreground and communicates via STDIO.
   It's designed to be launched by MCP clients, not run directly in a terminal.
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show detailed help for search command
  */
 export function showSearchHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl search - Search resources with filters
 
 Usage: c8ctl search <resource> [flags]
@@ -1055,14 +1506,16 @@ Examples:
   c8ctl search auth --ownerId=john --resourceId=my-resource
   c8ctl search mapping-rules --claimName=department
   c8ctl search mapping-rules --mappingRuleId=my-rule
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show detailed help for deploy command
  */
 export function showDeployHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl deploy - Deploy BPMN, DMN, and form files
 
 Usage: c8ctl deploy [path...] [flags]
@@ -1090,14 +1543,16 @@ Examples:
   c8ctl deploy ./process.bpmn           Deploy a specific BPMN file
   c8ctl deploy ./src ./forms            Deploy from multiple directories
   c8ctl deploy --profile=prod          Deploy using specific profile
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show detailed help for run command
  */
 export function showRunHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl run - Deploy and start a process
 
 Usage: c8ctl run <path> [flags]
@@ -1114,14 +1569,16 @@ Examples:
   c8ctl run ./my-process.bpmn
   c8ctl run ./my-process.bpmn --variables='{"orderId":"12345"}'
   c8ctl run ./my-process.bpmn --profile=prod
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show detailed help for watch command
  */
 export function showWatchHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl watch - Watch files for changes and auto-deploy
 
 Usage: c8ctl watch [path...] [flags]
@@ -1153,14 +1610,16 @@ Examples:
   c8ctl w ./src                         Use short alias
   c8ctl watch --profile=dev             Watch using specific profile
   c8ctl watch --force                   Keep watching after all deployment errors
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show detailed help for open command
  */
 export function showOpenHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl open - Open a Camunda web application in the browser
 
 Usage: c8ctl open <app> [flags]
@@ -1191,14 +1650,16 @@ Examples:
   c8ctl open optimize
   c8ctl open operate --profile=prod
   c8ctl open operate --dry-run
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show detailed help for cancel command
  */
 export function showCancelHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl cancel - Cancel a resource
 
 Usage: c8ctl cancel <resource> <key> [flags]
@@ -1211,14 +1672,16 @@ Resources and their available flags:
 Examples:
   c8ctl cancel pi 2251799813685249
   c8ctl cancel pi 2251799813685249 --profile=prod
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show detailed help for resolve command
  */
 export function showResolveHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl resolve - Resolve an incident
 
 Usage: c8ctl resolve incident <key> [flags]
@@ -1236,14 +1699,16 @@ Examples:
   c8ctl resolve inc 2251799813685251
   c8ctl resolve incident 2251799813685251
   c8ctl resolve inc 2251799813685251 --profile=prod
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show detailed help for fail command
  */
 export function showFailHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl fail - Fail a job
 
 Usage: c8ctl fail job <key> [flags]
@@ -1261,14 +1726,16 @@ Examples:
   c8ctl fail job 2251799813685252 --retries=3
   c8ctl fail job 2251799813685252 --errorMessage="Connection timeout"
   c8ctl fail job 2251799813685252 --retries=2 --errorMessage="Temporary failure"
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show detailed help for activate command
  */
 export function showActivateHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl activate - Activate jobs by type
 
 Usage: c8ctl activate jobs <type> [flags]
@@ -1287,14 +1754,16 @@ Examples:
   c8ctl activate jobs payment-processor --maxJobsToActivate=5
   c8ctl activate jobs data-sync --timeout=120000 --worker=my-worker
   c8ctl activate jobs batch-job --maxJobsToActivate=100 --profile=prod
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show detailed help for publish command
  */
 export function showPublishHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl publish - Publish a message
 
 Usage: c8ctl publish message <name> [flags]
@@ -1315,14 +1784,16 @@ Examples:
   c8ctl publish message order-confirmed --correlationKey=order-123
   c8ctl publish msg invoice-paid --variables='{"amount":1000}'
   c8ctl publish msg notification --correlationKey=user-456 --timeToLive=30000
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show detailed help for correlate command
  */
 export function showCorrelateHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl correlate - Correlate a message
 
 Usage: c8ctl correlate message <name> [flags]
@@ -1342,14 +1813,16 @@ Examples:
   c8ctl correlate msg payment-received --correlationKey=order-123
   c8ctl correlate message order-confirmed --correlationKey=order-456 --variables='{"status":"confirmed"}'
   c8ctl correlate msg invoice-paid --correlationKey=inv-789 --timeToLive=60000
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show detailed help for profile management
  */
 export function showProfilesHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl profiles - Profile management
 
 Usage: c8ctl <command> profile[s] [args] [flags]
@@ -1420,14 +1893,16 @@ Examples:
   c8ctl use profile "modeler:Local Dev"
   c8ctl use profile --none
   c8ctl remove profile local
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show detailed help for plugin management
  */
 export function showPluginHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl plugin - Plugin management
 
 Usage: c8ctl <command> plugin [args] [flags]
@@ -1486,14 +1961,16 @@ Examples:
   c8ctl upgrade plugin my-plugin 1.2.3
   c8ctl downgrade plugin my-plugin 1.0.0
   c8ctl init plugin my-plugin
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show detailed help for delete command
  */
 export function showDeleteHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl delete - Delete a resource
 
 Usage: c8ctl delete <resource> <id> [flags]
@@ -1525,14 +2002,16 @@ Examples:
   c8ctl delete tenant prod
   c8ctl delete auth 123456
   c8ctl delete mapping-rule abc123
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show detailed help for assign command
  */
 export function showAssignHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl assign - Assign a resource to a target
 
 Usage: c8ctl assign <resource> <id> --to-<target>=<targetId> [flags]
@@ -1567,14 +2046,16 @@ Examples:
   c8ctl assign user john --to-tenant=prod
   c8ctl assign group developers --to-tenant=prod
   c8ctl assign mapping-rule my-rule --to-group=developers
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show detailed help for unassign command
  */
 export function showUnassignHelp(): void {
-  console.log(`
+	console.log(
+		`
 c8ctl unassign - Unassign a resource from a target
 
 Usage: c8ctl unassign <resource> <id> --from-<target>=<targetId> [flags]
@@ -1608,103 +2089,107 @@ Examples:
   c8ctl unassign user john --from-group=developers
   c8ctl unassign group developers --from-tenant=prod
   c8ctl unassign mapping-rule my-rule --from-group=developers
-`.trim());
+`.trim(),
+	);
 }
 
 /**
  * Show detailed help for specific commands
  */
 export function showCommandHelp(command: string): void {
-  const logger = getLogger();
+	const logger = getLogger();
 
-  // JSON mode: emit structured help for machine/agent consumption
-  if (logger.mode === 'json') {
-    const version = getVersion();
-    const pluginCommandsInfo = getPluginCommandsInfo();
-    const allHelp = buildHelpJson(version, pluginCommandsInfo);
-    const commandEntry = allHelp.commands.find((c) => c.verb === command);
-    logger.json({
-      command,
-      ...(commandEntry ?? { verb: command, description: `No detailed help available for: ${command}` }),
-      globalFlags: allHelp.globalFlags,
-      searchFlags: allHelp.searchFlags,
-      agentFlags: allHelp.agentFlags,
-    });
-    return;
-  }
+	// JSON mode: emit structured help for machine/agent consumption
+	if (logger.mode === "json") {
+		const version = getVersion();
+		const pluginCommandsInfo = getPluginCommandsInfo();
+		const allHelp = buildHelpJson(version, pluginCommandsInfo);
+		const commandEntry = allHelp.commands.find((c) => c.verb === command);
+		logger.json({
+			command,
+			...(commandEntry ?? {
+				verb: command,
+				description: `No detailed help available for: ${command}`,
+			}),
+			globalFlags: allHelp.globalFlags,
+			searchFlags: allHelp.searchFlags,
+			agentFlags: allHelp.agentFlags,
+		});
+		return;
+	}
 
-  switch (command) {
-    case 'list':
-      showListHelp();
-      break;
-    case 'get':
-      showGetHelp();
-      break;
-    case 'create':
-      showCreateHelp();
-      break;
-    case 'complete':
-      showCompleteHelp();
-      break;
-    case 'await':
-      showAwaitHelp();
-      break;
-    case 'mcp-proxy':
-      showMcpProxyHelp();
-      break;
-    case 'search':
-      showSearchHelp();
-      break;
-    case 'deploy':
-      showDeployHelp();
-      break;
-    case 'run':
-      showRunHelp();
-      break;
-    case 'watch':
-    case 'w':
-      showWatchHelp();
-      break;
-    case 'open':
-      showOpenHelp();
-      break;
-    case 'cancel':
-      showCancelHelp();
-      break;
-    case 'resolve':
-      showResolveHelp();
-      break;
-    case 'fail':
-      showFailHelp();
-      break;
-    case 'activate':
-      showActivateHelp();
-      break;
-    case 'publish':
-      showPublishHelp();
-      break;
-    case 'correlate':
-      showCorrelateHelp();
-      break;
-    case 'delete':
-      showDeleteHelp();
-      break;
-    case 'assign':
-      showAssignHelp();
-      break;
-    case 'unassign':
-      showUnassignHelp();
-      break;
-    case 'profiles':
-    case 'profile':
-      showProfilesHelp();
-      break;
-    case 'plugin':
-    case 'plugins':
-      showPluginHelp();
-      break;
-    default:
-      console.log(`\nNo detailed help available for: ${command}`);
-      console.log('Run "c8ctl help" for general usage information.');
-  }
+	switch (command) {
+		case "list":
+			showListHelp();
+			break;
+		case "get":
+			showGetHelp();
+			break;
+		case "create":
+			showCreateHelp();
+			break;
+		case "complete":
+			showCompleteHelp();
+			break;
+		case "await":
+			showAwaitHelp();
+			break;
+		case "mcp-proxy":
+			showMcpProxyHelp();
+			break;
+		case "search":
+			showSearchHelp();
+			break;
+		case "deploy":
+			showDeployHelp();
+			break;
+		case "run":
+			showRunHelp();
+			break;
+		case "watch":
+		case "w":
+			showWatchHelp();
+			break;
+		case "open":
+			showOpenHelp();
+			break;
+		case "cancel":
+			showCancelHelp();
+			break;
+		case "resolve":
+			showResolveHelp();
+			break;
+		case "fail":
+			showFailHelp();
+			break;
+		case "activate":
+			showActivateHelp();
+			break;
+		case "publish":
+			showPublishHelp();
+			break;
+		case "correlate":
+			showCorrelateHelp();
+			break;
+		case "delete":
+			showDeleteHelp();
+			break;
+		case "assign":
+			showAssignHelp();
+			break;
+		case "unassign":
+			showUnassignHelp();
+			break;
+		case "profiles":
+		case "profile":
+			showProfilesHelp();
+			break;
+		case "plugin":
+		case "plugins":
+			showPluginHelp();
+			break;
+		default:
+			console.log(`\nNo detailed help available for: ${command}`);
+			console.log('Run "c8ctl help" for general usage information.');
+	}
 }

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -30,7 +30,7 @@ interface HelpCommand {
   resources: string[];
   description: string;
   mutating: boolean;
-  examples?: string[];
+  examples?: Array<{ command: string; description: string }> | string[];
 }
 
 interface HelpJson {

--- a/src/commands/identity-authorizations.ts
+++ b/src/commands/identity-authorizations.ts
@@ -9,7 +9,6 @@ import { resolveClusterConfig } from '../config.ts';
 import { c8ctl } from '../runtime.ts';
 import { handleCommandError } from '../errors.ts';
 import { AuthorizationKey } from '@camunda8/orchestration-cluster-api';
-import type { createAuthorizationInput } from '@camunda8/orchestration-cluster-api';
 
 /**
  * List all authorizations
@@ -154,7 +153,7 @@ export async function createIdentityAuthorization(options: {
     process.exit(1);
   }
 
-  const body: Record<string, unknown> = {
+  const body = {
     ownerId: options.ownerId,
     ownerType: options.ownerType,
     resourceType: options.resourceType,
@@ -177,7 +176,7 @@ export async function createIdentityAuthorization(options: {
   const client = createClient(options.profile);
 
   try {
-    await client.createAuthorization(body as createAuthorizationInput);
+    await client.createAuthorization(body);
     logger.success('Authorization created');
   } catch (error) {
     handleCommandError(logger, 'Failed to create authorization', error);

--- a/src/commands/identity-authorizations.ts
+++ b/src/commands/identity-authorizations.ts
@@ -8,6 +8,8 @@ import { createClient, fetchAllPages } from '../client.ts';
 import { resolveClusterConfig } from '../config.ts';
 import { c8ctl } from '../runtime.ts';
 import { handleCommandError } from '../errors.ts';
+import { AuthorizationKey } from '@camunda8/orchestration-cluster-api';
+import type { createAuthorizationInput } from '@camunda8/orchestration-cluster-api';
 
 /**
  * List all authorizations
@@ -111,7 +113,7 @@ export async function getIdentityAuthorization(authorizationKey: string, options
   const client = createClient(options.profile);
 
   try {
-    const result = await client.getAuthorization({ authorizationKey: authorizationKey as any }, { consistency: { waitUpToMs: 0 } });
+    const result = await client.getAuthorization({ authorizationKey: AuthorizationKey.assumeExists(authorizationKey) }, { consistency: { waitUpToMs: 0 } });
     logger.json(result);
   } catch (error) {
     handleCommandError(logger, `Failed to get authorization '${authorizationKey}'`, error);
@@ -175,7 +177,7 @@ export async function createIdentityAuthorization(options: {
   const client = createClient(options.profile);
 
   try {
-    await client.createAuthorization(body as any);
+    await client.createAuthorization(body as createAuthorizationInput);
     logger.success('Authorization created');
   } catch (error) {
     handleCommandError(logger, 'Failed to create authorization', error);
@@ -205,7 +207,7 @@ export async function deleteIdentityAuthorization(authorizationKey: string, opti
   const client = createClient(options.profile);
 
   try {
-    await client.deleteAuthorization({ authorizationKey: authorizationKey as any });
+    await client.deleteAuthorization({ authorizationKey: AuthorizationKey.assumeExists(authorizationKey) });
     logger.success(`Authorization '${authorizationKey}' deleted`);
   } catch (error) {
     handleCommandError(logger, `Failed to delete authorization '${authorizationKey}'`, error);

--- a/src/commands/identity-authorizations.ts
+++ b/src/commands/identity-authorizations.ts
@@ -9,6 +9,7 @@ import { resolveClusterConfig } from '../config.ts';
 import { c8ctl } from '../runtime.ts';
 import { handleCommandError } from '../errors.ts';
 import { AuthorizationKey } from '@camunda8/orchestration-cluster-api';
+import type { OwnerTypeEnum, ResourceTypeEnum, PermissionTypeEnum } from '@camunda8/orchestration-cluster-api';
 
 /**
  * List all authorizations
@@ -155,10 +156,10 @@ export async function createIdentityAuthorization(options: {
 
   const body = {
     ownerId: options.ownerId,
-    ownerType: options.ownerType,
-    resourceType: options.resourceType,
+    ownerType: options.ownerType as OwnerTypeEnum,
+    resourceType: options.resourceType as ResourceTypeEnum,
     resourceId: options.resourceId,
-    permissionTypes: options.permissions.split(',').map(p => p.trim()).filter(p => p.length > 0),
+    permissionTypes: options.permissions.split(',').map(p => p.trim()).filter(p => p.length > 0) as PermissionTypeEnum[],
   };
 
   if (c8ctl.dryRun) {

--- a/src/commands/identity-authorizations.ts
+++ b/src/commands/identity-authorizations.ts
@@ -2,214 +2,256 @@
  * Identity authorization commands
  */
 
-import { getLogger } from '../logger.ts';
-import { sortTableData, type SortOrder } from '../logger.ts';
-import { createClient, fetchAllPages } from '../client.ts';
-import { resolveClusterConfig } from '../config.ts';
-import { c8ctl } from '../runtime.ts';
-import { handleCommandError } from '../errors.ts';
-import { AuthorizationKey } from '@camunda8/orchestration-cluster-api';
-import type { OwnerTypeEnum, ResourceTypeEnum, PermissionTypeEnum } from '@camunda8/orchestration-cluster-api';
+import type {
+	OwnerTypeEnum,
+	PermissionTypeEnum,
+	ResourceTypeEnum,
+} from "@camunda8/orchestration-cluster-api";
+import { AuthorizationKey } from "@camunda8/orchestration-cluster-api";
+import { createClient, fetchAllPages } from "../client.ts";
+import { resolveClusterConfig } from "../config.ts";
+import { handleCommandError } from "../errors.ts";
+import { getLogger, type SortOrder, sortTableData } from "../logger.ts";
+import { c8ctl } from "../runtime.ts";
 
 /**
  * List all authorizations
  */
 export async function listAuthorizations(options: {
-  profile?: string;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  limit?: number;
+	profile?: string;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	limit?: number;
 }): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const items = await fetchAllPages(
-      (filter: any, opts: any) => client.searchAuthorizations(filter, opts),
-      {},
-      undefined,
-      options.limit,
-    );
+	try {
+		const items = await fetchAllPages(
+			(filter, opts) => client.searchAuthorizations(filter, opts),
+			{},
+			undefined,
+			options.limit,
+		);
 
-    if (items.length === 0) {
-      logger.info('No authorizations found');
-      return;
-    }
+		if (items.length === 0) {
+			logger.info("No authorizations found");
+			return;
+		}
 
-    let tableData = items.map((a: any) => ({
-      Key: a.authorizationKey ?? '',
-      'Owner ID': a.ownerId ?? '',
-      'Owner Type': a.ownerType ?? '',
-      'Resource Type': a.resourceType ?? '',
-      'Resource ID': a.resourceId ?? '',
-      Permissions: Array.isArray(a.permissionTypes) ? a.permissionTypes.join(', ') : '',
-    }));
-    tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-    logger.table(tableData);
-  } catch (error) {
-    handleCommandError(logger, 'Failed to list authorizations', error);
-  }
+		let tableData = items.map((a) => ({
+			Key: a.authorizationKey ?? "",
+			"Owner ID": a.ownerId ?? "",
+			"Owner Type": a.ownerType ?? "",
+			"Resource Type": a.resourceType ?? "",
+			"Resource ID": a.resourceId ?? "",
+			Permissions: Array.isArray(a.permissionTypes)
+				? a.permissionTypes.join(", ")
+				: "",
+		}));
+		tableData = sortTableData(
+			tableData,
+			options.sortBy,
+			logger,
+			options.sortOrder,
+		);
+		logger.table(tableData);
+	} catch (error) {
+		handleCommandError(logger, "Failed to list authorizations", error);
+	}
 }
 
 /**
  * Search authorizations with filters
  */
 export async function searchIdentityAuthorizations(options: {
-  profile?: string;
-  ownerId?: string;
-  ownerType?: string;
-  resourceType?: string;
-  resourceId?: string;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  limit?: number;
+	profile?: string;
+	ownerId?: string;
+	ownerType?: string;
+	resourceType?: string;
+	resourceId?: string;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	limit?: number;
 }): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const filter: any = {};
-    if (options.ownerId) filter.ownerId = options.ownerId;
-    if (options.ownerType) filter.ownerType = options.ownerType;
-    if (options.resourceType) filter.resourceType = options.resourceType;
-    if (options.resourceId) filter.resourceIds = [options.resourceId];
+	try {
+		const filter: Record<string, unknown> = {};
+		if (options.ownerId) filter.ownerId = options.ownerId;
+		if (options.ownerType) filter.ownerType = options.ownerType;
+		if (options.resourceType) filter.resourceType = options.resourceType;
+		if (options.resourceId) filter.resourceIds = [options.resourceId];
 
-    const searchFilter = Object.keys(filter).length > 0 ? { filter } : {};
+		const searchFilter = Object.keys(filter).length > 0 ? { filter } : {};
 
-    const items = await fetchAllPages(
-      (f: any, opts: any) => client.searchAuthorizations(f, opts),
-      searchFilter,
-      undefined,
-      options.limit,
-    );
+		const items = await fetchAllPages(
+			(f, opts) => client.searchAuthorizations(f, opts),
+			searchFilter,
+			undefined,
+			options.limit,
+		);
 
-    if (items.length === 0) {
-      logger.info('No authorizations found');
-      return;
-    }
+		if (items.length === 0) {
+			logger.info("No authorizations found");
+			return;
+		}
 
-    let tableData = items.map((a: any) => ({
-      Key: a.authorizationKey ?? '',
-      'Owner ID': a.ownerId ?? '',
-      'Owner Type': a.ownerType ?? '',
-      'Resource Type': a.resourceType ?? '',
-      'Resource ID': a.resourceId ?? '',
-      Permissions: Array.isArray(a.permissionTypes) ? a.permissionTypes.join(', ') : '',
-    }));
-    tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-    logger.table(tableData);
-  } catch (error) {
-    handleCommandError(logger, 'Failed to search authorizations', error);
-  }
+		let tableData = items.map((a) => ({
+			Key: a.authorizationKey ?? "",
+			"Owner ID": a.ownerId ?? "",
+			"Owner Type": a.ownerType ?? "",
+			"Resource Type": a.resourceType ?? "",
+			"Resource ID": a.resourceId ?? "",
+			Permissions: Array.isArray(a.permissionTypes)
+				? a.permissionTypes.join(", ")
+				: "",
+		}));
+		tableData = sortTableData(
+			tableData,
+			options.sortBy,
+			logger,
+			options.sortOrder,
+		);
+		logger.table(tableData);
+	} catch (error) {
+		handleCommandError(logger, "Failed to search authorizations", error);
+	}
 }
 
 /**
  * Get a single authorization by key
  */
-export async function getIdentityAuthorization(authorizationKey: string, options: {
-  profile?: string;
-}): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+export async function getIdentityAuthorization(
+	authorizationKey: string,
+	options: {
+		profile?: string;
+	},
+): Promise<void> {
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const result = await client.getAuthorization({ authorizationKey: AuthorizationKey.assumeExists(authorizationKey) }, { consistency: { waitUpToMs: 0 } });
-    logger.json(result);
-  } catch (error) {
-    handleCommandError(logger, `Failed to get authorization '${authorizationKey}'`, error);
-  }
+	try {
+		const result = await client.getAuthorization(
+			{ authorizationKey: AuthorizationKey.assumeExists(authorizationKey) },
+			{ consistency: { waitUpToMs: 0 } },
+		);
+		logger.json(result);
+	} catch (error) {
+		handleCommandError(
+			logger,
+			`Failed to get authorization '${authorizationKey}'`,
+			error,
+		);
+	}
 }
 
 /**
  * Create a new authorization
  */
 export async function createIdentityAuthorization(options: {
-  profile?: string;
-  ownerId?: string;
-  ownerType?: string;
-  resourceType?: string;
-  resourceId?: string;
-  permissions?: string;
+	profile?: string;
+	ownerId?: string;
+	ownerType?: string;
+	resourceType?: string;
+	resourceId?: string;
+	permissions?: string;
 }): Promise<void> {
-  const logger = getLogger();
+	const logger = getLogger();
 
-  if (!options.ownerId) {
-    logger.error('--ownerId is required');
-    process.exit(1);
-  }
-  if (!options.ownerType) {
-    logger.error('--ownerType is required');
-    process.exit(1);
-  }
-  if (!options.resourceType) {
-    logger.error('--resourceType is required');
-    process.exit(1);
-  }
-  if (!options.resourceId) {
-    logger.error('--resourceId is required');
-    process.exit(1);
-  }
-  if (!options.permissions) {
-    logger.error('--permissions is required');
-    process.exit(1);
-  }
+	if (!options.ownerId) {
+		logger.error("--ownerId is required");
+		process.exit(1);
+	}
+	if (!options.ownerType) {
+		logger.error("--ownerType is required");
+		process.exit(1);
+	}
+	if (!options.resourceType) {
+		logger.error("--resourceType is required");
+		process.exit(1);
+	}
+	if (!options.resourceId) {
+		logger.error("--resourceId is required");
+		process.exit(1);
+	}
+	if (!options.permissions) {
+		logger.error("--permissions is required");
+		process.exit(1);
+	}
 
-  const body = {
-    ownerId: options.ownerId,
-    ownerType: options.ownerType as OwnerTypeEnum,
-    resourceType: options.resourceType as ResourceTypeEnum,
-    resourceId: options.resourceId,
-    permissionTypes: options.permissions.split(',').map(p => p.trim()).filter(p => p.length > 0) as PermissionTypeEnum[],
-  };
+	const body = {
+		ownerId: options.ownerId,
+		// biome-ignore lint/plugin: CLI string → SDK enum, validated by API at runtime (#218)
+		ownerType: options.ownerType as OwnerTypeEnum,
+		// biome-ignore lint/plugin: CLI string → SDK enum, validated by API at runtime (#218)
+		resourceType: options.resourceType as ResourceTypeEnum,
+		resourceId: options.resourceId,
+		// biome-ignore lint/plugin: CLI strings → SDK enum, validated by API at runtime (#218)
+		permissionTypes: options.permissions
+			.split(",")
+			.map((p) => p.trim())
+			.filter((p) => p.length > 0) as PermissionTypeEnum[],
+	};
 
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    logger.json({
-      dryRun: true,
-      command: 'create authorization',
-      method: 'POST',
-      url: `${config.baseUrl}/authorizations`,
-      body,
-    });
-    return;
-  }
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		logger.json({
+			dryRun: true,
+			command: "create authorization",
+			method: "POST",
+			url: `${config.baseUrl}/authorizations`,
+			body,
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
+	const client = createClient(options.profile);
 
-  try {
-    await client.createAuthorization(body);
-    logger.success('Authorization created');
-  } catch (error) {
-    handleCommandError(logger, 'Failed to create authorization', error);
-  }
+	try {
+		await client.createAuthorization(body);
+		logger.success("Authorization created");
+	} catch (error) {
+		handleCommandError(logger, "Failed to create authorization", error);
+	}
 }
 
 /**
  * Delete an authorization by key
  */
-export async function deleteIdentityAuthorization(authorizationKey: string, options: {
-  profile?: string;
-}): Promise<void> {
-  const logger = getLogger();
+export async function deleteIdentityAuthorization(
+	authorizationKey: string,
+	options: {
+		profile?: string;
+	},
+): Promise<void> {
+	const logger = getLogger();
 
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    logger.json({
-      dryRun: true,
-      command: 'delete authorization',
-      method: 'DELETE',
-      url: `${config.baseUrl}/authorizations/${encodeURIComponent(String(authorizationKey))}`,
-      body: null,
-    });
-    return;
-  }
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		logger.json({
+			dryRun: true,
+			command: "delete authorization",
+			method: "DELETE",
+			url: `${config.baseUrl}/authorizations/${encodeURIComponent(String(authorizationKey))}`,
+			body: null,
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
+	const client = createClient(options.profile);
 
-  try {
-    await client.deleteAuthorization({ authorizationKey: AuthorizationKey.assumeExists(authorizationKey) });
-    logger.success(`Authorization '${authorizationKey}' deleted`);
-  } catch (error) {
-    handleCommandError(logger, `Failed to delete authorization '${authorizationKey}'`, error);
-  }
+	try {
+		await client.deleteAuthorization({
+			authorizationKey: AuthorizationKey.assumeExists(authorizationKey),
+		});
+		logger.success(`Authorization '${authorizationKey}' deleted`);
+	} catch (error) {
+		handleCommandError(
+			logger,
+			`Failed to delete authorization '${authorizationKey}'`,
+			error,
+		);
+	}
 }

--- a/src/commands/identity-groups.ts
+++ b/src/commands/identity-groups.ts
@@ -2,182 +2,200 @@
  * Identity group commands
  */
 
-import { getLogger } from '../logger.ts';
-import { sortTableData, type SortOrder } from '../logger.ts';
-import { createClient, fetchAllPages } from '../client.ts';
-import { toStringFilter } from './search.ts';
-import { resolveClusterConfig } from '../config.ts';
-import { c8ctl } from '../runtime.ts';
-import { handleCommandError } from '../errors.ts';
+import { createClient, fetchAllPages } from "../client.ts";
+import { resolveClusterConfig } from "../config.ts";
+import { handleCommandError } from "../errors.ts";
+import { getLogger, type SortOrder, sortTableData } from "../logger.ts";
+import { c8ctl } from "../runtime.ts";
+import { toStringFilter } from "./search.ts";
 
 /**
  * List all groups
  */
 export async function listGroups(options: {
-  profile?: string;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  limit?: number;
+	profile?: string;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	limit?: number;
 }): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const items = await fetchAllPages(
-      (filter: any, opts: any) => client.searchGroups(filter, opts),
-      {},
-      undefined,
-      options.limit,
-    );
+	try {
+		const items = await fetchAllPages(
+			(filter, opts) => client.searchGroups(filter, opts),
+			{},
+			undefined,
+			options.limit,
+		);
 
-    if (items.length === 0) {
-      logger.info('No groups found');
-      return;
-    }
+		if (items.length === 0) {
+			logger.info("No groups found");
+			return;
+		}
 
-    let tableData = items.map((g: any) => ({
-      'Group ID': g.groupId ?? '',
-      Name: g.name ?? '',
-      Description: g.description ?? '',
-    }));
-    tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-    logger.table(tableData);
-  } catch (error) {
-    handleCommandError(logger, 'Failed to list groups', error);
-  }
+		let tableData = items.map((g) => ({
+			"Group ID": g.groupId ?? "",
+			Name: g.name ?? "",
+			Description: g.description ?? "",
+		}));
+		tableData = sortTableData(
+			tableData,
+			options.sortBy,
+			logger,
+			options.sortOrder,
+		);
+		logger.table(tableData);
+	} catch (error) {
+		handleCommandError(logger, "Failed to list groups", error);
+	}
 }
 
 /**
  * Search groups with filters
  */
 export async function searchIdentityGroups(options: {
-  profile?: string;
-  groupId?: string;
-  name?: string;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  limit?: number;
+	profile?: string;
+	groupId?: string;
+	name?: string;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	limit?: number;
 }): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const filter: any = {};
-    if (options.groupId) filter.groupId = toStringFilter(options.groupId);
-    if (options.name) filter.name = options.name;
+	try {
+		const filter: Record<string, unknown> = {};
+		if (options.groupId) filter.groupId = toStringFilter(options.groupId);
+		if (options.name) filter.name = options.name;
 
-    const searchFilter = Object.keys(filter).length > 0 ? { filter } : {};
+		const searchFilter = Object.keys(filter).length > 0 ? { filter } : {};
 
-    const items = await fetchAllPages(
-      (f: any, opts: any) => client.searchGroups(f, opts),
-      searchFilter,
-      undefined,
-      options.limit,
-    );
+		const items = await fetchAllPages(
+			(f, opts) => client.searchGroups(f, opts),
+			searchFilter,
+			undefined,
+			options.limit,
+		);
 
-    if (items.length === 0) {
-      logger.info('No groups found');
-      return;
-    }
+		if (items.length === 0) {
+			logger.info("No groups found");
+			return;
+		}
 
-    let tableData = items.map((g: any) => ({
-      'Group ID': g.groupId ?? '',
-      Name: g.name ?? '',
-      Description: g.description ?? '',
-    }));
-    tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-    logger.table(tableData);
-  } catch (error) {
-    handleCommandError(logger, 'Failed to search groups', error);
-  }
+		let tableData = items.map((g) => ({
+			"Group ID": g.groupId ?? "",
+			Name: g.name ?? "",
+			Description: g.description ?? "",
+		}));
+		tableData = sortTableData(
+			tableData,
+			options.sortBy,
+			logger,
+			options.sortOrder,
+		);
+		logger.table(tableData);
+	} catch (error) {
+		handleCommandError(logger, "Failed to search groups", error);
+	}
 }
 
 /**
  * Get a single group by groupId
  */
-export async function getIdentityGroup(groupId: string, options: {
-  profile?: string;
-}): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+export async function getIdentityGroup(
+	groupId: string,
+	options: {
+		profile?: string;
+	},
+): Promise<void> {
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const result = await client.getGroup({ groupId: groupId }, { consistency: { waitUpToMs: 0 } });
-    logger.json(result);
-  } catch (error) {
-    handleCommandError(logger, `Failed to get group '${groupId}'`, error);
-  }
+	try {
+		const result = await client.getGroup(
+			{ groupId: groupId },
+			{ consistency: { waitUpToMs: 0 } },
+		);
+		logger.json(result);
+	} catch (error) {
+		handleCommandError(logger, `Failed to get group '${groupId}'`, error);
+	}
 }
 
 /**
  * Create a new group
  */
 export async function createIdentityGroup(options: {
-  profile?: string;
-  groupId?: string;
-  name?: string;
+	profile?: string;
+	groupId?: string;
+	name?: string;
 }): Promise<void> {
-  const logger = getLogger();
+	const logger = getLogger();
 
-  if (!options.groupId) {
-    logger.error('--groupId is required');
-    process.exit(1);
-  }
-  if (!options.name) {
-    logger.error('--name is required');
-    process.exit(1);
-  }
+	if (!options.groupId) {
+		logger.error("--groupId is required");
+		process.exit(1);
+	}
+	if (!options.name) {
+		logger.error("--name is required");
+		process.exit(1);
+	}
 
-  const body = { groupId: options.groupId, name: options.name };
+	const body = { groupId: options.groupId, name: options.name };
 
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    logger.json({
-      dryRun: true,
-      command: 'create group',
-      method: 'POST',
-      url: `${config.baseUrl}/groups`,
-      body,
-    });
-    return;
-  }
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		logger.json({
+			dryRun: true,
+			command: "create group",
+			method: "POST",
+			url: `${config.baseUrl}/groups`,
+			body,
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
+	const client = createClient(options.profile);
 
-  try {
-    await client.createGroup(body);
-    logger.success(`Group '${options.name}' created`);
-  } catch (error) {
-    handleCommandError(logger, 'Failed to create group', error);
-  }
+	try {
+		await client.createGroup(body);
+		logger.success(`Group '${options.name}' created`);
+	} catch (error) {
+		handleCommandError(logger, "Failed to create group", error);
+	}
 }
 
 /**
  * Delete a group by groupId
  */
-export async function deleteIdentityGroup(groupId: string, options: {
-  profile?: string;
-}): Promise<void> {
-  const logger = getLogger();
+export async function deleteIdentityGroup(
+	groupId: string,
+	options: {
+		profile?: string;
+	},
+): Promise<void> {
+	const logger = getLogger();
 
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    logger.json({
-      dryRun: true,
-      command: 'delete group',
-      method: 'DELETE',
-      url: `${config.baseUrl}/groups/${encodeURIComponent(groupId)}`,
-      body: null,
-    });
-    return;
-  }
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		logger.json({
+			dryRun: true,
+			command: "delete group",
+			method: "DELETE",
+			url: `${config.baseUrl}/groups/${encodeURIComponent(groupId)}`,
+			body: null,
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
+	const client = createClient(options.profile);
 
-  try {
-    await client.deleteGroup({ groupId: groupId });
-    logger.success(`Group '${groupId}' deleted`);
-  } catch (error) {
-    handleCommandError(logger, `Failed to delete group '${groupId}'`, error);
-  }
+	try {
+		await client.deleteGroup({ groupId: groupId });
+		logger.success(`Group '${groupId}' deleted`);
+	} catch (error) {
+		handleCommandError(logger, `Failed to delete group '${groupId}'`, error);
+	}
 }

--- a/src/commands/identity-groups.ts
+++ b/src/commands/identity-groups.ts
@@ -9,6 +9,7 @@ import { toStringFilter } from './search.ts';
 import { resolveClusterConfig } from '../config.ts';
 import { c8ctl } from '../runtime.ts';
 import { handleCommandError } from '../errors.ts';
+import type { createGroupInput } from '@camunda8/orchestration-cluster-api';
 
 /**
  * List all groups
@@ -102,7 +103,7 @@ export async function getIdentityGroup(groupId: string, options: {
   const client = createClient(options.profile);
 
   try {
-    const result = await client.getGroup({ groupId: groupId as any }, { consistency: { waitUpToMs: 0 } });
+    const result = await client.getGroup({ groupId: groupId }, { consistency: { waitUpToMs: 0 } });
     logger.json(result);
   } catch (error) {
     handleCommandError(logger, `Failed to get group '${groupId}'`, error);
@@ -140,7 +141,7 @@ export async function createIdentityGroup(options: {
   const client = createClient(options.profile);
 
   try {
-    await client.createGroup(body as any);
+    await client.createGroup(body as createGroupInput);
     logger.success(`Group '${options.name}' created`);
   } catch (error) {
     handleCommandError(logger, 'Failed to create group', error);
@@ -170,7 +171,7 @@ export async function deleteIdentityGroup(groupId: string, options: {
   const client = createClient(options.profile);
 
   try {
-    await client.deleteGroup({ groupId: groupId as any });
+    await client.deleteGroup({ groupId: groupId });
     logger.success(`Group '${groupId}' deleted`);
   } catch (error) {
     handleCommandError(logger, `Failed to delete group '${groupId}'`, error);

--- a/src/commands/identity-groups.ts
+++ b/src/commands/identity-groups.ts
@@ -9,7 +9,6 @@ import { toStringFilter } from './search.ts';
 import { resolveClusterConfig } from '../config.ts';
 import { c8ctl } from '../runtime.ts';
 import { handleCommandError } from '../errors.ts';
-import type { GroupCreateRequest } from '@camunda8/orchestration-cluster-api';
 
 /**
  * List all groups
@@ -115,16 +114,21 @@ export async function getIdentityGroup(groupId: string, options: {
  */
 export async function createIdentityGroup(options: {
   profile?: string;
+  groupId?: string;
   name?: string;
 }): Promise<void> {
   const logger = getLogger();
 
+  if (!options.groupId) {
+    logger.error('--groupId is required');
+    process.exit(1);
+  }
   if (!options.name) {
     logger.error('--name is required');
     process.exit(1);
   }
 
-  const body = { name: options.name };
+  const body = { groupId: options.groupId, name: options.name };
 
   if (c8ctl.dryRun) {
     const config = resolveClusterConfig(options.profile);
@@ -141,7 +145,7 @@ export async function createIdentityGroup(options: {
   const client = createClient(options.profile);
 
   try {
-    await client.createGroup(body as GroupCreateRequest);
+    await client.createGroup(body);
     logger.success(`Group '${options.name}' created`);
   } catch (error) {
     handleCommandError(logger, 'Failed to create group', error);

--- a/src/commands/identity-groups.ts
+++ b/src/commands/identity-groups.ts
@@ -9,6 +9,7 @@ import { toStringFilter } from './search.ts';
 import { resolveClusterConfig } from '../config.ts';
 import { c8ctl } from '../runtime.ts';
 import { handleCommandError } from '../errors.ts';
+import type { GroupCreateRequest } from '@camunda8/orchestration-cluster-api';
 
 /**
  * List all groups
@@ -140,7 +141,7 @@ export async function createIdentityGroup(options: {
   const client = createClient(options.profile);
 
   try {
-    await client.createGroup(body);
+    await client.createGroup(body as GroupCreateRequest);
     logger.success(`Group '${options.name}' created`);
   } catch (error) {
     handleCommandError(logger, 'Failed to create group', error);

--- a/src/commands/identity-groups.ts
+++ b/src/commands/identity-groups.ts
@@ -9,7 +9,6 @@ import { toStringFilter } from './search.ts';
 import { resolveClusterConfig } from '../config.ts';
 import { c8ctl } from '../runtime.ts';
 import { handleCommandError } from '../errors.ts';
-import type { createGroupInput } from '@camunda8/orchestration-cluster-api';
 
 /**
  * List all groups
@@ -124,7 +123,7 @@ export async function createIdentityGroup(options: {
     process.exit(1);
   }
 
-  const body: Record<string, unknown> = { name: options.name };
+  const body = { name: options.name };
 
   if (c8ctl.dryRun) {
     const config = resolveClusterConfig(options.profile);
@@ -141,7 +140,7 @@ export async function createIdentityGroup(options: {
   const client = createClient(options.profile);
 
   try {
-    await client.createGroup(body as createGroupInput);
+    await client.createGroup(body);
     logger.success(`Group '${options.name}' created`);
   } catch (error) {
     handleCommandError(logger, 'Failed to create group', error);

--- a/src/commands/identity-mapping-rules.ts
+++ b/src/commands/identity-mapping-rules.ts
@@ -8,7 +8,6 @@ import { createClient, fetchAllPages } from '../client.ts';
 import { resolveClusterConfig } from '../config.ts';
 import { c8ctl } from '../runtime.ts';
 import { handleCommandError } from '../errors.ts';
-import type { createMappingRuleInput } from '@camunda8/orchestration-cluster-api';
 
 /**
  * List all mapping rules
@@ -144,7 +143,7 @@ export async function createIdentityMappingRule(options: {
     process.exit(1);
   }
 
-  const body: Record<string, unknown> = {
+  const body = {
     mappingRuleId: options.mappingRuleId,
     name: options.name,
     claimName: options.claimName,
@@ -166,7 +165,7 @@ export async function createIdentityMappingRule(options: {
   const client = createClient(options.profile);
 
   try {
-    await client.createMappingRule(body as createMappingRuleInput);
+    await client.createMappingRule(body);
     logger.success(`Mapping rule '${options.name}' created`);
   } catch (error) {
     handleCommandError(logger, 'Failed to create mapping rule', error);

--- a/src/commands/identity-mapping-rules.ts
+++ b/src/commands/identity-mapping-rules.ts
@@ -2,202 +2,228 @@
  * Identity mapping rule commands
  */
 
-import { getLogger } from '../logger.ts';
-import { sortTableData, type SortOrder } from '../logger.ts';
-import { createClient, fetchAllPages } from '../client.ts';
-import { resolveClusterConfig } from '../config.ts';
-import { c8ctl } from '../runtime.ts';
-import { handleCommandError } from '../errors.ts';
+import { createClient, fetchAllPages } from "../client.ts";
+import { resolveClusterConfig } from "../config.ts";
+import { handleCommandError } from "../errors.ts";
+import { getLogger, type SortOrder, sortTableData } from "../logger.ts";
+import { c8ctl } from "../runtime.ts";
 
 /**
  * List all mapping rules
  */
 export async function listMappingRules(options: {
-  profile?: string;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  limit?: number;
+	profile?: string;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	limit?: number;
 }): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const items = await fetchAllPages(
-      (filter: any, opts: any) => client.searchMappingRule(filter, opts),
-      {},
-      undefined,
-      options.limit,
-    );
+	try {
+		const items = await fetchAllPages(
+			(filter, opts) => client.searchMappingRule(filter, opts),
+			{},
+			undefined,
+			options.limit,
+		);
 
-    if (items.length === 0) {
-      logger.info('No mapping rules found');
-      return;
-    }
+		if (items.length === 0) {
+			logger.info("No mapping rules found");
+			return;
+		}
 
-    let tableData = items.map((m: any) => ({
-      'Mapping Rule ID': m.mappingRuleId ?? '',
-      Name: m.name ?? '',
-      'Claim Name': m.claimName ?? '',
-      'Claim Value': m.claimValue ?? '',
-    }));
-    tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-    logger.table(tableData);
-  } catch (error) {
-    handleCommandError(logger, 'Failed to list mapping rules', error);
-  }
+		let tableData = items.map((m) => ({
+			"Mapping Rule ID": m.mappingRuleId ?? "",
+			Name: m.name ?? "",
+			"Claim Name": m.claimName ?? "",
+			"Claim Value": m.claimValue ?? "",
+		}));
+		tableData = sortTableData(
+			tableData,
+			options.sortBy,
+			logger,
+			options.sortOrder,
+		);
+		logger.table(tableData);
+	} catch (error) {
+		handleCommandError(logger, "Failed to list mapping rules", error);
+	}
 }
 
 /**
  * Search mapping rules with filters
  */
 export async function searchIdentityMappingRules(options: {
-  profile?: string;
-  mappingRuleId?: string;
-  name?: string;
-  claimName?: string;
-  claimValue?: string;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  limit?: number;
+	profile?: string;
+	mappingRuleId?: string;
+	name?: string;
+	claimName?: string;
+	claimValue?: string;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	limit?: number;
 }): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const filter: any = {};
-    if (options.mappingRuleId) filter.mappingRuleId = options.mappingRuleId;
-    if (options.name) filter.name = options.name;
-    if (options.claimName) filter.claimName = options.claimName;
-    if (options.claimValue) filter.claimValue = options.claimValue;
+	try {
+		const filter: Record<string, unknown> = {};
+		if (options.mappingRuleId) filter.mappingRuleId = options.mappingRuleId;
+		if (options.name) filter.name = options.name;
+		if (options.claimName) filter.claimName = options.claimName;
+		if (options.claimValue) filter.claimValue = options.claimValue;
 
-    const searchFilter = Object.keys(filter).length > 0 ? { filter } : {};
+		const searchFilter = Object.keys(filter).length > 0 ? { filter } : {};
 
-    const items = await fetchAllPages(
-      (f: any, opts: any) => client.searchMappingRule(f, opts),
-      searchFilter,
-      undefined,
-      options.limit,
-    );
+		const items = await fetchAllPages(
+			(f, opts) => client.searchMappingRule(f, opts),
+			searchFilter,
+			undefined,
+			options.limit,
+		);
 
-    if (items.length === 0) {
-      logger.info('No mapping rules found');
-      return;
-    }
+		if (items.length === 0) {
+			logger.info("No mapping rules found");
+			return;
+		}
 
-    let tableData = items.map((m: any) => ({
-      'Mapping Rule ID': m.mappingRuleId ?? '',
-      Name: m.name ?? '',
-      'Claim Name': m.claimName ?? '',
-      'Claim Value': m.claimValue ?? '',
-    }));
-    tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-    logger.table(tableData);
-  } catch (error) {
-    handleCommandError(logger, 'Failed to search mapping rules', error);
-  }
+		let tableData = items.map((m) => ({
+			"Mapping Rule ID": m.mappingRuleId ?? "",
+			Name: m.name ?? "",
+			"Claim Name": m.claimName ?? "",
+			"Claim Value": m.claimValue ?? "",
+		}));
+		tableData = sortTableData(
+			tableData,
+			options.sortBy,
+			logger,
+			options.sortOrder,
+		);
+		logger.table(tableData);
+	} catch (error) {
+		handleCommandError(logger, "Failed to search mapping rules", error);
+	}
 }
 
 /**
  * Get a single mapping rule by mappingRuleId
  */
-export async function getIdentityMappingRule(mappingRuleId: string, options: {
-  profile?: string;
-}): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+export async function getIdentityMappingRule(
+	mappingRuleId: string,
+	options: {
+		profile?: string;
+	},
+): Promise<void> {
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const result = await client.getMappingRule({ mappingRuleId: mappingRuleId }, { consistency: { waitUpToMs: 0 } });
-    logger.json(result);
-  } catch (error) {
-    handleCommandError(logger, `Failed to get mapping rule '${mappingRuleId}'`, error);
-  }
+	try {
+		const result = await client.getMappingRule(
+			{ mappingRuleId: mappingRuleId },
+			{ consistency: { waitUpToMs: 0 } },
+		);
+		logger.json(result);
+	} catch (error) {
+		handleCommandError(
+			logger,
+			`Failed to get mapping rule '${mappingRuleId}'`,
+			error,
+		);
+	}
 }
 
 /**
  * Create a new mapping rule
  */
 export async function createIdentityMappingRule(options: {
-  profile?: string;
-  mappingRuleId?: string;
-  name?: string;
-  claimName?: string;
-  claimValue?: string;
+	profile?: string;
+	mappingRuleId?: string;
+	name?: string;
+	claimName?: string;
+	claimValue?: string;
 }): Promise<void> {
-  const logger = getLogger();
+	const logger = getLogger();
 
-  if (!options.mappingRuleId) {
-    logger.error('--mappingRuleId is required');
-    process.exit(1);
-  }
-  if (!options.name) {
-    logger.error('--name is required');
-    process.exit(1);
-  }
-  if (!options.claimName) {
-    logger.error('--claimName is required');
-    process.exit(1);
-  }
-  if (!options.claimValue) {
-    logger.error('--claimValue is required');
-    process.exit(1);
-  }
+	if (!options.mappingRuleId) {
+		logger.error("--mappingRuleId is required");
+		process.exit(1);
+	}
+	if (!options.name) {
+		logger.error("--name is required");
+		process.exit(1);
+	}
+	if (!options.claimName) {
+		logger.error("--claimName is required");
+		process.exit(1);
+	}
+	if (!options.claimValue) {
+		logger.error("--claimValue is required");
+		process.exit(1);
+	}
 
-  const body = {
-    mappingRuleId: options.mappingRuleId,
-    name: options.name,
-    claimName: options.claimName,
-    claimValue: options.claimValue,
-  };
+	const body = {
+		mappingRuleId: options.mappingRuleId,
+		name: options.name,
+		claimName: options.claimName,
+		claimValue: options.claimValue,
+	};
 
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    logger.json({
-      dryRun: true,
-      command: 'create mapping-rule',
-      method: 'POST',
-      url: `${config.baseUrl}/mapping-rules`,
-      body,
-    });
-    return;
-  }
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		logger.json({
+			dryRun: true,
+			command: "create mapping-rule",
+			method: "POST",
+			url: `${config.baseUrl}/mapping-rules`,
+			body,
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
+	const client = createClient(options.profile);
 
-  try {
-    await client.createMappingRule(body);
-    logger.success(`Mapping rule '${options.name}' created`);
-  } catch (error) {
-    handleCommandError(logger, 'Failed to create mapping rule', error);
-  }
+	try {
+		await client.createMappingRule(body);
+		logger.success(`Mapping rule '${options.name}' created`);
+	} catch (error) {
+		handleCommandError(logger, "Failed to create mapping rule", error);
+	}
 }
 
 /**
  * Delete a mapping rule by mappingRuleId
  */
-export async function deleteIdentityMappingRule(mappingRuleId: string, options: {
-  profile?: string;
-}): Promise<void> {
-  const logger = getLogger();
+export async function deleteIdentityMappingRule(
+	mappingRuleId: string,
+	options: {
+		profile?: string;
+	},
+): Promise<void> {
+	const logger = getLogger();
 
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    logger.json({
-      dryRun: true,
-      command: 'delete mapping-rule',
-      method: 'DELETE',
-      url: `${config.baseUrl}/mapping-rules/${encodeURIComponent(mappingRuleId)}`,
-      body: null,
-    });
-    return;
-  }
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		logger.json({
+			dryRun: true,
+			command: "delete mapping-rule",
+			method: "DELETE",
+			url: `${config.baseUrl}/mapping-rules/${encodeURIComponent(mappingRuleId)}`,
+			body: null,
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
+	const client = createClient(options.profile);
 
-  try {
-    await client.deleteMappingRule({ mappingRuleId: mappingRuleId });
-    logger.success(`Mapping rule '${mappingRuleId}' deleted`);
-  } catch (error) {
-    handleCommandError(logger, `Failed to delete mapping rule '${mappingRuleId}'`, error);
-  }
+	try {
+		await client.deleteMappingRule({ mappingRuleId: mappingRuleId });
+		logger.success(`Mapping rule '${mappingRuleId}' deleted`);
+	} catch (error) {
+		handleCommandError(
+			logger,
+			`Failed to delete mapping rule '${mappingRuleId}'`,
+			error,
+		);
+	}
 }

--- a/src/commands/identity-mapping-rules.ts
+++ b/src/commands/identity-mapping-rules.ts
@@ -8,6 +8,7 @@ import { createClient, fetchAllPages } from '../client.ts';
 import { resolveClusterConfig } from '../config.ts';
 import { c8ctl } from '../runtime.ts';
 import { handleCommandError } from '../errors.ts';
+import type { createMappingRuleInput } from '@camunda8/orchestration-cluster-api';
 
 /**
  * List all mapping rules
@@ -107,7 +108,7 @@ export async function getIdentityMappingRule(mappingRuleId: string, options: {
   const client = createClient(options.profile);
 
   try {
-    const result = await client.getMappingRule({ mappingRuleId: mappingRuleId as any }, { consistency: { waitUpToMs: 0 } });
+    const result = await client.getMappingRule({ mappingRuleId: mappingRuleId }, { consistency: { waitUpToMs: 0 } });
     logger.json(result);
   } catch (error) {
     handleCommandError(logger, `Failed to get mapping rule '${mappingRuleId}'`, error);
@@ -165,7 +166,7 @@ export async function createIdentityMappingRule(options: {
   const client = createClient(options.profile);
 
   try {
-    await client.createMappingRule(body as any);
+    await client.createMappingRule(body as createMappingRuleInput);
     logger.success(`Mapping rule '${options.name}' created`);
   } catch (error) {
     handleCommandError(logger, 'Failed to create mapping rule', error);
@@ -195,7 +196,7 @@ export async function deleteIdentityMappingRule(mappingRuleId: string, options: 
   const client = createClient(options.profile);
 
   try {
-    await client.deleteMappingRule({ mappingRuleId: mappingRuleId as any });
+    await client.deleteMappingRule({ mappingRuleId: mappingRuleId });
     logger.success(`Mapping rule '${mappingRuleId}' deleted`);
   } catch (error) {
     handleCommandError(logger, `Failed to delete mapping rule '${mappingRuleId}'`, error);

--- a/src/commands/identity-roles.ts
+++ b/src/commands/identity-roles.ts
@@ -2,181 +2,199 @@
  * Identity role commands
  */
 
-import { getLogger } from '../logger.ts';
-import { sortTableData, type SortOrder } from '../logger.ts';
-import { createClient, fetchAllPages } from '../client.ts';
-import { resolveClusterConfig } from '../config.ts';
-import { c8ctl } from '../runtime.ts';
-import { handleCommandError } from '../errors.ts';
+import { createClient, fetchAllPages } from "../client.ts";
+import { resolveClusterConfig } from "../config.ts";
+import { handleCommandError } from "../errors.ts";
+import { getLogger, type SortOrder, sortTableData } from "../logger.ts";
+import { c8ctl } from "../runtime.ts";
 
 /**
  * List all roles
  */
 export async function listRoles(options: {
-  profile?: string;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  limit?: number;
+	profile?: string;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	limit?: number;
 }): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const items = await fetchAllPages(
-      (filter: any, opts: any) => client.searchRoles(filter, opts),
-      {},
-      undefined,
-      options.limit,
-    );
+	try {
+		const items = await fetchAllPages(
+			(filter, opts) => client.searchRoles(filter, opts),
+			{},
+			undefined,
+			options.limit,
+		);
 
-    if (items.length === 0) {
-      logger.info('No roles found');
-      return;
-    }
+		if (items.length === 0) {
+			logger.info("No roles found");
+			return;
+		}
 
-    let tableData = items.map((r: any) => ({
-      'Role ID': r.roleId ?? '',
-      Name: r.name ?? '',
-      Description: r.description ?? '',
-    }));
-    tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-    logger.table(tableData);
-  } catch (error) {
-    handleCommandError(logger, 'Failed to list roles', error);
-  }
+		let tableData = items.map((r) => ({
+			"Role ID": r.roleId ?? "",
+			Name: r.name ?? "",
+			Description: r.description ?? "",
+		}));
+		tableData = sortTableData(
+			tableData,
+			options.sortBy,
+			logger,
+			options.sortOrder,
+		);
+		logger.table(tableData);
+	} catch (error) {
+		handleCommandError(logger, "Failed to list roles", error);
+	}
 }
 
 /**
  * Search roles with filters
  */
 export async function searchIdentityRoles(options: {
-  profile?: string;
-  roleId?: string;
-  name?: string;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  limit?: number;
+	profile?: string;
+	roleId?: string;
+	name?: string;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	limit?: number;
 }): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const filter: any = {};
-    if (options.roleId) filter.roleId = options.roleId;
-    if (options.name) filter.name = options.name;
+	try {
+		const filter: Record<string, unknown> = {};
+		if (options.roleId) filter.roleId = options.roleId;
+		if (options.name) filter.name = options.name;
 
-    const searchFilter = Object.keys(filter).length > 0 ? { filter } : {};
+		const searchFilter = Object.keys(filter).length > 0 ? { filter } : {};
 
-    const items = await fetchAllPages(
-      (f: any, opts: any) => client.searchRoles(f, opts),
-      searchFilter,
-      undefined,
-      options.limit,
-    );
+		const items = await fetchAllPages(
+			(f, opts) => client.searchRoles(f, opts),
+			searchFilter,
+			undefined,
+			options.limit,
+		);
 
-    if (items.length === 0) {
-      logger.info('No roles found');
-      return;
-    }
+		if (items.length === 0) {
+			logger.info("No roles found");
+			return;
+		}
 
-    let tableData = items.map((r: any) => ({
-      'Role ID': r.roleId ?? '',
-      Name: r.name ?? '',
-      Description: r.description ?? '',
-    }));
-    tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-    logger.table(tableData);
-  } catch (error) {
-    handleCommandError(logger, 'Failed to search roles', error);
-  }
+		let tableData = items.map((r) => ({
+			"Role ID": r.roleId ?? "",
+			Name: r.name ?? "",
+			Description: r.description ?? "",
+		}));
+		tableData = sortTableData(
+			tableData,
+			options.sortBy,
+			logger,
+			options.sortOrder,
+		);
+		logger.table(tableData);
+	} catch (error) {
+		handleCommandError(logger, "Failed to search roles", error);
+	}
 }
 
 /**
  * Get a single role by roleId
  */
-export async function getIdentityRole(roleId: string, options: {
-  profile?: string;
-}): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+export async function getIdentityRole(
+	roleId: string,
+	options: {
+		profile?: string;
+	},
+): Promise<void> {
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const result = await client.getRole({ roleId: roleId }, { consistency: { waitUpToMs: 0 } });
-    logger.json(result);
-  } catch (error) {
-    handleCommandError(logger, `Failed to get role '${roleId}'`, error);
-  }
+	try {
+		const result = await client.getRole(
+			{ roleId: roleId },
+			{ consistency: { waitUpToMs: 0 } },
+		);
+		logger.json(result);
+	} catch (error) {
+		handleCommandError(logger, `Failed to get role '${roleId}'`, error);
+	}
 }
 
 /**
  * Create a new role
  */
 export async function createIdentityRole(options: {
-  profile?: string;
-  roleId?: string;
-  name?: string;
+	profile?: string;
+	roleId?: string;
+	name?: string;
 }): Promise<void> {
-  const logger = getLogger();
+	const logger = getLogger();
 
-  if (!options.roleId) {
-    logger.error('--roleId is required');
-    process.exit(1);
-  }
-  if (!options.name) {
-    logger.error('--name is required');
-    process.exit(1);
-  }
+	if (!options.roleId) {
+		logger.error("--roleId is required");
+		process.exit(1);
+	}
+	if (!options.name) {
+		logger.error("--name is required");
+		process.exit(1);
+	}
 
-  const body = { roleId: options.roleId, name: options.name };
+	const body = { roleId: options.roleId, name: options.name };
 
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    logger.json({
-      dryRun: true,
-      command: 'create role',
-      method: 'POST',
-      url: `${config.baseUrl}/roles`,
-      body,
-    });
-    return;
-  }
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		logger.json({
+			dryRun: true,
+			command: "create role",
+			method: "POST",
+			url: `${config.baseUrl}/roles`,
+			body,
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
+	const client = createClient(options.profile);
 
-  try {
-    await client.createRole(body);
-    logger.success(`Role '${options.name}' created`);
-  } catch (error) {
-    handleCommandError(logger, 'Failed to create role', error);
-  }
+	try {
+		await client.createRole(body);
+		logger.success(`Role '${options.name}' created`);
+	} catch (error) {
+		handleCommandError(logger, "Failed to create role", error);
+	}
 }
 
 /**
  * Delete a role by roleId
  */
-export async function deleteIdentityRole(roleId: string, options: {
-  profile?: string;
-}): Promise<void> {
-  const logger = getLogger();
+export async function deleteIdentityRole(
+	roleId: string,
+	options: {
+		profile?: string;
+	},
+): Promise<void> {
+	const logger = getLogger();
 
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    logger.json({
-      dryRun: true,
-      command: 'delete role',
-      method: 'DELETE',
-      url: `${config.baseUrl}/roles/${encodeURIComponent(roleId)}`,
-      body: null,
-    });
-    return;
-  }
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		logger.json({
+			dryRun: true,
+			command: "delete role",
+			method: "DELETE",
+			url: `${config.baseUrl}/roles/${encodeURIComponent(roleId)}`,
+			body: null,
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
+	const client = createClient(options.profile);
 
-  try {
-    await client.deleteRole({ roleId: roleId });
-    logger.success(`Role '${roleId}' deleted`);
-  } catch (error) {
-    handleCommandError(logger, `Failed to delete role '${roleId}'`, error);
-  }
+	try {
+		await client.deleteRole({ roleId: roleId });
+		logger.success(`Role '${roleId}' deleted`);
+	} catch (error) {
+		handleCommandError(logger, `Failed to delete role '${roleId}'`, error);
+	}
 }

--- a/src/commands/identity-roles.ts
+++ b/src/commands/identity-roles.ts
@@ -8,6 +8,8 @@ import { createClient, fetchAllPages } from '../client.ts';
 import { resolveClusterConfig } from '../config.ts';
 import { c8ctl } from '../runtime.ts';
 import { handleCommandError } from '../errors.ts';
+import type { createRoleInput } from '@camunda8/orchestration-cluster-api';
+import type { createRoleInput } from '@camunda8/orchestration-cluster-api';
 
 /**
  * List all roles
@@ -101,7 +103,7 @@ export async function getIdentityRole(roleId: string, options: {
   const client = createClient(options.profile);
 
   try {
-    const result = await client.getRole({ roleId: roleId as any }, { consistency: { waitUpToMs: 0 } });
+    const result = await client.getRole({ roleId: roleId }, { consistency: { waitUpToMs: 0 } });
     logger.json(result);
   } catch (error) {
     handleCommandError(logger, `Failed to get role '${roleId}'`, error);
@@ -139,7 +141,7 @@ export async function createIdentityRole(options: {
   const client = createClient(options.profile);
 
   try {
-    await client.createRole(body as any);
+    await client.createRole(body as createRoleInput);
     logger.success(`Role '${options.name}' created`);
   } catch (error) {
     handleCommandError(logger, 'Failed to create role', error);
@@ -169,7 +171,7 @@ export async function deleteIdentityRole(roleId: string, options: {
   const client = createClient(options.profile);
 
   try {
-    await client.deleteRole({ roleId: roleId as any });
+    await client.deleteRole({ roleId: roleId });
     logger.success(`Role '${roleId}' deleted`);
   } catch (error) {
     handleCommandError(logger, `Failed to delete role '${roleId}'`, error);

--- a/src/commands/identity-roles.ts
+++ b/src/commands/identity-roles.ts
@@ -8,7 +8,7 @@ import { createClient, fetchAllPages } from '../client.ts';
 import { resolveClusterConfig } from '../config.ts';
 import { c8ctl } from '../runtime.ts';
 import { handleCommandError } from '../errors.ts';
-import type { createRoleInput } from '@camunda8/orchestration-cluster-api';
+import type { RoleCreateRequest } from '@camunda8/orchestration-cluster-api';
 
 /**
  * List all roles
@@ -140,7 +140,7 @@ export async function createIdentityRole(options: {
   const client = createClient(options.profile);
 
   try {
-    await client.createRole(body);
+    await client.createRole(body as RoleCreateRequest);
     logger.success(`Role '${options.name}' created`);
   } catch (error) {
     handleCommandError(logger, 'Failed to create role', error);

--- a/src/commands/identity-roles.ts
+++ b/src/commands/identity-roles.ts
@@ -9,7 +9,6 @@ import { resolveClusterConfig } from '../config.ts';
 import { c8ctl } from '../runtime.ts';
 import { handleCommandError } from '../errors.ts';
 import type { createRoleInput } from '@camunda8/orchestration-cluster-api';
-import type { createRoleInput } from '@camunda8/orchestration-cluster-api';
 
 /**
  * List all roles
@@ -124,7 +123,7 @@ export async function createIdentityRole(options: {
     process.exit(1);
   }
 
-  const body: Record<string, unknown> = { name: options.name };
+  const body = { name: options.name };
 
   if (c8ctl.dryRun) {
     const config = resolveClusterConfig(options.profile);
@@ -141,7 +140,7 @@ export async function createIdentityRole(options: {
   const client = createClient(options.profile);
 
   try {
-    await client.createRole(body as createRoleInput);
+    await client.createRole(body);
     logger.success(`Role '${options.name}' created`);
   } catch (error) {
     handleCommandError(logger, 'Failed to create role', error);

--- a/src/commands/identity-roles.ts
+++ b/src/commands/identity-roles.ts
@@ -8,7 +8,6 @@ import { createClient, fetchAllPages } from '../client.ts';
 import { resolveClusterConfig } from '../config.ts';
 import { c8ctl } from '../runtime.ts';
 import { handleCommandError } from '../errors.ts';
-import type { RoleCreateRequest } from '@camunda8/orchestration-cluster-api';
 
 /**
  * List all roles
@@ -114,16 +113,21 @@ export async function getIdentityRole(roleId: string, options: {
  */
 export async function createIdentityRole(options: {
   profile?: string;
+  roleId?: string;
   name?: string;
 }): Promise<void> {
   const logger = getLogger();
 
+  if (!options.roleId) {
+    logger.error('--roleId is required');
+    process.exit(1);
+  }
   if (!options.name) {
     logger.error('--name is required');
     process.exit(1);
   }
 
-  const body = { name: options.name };
+  const body = { roleId: options.roleId, name: options.name };
 
   if (c8ctl.dryRun) {
     const config = resolveClusterConfig(options.profile);
@@ -140,7 +144,7 @@ export async function createIdentityRole(options: {
   const client = createClient(options.profile);
 
   try {
-    await client.createRole(body as RoleCreateRequest);
+    await client.createRole(body);
     logger.success(`Role '${options.name}' created`);
   } catch (error) {
     handleCommandError(logger, 'Failed to create role', error);

--- a/src/commands/identity-tenants.ts
+++ b/src/commands/identity-tenants.ts
@@ -8,6 +8,8 @@ import { createClient, fetchAllPages } from '../client.ts';
 import { resolveClusterConfig } from '../config.ts';
 import { c8ctl } from '../runtime.ts';
 import { handleCommandError } from '../errors.ts';
+import { TenantId } from '@camunda8/orchestration-cluster-api';
+import type { createTenantInput } from '@camunda8/orchestration-cluster-api';
 
 /**
  * List all tenants
@@ -101,7 +103,7 @@ export async function getIdentityTenant(tenantId: string, options: {
   const client = createClient(options.profile);
 
   try {
-    const result = await client.getTenant({ tenantId: tenantId as any }, { consistency: { waitUpToMs: 0 } });
+    const result = await client.getTenant({ tenantId: TenantId.assumeExists(tenantId) }, { consistency: { waitUpToMs: 0 } });
     logger.json(result);
   } catch (error) {
     handleCommandError(logger, `Failed to get tenant '${tenantId}'`, error);
@@ -147,7 +149,7 @@ export async function createIdentityTenant(options: {
   const client = createClient(options.profile);
 
   try {
-    await client.createTenant(body as any);
+    await client.createTenant(body as createTenantInput);
     logger.success(`Tenant '${options.tenantId}' created`);
   } catch (error) {
     handleCommandError(logger, 'Failed to create tenant', error);
@@ -177,7 +179,7 @@ export async function deleteIdentityTenant(tenantId: string, options: {
   const client = createClient(options.profile);
 
   try {
-    await client.deleteTenant({ tenantId: tenantId as any });
+    await client.deleteTenant({ tenantId: TenantId.assumeExists(tenantId) });
     logger.success(`Tenant '${tenantId}' deleted`);
   } catch (error) {
     handleCommandError(logger, `Failed to delete tenant '${tenantId}'`, error);

--- a/src/commands/identity-tenants.ts
+++ b/src/commands/identity-tenants.ts
@@ -9,7 +9,6 @@ import { resolveClusterConfig } from '../config.ts';
 import { c8ctl } from '../runtime.ts';
 import { handleCommandError } from '../errors.ts';
 import { TenantId } from '@camunda8/orchestration-cluster-api';
-import type { createTenantInput } from '@camunda8/orchestration-cluster-api';
 
 /**
  * List all tenants
@@ -129,7 +128,7 @@ export async function createIdentityTenant(options: {
     process.exit(1);
   }
 
-  const body: Record<string, unknown> = {
+  const body = {
     tenantId: options.tenantId,
     name: options.name,
   };
@@ -149,7 +148,7 @@ export async function createIdentityTenant(options: {
   const client = createClient(options.profile);
 
   try {
-    await client.createTenant(body as createTenantInput);
+    await client.createTenant(body);
     logger.success(`Tenant '${options.tenantId}' created`);
   } catch (error) {
     handleCommandError(logger, 'Failed to create tenant', error);

--- a/src/commands/identity-tenants.ts
+++ b/src/commands/identity-tenants.ts
@@ -2,185 +2,203 @@
  * Identity tenant commands
  */
 
-import { getLogger } from '../logger.ts';
-import { sortTableData, type SortOrder } from '../logger.ts';
-import { createClient, fetchAllPages } from '../client.ts';
-import { resolveClusterConfig } from '../config.ts';
-import { c8ctl } from '../runtime.ts';
-import { handleCommandError } from '../errors.ts';
-import { TenantId } from '@camunda8/orchestration-cluster-api';
+import { TenantId } from "@camunda8/orchestration-cluster-api";
+import { createClient, fetchAllPages } from "../client.ts";
+import { resolveClusterConfig } from "../config.ts";
+import { handleCommandError } from "../errors.ts";
+import { getLogger, type SortOrder, sortTableData } from "../logger.ts";
+import { c8ctl } from "../runtime.ts";
 
 /**
  * List all tenants
  */
 export async function listTenants(options: {
-  profile?: string;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  limit?: number;
+	profile?: string;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	limit?: number;
 }): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const items = await fetchAllPages(
-      (filter: any, opts: any) => client.searchTenants(filter, opts),
-      {},
-      undefined,
-      options.limit,
-    );
+	try {
+		const items = await fetchAllPages(
+			(filter, opts) => client.searchTenants(filter, opts),
+			{},
+			undefined,
+			options.limit,
+		);
 
-    if (items.length === 0) {
-      logger.info('No tenants found');
-      return;
-    }
+		if (items.length === 0) {
+			logger.info("No tenants found");
+			return;
+		}
 
-    let tableData = items.map((t: any) => ({
-      'Tenant ID': t.tenantId ?? '',
-      Name: t.name ?? '',
-      Description: t.description ?? '',
-    }));
-    tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-    logger.table(tableData);
-  } catch (error) {
-    handleCommandError(logger, 'Failed to list tenants', error);
-  }
+		let tableData = items.map((t) => ({
+			"Tenant ID": t.tenantId ?? "",
+			Name: t.name ?? "",
+			Description: t.description ?? "",
+		}));
+		tableData = sortTableData(
+			tableData,
+			options.sortBy,
+			logger,
+			options.sortOrder,
+		);
+		logger.table(tableData);
+	} catch (error) {
+		handleCommandError(logger, "Failed to list tenants", error);
+	}
 }
 
 /**
  * Search tenants with filters
  */
 export async function searchIdentityTenants(options: {
-  profile?: string;
-  tenantId?: string;
-  name?: string;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  limit?: number;
+	profile?: string;
+	tenantId?: string;
+	name?: string;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	limit?: number;
 }): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const filter: any = {};
-    if (options.tenantId) filter.tenantId = options.tenantId;
-    if (options.name) filter.name = options.name;
+	try {
+		const filter: Record<string, unknown> = {};
+		if (options.tenantId) filter.tenantId = options.tenantId;
+		if (options.name) filter.name = options.name;
 
-    const searchFilter = Object.keys(filter).length > 0 ? { filter } : {};
+		const searchFilter = Object.keys(filter).length > 0 ? { filter } : {};
 
-    const items = await fetchAllPages(
-      (f: any, opts: any) => client.searchTenants(f, opts),
-      searchFilter,
-      undefined,
-      options.limit,
-    );
+		const items = await fetchAllPages(
+			(f, opts) => client.searchTenants(f, opts),
+			searchFilter,
+			undefined,
+			options.limit,
+		);
 
-    if (items.length === 0) {
-      logger.info('No tenants found');
-      return;
-    }
+		if (items.length === 0) {
+			logger.info("No tenants found");
+			return;
+		}
 
-    let tableData = items.map((t: any) => ({
-      'Tenant ID': t.tenantId ?? '',
-      Name: t.name ?? '',
-      Description: t.description ?? '',
-    }));
-    tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-    logger.table(tableData);
-  } catch (error) {
-    handleCommandError(logger, 'Failed to search tenants', error);
-  }
+		let tableData = items.map((t) => ({
+			"Tenant ID": t.tenantId ?? "",
+			Name: t.name ?? "",
+			Description: t.description ?? "",
+		}));
+		tableData = sortTableData(
+			tableData,
+			options.sortBy,
+			logger,
+			options.sortOrder,
+		);
+		logger.table(tableData);
+	} catch (error) {
+		handleCommandError(logger, "Failed to search tenants", error);
+	}
 }
 
 /**
  * Get a single tenant by tenantId
  */
-export async function getIdentityTenant(tenantId: string, options: {
-  profile?: string;
-}): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+export async function getIdentityTenant(
+	tenantId: string,
+	options: {
+		profile?: string;
+	},
+): Promise<void> {
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const result = await client.getTenant({ tenantId: TenantId.assumeExists(tenantId) }, { consistency: { waitUpToMs: 0 } });
-    logger.json(result);
-  } catch (error) {
-    handleCommandError(logger, `Failed to get tenant '${tenantId}'`, error);
-  }
+	try {
+		const result = await client.getTenant(
+			{ tenantId: TenantId.assumeExists(tenantId) },
+			{ consistency: { waitUpToMs: 0 } },
+		);
+		logger.json(result);
+	} catch (error) {
+		handleCommandError(logger, `Failed to get tenant '${tenantId}'`, error);
+	}
 }
 
 /**
  * Create a new tenant
  */
 export async function createIdentityTenant(options: {
-  profile?: string;
-  tenantId?: string;
-  name?: string;
+	profile?: string;
+	tenantId?: string;
+	name?: string;
 }): Promise<void> {
-  const logger = getLogger();
+	const logger = getLogger();
 
-  if (!options.tenantId) {
-    logger.error('--tenantId is required');
-    process.exit(1);
-  }
-  if (!options.name) {
-    logger.error('--name is required');
-    process.exit(1);
-  }
+	if (!options.tenantId) {
+		logger.error("--tenantId is required");
+		process.exit(1);
+	}
+	if (!options.name) {
+		logger.error("--name is required");
+		process.exit(1);
+	}
 
-  const body = {
-    tenantId: options.tenantId,
-    name: options.name,
-  };
+	const body = {
+		tenantId: options.tenantId,
+		name: options.name,
+	};
 
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    logger.json({
-      dryRun: true,
-      command: 'create tenant',
-      method: 'POST',
-      url: `${config.baseUrl}/tenants`,
-      body,
-    });
-    return;
-  }
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		logger.json({
+			dryRun: true,
+			command: "create tenant",
+			method: "POST",
+			url: `${config.baseUrl}/tenants`,
+			body,
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
+	const client = createClient(options.profile);
 
-  try {
-    await client.createTenant(body);
-    logger.success(`Tenant '${options.tenantId}' created`);
-  } catch (error) {
-    handleCommandError(logger, 'Failed to create tenant', error);
-  }
+	try {
+		await client.createTenant(body);
+		logger.success(`Tenant '${options.tenantId}' created`);
+	} catch (error) {
+		handleCommandError(logger, "Failed to create tenant", error);
+	}
 }
 
 /**
  * Delete a tenant by tenantId
  */
-export async function deleteIdentityTenant(tenantId: string, options: {
-  profile?: string;
-}): Promise<void> {
-  const logger = getLogger();
+export async function deleteIdentityTenant(
+	tenantId: string,
+	options: {
+		profile?: string;
+	},
+): Promise<void> {
+	const logger = getLogger();
 
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    logger.json({
-      dryRun: true,
-      command: 'delete tenant',
-      method: 'DELETE',
-      url: `${config.baseUrl}/tenants/${encodeURIComponent(tenantId)}`,
-      body: null,
-    });
-    return;
-  }
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		logger.json({
+			dryRun: true,
+			command: "delete tenant",
+			method: "DELETE",
+			url: `${config.baseUrl}/tenants/${encodeURIComponent(tenantId)}`,
+			body: null,
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
+	const client = createClient(options.profile);
 
-  try {
-    await client.deleteTenant({ tenantId: TenantId.assumeExists(tenantId) });
-    logger.success(`Tenant '${tenantId}' deleted`);
-  } catch (error) {
-    handleCommandError(logger, `Failed to delete tenant '${tenantId}'`, error);
-  }
+	try {
+		await client.deleteTenant({ tenantId: TenantId.assumeExists(tenantId) });
+		logger.success(`Tenant '${tenantId}' deleted`);
+	} catch (error) {
+		handleCommandError(logger, `Failed to delete tenant '${tenantId}'`, error);
+	}
 }

--- a/src/commands/identity-users.ts
+++ b/src/commands/identity-users.ts
@@ -2,192 +2,210 @@
  * Identity user commands
  */
 
-import { getLogger } from '../logger.ts';
-import { sortTableData, type SortOrder } from '../logger.ts';
-import { createClient, fetchAllPages } from '../client.ts';
-import { resolveClusterConfig } from '../config.ts';
-import { c8ctl } from '../runtime.ts';
-import { handleCommandError } from '../errors.ts';
-import { Username } from '@camunda8/orchestration-cluster-api';
-import { toStringFilter } from './search.ts';
+import { Username } from "@camunda8/orchestration-cluster-api";
+import { createClient, fetchAllPages } from "../client.ts";
+import { resolveClusterConfig } from "../config.ts";
+import { handleCommandError } from "../errors.ts";
+import { getLogger, type SortOrder, sortTableData } from "../logger.ts";
+import { c8ctl } from "../runtime.ts";
+import { toStringFilter } from "./search.ts";
 
 /**
  * List all users
  */
 export async function listUsers(options: {
-  profile?: string;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  limit?: number;
+	profile?: string;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	limit?: number;
 }): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const items = await fetchAllPages(
-      (filter: any, opts: any) => client.searchUsers(filter, opts),
-      {},
-      undefined,
-      options.limit,
-    );
+	try {
+		const items = await fetchAllPages(
+			(filter, opts) => client.searchUsers(filter, opts),
+			{},
+			undefined,
+			options.limit,
+		);
 
-    if (items.length === 0) {
-      logger.info('No users found');
-      return;
-    }
+		if (items.length === 0) {
+			logger.info("No users found");
+			return;
+		}
 
-    let tableData = items.map((u: any) => ({
-      Username: u.username ?? '',
-      Name: u.name ?? '',
-      Email: u.email ?? '',
-    }));
-    tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-    logger.table(tableData);
-  } catch (error) {
-    handleCommandError(logger, 'Failed to list users', error);
-  }
+		let tableData = items.map((u) => ({
+			Username: u.username ?? "",
+			Name: u.name ?? "",
+			Email: u.email ?? "",
+		}));
+		tableData = sortTableData(
+			tableData,
+			options.sortBy,
+			logger,
+			options.sortOrder,
+		);
+		logger.table(tableData);
+	} catch (error) {
+		handleCommandError(logger, "Failed to list users", error);
+	}
 }
 
 /**
  * Search users with filters
  */
 export async function searchIdentityUsers(options: {
-  profile?: string;
-  username?: string;
-  name?: string;
-  email?: string;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  limit?: number;
+	profile?: string;
+	username?: string;
+	name?: string;
+	email?: string;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	limit?: number;
 }): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const filter: any = {};
-    if (options.username) filter.username = toStringFilter(options.username);
-    if (options.name) filter.name = toStringFilter(options.name);
-    if (options.email) filter.email = toStringFilter(options.email);
+	try {
+		const filter: Record<string, unknown> = {};
+		if (options.username) filter.username = toStringFilter(options.username);
+		if (options.name) filter.name = toStringFilter(options.name);
+		if (options.email) filter.email = toStringFilter(options.email);
 
-    const searchFilter = Object.keys(filter).length > 0 ? { filter } : {};
+		const searchFilter = Object.keys(filter).length > 0 ? { filter } : {};
 
-    const items = await fetchAllPages(
-      (f: any, opts: any) => client.searchUsers(f, opts),
-      searchFilter,
-      undefined,
-      options.limit,
-    );
+		const items = await fetchAllPages(
+			(f, opts) => client.searchUsers(f, opts),
+			searchFilter,
+			undefined,
+			options.limit,
+		);
 
-    if (items.length === 0) {
-      logger.info('No users found');
-      return;
-    }
+		if (items.length === 0) {
+			logger.info("No users found");
+			return;
+		}
 
-    let tableData = items.map((u: any) => ({
-      Username: u.username ?? '',
-      Name: u.name ?? '',
-      Email: u.email ?? '',
-    }));
-    tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-    logger.table(tableData);
-  } catch (error) {
-    handleCommandError(logger, 'Failed to search users', error);
-  }
+		let tableData = items.map((u) => ({
+			Username: u.username ?? "",
+			Name: u.name ?? "",
+			Email: u.email ?? "",
+		}));
+		tableData = sortTableData(
+			tableData,
+			options.sortBy,
+			logger,
+			options.sortOrder,
+		);
+		logger.table(tableData);
+	} catch (error) {
+		handleCommandError(logger, "Failed to search users", error);
+	}
 }
 
 /**
  * Get a single user by username
  */
-export async function getIdentityUser(username: string, options: {
-  profile?: string;
-}): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+export async function getIdentityUser(
+	username: string,
+	options: {
+		profile?: string;
+	},
+): Promise<void> {
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const result = await client.getUser({ username: Username.assumeExists(username) }, { consistency: { waitUpToMs: 0 } });
-    logger.json(result);
-  } catch (error) {
-    handleCommandError(logger, `Failed to get user '${username}'`, error);
-  }
+	try {
+		const result = await client.getUser(
+			{ username: Username.assumeExists(username) },
+			{ consistency: { waitUpToMs: 0 } },
+		);
+		logger.json(result);
+	} catch (error) {
+		handleCommandError(logger, `Failed to get user '${username}'`, error);
+	}
 }
 
 /**
  * Create a new user
  */
 export async function createIdentityUser(options: {
-  profile?: string;
-  username?: string;
-  name?: string;
-  email?: string;
-  password?: string;
+	profile?: string;
+	username?: string;
+	name?: string;
+	email?: string;
+	password?: string;
 }): Promise<void> {
-  const logger = getLogger();
+	const logger = getLogger();
 
-  if (!options.username) {
-    logger.error('--username is required');
-    process.exit(1);
-  }
-  if (!options.password) {
-    logger.error('--password is required');
-    process.exit(1);
-  }
+	if (!options.username) {
+		logger.error("--username is required");
+		process.exit(1);
+	}
+	if (!options.password) {
+		logger.error("--password is required");
+		process.exit(1);
+	}
 
-  const body = {
-    username: options.username,
-    password: options.password,
-    ...(options.name ? { name: options.name } : {}),
-    ...(options.email ? { email: options.email } : {}),
-  };
+	const body = {
+		username: options.username,
+		password: options.password,
+		...(options.name ? { name: options.name } : {}),
+		...(options.email ? { email: options.email } : {}),
+	};
 
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    logger.json({
-      dryRun: true,
-      command: 'create user',
-      method: 'POST',
-      url: `${config.baseUrl}/users`,
-      body,
-    });
-    return;
-  }
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		logger.json({
+			dryRun: true,
+			command: "create user",
+			method: "POST",
+			url: `${config.baseUrl}/users`,
+			body,
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
+	const client = createClient(options.profile);
 
-  try {
-    await client.createUser(body);
-    logger.success(`User '${options.username}' created`);
-  } catch (error) {
-    handleCommandError(logger, 'Failed to create user', error);
-  }
+	try {
+		await client.createUser(body);
+		logger.success(`User '${options.username}' created`);
+	} catch (error) {
+		handleCommandError(logger, "Failed to create user", error);
+	}
 }
 
 /**
  * Delete a user by username
  */
-export async function deleteIdentityUser(username: string, options: {
-  profile?: string;
-}): Promise<void> {
-  const logger = getLogger();
+export async function deleteIdentityUser(
+	username: string,
+	options: {
+		profile?: string;
+	},
+): Promise<void> {
+	const logger = getLogger();
 
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    logger.json({
-      dryRun: true,
-      command: 'delete user',
-      method: 'DELETE',
-      url: `${config.baseUrl}/users/${encodeURIComponent(username)}`,
-      body: null,
-    });
-    return;
-  }
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		logger.json({
+			dryRun: true,
+			command: "delete user",
+			method: "DELETE",
+			url: `${config.baseUrl}/users/${encodeURIComponent(username)}`,
+			body: null,
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
+	const client = createClient(options.profile);
 
-  try {
-    await client.deleteUser({ username: Username.assumeExists(username) });
-    logger.success(`User '${username}' deleted`);
-  } catch (error) {
-    handleCommandError(logger, `Failed to delete user '${username}'`, error);
-  }
+	try {
+		await client.deleteUser({ username: Username.assumeExists(username) });
+		logger.success(`User '${username}' deleted`);
+	} catch (error) {
+		handleCommandError(logger, `Failed to delete user '${username}'`, error);
+	}
 }

--- a/src/commands/identity-users.ts
+++ b/src/commands/identity-users.ts
@@ -9,7 +9,6 @@ import { resolveClusterConfig } from '../config.ts';
 import { c8ctl } from '../runtime.ts';
 import { handleCommandError } from '../errors.ts';
 import { Username } from '@camunda8/orchestration-cluster-api';
-import type { createUserInput } from '@camunda8/orchestration-cluster-api';
 import { toStringFilter } from './search.ts';
 
 /**
@@ -134,12 +133,12 @@ export async function createIdentityUser(options: {
     process.exit(1);
   }
 
-  const body: Record<string, unknown> = {
+  const body = {
     username: options.username,
     password: options.password,
+    ...(options.name ? { name: options.name } : {}),
+    ...(options.email ? { email: options.email } : {}),
   };
-  if (options.name) body.name = options.name;
-  if (options.email) body.email = options.email;
 
   if (c8ctl.dryRun) {
     const config = resolveClusterConfig(options.profile);
@@ -156,7 +155,7 @@ export async function createIdentityUser(options: {
   const client = createClient(options.profile);
 
   try {
-    await client.createUser(body as createUserInput);
+    await client.createUser(body);
     logger.success(`User '${options.username}' created`);
   } catch (error) {
     handleCommandError(logger, 'Failed to create user', error);

--- a/src/commands/identity-users.ts
+++ b/src/commands/identity-users.ts
@@ -8,6 +8,8 @@ import { createClient, fetchAllPages } from '../client.ts';
 import { resolveClusterConfig } from '../config.ts';
 import { c8ctl } from '../runtime.ts';
 import { handleCommandError } from '../errors.ts';
+import { Username } from '@camunda8/orchestration-cluster-api';
+import type { createUserInput } from '@camunda8/orchestration-cluster-api';
 import { toStringFilter } from './search.ts';
 
 /**
@@ -104,7 +106,7 @@ export async function getIdentityUser(username: string, options: {
   const client = createClient(options.profile);
 
   try {
-    const result = await client.getUser({ username: username as any }, { consistency: { waitUpToMs: 0 } });
+    const result = await client.getUser({ username: Username.assumeExists(username) }, { consistency: { waitUpToMs: 0 } });
     logger.json(result);
   } catch (error) {
     handleCommandError(logger, `Failed to get user '${username}'`, error);
@@ -154,7 +156,7 @@ export async function createIdentityUser(options: {
   const client = createClient(options.profile);
 
   try {
-    await client.createUser(body as any);
+    await client.createUser(body as createUserInput);
     logger.success(`User '${options.username}' created`);
   } catch (error) {
     handleCommandError(logger, 'Failed to create user', error);
@@ -184,7 +186,7 @@ export async function deleteIdentityUser(username: string, options: {
   const client = createClient(options.profile);
 
   try {
-    await client.deleteUser({ username: username as any });
+    await client.deleteUser({ username: Username.assumeExists(username) });
     logger.success(`User '${username}' deleted`);
   } catch (error) {
     handleCommandError(logger, `Failed to delete user '${username}'`, error);

--- a/src/commands/identity.ts
+++ b/src/commands/identity.ts
@@ -7,6 +7,7 @@ import { createClient } from '../client.ts';
 import { resolveClusterConfig } from '../config.ts';
 import { c8ctl } from '../runtime.ts';
 import { handleCommandError } from '../errors.ts';
+import { TenantId, Username } from '@camunda8/orchestration-cluster-api';
 
 // Re-exports
 export { listUsers, searchIdentityUsers, getIdentityUser, createIdentityUser, deleteIdentityUser } from './identity-users.ts';
@@ -103,16 +104,16 @@ export async function handleAssign(resource: string, id: string, values: Record<
     switch (resource) {
       case 'role': {
         if (values['to-user']) {
-          await client.assignRoleToUser({ roleId: id as any, username: values['to-user'] as any });
+          await client.assignRoleToUser({ roleId: id, username: Username.assumeExists(String(values['to-user'])) });
           logger.success(`Role '${id}' assigned to user '${values['to-user']}'`);
         } else if (values['to-group']) {
-          await client.assignRoleToGroup({ roleId: id as any, groupId: values['to-group'] as any });
+          await client.assignRoleToGroup({ roleId: id, groupId: String(values['to-group']) });
           logger.success(`Role '${id}' assigned to group '${values['to-group']}'`);
         } else if (values['to-tenant']) {
-          await client.assignRoleToTenant({ tenantId: values['to-tenant'] as any, roleId: id as any });
+          await client.assignRoleToTenant({ tenantId: TenantId.assumeExists(String(values['to-tenant'])), roleId: id });
           logger.success(`Role '${id}' assigned to tenant '${values['to-tenant']}'`);
         } else if (values['to-mapping-rule']) {
-          await client.assignRoleToMappingRule({ roleId: id as any, mappingRuleId: values['to-mapping-rule'] as any });
+          await client.assignRoleToMappingRule({ roleId: id, mappingRuleId: String(values['to-mapping-rule']) });
           logger.success(`Role '${id}' assigned to mapping rule '${values['to-mapping-rule']}'`);
         } else {
           logger.error('Target required. Use --to-user, --to-group, --to-tenant, or --to-mapping-rule.');
@@ -122,10 +123,10 @@ export async function handleAssign(resource: string, id: string, values: Record<
       }
       case 'user': {
         if (values['to-group']) {
-          await client.assignUserToGroup({ groupId: values['to-group'] as any, username: id as any });
+          await client.assignUserToGroup({ groupId: String(values['to-group']), username: Username.assumeExists(id) });
           logger.success(`User '${id}' assigned to group '${values['to-group']}'`);
         } else if (values['to-tenant']) {
-          await client.assignUserToTenant({ tenantId: values['to-tenant'] as any, username: id as any });
+          await client.assignUserToTenant({ tenantId: TenantId.assumeExists(String(values['to-tenant'])), username: Username.assumeExists(id) });
           logger.success(`User '${id}' assigned to tenant '${values['to-tenant']}'`);
         } else {
           logger.error('Target required. Use --to-group or --to-tenant.');
@@ -135,7 +136,7 @@ export async function handleAssign(resource: string, id: string, values: Record<
       }
       case 'group': {
         if (values['to-tenant']) {
-          await client.assignGroupToTenant({ tenantId: values['to-tenant'] as any, groupId: id as any });
+          await client.assignGroupToTenant({ tenantId: TenantId.assumeExists(String(values['to-tenant'])), groupId: id });
           logger.success(`Group '${id}' assigned to tenant '${values['to-tenant']}'`);
         } else {
           logger.error('Target required. Use --to-tenant.');
@@ -145,10 +146,10 @@ export async function handleAssign(resource: string, id: string, values: Record<
       }
       case 'mapping-rule': {
         if (values['to-group']) {
-          await client.assignMappingRuleToGroup({ groupId: values['to-group'] as any, mappingRuleId: id as any });
+          await client.assignMappingRuleToGroup({ groupId: String(values['to-group']), mappingRuleId: id });
           logger.success(`Mapping rule '${id}' assigned to group '${values['to-group']}'`);
         } else if (values['to-tenant']) {
-          await client.assignMappingRuleToTenant({ tenantId: values['to-tenant'] as any, mappingRuleId: id as any });
+          await client.assignMappingRuleToTenant({ tenantId: TenantId.assumeExists(String(values['to-tenant'])), mappingRuleId: id });
           logger.success(`Mapping rule '${id}' assigned to tenant '${values['to-tenant']}'`);
         } else {
           logger.error('Target required. Use --to-group or --to-tenant.');
@@ -216,16 +217,16 @@ export async function handleUnassign(resource: string, id: string, values: Recor
     switch (resource) {
       case 'role': {
         if (values['from-user']) {
-          await client.unassignRoleFromUser({ roleId: id as any, username: values['from-user'] as any });
+          await client.unassignRoleFromUser({ roleId: id, username: Username.assumeExists(String(values['from-user'])) });
           logger.success(`Role '${id}' unassigned from user '${values['from-user']}'`);
         } else if (values['from-group']) {
-          await client.unassignRoleFromGroup({ roleId: id as any, groupId: values['from-group'] as any });
+          await client.unassignRoleFromGroup({ roleId: id, groupId: String(values['from-group']) });
           logger.success(`Role '${id}' unassigned from group '${values['from-group']}'`);
         } else if (values['from-tenant']) {
-          await client.unassignRoleFromTenant({ tenantId: values['from-tenant'] as any, roleId: id as any });
+          await client.unassignRoleFromTenant({ tenantId: TenantId.assumeExists(String(values['from-tenant'])), roleId: id });
           logger.success(`Role '${id}' unassigned from tenant '${values['from-tenant']}'`);
         } else if (values['from-mapping-rule']) {
-          await client.unassignRoleFromMappingRule({ roleId: id as any, mappingRuleId: values['from-mapping-rule'] as any });
+          await client.unassignRoleFromMappingRule({ roleId: id, mappingRuleId: String(values['from-mapping-rule']) });
           logger.success(`Role '${id}' unassigned from mapping rule '${values['from-mapping-rule']}'`);
         } else {
           logger.error('Source required. Use --from-user, --from-group, --from-tenant, or --from-mapping-rule.');
@@ -235,10 +236,10 @@ export async function handleUnassign(resource: string, id: string, values: Recor
       }
       case 'user': {
         if (values['from-group']) {
-          await client.unassignUserFromGroup({ groupId: values['from-group'] as any, username: id as any });
+          await client.unassignUserFromGroup({ groupId: String(values['from-group']), username: Username.assumeExists(id) });
           logger.success(`User '${id}' unassigned from group '${values['from-group']}'`);
         } else if (values['from-tenant']) {
-          await client.unassignUserFromTenant({ tenantId: values['from-tenant'] as any, username: id as any });
+          await client.unassignUserFromTenant({ tenantId: TenantId.assumeExists(String(values['from-tenant'])), username: Username.assumeExists(id) });
           logger.success(`User '${id}' unassigned from tenant '${values['from-tenant']}'`);
         } else {
           logger.error('Source required. Use --from-group or --from-tenant.');
@@ -248,7 +249,7 @@ export async function handleUnassign(resource: string, id: string, values: Recor
       }
       case 'group': {
         if (values['from-tenant']) {
-          await client.unassignGroupFromTenant({ tenantId: values['from-tenant'] as any, groupId: id as any });
+          await client.unassignGroupFromTenant({ tenantId: TenantId.assumeExists(String(values['from-tenant'])), groupId: id });
           logger.success(`Group '${id}' unassigned from tenant '${values['from-tenant']}'`);
         } else {
           logger.error('Source required. Use --from-tenant.');
@@ -258,10 +259,10 @@ export async function handleUnassign(resource: string, id: string, values: Recor
       }
       case 'mapping-rule': {
         if (values['from-group']) {
-          await client.unassignMappingRuleFromGroup({ groupId: values['from-group'] as any, mappingRuleId: id as any });
+          await client.unassignMappingRuleFromGroup({ groupId: String(values['from-group']), mappingRuleId: id });
           logger.success(`Mapping rule '${id}' unassigned from group '${values['from-group']}'`);
         } else if (values['from-tenant']) {
-          await client.unassignMappingRuleFromTenant({ tenantId: values['from-tenant'] as any, mappingRuleId: id as any });
+          await client.unassignMappingRuleFromTenant({ tenantId: TenantId.assumeExists(String(values['from-tenant'])), mappingRuleId: id });
           logger.success(`Mapping rule '${id}' unassigned from tenant '${values['from-tenant']}'`);
         } else {
           logger.error('Source required. Use --from-group or --from-tenant.');

--- a/src/commands/identity.ts
+++ b/src/commands/identity.ts
@@ -2,279 +2,454 @@
  * Identity shared helpers and assignment dispatcher
  */
 
-import { getLogger } from '../logger.ts';
-import { createClient } from '../client.ts';
-import { resolveClusterConfig } from '../config.ts';
-import { c8ctl } from '../runtime.ts';
-import { handleCommandError } from '../errors.ts';
-import { TenantId, Username } from '@camunda8/orchestration-cluster-api';
+import { TenantId, Username } from "@camunda8/orchestration-cluster-api";
+import { createClient } from "../client.ts";
+import { resolveClusterConfig } from "../config.ts";
+import { handleCommandError } from "../errors.ts";
+import { getLogger } from "../logger.ts";
+import { c8ctl } from "../runtime.ts";
 
+export {
+	createIdentityAuthorization,
+	deleteIdentityAuthorization,
+	getIdentityAuthorization,
+	listAuthorizations,
+	searchIdentityAuthorizations,
+} from "./identity-authorizations.ts";
+export {
+	createIdentityGroup,
+	deleteIdentityGroup,
+	getIdentityGroup,
+	listGroups,
+	searchIdentityGroups,
+} from "./identity-groups.ts";
+export {
+	createIdentityMappingRule,
+	deleteIdentityMappingRule,
+	getIdentityMappingRule,
+	listMappingRules,
+	searchIdentityMappingRules,
+} from "./identity-mapping-rules.ts";
+export {
+	createIdentityRole,
+	deleteIdentityRole,
+	getIdentityRole,
+	listRoles,
+	searchIdentityRoles,
+} from "./identity-roles.ts";
+export {
+	createIdentityTenant,
+	deleteIdentityTenant,
+	getIdentityTenant,
+	listTenants,
+	searchIdentityTenants,
+} from "./identity-tenants.ts";
 // Re-exports
-export { listUsers, searchIdentityUsers, getIdentityUser, createIdentityUser, deleteIdentityUser } from './identity-users.ts';
-export { listRoles, searchIdentityRoles, getIdentityRole, createIdentityRole, deleteIdentityRole } from './identity-roles.ts';
-export { listGroups, searchIdentityGroups, getIdentityGroup, createIdentityGroup, deleteIdentityGroup } from './identity-groups.ts';
-export { listTenants, searchIdentityTenants, getIdentityTenant, createIdentityTenant, deleteIdentityTenant } from './identity-tenants.ts';
-export { listAuthorizations, searchIdentityAuthorizations, getIdentityAuthorization, createIdentityAuthorization, deleteIdentityAuthorization } from './identity-authorizations.ts';
-export { listMappingRules, searchIdentityMappingRules, getIdentityMappingRule, createIdentityMappingRule, deleteIdentityMappingRule } from './identity-mapping-rules.ts';
+export {
+	createIdentityUser,
+	deleteIdentityUser,
+	getIdentityUser,
+	listUsers,
+	searchIdentityUsers,
+} from "./identity-users.ts";
 
-type AssignTargetFlag = 'to-user' | 'to-group' | 'to-tenant' | 'to-mapping-rule';
-type UnassignSourceFlag = 'from-user' | 'from-group' | 'from-tenant' | 'from-mapping-rule';
+type AssignTargetFlag =
+	| "to-user"
+	| "to-group"
+	| "to-tenant"
+	| "to-mapping-rule";
+type UnassignSourceFlag =
+	| "from-user"
+	| "from-group"
+	| "from-tenant"
+	| "from-mapping-rule";
 
-const ASSIGN_TARGET_FLAGS: readonly AssignTargetFlag[] = ['to-user', 'to-group', 'to-tenant', 'to-mapping-rule'];
-const UNASSIGN_SOURCE_FLAGS: readonly UnassignSourceFlag[] = ['from-user', 'from-group', 'from-tenant', 'from-mapping-rule'];
+const ASSIGN_TARGET_FLAGS: readonly AssignTargetFlag[] = [
+	"to-user",
+	"to-group",
+	"to-tenant",
+	"to-mapping-rule",
+];
+const UNASSIGN_SOURCE_FLAGS: readonly UnassignSourceFlag[] = [
+	"from-user",
+	"from-group",
+	"from-tenant",
+	"from-mapping-rule",
+];
 
 /** Allowed --to-* flags per resource for assign */
 const ALLOWED_ASSIGN_TARGETS: Record<string, readonly AssignTargetFlag[]> = {
-  role: ['to-user', 'to-group', 'to-tenant', 'to-mapping-rule'],
-  user: ['to-group', 'to-tenant'],
-  group: ['to-tenant'],
-  'mapping-rule': ['to-group', 'to-tenant'],
+	role: ["to-user", "to-group", "to-tenant", "to-mapping-rule"],
+	user: ["to-group", "to-tenant"],
+	group: ["to-tenant"],
+	"mapping-rule": ["to-group", "to-tenant"],
 };
 
 /** Allowed --from-* flags per resource for unassign */
-const ALLOWED_UNASSIGN_SOURCES: Record<string, readonly UnassignSourceFlag[]> = {
-  role: ['from-user', 'from-group', 'from-tenant', 'from-mapping-rule'],
-  user: ['from-group', 'from-tenant'],
-  group: ['from-tenant'],
-  'mapping-rule': ['from-group', 'from-tenant'],
-};
+const ALLOWED_UNASSIGN_SOURCES: Record<string, readonly UnassignSourceFlag[]> =
+	{
+		role: ["from-user", "from-group", "from-tenant", "from-mapping-rule"],
+		user: ["from-group", "from-tenant"],
+		group: ["from-tenant"],
+		"mapping-rule": ["from-group", "from-tenant"],
+	};
 
 /** Plural path segment for each resource */
 const RESOURCE_PATHS: Record<string, string> = {
-  user: 'users',
-  role: 'roles',
-  group: 'groups',
-  tenant: 'tenants',
-  authorization: 'authorizations',
-  'mapping-rule': 'mapping-rules',
+	user: "users",
+	role: "roles",
+	group: "groups",
+	tenant: "tenants",
+	authorization: "authorizations",
+	"mapping-rule": "mapping-rules",
 };
 
 function formatFlags(flags: readonly string[]): string {
-  return flags.map(f => `--${f}`).join(', ');
+	return flags.map((f) => `--${f}`).join(", ");
 }
 
 /**
  * Handle assign command: c8 assign <resource> <id> --to-<target>=<targetId>
  */
-export async function handleAssign(resource: string, id: string, values: Record<string, unknown>, options: { profile?: string }): Promise<void> {
-  const logger = getLogger();
+export async function handleAssign(
+	resource: string,
+	id: string,
+	values: Record<string, unknown>,
+	options: { profile?: string },
+): Promise<void> {
+	const logger = getLogger();
 
-  const allowedTargets = ALLOWED_ASSIGN_TARGETS[resource];
-  if (!allowedTargets) {
-    logger.error(`Cannot assign resource type: ${resource}. Supported: ${Object.keys(ALLOWED_ASSIGN_TARGETS).join(', ')}.`);
-    process.exit(1);
-  }
+	const allowedTargets = ALLOWED_ASSIGN_TARGETS[resource];
+	if (!allowedTargets) {
+		logger.error(
+			`Cannot assign resource type: ${resource}. Supported: ${Object.keys(ALLOWED_ASSIGN_TARGETS).join(", ")}.`,
+		);
+		process.exit(1);
+	}
 
-  // Validate exactly one --to-* flag is provided
-  const provided = ASSIGN_TARGET_FLAGS.filter(f => values[f]);
-  if (provided.length > 1) {
-    logger.error(`Exactly one target flag is required. Conflicting flags: ${formatFlags(provided)}`);
-    process.exit(1);
-  }
-  if (provided.length === 0) {
-    logger.error(`Target required. Use ${formatFlags(allowedTargets)}.`);
-    process.exit(1);
-  }
+	// Validate exactly one --to-* flag is provided
+	const provided = ASSIGN_TARGET_FLAGS.filter((f) => values[f]);
+	if (provided.length > 1) {
+		logger.error(
+			`Exactly one target flag is required. Conflicting flags: ${formatFlags(provided)}`,
+		);
+		process.exit(1);
+	}
+	if (provided.length === 0) {
+		logger.error(`Target required. Use ${formatFlags(allowedTargets)}.`);
+		process.exit(1);
+	}
 
-  const targetFlag = provided[0];
-  if (!allowedTargets.includes(targetFlag)) {
-    logger.error(`Unsupported target flag --${targetFlag} for resource '${resource}'. Use ${formatFlags(allowedTargets)}.`);
-    process.exit(1);
-  }
+	const targetFlag = provided[0];
+	if (!allowedTargets.includes(targetFlag)) {
+		logger.error(
+			`Unsupported target flag --${targetFlag} for resource '${resource}'. Use ${formatFlags(allowedTargets)}.`,
+		);
+		process.exit(1);
+	}
 
-  const targetValue = values[targetFlag];
-  const resourcePath = RESOURCE_PATHS[resource];
-  const targetPath = targetFlag.replace(/^to-/, '') + 's';
+	const targetValue = values[targetFlag];
+	const resourcePath = RESOURCE_PATHS[resource];
+	const targetPath = `${targetFlag.replace(/^to-/, "")}s`;
 
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    logger.json({
-      dryRun: true,
-      command: 'assign',
-      method: 'POST',
-      url: `${config.baseUrl}/${resourcePath}/${encodeURIComponent(String(id))}/${targetPath}/${encodeURIComponent(String(targetValue))}`,
-      body: null,
-    });
-    return;
-  }
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		logger.json({
+			dryRun: true,
+			command: "assign",
+			method: "POST",
+			url: `${config.baseUrl}/${resourcePath}/${encodeURIComponent(String(id))}/${targetPath}/${encodeURIComponent(String(targetValue))}`,
+			body: null,
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
+	const client = createClient(options.profile);
 
-  try {
-    switch (resource) {
-      case 'role': {
-        if (values['to-user']) {
-          await client.assignRoleToUser({ roleId: id, username: Username.assumeExists(String(values['to-user'])) });
-          logger.success(`Role '${id}' assigned to user '${values['to-user']}'`);
-        } else if (values['to-group']) {
-          await client.assignRoleToGroup({ roleId: id, groupId: String(values['to-group']) });
-          logger.success(`Role '${id}' assigned to group '${values['to-group']}'`);
-        } else if (values['to-tenant']) {
-          await client.assignRoleToTenant({ tenantId: TenantId.assumeExists(String(values['to-tenant'])), roleId: id });
-          logger.success(`Role '${id}' assigned to tenant '${values['to-tenant']}'`);
-        } else if (values['to-mapping-rule']) {
-          await client.assignRoleToMappingRule({ roleId: id, mappingRuleId: String(values['to-mapping-rule']) });
-          logger.success(`Role '${id}' assigned to mapping rule '${values['to-mapping-rule']}'`);
-        } else {
-          logger.error('Target required. Use --to-user, --to-group, --to-tenant, or --to-mapping-rule.');
-          process.exit(1);
-        }
-        break;
-      }
-      case 'user': {
-        if (values['to-group']) {
-          await client.assignUserToGroup({ groupId: String(values['to-group']), username: Username.assumeExists(id) });
-          logger.success(`User '${id}' assigned to group '${values['to-group']}'`);
-        } else if (values['to-tenant']) {
-          await client.assignUserToTenant({ tenantId: TenantId.assumeExists(String(values['to-tenant'])), username: Username.assumeExists(id) });
-          logger.success(`User '${id}' assigned to tenant '${values['to-tenant']}'`);
-        } else {
-          logger.error('Target required. Use --to-group or --to-tenant.');
-          process.exit(1);
-        }
-        break;
-      }
-      case 'group': {
-        if (values['to-tenant']) {
-          await client.assignGroupToTenant({ tenantId: TenantId.assumeExists(String(values['to-tenant'])), groupId: id });
-          logger.success(`Group '${id}' assigned to tenant '${values['to-tenant']}'`);
-        } else {
-          logger.error('Target required. Use --to-tenant.');
-          process.exit(1);
-        }
-        break;
-      }
-      case 'mapping-rule': {
-        if (values['to-group']) {
-          await client.assignMappingRuleToGroup({ groupId: String(values['to-group']), mappingRuleId: id });
-          logger.success(`Mapping rule '${id}' assigned to group '${values['to-group']}'`);
-        } else if (values['to-tenant']) {
-          await client.assignMappingRuleToTenant({ tenantId: TenantId.assumeExists(String(values['to-tenant'])), mappingRuleId: id });
-          logger.success(`Mapping rule '${id}' assigned to tenant '${values['to-tenant']}'`);
-        } else {
-          logger.error('Target required. Use --to-group or --to-tenant.');
-          process.exit(1);
-        }
-        break;
-      }
-      default:
-        logger.error(`Cannot assign resource type: ${resource}. Supported: role, user, group, mapping-rule.`);
-        process.exit(1);
-    }
-  } catch (error) {
-    handleCommandError(logger, `Failed to assign ${resource}`, error);
-  }
+	try {
+		switch (resource) {
+			case "role": {
+				if (values["to-user"]) {
+					await client.assignRoleToUser({
+						roleId: id,
+						username: Username.assumeExists(String(values["to-user"])),
+					});
+					logger.success(
+						`Role '${id}' assigned to user '${values["to-user"]}'`,
+					);
+				} else if (values["to-group"]) {
+					await client.assignRoleToGroup({
+						roleId: id,
+						groupId: String(values["to-group"]),
+					});
+					logger.success(
+						`Role '${id}' assigned to group '${values["to-group"]}'`,
+					);
+				} else if (values["to-tenant"]) {
+					await client.assignRoleToTenant({
+						tenantId: TenantId.assumeExists(String(values["to-tenant"])),
+						roleId: id,
+					});
+					logger.success(
+						`Role '${id}' assigned to tenant '${values["to-tenant"]}'`,
+					);
+				} else if (values["to-mapping-rule"]) {
+					await client.assignRoleToMappingRule({
+						roleId: id,
+						mappingRuleId: String(values["to-mapping-rule"]),
+					});
+					logger.success(
+						`Role '${id}' assigned to mapping rule '${values["to-mapping-rule"]}'`,
+					);
+				} else {
+					logger.error(
+						"Target required. Use --to-user, --to-group, --to-tenant, or --to-mapping-rule.",
+					);
+					process.exit(1);
+				}
+				break;
+			}
+			case "user": {
+				if (values["to-group"]) {
+					await client.assignUserToGroup({
+						groupId: String(values["to-group"]),
+						username: Username.assumeExists(id),
+					});
+					logger.success(
+						`User '${id}' assigned to group '${values["to-group"]}'`,
+					);
+				} else if (values["to-tenant"]) {
+					await client.assignUserToTenant({
+						tenantId: TenantId.assumeExists(String(values["to-tenant"])),
+						username: Username.assumeExists(id),
+					});
+					logger.success(
+						`User '${id}' assigned to tenant '${values["to-tenant"]}'`,
+					);
+				} else {
+					logger.error("Target required. Use --to-group or --to-tenant.");
+					process.exit(1);
+				}
+				break;
+			}
+			case "group": {
+				if (values["to-tenant"]) {
+					await client.assignGroupToTenant({
+						tenantId: TenantId.assumeExists(String(values["to-tenant"])),
+						groupId: id,
+					});
+					logger.success(
+						`Group '${id}' assigned to tenant '${values["to-tenant"]}'`,
+					);
+				} else {
+					logger.error("Target required. Use --to-tenant.");
+					process.exit(1);
+				}
+				break;
+			}
+			case "mapping-rule": {
+				if (values["to-group"]) {
+					await client.assignMappingRuleToGroup({
+						groupId: String(values["to-group"]),
+						mappingRuleId: id,
+					});
+					logger.success(
+						`Mapping rule '${id}' assigned to group '${values["to-group"]}'`,
+					);
+				} else if (values["to-tenant"]) {
+					await client.assignMappingRuleToTenant({
+						tenantId: TenantId.assumeExists(String(values["to-tenant"])),
+						mappingRuleId: id,
+					});
+					logger.success(
+						`Mapping rule '${id}' assigned to tenant '${values["to-tenant"]}'`,
+					);
+				} else {
+					logger.error("Target required. Use --to-group or --to-tenant.");
+					process.exit(1);
+				}
+				break;
+			}
+			default:
+				logger.error(
+					`Cannot assign resource type: ${resource}. Supported: role, user, group, mapping-rule.`,
+				);
+				process.exit(1);
+		}
+	} catch (error) {
+		handleCommandError(logger, `Failed to assign ${resource}`, error);
+	}
 }
 
 /**
  * Handle unassign command: c8 unassign <resource> <id> --from-<target>=<targetId>
  */
-export async function handleUnassign(resource: string, id: string, values: Record<string, unknown>, options: { profile?: string }): Promise<void> {
-  const logger = getLogger();
+export async function handleUnassign(
+	resource: string,
+	id: string,
+	values: Record<string, unknown>,
+	options: { profile?: string },
+): Promise<void> {
+	const logger = getLogger();
 
-  const allowedSources = ALLOWED_UNASSIGN_SOURCES[resource];
-  if (!allowedSources) {
-    logger.error(`Cannot unassign resource type: ${resource}. Supported: ${Object.keys(ALLOWED_UNASSIGN_SOURCES).join(', ')}.`);
-    process.exit(1);
-  }
+	const allowedSources = ALLOWED_UNASSIGN_SOURCES[resource];
+	if (!allowedSources) {
+		logger.error(
+			`Cannot unassign resource type: ${resource}. Supported: ${Object.keys(ALLOWED_UNASSIGN_SOURCES).join(", ")}.`,
+		);
+		process.exit(1);
+	}
 
-  // Validate exactly one --from-* flag is provided
-  const provided = UNASSIGN_SOURCE_FLAGS.filter(f => values[f]);
-  if (provided.length > 1) {
-    logger.error(`Exactly one source flag is required. Conflicting flags: ${formatFlags(provided)}`);
-    process.exit(1);
-  }
-  if (provided.length === 0) {
-    logger.error(`Source required. Use ${formatFlags(allowedSources)}.`);
-    process.exit(1);
-  }
+	// Validate exactly one --from-* flag is provided
+	const provided = UNASSIGN_SOURCE_FLAGS.filter((f) => values[f]);
+	if (provided.length > 1) {
+		logger.error(
+			`Exactly one source flag is required. Conflicting flags: ${formatFlags(provided)}`,
+		);
+		process.exit(1);
+	}
+	if (provided.length === 0) {
+		logger.error(`Source required. Use ${formatFlags(allowedSources)}.`);
+		process.exit(1);
+	}
 
-  const sourceFlag = provided[0];
-  if (!allowedSources.includes(sourceFlag)) {
-    logger.error(`Unsupported source flag --${sourceFlag} for resource '${resource}'. Use ${formatFlags(allowedSources)}.`);
-    process.exit(1);
-  }
+	const sourceFlag = provided[0];
+	if (!allowedSources.includes(sourceFlag)) {
+		logger.error(
+			`Unsupported source flag --${sourceFlag} for resource '${resource}'. Use ${formatFlags(allowedSources)}.`,
+		);
+		process.exit(1);
+	}
 
-  const sourceValue = values[sourceFlag];
-  const resourcePath = RESOURCE_PATHS[resource];
-  const sourcePath = sourceFlag.replace(/^from-/, '') + 's';
+	const sourceValue = values[sourceFlag];
+	const resourcePath = RESOURCE_PATHS[resource];
+	const sourcePath = `${sourceFlag.replace(/^from-/, "")}s`;
 
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    logger.json({
-      dryRun: true,
-      command: 'unassign',
-      method: 'DELETE',
-      url: `${config.baseUrl}/${resourcePath}/${encodeURIComponent(String(id))}/${sourcePath}/${encodeURIComponent(String(sourceValue))}`,
-      body: null,
-    });
-    return;
-  }
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		logger.json({
+			dryRun: true,
+			command: "unassign",
+			method: "DELETE",
+			url: `${config.baseUrl}/${resourcePath}/${encodeURIComponent(String(id))}/${sourcePath}/${encodeURIComponent(String(sourceValue))}`,
+			body: null,
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
+	const client = createClient(options.profile);
 
-  try {
-    switch (resource) {
-      case 'role': {
-        if (values['from-user']) {
-          await client.unassignRoleFromUser({ roleId: id, username: Username.assumeExists(String(values['from-user'])) });
-          logger.success(`Role '${id}' unassigned from user '${values['from-user']}'`);
-        } else if (values['from-group']) {
-          await client.unassignRoleFromGroup({ roleId: id, groupId: String(values['from-group']) });
-          logger.success(`Role '${id}' unassigned from group '${values['from-group']}'`);
-        } else if (values['from-tenant']) {
-          await client.unassignRoleFromTenant({ tenantId: TenantId.assumeExists(String(values['from-tenant'])), roleId: id });
-          logger.success(`Role '${id}' unassigned from tenant '${values['from-tenant']}'`);
-        } else if (values['from-mapping-rule']) {
-          await client.unassignRoleFromMappingRule({ roleId: id, mappingRuleId: String(values['from-mapping-rule']) });
-          logger.success(`Role '${id}' unassigned from mapping rule '${values['from-mapping-rule']}'`);
-        } else {
-          logger.error('Source required. Use --from-user, --from-group, --from-tenant, or --from-mapping-rule.');
-          process.exit(1);
-        }
-        break;
-      }
-      case 'user': {
-        if (values['from-group']) {
-          await client.unassignUserFromGroup({ groupId: String(values['from-group']), username: Username.assumeExists(id) });
-          logger.success(`User '${id}' unassigned from group '${values['from-group']}'`);
-        } else if (values['from-tenant']) {
-          await client.unassignUserFromTenant({ tenantId: TenantId.assumeExists(String(values['from-tenant'])), username: Username.assumeExists(id) });
-          logger.success(`User '${id}' unassigned from tenant '${values['from-tenant']}'`);
-        } else {
-          logger.error('Source required. Use --from-group or --from-tenant.');
-          process.exit(1);
-        }
-        break;
-      }
-      case 'group': {
-        if (values['from-tenant']) {
-          await client.unassignGroupFromTenant({ tenantId: TenantId.assumeExists(String(values['from-tenant'])), groupId: id });
-          logger.success(`Group '${id}' unassigned from tenant '${values['from-tenant']}'`);
-        } else {
-          logger.error('Source required. Use --from-tenant.');
-          process.exit(1);
-        }
-        break;
-      }
-      case 'mapping-rule': {
-        if (values['from-group']) {
-          await client.unassignMappingRuleFromGroup({ groupId: String(values['from-group']), mappingRuleId: id });
-          logger.success(`Mapping rule '${id}' unassigned from group '${values['from-group']}'`);
-        } else if (values['from-tenant']) {
-          await client.unassignMappingRuleFromTenant({ tenantId: TenantId.assumeExists(String(values['from-tenant'])), mappingRuleId: id });
-          logger.success(`Mapping rule '${id}' unassigned from tenant '${values['from-tenant']}'`);
-        } else {
-          logger.error('Source required. Use --from-group or --from-tenant.');
-          process.exit(1);
-        }
-        break;
-      }
-      default:
-        logger.error(`Cannot unassign resource type: ${resource}. Supported: role, user, group, mapping-rule.`);
-        process.exit(1);
-    }
-  } catch (error) {
-    handleCommandError(logger, `Failed to unassign ${resource}`, error);
-  }
+	try {
+		switch (resource) {
+			case "role": {
+				if (values["from-user"]) {
+					await client.unassignRoleFromUser({
+						roleId: id,
+						username: Username.assumeExists(String(values["from-user"])),
+					});
+					logger.success(
+						`Role '${id}' unassigned from user '${values["from-user"]}'`,
+					);
+				} else if (values["from-group"]) {
+					await client.unassignRoleFromGroup({
+						roleId: id,
+						groupId: String(values["from-group"]),
+					});
+					logger.success(
+						`Role '${id}' unassigned from group '${values["from-group"]}'`,
+					);
+				} else if (values["from-tenant"]) {
+					await client.unassignRoleFromTenant({
+						tenantId: TenantId.assumeExists(String(values["from-tenant"])),
+						roleId: id,
+					});
+					logger.success(
+						`Role '${id}' unassigned from tenant '${values["from-tenant"]}'`,
+					);
+				} else if (values["from-mapping-rule"]) {
+					await client.unassignRoleFromMappingRule({
+						roleId: id,
+						mappingRuleId: String(values["from-mapping-rule"]),
+					});
+					logger.success(
+						`Role '${id}' unassigned from mapping rule '${values["from-mapping-rule"]}'`,
+					);
+				} else {
+					logger.error(
+						"Source required. Use --from-user, --from-group, --from-tenant, or --from-mapping-rule.",
+					);
+					process.exit(1);
+				}
+				break;
+			}
+			case "user": {
+				if (values["from-group"]) {
+					await client.unassignUserFromGroup({
+						groupId: String(values["from-group"]),
+						username: Username.assumeExists(id),
+					});
+					logger.success(
+						`User '${id}' unassigned from group '${values["from-group"]}'`,
+					);
+				} else if (values["from-tenant"]) {
+					await client.unassignUserFromTenant({
+						tenantId: TenantId.assumeExists(String(values["from-tenant"])),
+						username: Username.assumeExists(id),
+					});
+					logger.success(
+						`User '${id}' unassigned from tenant '${values["from-tenant"]}'`,
+					);
+				} else {
+					logger.error("Source required. Use --from-group or --from-tenant.");
+					process.exit(1);
+				}
+				break;
+			}
+			case "group": {
+				if (values["from-tenant"]) {
+					await client.unassignGroupFromTenant({
+						tenantId: TenantId.assumeExists(String(values["from-tenant"])),
+						groupId: id,
+					});
+					logger.success(
+						`Group '${id}' unassigned from tenant '${values["from-tenant"]}'`,
+					);
+				} else {
+					logger.error("Source required. Use --from-tenant.");
+					process.exit(1);
+				}
+				break;
+			}
+			case "mapping-rule": {
+				if (values["from-group"]) {
+					await client.unassignMappingRuleFromGroup({
+						groupId: String(values["from-group"]),
+						mappingRuleId: id,
+					});
+					logger.success(
+						`Mapping rule '${id}' unassigned from group '${values["from-group"]}'`,
+					);
+				} else if (values["from-tenant"]) {
+					await client.unassignMappingRuleFromTenant({
+						tenantId: TenantId.assumeExists(String(values["from-tenant"])),
+						mappingRuleId: id,
+					});
+					logger.success(
+						`Mapping rule '${id}' unassigned from tenant '${values["from-tenant"]}'`,
+					);
+				} else {
+					logger.error("Source required. Use --from-group or --from-tenant.");
+					process.exit(1);
+				}
+				break;
+			}
+			default:
+				logger.error(
+					`Cannot unassign resource type: ${resource}. Supported: role, user, group, mapping-rule.`,
+				);
+				process.exit(1);
+		}
+	} catch (error) {
+		handleCommandError(logger, `Failed to unassign ${resource}`, error);
+	}
 }

--- a/src/commands/incidents.ts
+++ b/src/commands/incidents.ts
@@ -89,7 +89,7 @@ export async function getIncident(key: string, options: {
   const client = createClient(options.profile);
 
   try {
-    const result = await client.getIncident({ incidentKey: key as any }, { consistency: { waitUpToMs: 0 } });
+    const result = await client.getIncident({ incidentKey: IncidentKey.assumeExists(key) }, { consistency: { waitUpToMs: 0 } });
     logger.json(result);
   } catch (error) {
     handleCommandError(logger, `Failed to get incident ${key}`, error);

--- a/src/commands/incidents.ts
+++ b/src/commands/incidents.ts
@@ -2,127 +2,144 @@
  * Incident commands
  */
 
-import { getLogger } from '../logger.ts';
-import { sortTableData, type SortOrder } from '../logger.ts';
-import { createClient, fetchAllPages } from '../client.ts';
-import { resolveTenantId, resolveClusterConfig } from '../config.ts';
-import { parseBetween, buildDateFilter } from '../date-filter.ts';
-import { c8ctl } from '../runtime.ts';
-import { IncidentKey } from '@camunda8/orchestration-cluster-api';
-import { handleCommandError } from '../errors.ts';
+import { IncidentKey } from "@camunda8/orchestration-cluster-api";
+import { createClient, fetchAllPages } from "../client.ts";
+import { resolveClusterConfig, resolveTenantId } from "../config.ts";
+import { buildDateFilter, parseBetween } from "../date-filter.ts";
+import { handleCommandError } from "../errors.ts";
+import { getLogger, type SortOrder, sortTableData } from "../logger.ts";
+import { c8ctl } from "../runtime.ts";
 
 /**
  * List incidents
  */
 export async function listIncidents(options: {
-  profile?: string;
-  state?: string;
-  processInstanceKey?: string;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  limit?: number;
-  between?: string;
+	profile?: string;
+	state?: string;
+	processInstanceKey?: string;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	limit?: number;
+	between?: string;
 }): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
-  const tenantId = resolveTenantId(options.profile);
+	const logger = getLogger();
+	const client = createClient(options.profile);
+	const tenantId = resolveTenantId(options.profile);
 
-  try {
-    const filter: any = {
-      filter: {
-        tenantId,
-      },
-    };
+	try {
+		const filter: { filter: Record<string, unknown> } = {
+			filter: {
+				tenantId,
+			},
+		};
 
-    if (options.state) {
-      filter.filter.state = options.state;
-    }
+		if (options.state) {
+			filter.filter.state = options.state;
+		}
 
-    if (options.processInstanceKey) {
-      filter.filter.processInstanceKey = options.processInstanceKey;
-    }
+		if (options.processInstanceKey) {
+			filter.filter.processInstanceKey = options.processInstanceKey;
+		}
 
-    if (options.between) {
-      const parsed = parseBetween(options.between);
-      if (parsed) {
-        filter.filter.creationTime = buildDateFilter(parsed.from, parsed.to);
-      } else {
-        logger.error('Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)');
-        process.exit(1);
-      }
-    }
+		if (options.between) {
+			const parsed = parseBetween(options.between);
+			if (parsed) {
+				filter.filter.creationTime = buildDateFilter(parsed.from, parsed.to);
+			} else {
+				logger.error(
+					"Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)",
+				);
+				process.exit(1);
+			}
+		}
 
-    const allItems = await fetchAllPages(
-      (f, opts) => client.searchIncidents(f, opts),
-      filter,
-      undefined,
-      options.limit,
-    );
-    
-    if (allItems.length > 0) {
-      let tableData = allItems.map((incident: any) => ({
-        Key: incident.incidentKey || incident.key,
-        Type: incident.errorType,
-        Message: incident.errorMessage?.substring(0, 50) || '',
-        State: incident.state,
-        Created: incident.creationTime || '-',
-        'Process Instance': incident.processInstanceKey,
-        'Tenant ID': incident.tenantId,
-      }));
-      tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-      logger.table(tableData);
-    } else {
-      logger.info('No incidents found');
-    }
-  } catch (error) {
-    handleCommandError(logger, 'Failed to list incidents', error);
-  }
+		const allItems = await fetchAllPages(
+			(f, opts) => client.searchIncidents(f, opts),
+			filter,
+			undefined,
+			options.limit,
+		);
+
+		if (allItems.length > 0) {
+			let tableData = allItems.map((incident) => ({
+				Key: incident.incidentKey,
+				Type: incident.errorType,
+				Message: incident.errorMessage?.substring(0, 50) || "",
+				State: incident.state,
+				Created: incident.creationTime || "-",
+				"Process Instance": incident.processInstanceKey,
+				"Tenant ID": incident.tenantId,
+			}));
+			tableData = sortTableData(
+				tableData,
+				options.sortBy,
+				logger,
+				options.sortOrder,
+			);
+			logger.table(tableData);
+		} else {
+			logger.info("No incidents found");
+		}
+	} catch (error) {
+		handleCommandError(logger, "Failed to list incidents", error);
+	}
 }
 
 /**
  * Get incident by key
  */
-export async function getIncident(key: string, options: {
-  profile?: string;
-}): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+export async function getIncident(
+	key: string,
+	options: {
+		profile?: string;
+	},
+): Promise<void> {
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const result = await client.getIncident({ incidentKey: IncidentKey.assumeExists(key) }, { consistency: { waitUpToMs: 0 } });
-    logger.json(result);
-  } catch (error) {
-    handleCommandError(logger, `Failed to get incident ${key}`, error);
-  }
+	try {
+		const result = await client.getIncident(
+			{ incidentKey: IncidentKey.assumeExists(key) },
+			{ consistency: { waitUpToMs: 0 } },
+		);
+		logger.json(result);
+	} catch (error) {
+		handleCommandError(logger, `Failed to get incident ${key}`, error);
+	}
 }
 
 /**
  * Resolve incident
  */
-export async function resolveIncident(key: string, options: {
-  profile?: string;
-}): Promise<void> {
-  const logger = getLogger();
+export async function resolveIncident(
+	key: string,
+	options: {
+		profile?: string;
+	},
+): Promise<void> {
+	const logger = getLogger();
 
-  // Dry-run: emit the would-be API request without executing
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    logger.json({
-      dryRun: true,
-      command: 'resolve incident',
-      method: 'POST',
-      url: `${config.baseUrl}/incidents/${key}/resolution`,
-      body: {},
-    });
-    return;
-  }
+	// Dry-run: emit the would-be API request without executing
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		logger.json({
+			dryRun: true,
+			command: "resolve incident",
+			method: "POST",
+			url: `${config.baseUrl}/incidents/${key}/resolution`,
+			body: {},
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
+	const client = createClient(options.profile);
 
-  try {
-    await client.resolveIncident({ incidentKey: IncidentKey.assumeExists(key) });
-    logger.success(`Incident ${key} resolved`);
-  } catch (error) {
-    handleCommandError(logger, `Failed to resolve incident ${key}`, error);
-  }
+	try {
+		await client.resolveIncident({
+			incidentKey: IncidentKey.assumeExists(key),
+		});
+		logger.success(`Incident ${key} resolved`);
+	} catch (error) {
+		handleCommandError(logger, `Failed to resolve incident ${key}`, error);
+	}
 }

--- a/src/commands/incidents.ts
+++ b/src/commands/incidents.ts
@@ -8,6 +8,7 @@ import { createClient, fetchAllPages } from '../client.ts';
 import { resolveTenantId, resolveClusterConfig } from '../config.ts';
 import { parseBetween, buildDateFilter } from '../date-filter.ts';
 import { c8ctl } from '../runtime.ts';
+import { IncidentKey } from '@camunda8/orchestration-cluster-api';
 import { handleCommandError } from '../errors.ts';
 
 /**
@@ -119,7 +120,7 @@ export async function resolveIncident(key: string, options: {
   const client = createClient(options.profile);
 
   try {
-    await client.resolveIncident({ incidentKey: key as any });
+    await client.resolveIncident({ incidentKey: IncidentKey.assumeExists(key) });
     logger.success(`Incident ${key} resolved`);
   } catch (error) {
     handleCommandError(logger, `Failed to resolve incident ${key}`, error);

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -2,230 +2,240 @@
  * Job commands
  */
 
-import { getLogger } from '../logger.ts';
-import { sortTableData, type SortOrder } from '../logger.ts';
-import { createClient, fetchAllPages } from '../client.ts';
-import { resolveTenantId, resolveClusterConfig } from '../config.ts';
-import { parseBetween, buildDateFilter } from '../date-filter.ts';
-import { c8ctl } from '../runtime.ts';
-import { handleCommandError } from '../errors.ts';
+import { JobKey, TenantId } from "@camunda8/orchestration-cluster-api";
+import { createClient, fetchAllPages } from "../client.ts";
+import { resolveClusterConfig, resolveTenantId } from "../config.ts";
+import { buildDateFilter, parseBetween } from "../date-filter.ts";
+import { handleCommandError } from "../errors.ts";
+import { getLogger, type SortOrder, sortTableData } from "../logger.ts";
+import { c8ctl } from "../runtime.ts";
 
 /**
  * List jobs
  */
 export async function listJobs(options: {
-  profile?: string;
-  state?: string;
-  type?: string;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  limit?: number;
-  between?: string;
-  dateField?: string;
+	profile?: string;
+	state?: string;
+	type?: string;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	limit?: number;
+	between?: string;
+	dateField?: string;
 }): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
-  const tenantId = resolveTenantId(options.profile);
+	const logger = getLogger();
+	const client = createClient(options.profile);
+	const tenantId = resolveTenantId(options.profile);
 
-  try {
-    const filter: any = {
-      filter: {
-        tenantId,
-      },
-    };
+	try {
+		const filter: { filter: Record<string, unknown> } = {
+			filter: {
+				tenantId,
+			},
+		};
 
-    if (options.state) {
-      filter.filter.state = options.state;
-    }
+		if (options.state) {
+			filter.filter.state = options.state;
+		}
 
-    if (options.type) {
-      filter.filter.type = options.type;
-    }
+		if (options.type) {
+			filter.filter.type = options.type;
+		}
 
-    if (options.between) {
-      const parsed = parseBetween(options.between);
-      if (parsed) {
-        const field = options.dateField ?? 'creationTime';
-        filter.filter[field] = buildDateFilter(parsed.from, parsed.to);
-      } else {
-        logger.error('Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)');
-        process.exit(1);
-      }
-    }
+		if (options.between) {
+			const parsed = parseBetween(options.between);
+			if (parsed) {
+				const field = options.dateField ?? "creationTime";
+				filter.filter[field] = buildDateFilter(parsed.from, parsed.to);
+			} else {
+				logger.error(
+					"Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)",
+				);
+				process.exit(1);
+			}
+		}
 
-    const allItems = await fetchAllPages(
-      (f, opts) => client.searchJobs(f, opts),
-      filter,
-      undefined,
-      options.limit,
-    );
-    
-    if (allItems.length > 0) {
-      let tableData = allItems.map((job: any) => ({
-        Key: job.jobKey || job.key,
-        Type: job.type,
-        State: job.state,
-        Retries: job.retries,
-        Created: job.creationTime || '-',
-        'Process Instance': job.processInstanceKey,
-        'Tenant ID': job.tenantId,
-      }));
-      tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-      logger.table(tableData);
-    } else {
-      logger.info('No jobs found');
-    }
-  } catch (error) {
-    handleCommandError(logger, 'Failed to list jobs', error);
-  }
+		const allItems = await fetchAllPages(
+			(f, opts) => client.searchJobs(f, opts),
+			filter,
+			undefined,
+			options.limit,
+		);
+
+		if (allItems.length > 0) {
+			let tableData = allItems.map((job) => ({
+				Key: job.jobKey,
+				Type: job.type,
+				State: job.state,
+				Retries: job.retries,
+				Created: job.creationTime || "-",
+				"Process Instance": job.processInstanceKey,
+				"Tenant ID": job.tenantId,
+			}));
+			tableData = sortTableData(
+				tableData,
+				options.sortBy,
+				logger,
+				options.sortOrder,
+			);
+			logger.table(tableData);
+		} else {
+			logger.info("No jobs found");
+		}
+	} catch (error) {
+		handleCommandError(logger, "Failed to list jobs", error);
+	}
 }
 
 /**
  * Activate jobs
  */
-export async function activateJobs(type: string, options: {
-  profile?: string;
-  maxJobsToActivate?: number;
-  timeout?: number;
-  worker?: string;
-}): Promise<void> {
-  const logger = getLogger();
+export async function activateJobs(
+	type: string,
+	options: {
+		profile?: string;
+		maxJobsToActivate?: number;
+		timeout?: number;
+		worker?: string;
+	},
+): Promise<void> {
+	const logger = getLogger();
 
-  // Dry-run: emit the would-be API request without executing
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    const tenantId = resolveTenantId(options.profile);
-    logger.json({
-      dryRun: true,
-      command: 'activate jobs',
-      method: 'POST',
-      url: `${config.baseUrl}/jobs/activation`,
-      body: {
-        type,
-        tenantIds: [tenantId],
-        maxJobsToActivate: options.maxJobsToActivate || 10,
-        timeout: options.timeout || 60000,
-        worker: options.worker || 'c8ctl',
-      },
-    });
-    return;
-  }
+	// Dry-run: emit the would-be API request without executing
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		const tenantId = resolveTenantId(options.profile);
+		logger.json({
+			dryRun: true,
+			command: "activate jobs",
+			method: "POST",
+			url: `${config.baseUrl}/jobs/activation`,
+			body: {
+				type,
+				tenantIds: [tenantId],
+				maxJobsToActivate: options.maxJobsToActivate || 10,
+				timeout: options.timeout || 60000,
+				worker: options.worker || "c8ctl",
+			},
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
-  const tenantId = resolveTenantId(options.profile);
+	const client = createClient(options.profile);
+	const tenantId = resolveTenantId(options.profile);
 
-  try {
-    const request: any = {
-      type,
-      tenantIds: [tenantId],
-      maxJobsToActivate: options.maxJobsToActivate || 10,
-      timeout: options.timeout || 60000,
-      worker: options.worker || 'c8ctl',
-    };
+	try {
+		const result = await client.activateJobs({
+			type,
+			tenantIds: [TenantId.assumeExists(tenantId)],
+			maxJobsToActivate: options.maxJobsToActivate || 10,
+			timeout: options.timeout || 60000,
+			worker: options.worker || "c8ctl",
+		});
 
-    const result = await client.activateJobs(request);
-    
-    if (result.jobs && result.jobs.length > 0) {
-      logger.success(`Activated ${result.jobs.length} jobs of type '${type}'`);
-      const tableData = result.jobs.map((job: any) => ({
-        Key: job.jobKey || job.key,
-        Type: job.type,
-        Retries: job.retries,
-        'Process Instance': job.processInstanceKey,
-      }));
-      logger.table(tableData);
-    } else {
-      logger.info(`No jobs of type '${type}' available to activate`);
-    }
-  } catch (error) {
-    handleCommandError(logger, `Failed to activate jobs of type '${type}'`, error);
-  }
+		if (result.jobs && result.jobs.length > 0) {
+			logger.success(`Activated ${result.jobs.length} jobs of type '${type}'`);
+			const tableData = result.jobs.map((job) => ({
+				Key: job.jobKey,
+				Type: job.type,
+				Retries: job.retries,
+				"Process Instance": job.processInstanceKey,
+			}));
+			logger.table(tableData);
+		} else {
+			logger.info(`No jobs of type '${type}' available to activate`);
+		}
+	} catch (error) {
+		handleCommandError(
+			logger,
+			`Failed to activate jobs of type '${type}'`,
+			error,
+		);
+	}
 }
 
 /**
  * Complete job
  */
-export async function completeJob(key: string, options: {
-  profile?: string;
-  variables?: string;
-}): Promise<void> {
-  const logger = getLogger();
+export async function completeJob(
+	key: string,
+	options: {
+		profile?: string;
+		variables?: string;
+	},
+): Promise<void> {
+	const logger = getLogger();
 
-  // Dry-run: emit the would-be API request without executing
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    const body: Record<string, unknown> = {};
-    if (options.variables) body.variables = JSON.parse(options.variables);
-    logger.json({
-      dryRun: true,
-      command: 'complete job',
-      method: 'POST',
-      url: `${config.baseUrl}/jobs/${key}/completion`,
-      body,
-    });
-    return;
-  }
+	// Dry-run: emit the would-be API request without executing
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		const body: Record<string, unknown> = {};
+		if (options.variables) body.variables = JSON.parse(options.variables);
+		logger.json({
+			dryRun: true,
+			command: "complete job",
+			method: "POST",
+			url: `${config.baseUrl}/jobs/${key}/completion`,
+			body,
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
+	const client = createClient(options.profile);
 
-  try {
-    const request: any = {
-      jobKey: key,
-    };
-
-    if (options.variables) {
-      try {
-        request.variables = JSON.parse(options.variables);
-      } catch (error) {
-        handleCommandError(logger, 'Invalid JSON for variables', error);
-      }
-    }
-
-    await client.completeJob(request);
-    logger.success(`Job ${key} completed`);
-  } catch (error) {
-    handleCommandError(logger, `Failed to complete job ${key}`, error);
-  }
+	try {
+		const variables = options.variables
+			? JSON.parse(options.variables)
+			: undefined;
+		await client.completeJob({
+			jobKey: JobKey.assumeExists(key),
+			...(variables !== undefined && { variables }),
+		});
+		logger.success(`Job ${key} completed`);
+	} catch (error) {
+		handleCommandError(logger, `Failed to complete job ${key}`, error);
+	}
 }
 
 /**
  * Fail job
  */
-export async function failJob(key: string, options: {
-  profile?: string;
-  retries?: number;
-  errorMessage?: string;
-}): Promise<void> {
-  const logger = getLogger();
+export async function failJob(
+	key: string,
+	options: {
+		profile?: string;
+		retries?: number;
+		errorMessage?: string;
+	},
+): Promise<void> {
+	const logger = getLogger();
 
-  // Dry-run: emit the would-be API request without executing
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    logger.json({
-      dryRun: true,
-      command: 'fail job',
-      method: 'POST',
-      url: `${config.baseUrl}/jobs/${key}/failure`,
-      body: {
-        retries: options.retries !== undefined ? options.retries : 0,
-        errorMessage: options.errorMessage || 'Job failed via c8ctl',
-      },
-    });
-    return;
-  }
+	// Dry-run: emit the would-be API request without executing
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		logger.json({
+			dryRun: true,
+			command: "fail job",
+			method: "POST",
+			url: `${config.baseUrl}/jobs/${key}/failure`,
+			body: {
+				retries: options.retries !== undefined ? options.retries : 0,
+				errorMessage: options.errorMessage || "Job failed via c8ctl",
+			},
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
+	const client = createClient(options.profile);
 
-  try {
-    const request: any = {
-      jobKey: key,
-      retries: options.retries !== undefined ? options.retries : 0,
-      errorMessage: options.errorMessage || 'Job failed via c8ctl',
-    };
-
-    await client.failJob(request);
-    logger.success(`Job ${key} failed`);
-  } catch (error) {
-    handleCommandError(logger, `Failed to fail job ${key}`, error);
-  }
+	try {
+		await client.failJob({
+			jobKey: JobKey.assumeExists(key),
+			retries: options.retries !== undefined ? options.retries : 0,
+			errorMessage: options.errorMessage || "Job failed via c8ctl",
+		});
+		logger.success(`Job ${key} failed`);
+	} catch (error) {
+		handleCommandError(logger, `Failed to fail job ${key}`, error);
+	}
 }

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -184,9 +184,15 @@ export async function completeJob(
 	const client = createClient(options.profile);
 
 	try {
-		const variables = options.variables
-			? JSON.parse(options.variables)
-			: undefined;
+		let variables: Record<string, unknown> | undefined;
+		if (options.variables) {
+			try {
+				variables = JSON.parse(options.variables);
+			} catch (error) {
+				handleCommandError(logger, "Invalid JSON for variables", error);
+				return;
+			}
+		}
 		await client.completeJob({
 			jobKey: JobKey.assumeExists(key),
 			...(variables !== undefined && { variables }),

--- a/src/commands/mcp-proxy.ts
+++ b/src/commands/mcp-proxy.ts
@@ -1,19 +1,20 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import type { CamundaClient } from "@camunda8/orchestration-cluster-api";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import {
-  ListToolsRequestSchema,
-  CallToolRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+	StreamableHTTPClientTransport,
+	StreamableHTTPError,
+} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
-  StreamableHTTPClientTransport,
-  StreamableHTTPError,
-} from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { type CamundaClient } from '@camunda8/orchestration-cluster-api';
-import { createClient } from '../client.ts';
-import { getVersion } from './help.ts';
-import { Logger, type LogWriter } from '../logger.ts';
-import { handleCommandError } from '../errors.ts';
+	CallToolRequestSchema,
+	ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { createClient } from "../client.ts";
+import { handleCommandError } from "../errors.ts";
+import { isRecord } from "../index.ts";
+import { Logger, type LogWriter } from "../logger.ts";
+import { getVersion } from "./help.ts";
 
 /**
  * Creates a custom fetch function that injects Camunda authentication headers
@@ -24,96 +25,99 @@ import { handleCommandError } from '../errors.ts';
  * @returns Custom fetch function compatible with MCP SDK transport
  */
 export function createCamundaFetch(
-  camundaClient: CamundaClient,
-  logger: Logger,
-  timeout: number = 60000,
+	camundaClient: CamundaClient,
+	logger: Logger,
+	timeout: number = 60000,
 ): typeof fetch {
-  return async (
-    input: string | URL | Request,
-    init?: RequestInit,
-  ): Promise<Response> => {
-    // Get fresh auth headers from orchestration-cluster-api
-    const authHeaders = await camundaClient.getAuthHeaders();
+	return async (
+		input: string | URL | Request,
+		init?: RequestInit,
+	): Promise<Response> => {
+		// Get fresh auth headers from orchestration-cluster-api
+		const authHeaders = await camundaClient.getAuthHeaders();
 
-    // Merge with existing headers
-    const headers = new Headers(init?.headers);
-    Object.entries(authHeaders).forEach(([key, value]) => {
-      headers.set(key, value);
-    });
+		// Merge with existing headers
+		const headers = new Headers(init?.headers);
+		Object.entries(authHeaders).forEach(([key, value]) => {
+			headers.set(key, value);
+		});
 
-    // Create timeout abort controller
-    const timeoutController = new AbortController();
-    const timeoutId = setTimeout(() => timeoutController.abort(), timeout);
+		// Create timeout abort controller
+		const timeoutController = new AbortController();
+		const timeoutId = setTimeout(() => timeoutController.abort(), timeout);
 
-    try {
-      // Merge abort signals (SDK's signal + timeout signal)
-      const signal = init?.signal
-        ? AbortSignal.any([init.signal, timeoutController.signal])
-        : timeoutController.signal;
+		try {
+			// Merge abort signals (SDK's signal + timeout signal)
+			const signal = init?.signal
+				? AbortSignal.any([init.signal, timeoutController.signal])
+				: timeoutController.signal;
 
-      // Make the request with merged headers
-      const response = await fetch(input, { ...init, headers, signal });
+			// Make the request with merged headers
+			const response = await fetch(input, { ...init, headers, signal });
 
-      // Handle 401 with token refresh and retry
-      if (response.status === 401) {
-        clearTimeout(timeoutId);
+			// Handle 401 with token refresh and retry
+			if (response.status === 401) {
+				clearTimeout(timeoutId);
 
-        logger.info(
-          'Received 401 (Unauthorized) response, attempting token refresh and retrying',
-        );
+				logger.info(
+					"Received 401 (Unauthorized) response, attempting token refresh and retrying",
+				);
 
-        // Force token refresh and rebuild headers
-        await camundaClient.forceAuthRefresh();
-        const freshHeaders = await camundaClient.getAuthHeaders();
-        const retryHeaders = new Headers(init?.headers);
-        Object.entries(freshHeaders).forEach(([key, value]) => {
-          retryHeaders.set(key, value);
-        });
+				// Force token refresh and rebuild headers
+				await camundaClient.forceAuthRefresh();
+				const freshHeaders = await camundaClient.getAuthHeaders();
+				const retryHeaders = new Headers(init?.headers);
+				Object.entries(freshHeaders).forEach(([key, value]) => {
+					retryHeaders.set(key, value);
+				});
 
-        // Retry with fresh token and timeout
-        const retryTimeoutController = new AbortController();
-        const retryTimeoutId = setTimeout(() => retryTimeoutController.abort(), timeout);
+				// Retry with fresh token and timeout
+				const retryTimeoutController = new AbortController();
+				const retryTimeoutId = setTimeout(
+					() => retryTimeoutController.abort(),
+					timeout,
+				);
 
-        try {
-          const retrySignal = init?.signal
-            ? AbortSignal.any([init.signal, retryTimeoutController.signal])
-            : retryTimeoutController.signal;
+				try {
+					const retrySignal = init?.signal
+						? AbortSignal.any([init.signal, retryTimeoutController.signal])
+						: retryTimeoutController.signal;
 
-          return await fetch(input, {
-            ...init,
-            headers: retryHeaders,
-            signal: retrySignal,
-          });
-        } finally {
-          clearTimeout(retryTimeoutId);
-        }
-      }
+					return await fetch(input, {
+						...init,
+						headers: retryHeaders,
+						signal: retrySignal,
+					});
+				} finally {
+					clearTimeout(retryTimeoutId);
+				}
+			}
 
-      clearTimeout(timeoutId);
-      return response;
-    } catch (error) {
-      clearTimeout(timeoutId);
+			clearTimeout(timeoutId);
+			return response;
+		} catch (error) {
+			clearTimeout(timeoutId);
 
-      // Convert AbortError to more descriptive timeout error
-      if (error instanceof Error && error.name === 'AbortError') {
-        throw new Error(`Request timeout after ${timeout}ms`);
-      }
+			// Convert AbortError to more descriptive timeout error
+			if (error instanceof Error && error.name === "AbortError") {
+				throw new Error(`Request timeout after ${timeout}ms`);
+			}
 
-      // Walk the cause chain to handle both Node 22 (shallow) and Node 24 (deeper nesting)
-      let cause: unknown = error instanceof Error ? error.cause : undefined;
-      while (cause != null) {
-        if (typeof cause === 'object' && cause !== null && 'code' in cause && (cause as { code?: string }).code === 'ECONNREFUSED') {
-          const url = typeof input === 'string' ? input : input.toString();
-          throw new Error(
-            `Connection refused: Unable to connect to ${url}. Please verify the server is running and accessible.`,
-          );
-        }
-        cause = typeof cause === 'object' && cause !== null && 'cause' in cause ? (cause as { cause: unknown }).cause : undefined;
-      }
+			// Walk the cause chain to handle both Node 22 (shallow) and Node 24 (deeper nesting)
+			let cause: unknown = error instanceof Error ? error.cause : undefined;
+			while (cause != null) {
+				if (isRecord(cause) && cause.code === "ECONNREFUSED") {
+					const url = typeof input === "string" ? input : input.toString();
+					throw new Error(
+						`Connection refused: Unable to connect to ${url}. Please verify the server is running and accessible.`,
+					);
+				}
+				cause = isRecord(cause) ? cause.cause : undefined;
+			}
 
-      throw error;
-    }
-  };
+			throw error;
+		}
+	};
 }
 
 /**
@@ -121,27 +125,30 @@ export function createCamundaFetch(
  * - If URL has no path or just "/", append "/mcp/cluster"
  * - If URL ends with "/v2" or "/v2/", replace with "/mcp/cluster"
  */
-export function normalizeRemoteMcpUrl(url: string, mcpServerPath: string): string {
-  try {
-    const urlObj = new URL(url);
+export function normalizeRemoteMcpUrl(
+	url: string,
+	mcpServerPath: string,
+): string {
+	try {
+		const urlObj = new URL(url);
 
-    // If path is empty or just "/", append MCP server path
-    if (urlObj.pathname === '' || urlObj.pathname === '/') {
-      urlObj.pathname = mcpServerPath;
-      return urlObj.toString();
-    }
+		// If path is empty or just "/", append MCP server path
+		if (urlObj.pathname === "" || urlObj.pathname === "/") {
+			urlObj.pathname = mcpServerPath;
+			return urlObj.toString();
+		}
 
-    // If path ends with "/v2" (with or without trailing slash), replace with MCP server path
-    if (urlObj.pathname.match(/\/v2\/?$/)) {
-      urlObj.pathname = urlObj.pathname.replace(/\/v2\/?$/, mcpServerPath);
-      return urlObj.toString();
-    }
+		// If path ends with "/v2" (with or without trailing slash), replace with MCP server path
+		if (urlObj.pathname.match(/\/v2\/?$/)) {
+			urlObj.pathname = urlObj.pathname.replace(/\/v2\/?$/, mcpServerPath);
+			return urlObj.toString();
+		}
 
-    // Already ends with MCP server path or has custom path - keep as is
-    return url;
-  } catch (e) {
-    return url;
-  }
+		// Already ends with MCP server path or has custom path - keep as is
+		return url;
+	} catch (_e) {
+		return url;
+	}
 }
 
 /**
@@ -155,238 +162,248 @@ export function normalizeRemoteMcpUrl(url: string, mcpServerPath: string): strin
  * Flow: MCP Client (STDIO) → Server → Client → StreamableHTTP + CamundaAuth → Remote MCP Server
  */
 class McpProxy {
-  private camundaClient: CamundaClient;
-  private logger: Logger;
+	private camundaClient: CamundaClient;
+	private logger: Logger;
 
-  private mcpRemoteUrl: string;
+	private mcpRemoteUrl: string;
 
-  private client: Client;
-  private clientTransport: StreamableHTTPClientTransport;
+	private client: Client;
+	private clientTransport: StreamableHTTPClientTransport;
 
-  private mcpServer: McpServer;
-  private serverTransport: StdioServerTransport | null = null;
+	private mcpServer: McpServer;
+	private serverTransport: StdioServerTransport | null = null;
 
-  constructor(
-    camundaClient: CamundaClient,
-    logger: Logger,
-    mcpServerPath: string,
-  ) {
-    this.camundaClient = camundaClient;
-    this.logger = logger;
+	constructor(
+		camundaClient: CamundaClient,
+		logger: Logger,
+		mcpServerPath: string,
+	) {
+		this.camundaClient = camundaClient;
+		this.logger = logger;
 
-    this.mcpRemoteUrl = normalizeRemoteMcpUrl(
-      this.camundaClient.getConfig().restAddress,
-      mcpServerPath,
-    );
+		this.mcpRemoteUrl = normalizeRemoteMcpUrl(
+			this.camundaClient.getConfig().restAddress,
+			mcpServerPath,
+		);
 
-    // Create transport to remote MCP server including custom fetch for Camunda authentication
-    this.clientTransport = new StreamableHTTPClientTransport(
-      new URL(this.mcpRemoteUrl),
-      {
-        fetch: createCamundaFetch(this.camundaClient, this.logger),
-      },
-    );
+		// Create transport to remote MCP server including custom fetch for Camunda authentication
+		this.clientTransport = new StreamableHTTPClientTransport(
+			new URL(this.mcpRemoteUrl),
+			{
+				fetch: createCamundaFetch(this.camundaClient, this.logger),
+			},
+		);
 
-    const version = getVersion();
+		const version = getVersion();
 
-    // Create MCP client to call remote server
-    this.client = new Client(
-      { name: 'c8ctl-mcp-proxy', version },
-      { capabilities: {} },
-    );
+		// Create MCP client to call remote server
+		this.client = new Client(
+			{ name: "c8ctl-mcp-proxy", version },
+			{ capabilities: {} },
+		);
 
-    // Initialize MCP server for STDIO (stateless mode - tools only)
-    this.mcpServer = new McpServer(
-      {
-        name: 'c8ctl-mcp-proxy',
-        version,
-      },
-      {
-        capabilities: {
-          // Only advertise tools capability
-          tools: {},
-        },
-      },
-    );
-  }
+		// Initialize MCP server for STDIO (stateless mode - tools only)
+		this.mcpServer = new McpServer(
+			{
+				name: "c8ctl-mcp-proxy",
+				version,
+			},
+			{
+				capabilities: {
+					// Only advertise tools capability
+					tools: {},
+				},
+			},
+		);
+	}
 
-  /**
-   * Start the proxy server
-   */
-  async start(): Promise<void> {
-    this.logger.info('Starting MCP proxy...');
-    this.logger.info(
-      `Connecting to remote MCP server at: ${this.mcpRemoteUrl}`,
-    );
+	/**
+	 * Start the proxy server
+	 */
+	async start(): Promise<void> {
+		this.logger.info("Starting MCP proxy...");
+		this.logger.info(
+			`Connecting to remote MCP server at: ${this.mcpRemoteUrl}`,
+		);
 
-    try {
-      // Verify authentication works by getting auth headers
-      const authStrategy = this.camundaClient.getConfig().auth.strategy;
-      if (authStrategy !== 'NONE') {
-        this.logger.debug(`Resolving ${authStrategy} authentication...`);
-        await this.camundaClient.getAuthHeaders();
-        this.logger.debug(
-          `${authStrategy} authentication resolved successfully`,
-        );
-      } else {
-        this.logger.info('No authentication configured (auth.strategy=NONE)');
-      }
+		try {
+			// Verify authentication works by getting auth headers
+			const authStrategy = this.camundaClient.getConfig().auth.strategy;
+			if (authStrategy !== "NONE") {
+				this.logger.debug(`Resolving ${authStrategy} authentication...`);
+				await this.camundaClient.getAuthHeaders();
+				this.logger.debug(
+					`${authStrategy} authentication resolved successfully`,
+				);
+			} else {
+				this.logger.info("No authentication configured (auth.strategy=NONE)");
+			}
 
-      // Connect client to remote server
-      this.logger.debug('Connecting to remote MCP server');
-      await this.client.connect(this.clientTransport);
-      this.logger.info('Connected to remote MCP server');
+			// Connect client to remote server
+			this.logger.debug("Connecting to remote MCP server");
+			await this.client.connect(this.clientTransport);
+			this.logger.info("Connected to remote MCP server");
 
-      // Set up request forwarding handlers
-      this.setupHandlers();
+			// Set up request forwarding handlers
+			this.setupHandlers();
 
-      // Create STDIO transport for local server
-      this.serverTransport = new StdioServerTransport();
+			// Create STDIO transport for local server
+			this.serverTransport = new StdioServerTransport();
 
-      // Connect server to STDIO transport
-      await this.mcpServer.connect(this.serverTransport);
+			// Connect server to STDIO transport
+			await this.mcpServer.connect(this.serverTransport);
 
-      this.logger.info('MCP proxy started successfully');
-    } catch (error) {
-      this.logger.error(
-        `Failed to start MCP proxy: ${error instanceof Error ? error.message : String(error)}`,
-      );
+			this.logger.info("MCP proxy started successfully");
+		} catch (error) {
+			this.logger.error(
+				`Failed to start MCP proxy: ${error instanceof Error ? error.message : String(error)}`,
+			);
 
-      if (error instanceof StreamableHTTPError && error.code === 404) {
-        this.logger.error(
-          'Please verify that the server is running and accessible and that the MCP gateway is enabled.',
-        );
-      }
+			if (error instanceof StreamableHTTPError && error.code === 404) {
+				this.logger.error(
+					"Please verify that the server is running and accessible and that the MCP gateway is enabled.",
+				);
+			}
 
-      throw error;
-    }
-  }
+			throw error;
+		}
+	}
 
-  /**
-   * Stop the proxy server
-   */
-  async stop(): Promise<void> {
-    this.logger.info('Stopping MCP proxy...');
+	/**
+	 * Stop the proxy server
+	 */
+	async stop(): Promise<void> {
+		this.logger.info("Stopping MCP proxy...");
 
-    try {
-      // Close server (internally closes serverTransport)
-      await this.mcpServer.close();
+		try {
+			// Close server (internally closes serverTransport)
+			await this.mcpServer.close();
 
-      // Close client (internally closes clientTransport)
-      await this.client.close();
+			// Close client (internally closes clientTransport)
+			await this.client.close();
 
-      this.logger.debug('MCP proxy stopped');
-    } catch (error) {
-      this.logger.error(
-        `Error during shutdown: ${error instanceof Error ? error.message : String(error)}`,
-      );
-    }
-  }
+			this.logger.debug("MCP proxy stopped");
+		} catch (error) {
+			this.logger.error(
+				`Error during shutdown: ${error instanceof Error ? error.message : String(error)}`,
+			);
+		}
+	}
 
-  /**
-   * Set up request forwarding handlers for tools only (stateless mode)
-   * Forwards requests from STDIO server to remote MCP client
-   */
-  private setupHandlers(): void {
-    // Forward tools/list to remote server
-    this.mcpServer.server.setRequestHandler(ListToolsRequestSchema, async (request) => {
-      this.logger.debug('Forwarding tools/list request');
-      try {
-        const result = await this.client.listTools(request.params);
-        this.logger.debug('Received tools/list response');
-        return result;
-      } catch (error) {
-        this.logger.error(
-          'Failed to forward tools/list',
-          error instanceof Error ? error : undefined,
-        );
-        throw error;
-      }
-    });
+	/**
+	 * Set up request forwarding handlers for tools only (stateless mode)
+	 * Forwards requests from STDIO server to remote MCP client
+	 */
+	private setupHandlers(): void {
+		// Forward tools/list to remote server
+		this.mcpServer.server.setRequestHandler(
+			ListToolsRequestSchema,
+			async (request) => {
+				this.logger.debug("Forwarding tools/list request");
+				try {
+					const result = await this.client.listTools(request.params);
+					this.logger.debug("Received tools/list response");
+					return result;
+				} catch (error) {
+					this.logger.error(
+						"Failed to forward tools/list",
+						error instanceof Error ? error : undefined,
+					);
+					throw error;
+				}
+			},
+		);
 
-    // Forward tools/call to remote server
-    this.mcpServer.server.setRequestHandler(CallToolRequestSchema, async (request) => {
-      this.logger.debug(`Forwarding tools/call: ${request.params?.name}`);
-      try {
-        const result = await this.client.callTool(request.params);
-        this.logger.debug(
-          `Received tools/call response: ${request.params?.name}`,
-        );
-        return result;
-      } catch (error) {
-        this.logger.error(
-          `Failed to forward tools/call: ${request.params?.name}`,
-          error instanceof Error ? error : undefined,
-        );
-        throw error;
-      }
-    });
+		// Forward tools/call to remote server
+		this.mcpServer.server.setRequestHandler(
+			CallToolRequestSchema,
+			async (request) => {
+				this.logger.debug(`Forwarding tools/call: ${request.params?.name}`);
+				try {
+					const result = await this.client.callTool(request.params);
+					this.logger.debug(
+						`Received tools/call response: ${request.params?.name}`,
+					);
+					return result;
+				} catch (error) {
+					this.logger.error(
+						`Failed to forward tools/call: ${request.params?.name}`,
+						error instanceof Error ? error : undefined,
+					);
+					throw error;
+				}
+			},
+		);
 
-    this.logger.debug(
-      'Request handlers registered (tools only, stateless mode)',
-    );
-  }
+		this.logger.debug(
+			"Request handlers registered (tools only, stateless mode)",
+		);
+	}
 }
 
 async function runProxy(
-  camundaClient: CamundaClient,
-  logger: Logger,
-  mcpServerPath: string,
+	camundaClient: CamundaClient,
+	logger: Logger,
+	mcpServerPath: string,
 ) {
-  let proxy: McpProxy | null = null;
+	let proxy: McpProxy | null = null;
 
-  try {
-    // Create and start proxy
-    proxy = new McpProxy(camundaClient, logger, mcpServerPath);
-    await proxy.start();
+	try {
+		// Create and start proxy
+		proxy = new McpProxy(camundaClient, logger, mcpServerPath);
+		await proxy.start();
 
-    // Handle graceful shutdown
-    const shutdown = async (signal: string) => {
-      logger.info(`Received ${signal}, shutting down gracefully...`);
-      if (proxy) {
-        await proxy.stop();
-      }
-      process.exit(0);
-    };
+		// Handle graceful shutdown
+		const shutdown = async (signal: string) => {
+			logger.info(`Received ${signal}, shutting down gracefully...`);
+			if (proxy) {
+				await proxy.stop();
+			}
+			process.exit(0);
+		};
 
-    process.on('SIGINT', () => shutdown('SIGINT'));
-    process.on('SIGTERM', () => shutdown('SIGTERM'));
+		process.on("SIGINT", () => shutdown("SIGINT"));
+		process.on("SIGTERM", () => shutdown("SIGTERM"));
 
-    // Keep process alive
-    await new Promise(() => {});
-  } catch (error) {
-    if (proxy) {
-      await proxy.stop().catch(() => {});
-    }
-    handleCommandError(logger, 'Failed to run MCP proxy. Shutting down...', error);
-  }
+		// Keep process alive
+		await new Promise(() => {});
+	} catch (error) {
+		if (proxy) {
+			await proxy.stop().catch(() => {});
+		}
+		handleCommandError(
+			logger,
+			"Failed to run MCP proxy. Shutting down...",
+			error,
+		);
+	}
 }
 
 /**
  * Run STDIO to remote HTTP MCP proxy with Camunda authentication
  */
 export async function mcpProxy(
-  args: string[],
-  options: { profile?: string },
+	args: string[],
+	options: { profile?: string },
 ): Promise<void> {
-  const stderrLogWriter: LogWriter = {
-    log(...data: any[]): void {
-      console.error(...data);
-    },
-    error(...data: any[]): void {
-      console.error(...data);
-    },
-  };
+	const stderrLogWriter: LogWriter = {
+		log(...data: unknown[]): void {
+			console.error(...data);
+		},
+		error(...data: unknown[]): void {
+			console.error(...data);
+		},
+	};
 
-  const logger = new Logger(stderrLogWriter);
-  const camundaClient = createClient(options.profile, {
-    log: {
-      transport: (evt) => {
-        logger.json(evt);
-      },
-    },
-  });
+	const logger = new Logger(stderrLogWriter);
+	const camundaClient = createClient(options.profile, {
+		log: {
+			transport: (evt) => {
+				logger.json(evt);
+			},
+		},
+	});
 
-  const mcpServerPath = args[0] ?? '/mcp/cluster';
-  await runProxy(camundaClient, logger, mcpServerPath);
+	const mcpServerPath = args[0] ?? "/mcp/cluster";
+	await runProxy(camundaClient, logger, mcpServerPath);
 }

--- a/src/commands/messages.ts
+++ b/src/commands/messages.ts
@@ -2,107 +2,113 @@
  * Message commands
  */
 
-import { getLogger } from '../logger.ts';
-import { createClient } from '../client.ts';
-import { resolveTenantId, resolveClusterConfig } from '../config.ts';
-import { c8ctl } from '../runtime.ts';
-import { handleCommandError } from '../errors.ts';
+import { TenantId } from "@camunda8/orchestration-cluster-api";
+import { createClient } from "../client.ts";
+import { resolveClusterConfig, resolveTenantId } from "../config.ts";
+import { handleCommandError } from "../errors.ts";
+import { getLogger } from "../logger.ts";
+import { c8ctl } from "../runtime.ts";
 
 /**
  * Publish message
  */
-export async function publishMessage(name: string, options: {
-  profile?: string;
-  correlationKey?: string;
-  variables?: string;
-  timeToLive?: number;
-}): Promise<void> {
-  const logger = getLogger();
+export async function publishMessage(
+	name: string,
+	options: {
+		profile?: string;
+		correlationKey?: string;
+		variables?: string;
+		timeToLive?: number;
+	},
+): Promise<void> {
+	const logger = getLogger();
 
-  // Dry-run: emit the would-be API request without executing
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    const tenantId = resolveTenantId(options.profile);
-    const body: Record<string, unknown> = {
-      name,
-      tenantId,
-      correlationKey: options.correlationKey || '',
-    };
-    if (options.variables) body.variables = JSON.parse(options.variables);
-    if (options.timeToLive !== undefined) body.timeToLive = options.timeToLive;
-    logger.json({
-      dryRun: true,
-      command: 'publish message',
-      method: 'POST',
-      url: `${config.baseUrl}/messages/publication`,
-      body,
-    });
-    return;
-  }
+	// Dry-run: emit the would-be API request without executing
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		const tenantId = resolveTenantId(options.profile);
+		const body: Record<string, unknown> = {
+			name,
+			tenantId,
+			correlationKey: options.correlationKey || "",
+		};
+		if (options.variables) body.variables = JSON.parse(options.variables);
+		if (options.timeToLive !== undefined) body.timeToLive = options.timeToLive;
+		logger.json({
+			dryRun: true,
+			command: "publish message",
+			method: "POST",
+			url: `${config.baseUrl}/messages/publication`,
+			body,
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
-  const tenantId = resolveTenantId(options.profile);
+	const client = createClient(options.profile);
+	const tenantId = resolveTenantId(options.profile);
 
-  try {
-    const request: any = {
-      name,
-      tenantId,
-      correlationKey: options.correlationKey || '',
-    };
+	try {
+		let variables: Record<string, unknown> | undefined;
+		if (options.variables) {
+			try {
+				variables = JSON.parse(options.variables);
+			} catch (error) {
+				handleCommandError(logger, "Invalid JSON for variables", error);
+			}
+		}
 
-    if (options.variables) {
-      try {
-        request.variables = JSON.parse(options.variables);
-      } catch (error) {
-        handleCommandError(logger, 'Invalid JSON for variables', error);
-      }
-    }
-
-    if (options.timeToLive !== undefined) {
-      request.timeToLive = options.timeToLive;
-    }
-
-    await client.publishMessage(request);
-    logger.success(`Message '${name}' published`);
-  } catch (error) {
-    handleCommandError(logger, `Failed to publish message '${name}'`, error);
-  }
+		await client.publishMessage({
+			name,
+			tenantId: TenantId.assumeExists(tenantId),
+			correlationKey: options.correlationKey || "",
+			...(variables !== undefined && { variables }),
+			...(options.timeToLive !== undefined && {
+				timeToLive: options.timeToLive,
+			}),
+		});
+		logger.success(`Message '${name}' published`);
+	} catch (error) {
+		handleCommandError(logger, `Failed to publish message '${name}'`, error);
+	}
 }
 
 /**
  * Correlate message
  */
-export async function correlateMessage(name: string, options: {
-  profile?: string;
-  correlationKey?: string;
-  variables?: string;
-  timeToLive?: number;
-}): Promise<void> {
-  const logger = getLogger();
+export async function correlateMessage(
+	name: string,
+	options: {
+		profile?: string;
+		correlationKey?: string;
+		variables?: string;
+		timeToLive?: number;
+	},
+): Promise<void> {
+	const logger = getLogger();
 
-  // Dry-run: emit the would-be API request without executing (uses correlation endpoint)
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    const tenantId = resolveTenantId(options.profile);
-    const body: Record<string, unknown> = {
-      name,
-      tenantId,
-      correlationKey: options.correlationKey || '',
-    };
-    if (options.variables) body.variables = JSON.parse(options.variables);
-    if (options.timeToLive !== undefined) body.timeToLive = options.timeToLive;
-    logger.json({
-      dryRun: true,
-      command: 'correlate message',
-      method: 'POST',
-      url: `${config.baseUrl}/messages/correlation`,
-      body,
-      note: 'SDK limitation: actual execution currently uses /messages/publication endpoint',
-    });
-    return;
-  }
+	// Dry-run: emit the would-be API request without executing (uses correlation endpoint)
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		const tenantId = resolveTenantId(options.profile);
+		const body: Record<string, unknown> = {
+			name,
+			tenantId,
+			correlationKey: options.correlationKey || "",
+		};
+		if (options.variables) body.variables = JSON.parse(options.variables);
+		if (options.timeToLive !== undefined) body.timeToLive = options.timeToLive;
+		logger.json({
+			dryRun: true,
+			command: "correlate message",
+			method: "POST",
+			url: `${config.baseUrl}/messages/correlation`,
+			body,
+			note: "SDK limitation: actual execution currently uses /messages/publication endpoint",
+		});
+		return;
+	}
 
-  // For now, correlate is the same as publish in most cases
-  // In the SDK, both use the same underlying method
-  await publishMessage(name, options);
+	// For now, correlate is the same as publish in most cases
+	// In the SDK, both use the same underlying method
+	await publishMessage(name, options);
 }

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -2,13 +2,23 @@
  * Open command - opens Camunda web applications in a browser
  */
 
-import { spawn } from 'node:child_process';
-import { platform } from 'node:os';
-import { getLogger } from '../logger.ts';
-import { resolveClusterConfig } from '../config.ts';
+import { spawn } from "node:child_process";
+import { platform } from "node:os";
+import { resolveClusterConfig } from "../config.ts";
+import { getLogger } from "../logger.ts";
 
-export const OPEN_APPS = ['operate', 'tasklist', 'modeler', 'optimize'] as const;
-export type AppName = typeof OPEN_APPS[number];
+export const OPEN_APPS = [
+	"operate",
+	"tasklist",
+	"modeler",
+	"optimize",
+] as const;
+export type AppName = (typeof OPEN_APPS)[number];
+
+export function isAppName(value: string): value is AppName {
+	// biome-ignore lint/plugin: safe widening — readonly tuple to readonly string[] for .includes() compatibility
+	return (OPEN_APPS as readonly string[]).includes(value);
+}
 
 /** Pattern that matches a self-managed REST API version suffix, e.g. `/v2` */
 const VERSION_SUFFIX_RE = /\/v\d+\/?$/;
@@ -21,11 +31,11 @@ const VERSION_SUFFIX_RE = /\/v\d+\/?$/;
  * does not look like a self-managed gateway (no `/v<n>` suffix).
  */
 export function deriveAppUrl(baseUrl: string, app: AppName): string | null {
-  if (!VERSION_SUFFIX_RE.test(baseUrl)) {
-    return null;
-  }
-  const base = baseUrl.replace(VERSION_SUFFIX_RE, '').replace(/\/$/, '');
-  return `${base}/${app}`;
+	if (!VERSION_SUFFIX_RE.test(baseUrl)) {
+		return null;
+	}
+	const base = baseUrl.replace(VERSION_SUFFIX_RE, "").replace(/\/$/, "");
+	return `${base}/${app}`;
 }
 
 /**
@@ -37,20 +47,21 @@ export function deriveAppUrl(baseUrl: string, app: AppName): string | null {
  * Accepts optional overrides for testing.
  */
 export function getBrowserCommand(
-  url: string,
-  plat: NodeJS.Platform = platform(),
-  env: Record<string, string | undefined> = process.env,
+	url: string,
+	plat: NodeJS.Platform = platform(),
+	env: Record<string, string | undefined> = process.env,
 ): { command: string; args: string[] } {
-  const isWsl = plat === 'linux' && Boolean(env.WSL_DISTRO_NAME || env.WSL_INTEROP);
+	const isWsl =
+		plat === "linux" && Boolean(env.WSL_DISTRO_NAME || env.WSL_INTEROP);
 
-  if (plat === 'darwin') {
-    return { command: 'open', args: [url] };
-  }
-  if (plat === 'win32' || isWsl) {
-    return { command: 'cmd.exe', args: ['/c', 'start', '', url] };
-  }
-  // Linux
-  return { command: 'xdg-open', args: [url] };
+	if (plat === "darwin") {
+		return { command: "open", args: [url] };
+	}
+	if (plat === "win32" || isWsl) {
+		return { command: "cmd.exe", args: ["/c", "start", "", url] };
+	}
+	// Linux
+	return { command: "xdg-open", args: [url] };
 }
 
 /**
@@ -58,52 +69,61 @@ export function getBrowserCommand(
  * Works on macOS, Linux, native Windows, and WSL.
  */
 export function openUrl(url: string): void {
-  const logger = getLogger();
-  const { command, args } = getBrowserCommand(url);
-  const child = spawn(command, args, { detached: true, stdio: 'ignore' });
+	const logger = getLogger();
+	const { command, args } = getBrowserCommand(url);
+	const child = spawn(command, args, { detached: true, stdio: "ignore" });
 
-  child.on('error', (error: NodeJS.ErrnoException) => {
-    if (error.code === 'ENOENT') {
-      logger.error(`Could not open the browser automatically because '${command}' is not available on PATH.`);
-      logger.info(`Open this URL manually: ${url}`);
-      return;
-    }
-    logger.error(`Could not open the browser automatically: ${error.message}`);
-    logger.info(`Open this URL manually: ${url}`);
-  });
+	child.on("error", (error: NodeJS.ErrnoException) => {
+		if (error.code === "ENOENT") {
+			logger.error(
+				`Could not open the browser automatically because '${command}' is not available on PATH.`,
+			);
+			logger.info(`Open this URL manually: ${url}`);
+			return;
+		}
+		logger.error(`Could not open the browser automatically: ${error.message}`);
+		logger.info(`Open this URL manually: ${url}`);
+	});
 
-  child.unref();
+	child.unref();
 }
 
 /**
  * Open a Camunda web application in the default browser.
  */
-export async function openApp(app: string | undefined, options: { profile?: string; dryRun?: boolean }): Promise<void> {
-  const logger = getLogger();
+export async function openApp(
+	app: string | undefined,
+	options: { profile?: string; dryRun?: boolean },
+): Promise<void> {
+	const logger = getLogger();
 
-  if (!app) {
-    logger.error(`Application required. Available: ${OPEN_APPS.join(', ')}`);
-    logger.info('Usage: c8 open <app> [--profile <name>]');
-    process.exit(1);
-  }
+	if (!app) {
+		logger.error(`Application required. Available: ${OPEN_APPS.join(", ")}`);
+		logger.info("Usage: c8 open <app> [--profile <name>]");
+		process.exit(1);
+	}
 
-  if (!(OPEN_APPS as readonly string[]).includes(app)) {
-    logger.error(`Unknown application '${app}'. Available: ${OPEN_APPS.join(', ')}`);
-    logger.info('Usage: c8 open <app> [--profile <name>]');
-    process.exit(1);
-  }
+	if (!isAppName(app)) {
+		logger.error(
+			`Unknown application '${app}'. Available: ${OPEN_APPS.join(", ")}`,
+		);
+		logger.info("Usage: c8 open <app> [--profile <name>]");
+		process.exit(1);
+	}
 
-  const config = resolveClusterConfig(options.profile);
-  const url = deriveAppUrl(config.baseUrl, app as AppName);
+	const config = resolveClusterConfig(options.profile);
+	const url = deriveAppUrl(config.baseUrl, app);
 
-  if (!url) {
-    logger.error(`Cannot derive ${app} URL from base URL: ${config.baseUrl}`);
-    logger.info('The open command is only supported for self-managed clusters whose base URL ends with /v<n> (e.g. http://localhost:8080/v2).');
-    process.exit(1);
-  }
+	if (!url) {
+		logger.error(`Cannot derive ${app} URL from base URL: ${config.baseUrl}`);
+		logger.info(
+			"The open command is only supported for self-managed clusters whose base URL ends with /v<n> (e.g. http://localhost:8080/v2).",
+		);
+		process.exit(1);
+	}
 
-  logger.info(`Opening ${app} at: ${url}`);
-  if (!options.dryRun) {
-    openUrl(url);
-  }
+	logger.info(`Opening ${app} at: ${url}`);
+	if (!options.dryRun) {
+		openUrl(url);
+	}
 }

--- a/src/commands/plugins.ts
+++ b/src/commands/plugins.ts
@@ -2,42 +2,51 @@
  * Plugin management commands
  */
 
-import { getLogger } from '../logger.ts';
-import { execFileSync, execSync } from 'node:child_process';
-import { readFileSync, existsSync, readdirSync, rmSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { clearLoadedPlugins } from '../plugin-loader.ts';
-import { ensurePluginsDir } from '../config.ts';
+import { execFileSync, execSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { ensurePluginsDir } from "../config.ts";
+import { handleCommandError } from "../errors.ts";
+import { getLogger } from "../logger.ts";
+import { clearLoadedPlugins } from "../plugin-loader.ts";
 import {
-  addPluginToRegistry,
-  removePluginFromRegistry,
-  getRegisteredPlugins,
-  isPluginRegistered,
-  getPluginEntry
-} from '../plugin-registry.ts';
-import { handleCommandError } from '../errors.ts';
+	addPluginToRegistry,
+	getPluginEntry,
+	getRegisteredPlugins,
+	isPluginRegistered,
+	removePluginFromRegistry,
+} from "../plugin-registry.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-type NpmListOutput = { dependencies?: Record<string, unknown> };
-type ExecFileErrorWithStdout = Error & { status?: number; stdout?: Buffer | string };
+type ExecFileErrorWithStdout = Error & {
+	status?: number;
+	stdout?: Buffer | string;
+};
+
+function isExecFileError(error: unknown): error is ExecFileErrorWithStdout {
+	return error instanceof Error && "stdout" in error;
+}
 
 function isAcceptedUrl(input: string): boolean {
-  return /^(https?:\/\/|git(\+https|\+ssh)?:\/\/|file:\/\/?)/i.test(input);
+	return /^(https?:\/\/|git(\+https|\+ssh)?:\/\/|file:\/\/?)/i.test(input);
 }
 
 function getTemplate(templateFileName: string): string {
-  const templatePath = join(__dirname, '..', 'templates', templateFileName);
-  return readFileSync(templatePath, 'utf-8');
+	const templatePath = join(__dirname, "..", "templates", templateFileName);
+	return readFileSync(templatePath, "utf-8");
 }
 
-function renderTemplate(templateFileName: string, replacements: Record<string, string> = {}): string {
-  let content = getTemplate(templateFileName);
-  for (const [key, value] of Object.entries(replacements)) {
-    content = content.replaceAll(`{{${key}}}`, value);
-  }
-  return content;
+function renderTemplate(
+	templateFileName: string,
+	replacements: Record<string, string> = {},
+): string {
+	let content = getTemplate(templateFileName);
+	for (const [key, value] of Object.entries(replacements)) {
+		content = content.replaceAll(`{{${key}}}`, value);
+	}
+	return content;
 }
 
 /**
@@ -45,193 +54,233 @@ function renderTemplate(templateFileName: string, replacements: Record<string, s
  * Supports either package name or --from flag with URL
  * Installs to global plugins directory
  */
-export async function loadPlugin(packageName?: string, fromUrl?: string): Promise<void> {
-  const logger = getLogger();
-  
-  // Validate input
-  if (fromUrl && packageName) {
-    logger.error('Cannot specify both a positional argument and --from flag. Use either "c8 load plugin <name>" or "c8 load plugin --from <url>"');
-    process.exit(1);
-  }
-  
-  if (!packageName && !fromUrl) {
-    logger.error('Package name or URL required. Usage: c8 load plugin <name> or c8 load plugin --from <url>');
-    process.exit(1);
-  }
-  
-  if (fromUrl && !isAcceptedUrl(fromUrl)) {
-    logger.error('Invalid URL format. Accepted URL formats include file://, https://, git:// (see help for more)');
-    process.exit(1);
-  }
-  
-  if (packageName && isAcceptedUrl(packageName)) {
-    logger.error('Package name cannot be a URL. If you want to load from a URL, use the --from flag. Usage: c8 load plugin --from <url>');
-    process.exit(1);
-  }
-  
-  // Get global plugins directory
-  const pluginsDir = ensurePluginsDir();
-  
-  try {
-    let pluginName: string;
-    let pluginSource: string;
-    
-    if (fromUrl) {
-      // Snapshot existing plugins before installation so we can identify the new one
-      const existingPluginNames = getInstalledPluginNames(pluginsDir);
+export async function loadPlugin(
+	packageName?: string,
+	fromUrl?: string,
+): Promise<void> {
+	const logger = getLogger();
 
-      // Install from URL (file://, https://, git://, etc.)
-      logger.info(`Loading plugin from: ${fromUrl}...`);
-      execSync(`npm install ${fromUrl} --prefix "${pluginsDir}"`, { stdio: 'inherit' });
-      
-      // Extract package name from installed package
-      pluginName = extractPackageNameFromUrl(fromUrl, pluginsDir, existingPluginNames);
-      pluginSource = fromUrl;
-      
-      // Validate plugin name
-      if (!pluginName || pluginName.trim() === '') {
-        logger.error('Failed to extract plugin name from URL');
-        logger.info('Ensure the URL points to a valid npm package with a package.json file');
-        process.exit(1);
-      }
-      
-      logger.success('Plugin loaded successfully from URL', fromUrl);
-    } else {
-      // Install from npm registry by package name
-      logger.info(`Loading plugin: ${packageName}...`);
-      execSync(`npm install ${packageName} --prefix "${pluginsDir}"`, { stdio: 'inherit' });
-      
-      pluginName = packageName!;
-      pluginSource = packageName!;
-      
-      logger.success('Plugin loaded successfully', packageName);
-    }
-    
-    // Add to plugin registry
-    addPluginToRegistry(pluginName, pluginSource);
-    logger.debug(`Added ${pluginName} to plugin registry`);
-    
-    // Note: Plugin will be available on next CLI invocation
-    // We don't reload in the same process to avoid module cache issues
-    logger.info('Plugin will be available on next command execution');
-  } catch (error) {
-    handleCommandError(logger, 'Failed to load plugin', error, [
-      'Check that the plugin name/URL is correct and you have network access if loading from a remote source',
-    ]);
-  }
+	// Validate input
+	if (fromUrl && packageName) {
+		logger.error(
+			'Cannot specify both a positional argument and --from flag. Use either "c8 load plugin <name>" or "c8 load plugin --from <url>"',
+		);
+		process.exit(1);
+	}
+
+	if (!packageName && !fromUrl) {
+		logger.error(
+			"Package name or URL required. Usage: c8 load plugin <name> or c8 load plugin --from <url>",
+		);
+		process.exit(1);
+	}
+
+	if (fromUrl && !isAcceptedUrl(fromUrl)) {
+		logger.error(
+			"Invalid URL format. Accepted URL formats include file://, https://, git:// (see help for more)",
+		);
+		process.exit(1);
+	}
+
+	if (packageName && isAcceptedUrl(packageName)) {
+		logger.error(
+			"Package name cannot be a URL. If you want to load from a URL, use the --from flag. Usage: c8 load plugin --from <url>",
+		);
+		process.exit(1);
+	}
+
+	// Get global plugins directory
+	const pluginsDir = ensurePluginsDir();
+
+	try {
+		let pluginName: string;
+		let pluginSource: string;
+
+		if (fromUrl) {
+			// Snapshot existing plugins before installation so we can identify the new one
+			const existingPluginNames = getInstalledPluginNames(pluginsDir);
+
+			// Install from URL (file://, https://, git://, etc.)
+			logger.info(`Loading plugin from: ${fromUrl}...`);
+			execSync(`npm install ${fromUrl} --prefix "${pluginsDir}"`, {
+				stdio: "inherit",
+			});
+
+			// Extract package name from installed package
+			pluginName = extractPackageNameFromUrl(
+				fromUrl,
+				pluginsDir,
+				existingPluginNames,
+			);
+			pluginSource = fromUrl;
+
+			// Validate plugin name
+			if (!pluginName || pluginName.trim() === "") {
+				logger.error("Failed to extract plugin name from URL");
+				logger.info(
+					"Ensure the URL points to a valid npm package with a package.json file",
+				);
+				process.exit(1);
+			}
+
+			logger.success("Plugin loaded successfully from URL", fromUrl);
+		} else {
+			// Install from npm registry by package name
+			// packageName is guaranteed non-nullish here: the early exit on line 72
+			// rejects (!packageName && !fromUrl), and this branch means !fromUrl.
+			if (!packageName) throw new Error("unreachable: packageName is required");
+
+			logger.info(`Loading plugin: ${packageName}...`);
+			execSync(`npm install ${packageName} --prefix "${pluginsDir}"`, {
+				stdio: "inherit",
+			});
+
+			pluginName = packageName;
+			pluginSource = packageName;
+
+			logger.success("Plugin loaded successfully", packageName);
+		}
+
+		// Add to plugin registry
+		addPluginToRegistry(pluginName, pluginSource);
+		logger.debug(`Added ${pluginName} to plugin registry`);
+
+		// Note: Plugin will be available on next CLI invocation
+		// We don't reload in the same process to avoid module cache issues
+		logger.info("Plugin will be available on next command execution");
+	} catch (error) {
+		handleCommandError(logger, "Failed to load plugin", error, [
+			"Check that the plugin name/URL is correct and you have network access if loading from a remote source",
+		]);
+	}
 }
 
 /**
  * Check if a package has a c8ctl plugin file
  */
 function hasPluginFile(packagePath: string): boolean {
-  return existsSync(join(packagePath, 'c8ctl-plugin.js')) ||
-         existsSync(join(packagePath, 'c8ctl-plugin.ts'));
+	return (
+		existsSync(join(packagePath, "c8ctl-plugin.js")) ||
+		existsSync(join(packagePath, "c8ctl-plugin.ts"))
+	);
 }
 
 /**
  * Check if a package is a valid c8ctl plugin
  */
 function isValidPlugin(pkgPath: string): boolean {
-  const pkgJsonPath = join(pkgPath, 'package.json');
-  if (!existsSync(pkgJsonPath)) return false;
-  
-  try {
-    const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
-    return hasPluginFile(pkgPath) && pkgJson.keywords?.includes('c8ctl');
-  } catch {
-    return false;
-  }
+	const pkgJsonPath = join(pkgPath, "package.json");
+	if (!existsSync(pkgJsonPath)) return false;
+
+	try {
+		const pkgJson = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+		return hasPluginFile(pkgPath) && pkgJson.keywords?.includes("c8ctl");
+	} catch {
+		return false;
+	}
 }
 
 /**
  * Get package name from a valid plugin directory
  */
 function getPackageName(pkgPath: string): string | null {
-  const pkgJsonPath = join(pkgPath, 'package.json');
-  try {
-    const pkgJson = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
-    return pkgJson.name;
-  } catch {
-    return null;
-  }
+	const pkgJsonPath = join(pkgPath, "package.json");
+	try {
+		const pkgJson = JSON.parse(readFileSync(pkgJsonPath, "utf-8"));
+		return pkgJson.name;
+	} catch {
+		return null;
+	}
 }
 
 /**
  * Try to read package name from source URL/path package.json
  */
 function getPackageNameFromSourceUrl(url: string): string | null {
-  const URL_SCHEME_PATTERN = /^[a-zA-Z]+:/;
-  let sourcePath: string | null = null;
-  try {
-    if (url.startsWith('file:')) {
-      sourcePath = fileURLToPath(url);
-    } else if (!URL_SCHEME_PATTERN.test(url)) {
-      sourcePath = url;
-    }
-  } catch {
-    sourcePath = null;
-  }
+	const URL_SCHEME_PATTERN = /^[a-zA-Z]+:/;
+	let sourcePath: string | null = null;
+	try {
+		if (url.startsWith("file:")) {
+			sourcePath = fileURLToPath(url);
+		} else if (!URL_SCHEME_PATTERN.test(url)) {
+			sourcePath = url;
+		}
+	} catch {
+		sourcePath = null;
+	}
 
-  if (!sourcePath) return null;
+	if (!sourcePath) return null;
 
-  const packageName = getPackageName(sourcePath);
-  if (packageName && packageName.trim() !== '') {
-    return packageName;
-  }
-  return null;
+	const packageName = getPackageName(sourcePath);
+	if (packageName && packageName.trim() !== "") {
+		return packageName;
+	}
+	return null;
 }
 
 function listTopLevelDependencies(pluginsDir: string): string[] {
-  const npmListArgs = ['list', '--depth', '0', '--json', '--prefix', pluginsDir];
-  const parseDependencyNames = (value: string): string[] => {
-    try {
-      const parsed = JSON.parse(value) as unknown;
-      if (typeof parsed !== 'object' || parsed === null) return [];
-      const { dependencies } = parsed as NpmListOutput;
-      if (!dependencies || typeof dependencies !== 'object') return [];
-      return Object.keys(dependencies);
-    } catch {
-      return [];
-    }
-  };
+	const npmListArgs = [
+		"list",
+		"--depth",
+		"0",
+		"--json",
+		"--prefix",
+		pluginsDir,
+	];
+	const parseDependencyNames = (value: string): string[] => {
+		try {
+			const parsed = JSON.parse(value);
+			if (typeof parsed !== "object" || parsed === null) return [];
+			const { dependencies } = parsed;
+			if (!dependencies || typeof dependencies !== "object") return [];
+			return Object.keys(dependencies);
+		} catch {
+			return [];
+		}
+	};
 
-  try {
-    const output = execFileSync('npm', npmListArgs, {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      encoding: 'utf-8',
-    });
-    return parseDependencyNames(output);
-  } catch (error) {
-    // npm list can return non-zero exit codes (e.g. unmet peer deps) and still print valid JSON to stdout
-    const { stdout } = error as ExecFileErrorWithStdout;
-    if (!stdout) return [];
-    return parseDependencyNames(typeof stdout === 'string' ? stdout : stdout.toString('utf-8'));
-  }
+	try {
+		const output = execFileSync("npm", npmListArgs, {
+			stdio: ["ignore", "pipe", "pipe"],
+			encoding: "utf-8",
+		});
+		return parseDependencyNames(output);
+	} catch (error: unknown) {
+		// npm list can return non-zero exit codes (e.g. unmet peer deps) and still print valid JSON to stdout
+		if (!isExecFileError(error) || !error.stdout) return [];
+		return parseDependencyNames(
+			typeof error.stdout === "string"
+				? error.stdout
+				: error.stdout.toString("utf-8"),
+		);
+	}
 }
 
-function resolvePackagePath(nodeModulesPath: string, packageName: string): string {
-  return join(nodeModulesPath, ...packageName.split('/'));
+function resolvePackagePath(
+	nodeModulesPath: string,
+	packageName: string,
+): string {
+	return join(nodeModulesPath, ...packageName.split("/"));
 }
 
 /**
  * Get the names of all valid c8ctl plugins currently in node_modules
  */
 function getInstalledPluginNames(pluginsDir: string): Set<string> {
-  const names = new Set<string>();
-  const nodeModulesPath = join(pluginsDir, 'node_modules');
-  if (!existsSync(nodeModulesPath)) return names;
+	const names = new Set<string>();
+	const nodeModulesPath = join(pluginsDir, "node_modules");
+	if (!existsSync(nodeModulesPath)) return names;
 
-  for (const dependencyName of listTopLevelDependencies(pluginsDir)) {
-    const pkgPath = resolvePackagePath(nodeModulesPath, dependencyName);
-    if (!isValidPlugin(pkgPath)) continue;
-    const name = getPackageName(pkgPath);
-    if (name) {
-      names.add(name);
-    }
-  }
+	for (const dependencyName of listTopLevelDependencies(pluginsDir)) {
+		const pkgPath = resolvePackagePath(nodeModulesPath, dependencyName);
+		if (!isValidPlugin(pkgPath)) continue;
+		const name = getPackageName(pkgPath);
+		if (name) {
+			names.add(name);
+		}
+	}
 
-  return names;
+	return names;
 }
 
 /**
@@ -239,284 +288,348 @@ function getInstalledPluginNames(pluginsDir: string): Set<string> {
  * Tries to read package.json from installed package, falls back to URL parsing.
  * When existingNames is provided, prefers a newly installed plugin not in that set.
  */
-function extractPackageNameFromUrl(url: string, pluginsDir: string, existingNames?: Set<string>): string {
-  const sourcePackageName = getPackageNameFromSourceUrl(url);
-  if (sourcePackageName) {
-    return sourcePackageName;
-  }
+function extractPackageNameFromUrl(
+	url: string,
+	pluginsDir: string,
+	existingNames?: Set<string>,
+): string {
+	const sourcePackageName = getPackageNameFromSourceUrl(url);
+	if (sourcePackageName) {
+		return sourcePackageName;
+	}
 
-  // Try to scan node_modules to find the package by reading package.json
-  try {
-    const nodeModulesPath = join(pluginsDir, 'node_modules');
-    if (existsSync(nodeModulesPath)) {
-      const dependencyNames = listTopLevelDependencies(pluginsDir);
+	// Try to scan node_modules to find the package by reading package.json
+	try {
+		const nodeModulesPath = join(pluginsDir, "node_modules");
+		if (existsSync(nodeModulesPath)) {
+			const dependencyNames = listTopLevelDependencies(pluginsDir);
 
-      if (existingNames) {
-        // Prefer the newly installed plugin (not present before install)
-        for (const dependencyName of dependencyNames) {
-          const pkgPath = resolvePackagePath(nodeModulesPath, dependencyName);
-          const name = getPackageName(pkgPath);
-          if (name && !existingNames.has(name) && isValidPlugin(pkgPath)) {
-            return name;
-          }
-        }
-      }
+			if (existingNames) {
+				// Prefer the newly installed plugin (not present before install)
+				for (const dependencyName of dependencyNames) {
+					const pkgPath = resolvePackagePath(nodeModulesPath, dependencyName);
+					const name = getPackageName(pkgPath);
+					if (name && !existingNames.has(name) && isValidPlugin(pkgPath)) {
+						return name;
+					}
+				}
+			}
 
-      // Fallback: return the first valid plugin found
-      for (const dependencyName of dependencyNames) {
-        const pkgPath = resolvePackagePath(nodeModulesPath, dependencyName);
-        if (!isValidPlugin(pkgPath)) continue;
-        const name = getPackageName(pkgPath);
-        if (name) return name;
-      }
-    }
-  } catch (error) {
-    // Fall through to URL-based name extraction
-  }
-  
-  // Fallback: extract from URL pattern
-  const match = url.match(/\/([^\/]+?)(\.git)?$/);
-  return match ? match[1] : url.replace(/[^a-zA-Z0-9-_@\/]/g, '-');
+			// Fallback: return the first valid plugin found
+			for (const dependencyName of dependencyNames) {
+				const pkgPath = resolvePackagePath(nodeModulesPath, dependencyName);
+				if (!isValidPlugin(pkgPath)) continue;
+				const name = getPackageName(pkgPath);
+				if (name) return name;
+			}
+		}
+	} catch (_error) {
+		// Fall through to URL-based name extraction
+	}
+
+	// Fallback: extract from URL pattern
+	const match = url.match(/\/([^/]+?)(\.git)?$/);
+	return match ? match[1] : url.replace(/[^a-zA-Z0-9-_@/]/g, "-");
 }
 
 /**
  * Unload a plugin (npm uninstall wrapper)
  * Uninstalls from global plugins directory
  */
-export async function unloadPlugin(packageName: string, { force = false }: { force?: boolean } = {}): Promise<void> {
-  const logger = getLogger();
+export async function unloadPlugin(
+	packageName: string,
+	{ force = false }: { force?: boolean } = {},
+): Promise<void> {
+	const logger = getLogger();
 
-  if (!packageName) {
-    logger.error('Package name required. Usage: c8ctl unload plugin <package-name>');
-    process.exit(1);
-  }
+	if (!packageName) {
+		logger.error(
+			"Package name required. Usage: c8ctl unload plugin <package-name>",
+		);
+		process.exit(1);
+	}
 
-  const pluginsDir = ensurePluginsDir();
-  const isRegistered = isPluginRegistered(packageName);
-  const isPresent = existsSync(join(pluginsDir, 'node_modules', packageName));
+	const pluginsDir = ensurePluginsDir();
+	const isRegistered = isPluginRegistered(packageName);
+	const isPresent = existsSync(join(pluginsDir, "node_modules", packageName));
 
-  if (!isRegistered && !isPresent) {
-    logger.error(`Plugin "${packageName}" is neither registered nor installed in the global plugins directory.`);
-    logger.info('Run "c8ctl list plugins" to see installed plugins');
-    process.exit(1);
-  }
+	if (!isRegistered && !isPresent) {
+		logger.error(
+			`Plugin "${packageName}" is neither registered nor installed in the global plugins directory.`,
+		);
+		logger.info('Run "c8ctl list plugins" to see installed plugins');
+		process.exit(1);
+	}
 
-  // Limbo state: present in node_modules but not in the registry — requires --force
-  if (!isRegistered && !force) {
-    logger.error(`Plugin "${packageName}" is installed in node_modules but not in the registry (limbo state).`);
-    logger.info('Use --force to remove it: c8ctl unload plugin ' + packageName + ' --force');
-    process.exit(1);
-  }
+	// Limbo state: present in node_modules but not in the registry — requires --force
+	if (!isRegistered && !force) {
+		logger.error(
+			`Plugin "${packageName}" is installed in node_modules but not in the registry (limbo state).`,
+		);
+		logger.info(
+			`Use --force to remove it: c8ctl unload plugin ${packageName} --force`,
+		);
+		process.exit(1);
+	}
 
-  const action = isRegistered ? 'Unloading' : 'Force-removing';
-  logger.info(`${action} plugin: ${packageName}...`);
+	const action = isRegistered ? "Unloading" : "Force-removing";
+	logger.info(`${action} plugin: ${packageName}...`);
 
-  try {
-    execFileSync('npm', ['uninstall', packageName, '--prefix', pluginsDir], { stdio: 'inherit' });
-  } catch (uninstallError) {
-    // npm uninstall may fail for untracked/extraneous packages; fall back to physical removal
-    logger.warn(`npm uninstall failed for plugin "${packageName}", attempting manual removal from node_modules`);
-    try {
-      rmSync(join(pluginsDir, 'node_modules', packageName), { recursive: true, force: true });
-      logger.debug(`Manually removed plugin directory for "${packageName}" from plugins directory`);
-    } catch (fsError) {
-      const uninstallErrorDetails =
-        uninstallError instanceof Error ? uninstallError.message : String(uninstallError);
-      const combinedError = new Error(
-        `Manual removal failed after npm uninstall failed for plugin "${packageName}". npm uninstall error: ${uninstallErrorDetails}`,
-        { cause: fsError },
-      );
-      handleCommandError(logger, `Failed to remove plugin "${packageName}" from the global plugins directory.`, combinedError, [
-        'Please verify file permissions for the plugins directory and try again with appropriate rights.',
-      ]);
-    }
-  }
+	try {
+		execFileSync("npm", ["uninstall", packageName, "--prefix", pluginsDir], {
+			stdio: "inherit",
+		});
+	} catch (uninstallError) {
+		// npm uninstall may fail for untracked/extraneous packages; fall back to physical removal
+		logger.warn(
+			`npm uninstall failed for plugin "${packageName}", attempting manual removal from node_modules`,
+		);
+		try {
+			rmSync(join(pluginsDir, "node_modules", packageName), {
+				recursive: true,
+				force: true,
+			});
+			logger.debug(
+				`Manually removed plugin directory for "${packageName}" from plugins directory`,
+			);
+		} catch (fsError) {
+			const uninstallErrorDetails =
+				uninstallError instanceof Error
+					? uninstallError.message
+					: String(uninstallError);
+			const combinedError = new Error(
+				`Manual removal failed after npm uninstall failed for plugin "${packageName}". npm uninstall error: ${uninstallErrorDetails}`,
+				{ cause: fsError },
+			);
+			handleCommandError(
+				logger,
+				`Failed to remove plugin "${packageName}" from the global plugins directory.`,
+				combinedError,
+				[
+					"Please verify file permissions for the plugins directory and try again with appropriate rights.",
+				],
+			);
+		}
+	}
 
-  if (isRegistered) {
-    removePluginFromRegistry(packageName);
-    logger.debug(`Removed ${packageName} from plugin registry`);
-  }
+	if (isRegistered) {
+		removePluginFromRegistry(packageName);
+		logger.debug(`Removed ${packageName} from plugin registry`);
+	}
 
-  clearLoadedPlugins();
-  if (isRegistered) {
-    logger.success('Plugin unloaded successfully', packageName);
-    logger.info('Plugin commands are no longer available');
-  } else {
-    logger.success('Plugin installation removed from global plugins directory', packageName);
-    logger.info('Plugin was not registered; no plugin commands were active to unload');
-  }
+	clearLoadedPlugins();
+	if (isRegistered) {
+		logger.success("Plugin unloaded successfully", packageName);
+		logger.info("Plugin commands are no longer available");
+	} else {
+		logger.success(
+			"Plugin installation removed from global plugins directory",
+			packageName,
+		);
+		logger.info(
+			"Plugin was not registered; no plugin commands were active to unload",
+		);
+	}
 }
 
 /**
  * Scan a directory entry for c8ctl plugins and add to the set
  */
-function addPluginIfFound(entry: string, nodeModulesPath: string, installedPlugins: Set<string>): void {
-  if (entry.startsWith('.')) return;
-  
-  if (entry.startsWith('@')) {
-    // Scoped package - scan subdirectories
-    const scopePath = join(nodeModulesPath, entry);
-    try {
-      readdirSync(scopePath)
-        .filter(pkg => !pkg.startsWith('.'))
-        .forEach(scopedPkg => {
-          const packageNameWithScope = `${entry}/${scopedPkg}`;
-          const packagePath = join(nodeModulesPath, entry, scopedPkg);
-          if (hasPluginFile(packagePath)) {
-            installedPlugins.add(packageNameWithScope);
-          }
-        });
-    } catch {
-      // Skip packages that can't be read
-    }
-  } else {
-    // Regular package
-    const packagePath = join(nodeModulesPath, entry);
-    if (hasPluginFile(packagePath)) {
-      installedPlugins.add(entry);
-    }
-  }
+function addPluginIfFound(
+	entry: string,
+	nodeModulesPath: string,
+	installedPlugins: Set<string>,
+): void {
+	if (entry.startsWith(".")) return;
+
+	if (entry.startsWith("@")) {
+		// Scoped package - scan subdirectories
+		const scopePath = join(nodeModulesPath, entry);
+		try {
+			readdirSync(scopePath)
+				.filter((pkg) => !pkg.startsWith("."))
+				.forEach((scopedPkg) => {
+					const packageNameWithScope = `${entry}/${scopedPkg}`;
+					const packagePath = join(nodeModulesPath, entry, scopedPkg);
+					if (hasPluginFile(packagePath)) {
+						installedPlugins.add(packageNameWithScope);
+					}
+				});
+		} catch {
+			// Skip packages that can't be read
+		}
+	} else {
+		// Regular package
+		const packagePath = join(nodeModulesPath, entry);
+		if (hasPluginFile(packagePath)) {
+			installedPlugins.add(entry);
+		}
+	}
 }
 
 /**
  * Scan node_modules for installed plugins
  */
 function scanInstalledPlugins(nodeModulesPath: string): Set<string> {
-  const installedPlugins = new Set<string>();
-  
-  if (!existsSync(nodeModulesPath)) {
-    return installedPlugins;
-  }
-  
-  try {
-    const entries = readdirSync(nodeModulesPath);
-    entries.forEach(entry => addPluginIfFound(entry, nodeModulesPath, installedPlugins));
-  } catch (error) {
-    getLogger().debug('Error scanning global plugins directory:', error);
-  }
-  
-  return installedPlugins;
+	const installedPlugins = new Set<string>();
+
+	if (!existsSync(nodeModulesPath)) {
+		return installedPlugins;
+	}
+
+	try {
+		const entries = readdirSync(nodeModulesPath);
+		entries.forEach((entry) => {
+			addPluginIfFound(entry, nodeModulesPath, installedPlugins);
+		});
+	} catch (error) {
+		getLogger().debug("Error scanning global plugins directory:", error);
+	}
+
+	return installedPlugins;
 }
 
 /**
  * Get installed plugin version from package.json
  */
-export function getInstalledPluginVersion(nodeModulesPath: string, packageName: string): string | null {
-  const packagePath = join(nodeModulesPath, ...packageName.split('/'));
-  const packageJsonPath = join(packagePath, 'package.json');
+export function getInstalledPluginVersion(
+	nodeModulesPath: string,
+	packageName: string,
+): string | null {
+	const packagePath = join(nodeModulesPath, ...packageName.split("/"));
+	const packageJsonPath = join(packagePath, "package.json");
 
-  if (!existsSync(packageJsonPath)) {
-    return null;
-  }
+	if (!existsSync(packageJsonPath)) {
+		return null;
+	}
 
-  try {
-    const pkgJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
-    return typeof pkgJson.version === 'string' ? pkgJson.version : null;
-  } catch {
-    return null;
-  }
+	try {
+		const pkgJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+		return typeof pkgJson.version === "string" ? pkgJson.version : null;
+	} catch {
+		return null;
+	}
 }
 
 /**
  * Extract version from a registry source like package@version
  */
-export function getVersionFromSource(source: string, packageName: string): string | null {
-  const packagePrefix = `${packageName}@`;
-  if (!source.startsWith(packagePrefix)) {
-    return null;
-  }
+export function getVersionFromSource(
+	source: string,
+	packageName: string,
+): string | null {
+	const packagePrefix = `${packageName}@`;
+	if (!source.startsWith(packagePrefix)) {
+		return null;
+	}
 
-  const version = source.slice(packagePrefix.length).trim();
-  return version.length > 0 ? version : null;
+	const version = source.slice(packagePrefix.length).trim();
+	return version.length > 0 ? version : null;
 }
 
 /**
  * Check if plugin source points to URL/git-style location
  */
 function isUrlSource(source: string): boolean {
-  return source.includes('://') ||
-    source.startsWith('git+') ||
-    source.startsWith('git@') ||
-    source.startsWith('github:');
+	return (
+		source.includes("://") ||
+		source.startsWith("git+") ||
+		source.startsWith("git@") ||
+		source.startsWith("github:")
+	);
 }
 
 /**
  * Resolve npm install target based on source type and version
  */
-function resolveInstallTarget(source: string, packageName: string, version?: string): string {
-  if (!version) {
-    return source;
-  }
+function resolveInstallTarget(
+	source: string,
+	packageName: string,
+	version?: string,
+): string {
+	if (!version) {
+		return source;
+	}
 
-  return isUrlSource(source)
-    ? `${source.split('#')[0]}#${version}`
-    : `${packageName}@${version}`;
+	return isUrlSource(source)
+		? `${source.split("#")[0]}#${version}`
+		: `${packageName}@${version}`;
 }
 
 /**
  * List installed plugins
  */
 export function listPlugins(): void {
-  const logger = getLogger();
-  
-  try {
-    // Get plugins from registry (local source of truth)
-    const registeredPlugins = getRegisteredPlugins();
-    
-    // Check global plugins directory
-    const pluginsDir = ensurePluginsDir();
-    const nodeModulesPath = join(pluginsDir, 'node_modules');
-    const installedPlugins = scanInstalledPlugins(nodeModulesPath);
-    
-    // Build unified list with status
-    const plugins: Array<{Name: string, Version: string, Status: string, Source: string, 'Installed At': string}> = [];
-    
-    // Add registered plugins
-    for (const plugin of registeredPlugins) {
-      const isInstalled = installedPlugins.has(plugin.name);
-      const installStatus = isInstalled ? '✓ Installed' : '⚠ Not installed';
-      const installedVersion = isInstalled ? getInstalledPluginVersion(nodeModulesPath, plugin.name) : null;
-      const sourceVersion = getVersionFromSource(plugin.source, plugin.name);
-      
-      plugins.push({
-        Name: plugin.name,
-        Version: installedVersion ?? sourceVersion ?? 'Unknown',
-        Status: installStatus,
-        Source: plugin.source,
-        'Installed At': new Date(plugin.installedAt).toLocaleString(),
-      });
-      
-      installedPlugins.delete(plugin.name);
-    }
-    
-    // Add any plugins installed but not in registry
-    for (const name of installedPlugins) {
-      plugins.push({
-        Name: name,
-        Version: getInstalledPluginVersion(nodeModulesPath, name) ?? 'Unknown',
-        Status: '⚠ Not in registry',
-        Source: 'Unknown',
-        'Installed At': 'Unknown',
-      });
-    }
-    
-    if (plugins.length === 0) {
-      logger.info('No c8ctl plugins installed');
-      return;
-    }
-    
-    // Check if there are sync issues
-    const needsSync = plugins.some(p => p.Status !== '✓ Installed');
-    
-    logger.table(plugins);
-    
-    if (needsSync) {
-      logger.info('');
-      logger.info('Some plugins are out of sync. Run "c8ctl sync plugins" to synchronize your plugins');
-    }
-  } catch (error) {
-    handleCommandError(logger, 'Failed to list plugins', error);
-  }
+	const logger = getLogger();
+
+	try {
+		// Get plugins from registry (local source of truth)
+		const registeredPlugins = getRegisteredPlugins();
+
+		// Check global plugins directory
+		const pluginsDir = ensurePluginsDir();
+		const nodeModulesPath = join(pluginsDir, "node_modules");
+		const installedPlugins = scanInstalledPlugins(nodeModulesPath);
+
+		// Build unified list with status
+		const plugins: Array<{
+			Name: string;
+			Version: string;
+			Status: string;
+			Source: string;
+			"Installed At": string;
+		}> = [];
+
+		// Add registered plugins
+		for (const plugin of registeredPlugins) {
+			const isInstalled = installedPlugins.has(plugin.name);
+			const installStatus = isInstalled ? "✓ Installed" : "⚠ Not installed";
+			const installedVersion = isInstalled
+				? getInstalledPluginVersion(nodeModulesPath, plugin.name)
+				: null;
+			const sourceVersion = getVersionFromSource(plugin.source, plugin.name);
+
+			plugins.push({
+				Name: plugin.name,
+				Version: installedVersion ?? sourceVersion ?? "Unknown",
+				Status: installStatus,
+				Source: plugin.source,
+				"Installed At": new Date(plugin.installedAt).toLocaleString(),
+			});
+
+			installedPlugins.delete(plugin.name);
+		}
+
+		// Add any plugins installed but not in registry
+		for (const name of installedPlugins) {
+			plugins.push({
+				Name: name,
+				Version: getInstalledPluginVersion(nodeModulesPath, name) ?? "Unknown",
+				Status: "⚠ Not in registry",
+				Source: "Unknown",
+				"Installed At": "Unknown",
+			});
+		}
+
+		if (plugins.length === 0) {
+			logger.info("No c8ctl plugins installed");
+			return;
+		}
+
+		// Check if there are sync issues
+		const needsSync = plugins.some((p) => p.Status !== "✓ Installed");
+
+		logger.table(plugins);
+
+		if (needsSync) {
+			logger.info("");
+			logger.info(
+				'Some plugins are out of sync. Run "c8ctl sync plugins" to synchronize your plugins',
+			);
+		}
+	} catch (error) {
+		handleCommandError(logger, "Failed to list plugins", error);
+	}
 }
 
 /**
@@ -524,300 +637,355 @@ export function listPlugins(): void {
  * Registry has precedence - plugins are installed to global directory
  */
 export async function syncPlugins(): Promise<void> {
-  const logger = getLogger();
-  
-  // Get global plugins directory
-  const pluginsDir = ensurePluginsDir();
-  const nodeModulesPath = join(pluginsDir, 'node_modules');
-  
-  logger.info('Starting plugin synchronization...');
-  logger.info('');
-  
-  // Get registered plugins (local source of truth)
-  const registeredPlugins = getRegisteredPlugins();
-  
-  if (registeredPlugins.length === 0) {
-    logger.info('No plugins registered. Nothing to sync.');
-    return;
-  }
-  
-  logger.info(`Found ${registeredPlugins.length} registered plugin(s):`);
-  for (const plugin of registeredPlugins) {
-    logger.info(`  - ${plugin.name} (${plugin.source})`);
-  }
-  logger.info('');
-  
-  let syncedCount = 0;
-  let failedCount = 0;
-  const failures: Array<{plugin: string, error: string}> = [];
-  
-  // Process each registered plugin
-  for (const plugin of registeredPlugins) {
-    logger.info(`Syncing ${plugin.name}...`);
-    
-    try {
-      // Check if plugin is installed in global directory
-      const packageDir = join(nodeModulesPath, plugin.name);
-      const isInstalled = existsSync(packageDir);
-      
-      if (isInstalled) {
-        logger.info(`  ✓ ${plugin.name} is already installed, attempting rebuild...`);
-        
-        // Try npm rebuild first
-        try {
-          execSync(`npm rebuild ${plugin.name} --prefix "${pluginsDir}"`, { stdio: 'pipe' });
-          logger.success(`  ✓ ${plugin.name} rebuilt successfully`);
-          syncedCount++;
-          continue;
-        } catch (rebuildError) {
-          logger.info(`  ⚠ Rebuild failed, attempting fresh install...`);
-        }
-      } else {
-        logger.info(`  ⚠ ${plugin.name} not found, installing...`);
-      }
-      
-      // Fresh install
-      try {
-        execSync(`npm install ${plugin.source} --prefix "${pluginsDir}"`, { stdio: 'inherit' });
-        logger.success(`  ✓ ${plugin.name} installed successfully`);
-        syncedCount++;
-      } catch (installError) {
-        logger.error(`  ✗ Failed to install ${plugin.name}`);
-        failedCount++;
-        failures.push({
-          plugin: plugin.name,
-          error: installError instanceof Error ? installError.message : String(installError),
-        });
-      }
-    } catch (error) {
-      logger.error(`  ✗ Failed to sync ${plugin.name}`);
-      failedCount++;
-      failures.push({
-        plugin: plugin.name,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
-    
-    logger.info('');
-  }
-  
-  // Summary
-  logger.info('Synchronization complete:');
-  logger.info(`  ✓ Synced: ${syncedCount} plugin(s)`);
-  
-  if (failedCount > 0) {
-    logger.info(`  ✗ Failed: ${failedCount} plugin(s)`);
-    logger.info('');
-    logger.info('Failed plugins:');
-    for (const failure of failures) {
-      logger.error(`  - ${failure.plugin}: ${failure.error}`);
-    }
-    logger.info('');
-    const syncError = new Error(failures.map(f => `${f.plugin}: ${f.error}`).join('; '));
-    handleCommandError(logger, `Failed to sync ${failedCount} plugin(s)`, syncError, [
-      'Check network connectivity and verify plugin sources are accessible. You may need to remove failed plugins from the registry with "c8ctl unload plugin <name>"',
-    ]);
-  }
-  
-  logger.success('All plugins synced successfully!');
+	const logger = getLogger();
+
+	// Get global plugins directory
+	const pluginsDir = ensurePluginsDir();
+	const nodeModulesPath = join(pluginsDir, "node_modules");
+
+	logger.info("Starting plugin synchronization...");
+	logger.info("");
+
+	// Get registered plugins (local source of truth)
+	const registeredPlugins = getRegisteredPlugins();
+
+	if (registeredPlugins.length === 0) {
+		logger.info("No plugins registered. Nothing to sync.");
+		return;
+	}
+
+	logger.info(`Found ${registeredPlugins.length} registered plugin(s):`);
+	for (const plugin of registeredPlugins) {
+		logger.info(`  - ${plugin.name} (${plugin.source})`);
+	}
+	logger.info("");
+
+	let syncedCount = 0;
+	let failedCount = 0;
+	const failures: Array<{ plugin: string; error: string }> = [];
+
+	// Process each registered plugin
+	for (const plugin of registeredPlugins) {
+		logger.info(`Syncing ${plugin.name}...`);
+
+		try {
+			// Check if plugin is installed in global directory
+			const packageDir = join(nodeModulesPath, plugin.name);
+			const isInstalled = existsSync(packageDir);
+
+			if (isInstalled) {
+				logger.info(
+					`  ✓ ${plugin.name} is already installed, attempting rebuild...`,
+				);
+
+				// Try npm rebuild first
+				try {
+					execSync(`npm rebuild ${plugin.name} --prefix "${pluginsDir}"`, {
+						stdio: "pipe",
+					});
+					logger.success(`  ✓ ${plugin.name} rebuilt successfully`);
+					syncedCount++;
+					continue;
+				} catch (_rebuildError) {
+					logger.info(`  ⚠ Rebuild failed, attempting fresh install...`);
+				}
+			} else {
+				logger.info(`  ⚠ ${plugin.name} not found, installing...`);
+			}
+
+			// Fresh install
+			try {
+				execSync(`npm install ${plugin.source} --prefix "${pluginsDir}"`, {
+					stdio: "inherit",
+				});
+				logger.success(`  ✓ ${plugin.name} installed successfully`);
+				syncedCount++;
+			} catch (installError) {
+				logger.error(`  ✗ Failed to install ${plugin.name}`);
+				failedCount++;
+				failures.push({
+					plugin: plugin.name,
+					error:
+						installError instanceof Error
+							? installError.message
+							: String(installError),
+				});
+			}
+		} catch (error) {
+			logger.error(`  ✗ Failed to sync ${plugin.name}`);
+			failedCount++;
+			failures.push({
+				plugin: plugin.name,
+				error: error instanceof Error ? error.message : String(error),
+			});
+		}
+
+		logger.info("");
+	}
+
+	// Summary
+	logger.info("Synchronization complete:");
+	logger.info(`  ✓ Synced: ${syncedCount} plugin(s)`);
+
+	if (failedCount > 0) {
+		logger.info(`  ✗ Failed: ${failedCount} plugin(s)`);
+		logger.info("");
+		logger.info("Failed plugins:");
+		for (const failure of failures) {
+			logger.error(`  - ${failure.plugin}: ${failure.error}`);
+		}
+		logger.info("");
+		const syncError = new Error(
+			failures.map((f) => `${f.plugin}: ${f.error}`).join("; "),
+		);
+		handleCommandError(
+			logger,
+			`Failed to sync ${failedCount} plugin(s)`,
+			syncError,
+			[
+				'Check network connectivity and verify plugin sources are accessible. You may need to remove failed plugins from the registry with "c8ctl unload plugin <name>"',
+			],
+		);
+	}
+
+	logger.success("All plugins synced successfully!");
 }
 
 /**
  * Upgrade a plugin to the latest version or a specific version
  */
-export async function upgradePlugin(packageName: string, version?: string): Promise<void> {
-  const logger = getLogger();
-  
-  if (!packageName) {
-    logger.error('Package name required. Usage: c8ctl upgrade plugin <package-name> [version]');
-    process.exit(1);
-  }
-  
-  // Check if plugin is registered
-  if (!isPluginRegistered(packageName)) {
-    logger.error(`Plugin "${packageName}" is not registered.`);
-    logger.info('Run "c8ctl list plugins" to see installed plugins');
-    process.exit(1);
-  }
-  
-  const pluginEntry = getPluginEntry(packageName);
-  const pluginsDir = ensurePluginsDir();
+export async function upgradePlugin(
+	packageName: string,
+	version?: string,
+): Promise<void> {
+	const logger = getLogger();
 
-  const source = pluginEntry?.source ?? packageName;
+	if (!packageName) {
+		logger.error(
+			"Package name required. Usage: c8ctl upgrade plugin <package-name> [version]",
+		);
+		process.exit(1);
+	}
 
-  // Versioned upgrade needs to respect source type
-  // File-based plugins do not have a version selector in npm install syntax
-  if (version && source.startsWith('file:')) {
-    logger.error(`Cannot upgrade file-based plugin "${packageName}" to a specific version.`);
-    logger.info(`Plugin source is: ${source}`);
-    logger.info('Use "c8ctl load plugin --from <file-url>" after checking out the desired plugin version in your local source directory');
-    process.exit(1);
-  }
+	// Check if plugin is registered
+	if (!isPluginRegistered(packageName)) {
+		logger.error(`Plugin "${packageName}" is not registered.`);
+		logger.info('Run "c8ctl list plugins" to see installed plugins');
+		process.exit(1);
+	}
 
-  const installTarget = resolveInstallTarget(source, packageName, version);
-  
-  try {
-    logger.info(`Upgrading plugin: ${packageName} to ${version || 'latest'}...`);
-    
-    // Uninstall current version
-    execSync(`npm uninstall ${packageName} --prefix "${pluginsDir}"`, { stdio: 'pipe' });
-    
-    // Install new version while respecting source type
-    execSync(`npm install ${installTarget} --prefix "${pluginsDir}"`, { stdio: 'inherit' });
-    
-    // Update registry with new source if version was specified
-    if (version) {
-      addPluginToRegistry(packageName, installTarget);
-    }
-    
-    // Clear plugin cache
-    clearLoadedPlugins();
-    
-    logger.success('Plugin upgraded successfully', packageName);
-    logger.info('Plugin will be available on next command execution');
-  } catch (error) {
-    handleCommandError(logger, 'Failed to upgrade plugin', error, [
-      'Check network connectivity and verify the package/version exists',
-    ]);
-  }
+	const pluginEntry = getPluginEntry(packageName);
+	const pluginsDir = ensurePluginsDir();
+
+	const source = pluginEntry?.source ?? packageName;
+
+	// Versioned upgrade needs to respect source type
+	// File-based plugins do not have a version selector in npm install syntax
+	if (version && source.startsWith("file:")) {
+		logger.error(
+			`Cannot upgrade file-based plugin "${packageName}" to a specific version.`,
+		);
+		logger.info(`Plugin source is: ${source}`);
+		logger.info(
+			'Use "c8ctl load plugin --from <file-url>" after checking out the desired plugin version in your local source directory',
+		);
+		process.exit(1);
+	}
+
+	const installTarget = resolveInstallTarget(source, packageName, version);
+
+	try {
+		logger.info(
+			`Upgrading plugin: ${packageName} to ${version || "latest"}...`,
+		);
+
+		// Uninstall current version
+		execSync(`npm uninstall ${packageName} --prefix "${pluginsDir}"`, {
+			stdio: "pipe",
+		});
+
+		// Install new version while respecting source type
+		execSync(`npm install ${installTarget} --prefix "${pluginsDir}"`, {
+			stdio: "inherit",
+		});
+
+		// Update registry with new source if version was specified
+		if (version) {
+			addPluginToRegistry(packageName, installTarget);
+		}
+
+		// Clear plugin cache
+		clearLoadedPlugins();
+
+		logger.success("Plugin upgraded successfully", packageName);
+		logger.info("Plugin will be available on next command execution");
+	} catch (error) {
+		handleCommandError(logger, "Failed to upgrade plugin", error, [
+			"Check network connectivity and verify the package/version exists",
+		]);
+	}
 }
 
 /**
  * Downgrade a plugin to a specific version
  */
-export async function downgradePlugin(packageName: string, version: string): Promise<void> {
-  const logger = getLogger();
-  
-  if (!packageName || !version) {
-    logger.error('Package name and version required. Usage: c8ctl downgrade plugin <package-name> <version>');
-    process.exit(1);
-  }
-  
-  // Check if plugin is registered
-  if (!isPluginRegistered(packageName)) {
-    logger.error(`Plugin "${packageName}" is not registered.`);
-    logger.info('Run "c8ctl list plugins" to see installed plugins');
-    process.exit(1);
-  }
-  
-  const pluginEntry = getPluginEntry(packageName);
-  const pluginsDir = ensurePluginsDir();
+export async function downgradePlugin(
+	packageName: string,
+	version: string,
+): Promise<void> {
+	const logger = getLogger();
 
-  const source = pluginEntry?.source ?? packageName;
+	if (!packageName || !version) {
+		logger.error(
+			"Package name and version required. Usage: c8ctl downgrade plugin <package-name> <version>",
+		);
+		process.exit(1);
+	}
 
-  // Downgrade needs to respect the plugin source
-  // File-based plugins do not have a version selector in npm install syntax
-  if (source.startsWith('file:')) {
-    logger.error(`Cannot downgrade file-based plugin "${packageName}" by version.`);
-    logger.info(`Plugin source is: ${source}`);
-    logger.info('Use "c8ctl load plugin --from <file-url>" after checking out the desired plugin version in your local source directory');
-    process.exit(1);
-  }
+	// Check if plugin is registered
+	if (!isPluginRegistered(packageName)) {
+		logger.error(`Plugin "${packageName}" is not registered.`);
+		logger.info('Run "c8ctl list plugins" to see installed plugins');
+		process.exit(1);
+	}
 
-  const installTarget = resolveInstallTarget(source, packageName, version);
-  
-  try {
-    logger.info(`Downgrading plugin: ${packageName} to version ${version}...`);
-    
-    // Uninstall current version
-    execSync(`npm uninstall ${packageName} --prefix "${pluginsDir}"`, { stdio: 'pipe' });
-    
-    // Install specific version while respecting source type
-    execSync(`npm install ${installTarget} --prefix "${pluginsDir}"`, { stdio: 'inherit' });
-    
-    // Update registry with new source
-    addPluginToRegistry(packageName, installTarget);
-    
-    // Clear plugin cache
-    clearLoadedPlugins();
-    
-    logger.success('Plugin downgraded successfully', packageName);
-    logger.info('Plugin will be available on next command execution');
-  } catch (error) {
-    handleCommandError(logger, 'Failed to downgrade plugin', error, [
-      'Check network connectivity and verify the version exists',
-    ]);
-  }
+	const pluginEntry = getPluginEntry(packageName);
+	const pluginsDir = ensurePluginsDir();
+
+	const source = pluginEntry?.source ?? packageName;
+
+	// Downgrade needs to respect the plugin source
+	// File-based plugins do not have a version selector in npm install syntax
+	if (source.startsWith("file:")) {
+		logger.error(
+			`Cannot downgrade file-based plugin "${packageName}" by version.`,
+		);
+		logger.info(`Plugin source is: ${source}`);
+		logger.info(
+			'Use "c8ctl load plugin --from <file-url>" after checking out the desired plugin version in your local source directory',
+		);
+		process.exit(1);
+	}
+
+	const installTarget = resolveInstallTarget(source, packageName, version);
+
+	try {
+		logger.info(`Downgrading plugin: ${packageName} to version ${version}...`);
+
+		// Uninstall current version
+		execSync(`npm uninstall ${packageName} --prefix "${pluginsDir}"`, {
+			stdio: "pipe",
+		});
+
+		// Install specific version while respecting source type
+		execSync(`npm install ${installTarget} --prefix "${pluginsDir}"`, {
+			stdio: "inherit",
+		});
+
+		// Update registry with new source
+		addPluginToRegistry(packageName, installTarget);
+
+		// Clear plugin cache
+		clearLoadedPlugins();
+
+		logger.success("Plugin downgraded successfully", packageName);
+		logger.info("Plugin will be available on next command execution");
+	} catch (error) {
+		handleCommandError(logger, "Failed to downgrade plugin", error, [
+			"Check network connectivity and verify the version exists",
+		]);
+	}
 }
 
 /**
  * Initialize a new plugin project with TypeScript template
  */
 export async function initPlugin(positionalName?: string): Promise<void> {
-  const logger = getLogger();
-  const { mkdirSync, writeFileSync } = await import('node:fs');
-  const { resolve } = await import('node:path');
-  
-  const rawName = positionalName || 'myplugin';
-  // Convention over configuration: plugin name is the suffix after 'c8ctl-plugin-'
-  const pluginName = rawName.startsWith('c8ctl-plugin-')
-    ? rawName.slice('c8ctl-plugin-'.length)
-    : rawName;
-  
-  if (!pluginName) {
-    logger.error('Plugin name cannot be empty. Provide a name suffix after "c8ctl-plugin-".');
-    logger.info('Example: c8ctl init plugin myplugin');
-    process.exit(1);
-  }
+	const logger = getLogger();
+	const { mkdirSync, writeFileSync } = await import("node:fs");
+	const { resolve } = await import("node:path");
 
-  const dirName = `c8ctl-plugin-${pluginName}`;
-  const pluginDir = resolve(process.cwd(), dirName);
-  
-  // Check if directory already exists
-  if (existsSync(pluginDir)) {
-    logger.error(`Directory "${dirName}" already exists.`);
-    logger.info('Choose a different name or remove the existing directory');
-    process.exit(1);
-  }
-  
-  try {
-    logger.info(`Creating plugin: ${dirName}...`);
+	const rawName = positionalName || "myplugin";
+	// Convention over configuration: plugin name is the suffix after 'c8ctl-plugin-'
+	const pluginName = rawName.startsWith("c8ctl-plugin-")
+		? rawName.slice("c8ctl-plugin-".length)
+		: rawName;
 
-    const templateVars = { PLUGIN_NAME: pluginName, PLUGIN_DIR: dirName };
-    
-    // Create plugin directory
-    mkdirSync(pluginDir, { recursive: true });
-    
-    // Create package.json
-    writeFileSync(join(pluginDir, 'package.json'), renderTemplate('package.json', templateVars));
+	if (!pluginName) {
+		logger.error(
+			'Plugin name cannot be empty. Provide a name suffix after "c8ctl-plugin-".',
+		);
+		logger.info("Example: c8ctl init plugin myplugin");
+		process.exit(1);
+	}
 
-    // Create tsconfig.json
-    writeFileSync(join(pluginDir, 'tsconfig.json'), getTemplate('tsconfig.json'));
-    
-    // Create src directory
-    mkdirSync(join(pluginDir, 'src'), { recursive: true });
+	const dirName = `c8ctl-plugin-${pluginName}`;
+	const pluginDir = resolve(process.cwd(), dirName);
 
-    // Create root c8ctl-plugin.js entry point
-    writeFileSync(join(pluginDir, 'c8ctl-plugin.js'), getTemplate('c8ctl-plugin.js'));
-    
-    // Create c8ctl-plugin.ts
-    writeFileSync(join(pluginDir, 'src', 'c8ctl-plugin.ts'), renderTemplate('c8ctl-plugin.ts', templateVars));
-    
-    // Create README.md
-    const readme = renderTemplate('README.md', templateVars);
-    
-    writeFileSync(
-      join(pluginDir, 'README.md'),
-      readme
-    );
+	// Check if directory already exists
+	if (existsSync(pluginDir)) {
+		logger.error(`Directory "${dirName}" already exists.`);
+		logger.info("Choose a different name or remove the existing directory");
+		process.exit(1);
+	}
 
-    // Create AGENTS.md
-    const agents = getTemplate('AGENTS.md');
+	try {
+		logger.info(`Creating plugin: ${dirName}...`);
 
-    writeFileSync(
-      join(pluginDir, 'AGENTS.md'),
-      agents
-    );
-    
-    // Create .gitignore (stored as 'gitignore' to survive npm publish)
-    writeFileSync(join(pluginDir, '.gitignore'), getTemplate('gitignore'));
-    
-    logger.success('Plugin scaffolding created successfully!');
-    const nextSteps = renderTemplate('init-plugin-next-steps.txt', templateVars);
-    for (const line of nextSteps.split('\n')) {
-      logger.info(line);
-    }
-  } catch (error) {
-    handleCommandError(logger, 'Failed to create plugin', error);
-  }
+		const templateVars = { PLUGIN_NAME: pluginName, PLUGIN_DIR: dirName };
+
+		// Create plugin directory
+		mkdirSync(pluginDir, { recursive: true });
+
+		// Create package.json
+		writeFileSync(
+			join(pluginDir, "package.json"),
+			renderTemplate("package.json", templateVars),
+		);
+
+		// Create tsconfig.json
+		writeFileSync(
+			join(pluginDir, "tsconfig.json"),
+			getTemplate("tsconfig.json"),
+		);
+
+		// Create src directory
+		mkdirSync(join(pluginDir, "src"), { recursive: true });
+
+		// Create root c8ctl-plugin.js entry point
+		writeFileSync(
+			join(pluginDir, "c8ctl-plugin.js"),
+			getTemplate("c8ctl-plugin.js"),
+		);
+
+		// Create c8ctl-plugin.ts
+		writeFileSync(
+			join(pluginDir, "src", "c8ctl-plugin.ts"),
+			renderTemplate("c8ctl-plugin.ts", templateVars),
+		);
+
+		// Create README.md
+		const readme = renderTemplate("README.md", templateVars);
+
+		writeFileSync(join(pluginDir, "README.md"), readme);
+
+		// Create AGENTS.md
+		const agents = getTemplate("AGENTS.md");
+
+		writeFileSync(join(pluginDir, "AGENTS.md"), agents);
+
+		// Create .gitignore (stored as 'gitignore' to survive npm publish)
+		writeFileSync(join(pluginDir, ".gitignore"), getTemplate("gitignore"));
+
+		logger.success("Plugin scaffolding created successfully!");
+		const nextSteps = renderTemplate(
+			"init-plugin-next-steps.txt",
+			templateVars,
+		);
+		for (const line of nextSteps.split("\n")) {
+			logger.info(line);
+		}
+	} catch (error) {
+		handleCommandError(logger, "Failed to create plugin", error);
+	}
 }

--- a/src/commands/plugins.ts
+++ b/src/commands/plugins.ts
@@ -2,7 +2,7 @@
  * Plugin management commands
  */
 
-import { execFileSync, execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -102,7 +102,7 @@ export async function loadPlugin(
 
 			// Install from URL (file://, https://, git://, etc.)
 			logger.info(`Loading plugin from: ${fromUrl}...`);
-			execSync(`npm install ${fromUrl} --prefix "${pluginsDir}"`, {
+			execFileSync("npm", ["install", fromUrl, "--prefix", pluginsDir], {
 				stdio: "inherit",
 			});
 
@@ -131,7 +131,7 @@ export async function loadPlugin(
 			if (!packageName) throw new Error("unreachable: packageName is required");
 
 			logger.info(`Loading plugin: ${packageName}...`);
-			execSync(`npm install ${packageName} --prefix "${pluginsDir}"`, {
+			execFileSync("npm", ["install", packageName, "--prefix", pluginsDir], {
 				stdio: "inherit",
 			});
 
@@ -680,7 +680,7 @@ export async function syncPlugins(): Promise<void> {
 
 				// Try npm rebuild first
 				try {
-					execSync(`npm rebuild ${plugin.name} --prefix "${pluginsDir}"`, {
+					execFileSync("npm", ["rebuild", plugin.name, "--prefix", pluginsDir], {
 						stdio: "pipe",
 					});
 					logger.success(`  ✓ ${plugin.name} rebuilt successfully`);
@@ -695,7 +695,7 @@ export async function syncPlugins(): Promise<void> {
 
 			// Fresh install
 			try {
-				execSync(`npm install ${plugin.source} --prefix "${pluginsDir}"`, {
+				execFileSync("npm", ["install", plugin.source, "--prefix", pluginsDir], {
 					stdio: "inherit",
 				});
 				logger.success(`  ✓ ${plugin.name} installed successfully`);
@@ -800,12 +800,12 @@ export async function upgradePlugin(
 		);
 
 		// Uninstall current version
-		execSync(`npm uninstall ${packageName} --prefix "${pluginsDir}"`, {
+		execFileSync("npm", ["uninstall", packageName, "--prefix", pluginsDir], {
 			stdio: "pipe",
 		});
 
 		// Install new version while respecting source type
-		execSync(`npm install ${installTarget} --prefix "${pluginsDir}"`, {
+		execFileSync("npm", ["install", installTarget, "--prefix", pluginsDir], {
 			stdio: "inherit",
 		});
 
@@ -873,12 +873,12 @@ export async function downgradePlugin(
 		logger.info(`Downgrading plugin: ${packageName} to version ${version}...`);
 
 		// Uninstall current version
-		execSync(`npm uninstall ${packageName} --prefix "${pluginsDir}"`, {
+		execFileSync("npm", ["uninstall", packageName, "--prefix", pluginsDir], {
 			stdio: "pipe",
 		});
 
 		// Install specific version while respecting source type
-		execSync(`npm install ${installTarget} --prefix "${pluginsDir}"`, {
+		execFileSync("npm", ["install", installTarget, "--prefix", pluginsDir], {
 			stdio: "inherit",
 		});
 

--- a/src/commands/plugins.ts
+++ b/src/commands/plugins.ts
@@ -680,9 +680,13 @@ export async function syncPlugins(): Promise<void> {
 
 				// Try npm rebuild first
 				try {
-					execFileSync("npm", ["rebuild", plugin.name, "--prefix", pluginsDir], {
-						stdio: "pipe",
-					});
+					execFileSync(
+						"npm",
+						["rebuild", plugin.name, "--prefix", pluginsDir],
+						{
+							stdio: "pipe",
+						},
+					);
 					logger.success(`  ✓ ${plugin.name} rebuilt successfully`);
 					syncedCount++;
 					continue;
@@ -695,9 +699,13 @@ export async function syncPlugins(): Promise<void> {
 
 			// Fresh install
 			try {
-				execFileSync("npm", ["install", plugin.source, "--prefix", pluginsDir], {
-					stdio: "inherit",
-				});
+				execFileSync(
+					"npm",
+					["install", plugin.source, "--prefix", pluginsDir],
+					{
+						stdio: "inherit",
+					},
+				);
 				logger.success(`  ✓ ${plugin.name} installed successfully`);
 				syncedCount++;
 			} catch (installError) {

--- a/src/commands/process-definitions.ts
+++ b/src/commands/process-definitions.ts
@@ -2,83 +2,94 @@
  * Process definition commands
  */
 
-import { getLogger } from '../logger.ts';
-import { sortTableData, type SortOrder } from '../logger.ts';
-import { createClient, fetchAllPages } from '../client.ts';
-import { resolveTenantId } from '../config.ts';
-import { handleCommandError } from '../errors.ts';
-import { ProcessDefinitionKey } from '@camunda8/orchestration-cluster-api';
+import { ProcessDefinitionKey } from "@camunda8/orchestration-cluster-api";
+import { createClient, fetchAllPages } from "../client.ts";
+import { resolveTenantId } from "../config.ts";
+import { handleCommandError } from "../errors.ts";
+import { getLogger, type SortOrder, sortTableData } from "../logger.ts";
 
 /**
  * List process definitions
  */
 export async function listProcessDefinitions(options: {
-  profile?: string;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  limit?: number;
+	profile?: string;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	limit?: number;
 }): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
-  const tenantId = resolveTenantId(options.profile);
+	const logger = getLogger();
+	const client = createClient(options.profile);
+	const tenantId = resolveTenantId(options.profile);
 
-  try {
-    const filter: any = {
-      filter: {
-        tenantId,
-      },
-    };
+	try {
+		const filter: Record<string, unknown> = {
+			filter: {
+				tenantId,
+			},
+		};
 
-    const allItems = await fetchAllPages(
-      (f, opts) => client.searchProcessDefinitions(f, opts),
-      filter,
-      undefined,
-      options.limit,
-    );
-    
-    if (allItems.length > 0) {
-      let tableData = allItems.map((pd: any) => ({
-        Key: pd.processDefinitionKey || pd.key,
-        'Process ID': pd.processDefinitionId,
-        Name: pd.name || '-',
-        Version: pd.version,
-        'Tenant ID': pd.tenantId,
-      }));
-      tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-      logger.table(tableData);
-    } else {
-      logger.info('No process definitions found');
-    }
-  } catch (error) {
-    handleCommandError(logger, 'Failed to list process definitions', error);
-  }
+		const allItems = await fetchAllPages(
+			(f, opts) => client.searchProcessDefinitions(f, opts),
+			filter,
+			undefined,
+			options.limit,
+		);
+
+		if (allItems.length > 0) {
+			let tableData = allItems.map((pd) => ({
+				Key: pd.processDefinitionKey,
+				"Process ID": pd.processDefinitionId,
+				Name: pd.name || "-",
+				Version: pd.version,
+				"Tenant ID": pd.tenantId,
+			}));
+			tableData = sortTableData(
+				tableData,
+				options.sortBy,
+				logger,
+				options.sortOrder,
+			);
+			logger.table(tableData);
+		} else {
+			logger.info("No process definitions found");
+		}
+	} catch (error) {
+		handleCommandError(logger, "Failed to list process definitions", error);
+	}
 }
 
 /**
  * Get process definition by key
  */
-export async function getProcessDefinition(key: string, options: {
-  profile?: string;
-  xml?: boolean;
-}): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+export async function getProcessDefinition(
+	key: string,
+	options: {
+		profile?: string;
+		xml?: boolean;
+	},
+): Promise<void> {
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    if (options.xml) {
-      const result = await client.getProcessDefinitionXml(
-        { processDefinitionKey: ProcessDefinitionKey.assumeExists(key) },
-        { consistency: { waitUpToMs: 0 } }
-      );
-      logger.output(result);
-    } else {
-      const result = await client.getProcessDefinition(
-        { processDefinitionKey: ProcessDefinitionKey.assumeExists(key) },
-        { consistency: { waitUpToMs: 0 } }
-      );
-      logger.json(result);
-    }
-  } catch (error) {
-    handleCommandError(logger, `Failed to get process definition ${key}`, error);
-  }
+	try {
+		if (options.xml) {
+			const result = await client.getProcessDefinitionXml(
+				{ processDefinitionKey: ProcessDefinitionKey.assumeExists(key) },
+				{ consistency: { waitUpToMs: 0 } },
+			);
+			logger.output(result);
+		} else {
+			const result = await client.getProcessDefinition(
+				{ processDefinitionKey: ProcessDefinitionKey.assumeExists(key) },
+				{ consistency: { waitUpToMs: 0 } },
+			);
+			logger.json(result);
+		}
+	} catch (error) {
+		handleCommandError(
+			logger,
+			`Failed to get process definition ${key}`,
+			error,
+		);
+	}
 }

--- a/src/commands/process-definitions.ts
+++ b/src/commands/process-definitions.ts
@@ -7,6 +7,7 @@ import { sortTableData, type SortOrder } from '../logger.ts';
 import { createClient, fetchAllPages } from '../client.ts';
 import { resolveTenantId } from '../config.ts';
 import { handleCommandError } from '../errors.ts';
+import { ProcessDefinitionKey } from '@camunda8/orchestration-cluster-api';
 
 /**
  * List process definitions
@@ -66,13 +67,13 @@ export async function getProcessDefinition(key: string, options: {
   try {
     if (options.xml) {
       const result = await client.getProcessDefinitionXml(
-        { processDefinitionKey: key as any },
+        { processDefinitionKey: ProcessDefinitionKey.assumeExists(key) },
         { consistency: { waitUpToMs: 0 } }
       );
       logger.output(result);
     } else {
       const result = await client.getProcessDefinition(
-        { processDefinitionKey: key as any },
+        { processDefinitionKey: ProcessDefinitionKey.assumeExists(key) },
         { consistency: { waitUpToMs: 0 } }
       );
       logger.json(result);

--- a/src/commands/process-instances.ts
+++ b/src/commands/process-instances.ts
@@ -2,7 +2,10 @@
  * Process instance commands
  */
 
-import type { ProcessInstanceResult } from "@camunda8/orchestration-cluster-api";
+import type {
+	ProcessInstanceResult,
+	createProcessInstanceInput,
+} from "@camunda8/orchestration-cluster-api";
 import {
 	ProcessDefinitionId,
 	ProcessInstanceKey,
@@ -227,43 +230,36 @@ export async function createProcessInstance(options: {
 	}
 
 	try {
-		// Build the request with properly branded types
-		const request: {
-			processDefinitionId: ReturnType<typeof ProcessDefinitionId.assumeExists>;
-			tenantId: ReturnType<typeof TenantId.assumeExists>;
-			processDefinitionVersion?: number;
-			variables?: Record<string, unknown>;
-			awaitCompletion?: boolean;
-			requestTimeout?: number;
-		} = {
+		// Parse variables early for clear error reporting
+		let variables: Record<string, unknown> | undefined;
+		if (options.variables) {
+			try {
+				variables = JSON.parse(options.variables);
+			} catch (error) {
+				handleCommandError(logger, "Invalid JSON for variables", error);
+				return;
+			}
+		}
+
+		if (options.awaitCompletion) {
+			logger.info("Waiting for process instance to complete...");
+		}
+
+		// Build the request with SDK types as single source of truth
+		const request = {
 			processDefinitionId: ProcessDefinitionId.assumeExists(
 				options.processDefinitionId,
 			),
 			tenantId: TenantId.assumeExists(tenantId),
-		};
-
-		if (options.version !== undefined) {
-			request.processDefinitionVersion = options.version;
-		}
-
-		if (options.variables) {
-			try {
-				request.variables = JSON.parse(options.variables);
-			} catch (error) {
-				handleCommandError(logger, "Invalid JSON for variables", error);
-			}
-		}
-
-		// Use the API's built-in awaitCompletion parameter
-		if (options.awaitCompletion) {
-			request.awaitCompletion = true;
-			logger.info("Waiting for process instance to complete...");
-		}
-
-		// Set requestTimeout if provided
-		if (options.requestTimeout !== undefined) {
-			request.requestTimeout = options.requestTimeout;
-		}
+			...(options.version !== undefined && {
+				processDefinitionVersion: options.version,
+			}),
+			...(variables !== undefined && { variables }),
+			...(options.awaitCompletion && { awaitCompletion: true }),
+			...(options.requestTimeout !== undefined && {
+				requestTimeout: options.requestTimeout,
+			}),
+		} satisfies createProcessInstanceInput;
 
 		const result = await client.createProcessInstance(request);
 

--- a/src/commands/process-instances.ts
+++ b/src/commands/process-instances.ts
@@ -8,8 +8,8 @@ import { createClient, fetchAllPages } from '../client.ts';
 import { resolveTenantId, resolveClusterConfig } from '../config.ts';
 import { parseBetween, buildDateFilter } from '../date-filter.ts';
 import { c8ctl } from '../runtime.ts';
-import { ProcessInstanceKey } from '@camunda8/orchestration-cluster-api';
-import type { ProcessInstanceCreationInstructionById, ProcessInstanceResult } from '@camunda8/orchestration-cluster-api';
+import { ProcessInstanceKey, ProcessDefinitionId, TenantId } from '@camunda8/orchestration-cluster-api';
+import type { ProcessInstanceResult } from '@camunda8/orchestration-cluster-api';
 import { handleCommandError } from '../errors.ts';
 
 /**
@@ -198,17 +198,17 @@ export async function createProcessInstance(options: {
   }
 
   try {
-    // Build the request matching ProcessInstanceCreationInstructionById type
+    // Build the request with properly branded types
     const request: {
-      processDefinitionId: string;
-      tenantId: string;
+      processDefinitionId: ReturnType<typeof ProcessDefinitionId.assumeExists>;
+      tenantId: ReturnType<typeof TenantId.assumeExists>;
       processDefinitionVersion?: number;
       variables?: Record<string, unknown>;
       awaitCompletion?: boolean;
       requestTimeout?: number;
     } = {
-      processDefinitionId: options.processDefinitionId,
-      tenantId,
+      processDefinitionId: ProcessDefinitionId.assumeExists(options.processDefinitionId),
+      tenantId: TenantId.assumeExists(tenantId),
     };
 
     if (options.version !== undefined) {
@@ -234,7 +234,7 @@ export async function createProcessInstance(options: {
       request.requestTimeout = options.requestTimeout;
     }
 
-    const result = await client.createProcessInstance(request as unknown as ProcessInstanceCreationInstructionById);
+    const result = await client.createProcessInstance(request);
     
     if (options.awaitCompletion) {
       // When awaitCompletion is true, the API returns the completed process instance with variables

--- a/src/commands/process-instances.ts
+++ b/src/commands/process-instances.ts
@@ -8,6 +8,7 @@ import { createClient, fetchAllPages } from '../client.ts';
 import { resolveTenantId, resolveClusterConfig } from '../config.ts';
 import { parseBetween, buildDateFilter } from '../date-filter.ts';
 import { c8ctl } from '../runtime.ts';
+import { ProcessInstanceKey } from '@camunda8/orchestration-cluster-api';
 import type { ProcessInstanceCreationInstructionById, ProcessInstanceResult } from '@camunda8/orchestration-cluster-api';
 import { handleCommandError } from '../errors.ts';
 
@@ -103,7 +104,7 @@ export async function getProcessInstance(key: string, options: {
   const consistencyOptions = { consistency: { waitUpToMs: 0 } };
 
   try {
-    const result = await client.getProcessInstance({ processInstanceKey: key as any }, consistencyOptions);
+    const result = await client.getProcessInstance({ processInstanceKey: ProcessInstanceKey.assumeExists(key) }, consistencyOptions);
     
     // Fetch variables if requested
     if (options.variables) {
@@ -111,7 +112,7 @@ export async function getProcessInstance(key: string, options: {
         const variablesResult = await client.searchVariables(
           {
             filter: {
-              processInstanceKey: key as any,
+              processInstanceKey: ProcessInstanceKey.assumeExists(key),
             },
             truncateValues: false,  // Get full variable values
           },
@@ -278,7 +279,7 @@ export async function cancelProcessInstance(key: string, options: {
   const client = createClient(options.profile);
 
   try {
-    await client.cancelProcessInstance({ processInstanceKey: key as any });
+    await client.cancelProcessInstance({ processInstanceKey: ProcessInstanceKey.assumeExists(key) });
     logger.success(`Process instance ${key} cancelled`);
   } catch (error) {
     handleCommandError(logger, `Failed to cancel process instance ${key}`, error);

--- a/src/commands/process-instances.ts
+++ b/src/commands/process-instances.ts
@@ -3,8 +3,8 @@
  */
 
 import type {
-	ProcessInstanceResult,
 	createProcessInstanceInput,
+	ProcessInstanceResult,
 } from "@camunda8/orchestration-cluster-api";
 import {
 	ProcessDefinitionId,

--- a/src/commands/process-instances.ts
+++ b/src/commands/process-instances.ts
@@ -2,286 +2,322 @@
  * Process instance commands
  */
 
-import { getLogger } from '../logger.ts';
-import { sortTableData, type SortOrder } from '../logger.ts';
-import { createClient, fetchAllPages } from '../client.ts';
-import { resolveTenantId, resolveClusterConfig } from '../config.ts';
-import { parseBetween, buildDateFilter } from '../date-filter.ts';
-import { c8ctl } from '../runtime.ts';
-import { ProcessInstanceKey, ProcessDefinitionId, TenantId } from '@camunda8/orchestration-cluster-api';
-import type { ProcessInstanceResult } from '@camunda8/orchestration-cluster-api';
-import { handleCommandError } from '../errors.ts';
+import type { ProcessInstanceResult } from "@camunda8/orchestration-cluster-api";
+import {
+	ProcessDefinitionId,
+	ProcessInstanceKey,
+	TenantId,
+} from "@camunda8/orchestration-cluster-api";
+import { createClient, fetchAllPages } from "../client.ts";
+import { resolveClusterConfig, resolveTenantId } from "../config.ts";
+import { buildDateFilter, parseBetween } from "../date-filter.ts";
+import { handleCommandError } from "../errors.ts";
+import { getLogger, type SortOrder, sortTableData } from "../logger.ts";
+import { c8ctl } from "../runtime.ts";
 
 /**
  * List process instances
  */
 export async function listProcessInstances(options: {
-  profile?: string;
-  processDefinitionId?: string;
-  version?: number;
-  state?: string;
-  all?: boolean;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  limit?: number;
-  between?: string;
-  dateField?: string;
+	profile?: string;
+	processDefinitionId?: string;
+	version?: number;
+	state?: string;
+	all?: boolean;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	limit?: number;
+	between?: string;
+	dateField?: string;
 }): Promise<{ items: ProcessInstanceResult[]; total?: number } | undefined> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
-  const tenantId = resolveTenantId(options.profile);
+	const logger = getLogger();
+	const client = createClient(options.profile);
+	const tenantId = resolveTenantId(options.profile);
 
-  try {
-    const filter: any = {
-      filter: {
-        tenantId,
-      },
-    };
+	try {
+		const filter: { filter: Record<string, unknown> } = {
+			filter: {
+				tenantId,
+			},
+		};
 
-    if (options.processDefinitionId) {
-      filter.filter.processDefinitionId = options.processDefinitionId;
-    }
+		if (options.processDefinitionId) {
+			filter.filter.processDefinitionId = options.processDefinitionId;
+		}
 
-    if (options.version !== undefined) {
-      filter.filter.processDefinitionVersion = options.version;
-    }
+		if (options.version !== undefined) {
+			filter.filter.processDefinitionVersion = options.version;
+		}
 
-    if (options.state) {
-      filter.filter.state = options.state;
-    } else if (!options.all) {
-      // By default, exclude COMPLETED instances unless --all is specified
-      filter.filter.state = 'ACTIVE';
-    }
+		if (options.state) {
+			filter.filter.state = options.state;
+		} else if (!options.all) {
+			// By default, exclude COMPLETED instances unless --all is specified
+			filter.filter.state = "ACTIVE";
+		}
 
-    if (options.between) {
-      const parsed = parseBetween(options.between);
-      if (parsed) {
-        const field = options.dateField ?? 'startDate';
-        filter.filter[field] = buildDateFilter(parsed.from, parsed.to);
-      } else {
-        logger.error('Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)');
-        process.exit(1);
-      }
-    }
+		if (options.between) {
+			const parsed = parseBetween(options.between);
+			if (parsed) {
+				const field = options.dateField ?? "startDate";
+				filter.filter[field] = buildDateFilter(parsed.from, parsed.to);
+			} else {
+				logger.error(
+					"Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)",
+				);
+				process.exit(1);
+			}
+		}
 
-    const allItems = await fetchAllPages(
-      (f, opts) => client.searchProcessInstances(f, opts),
-      filter,
-      undefined,
-      options.limit,
-    );
-    
-    if (allItems.length > 0) {
-      let tableData = allItems.map((pi: any) => ({
-        Key: `${pi.hasIncident ? '⚠ ' : ''}${pi.processInstanceKey || pi.key}`,
-        'Process ID': pi.processDefinitionId,
-        State: pi.state,
-        Version: pi.processDefinitionVersion || pi.version,
-        'Start Date': pi.startDate || '-',
-        'Tenant ID': pi.tenantId,
-      }));
-      tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-      logger.table(tableData);
-    } else {
-      logger.info('No process instances found');
-    }
-    
-    return { items: allItems, total: allItems.length };
-  } catch (error) {
-    handleCommandError(logger, 'Failed to list process instances', error);
-  }
+		const allItems = await fetchAllPages(
+			(f, opts) => client.searchProcessInstances(f, opts),
+			filter,
+			undefined,
+			options.limit,
+		);
+
+		if (allItems.length > 0) {
+			let tableData = allItems.map((pi) => ({
+				Key: `${pi.hasIncident ? "⚠ " : ""}${pi.processInstanceKey}`,
+				"Process ID": pi.processDefinitionId,
+				State: pi.state,
+				Version: pi.processDefinitionVersion,
+				"Start Date": pi.startDate || "-",
+				"Tenant ID": pi.tenantId,
+			}));
+			tableData = sortTableData(
+				tableData,
+				options.sortBy,
+				logger,
+				options.sortOrder,
+			);
+			logger.table(tableData);
+		} else {
+			logger.info("No process instances found");
+		}
+
+		return { items: allItems, total: allItems.length };
+	} catch (error) {
+		handleCommandError(logger, "Failed to list process instances", error);
+	}
 }
 
 /**
  * Get process instance by key
  */
-export async function getProcessInstance(key: string, options: {
-  profile?: string;
-  variables?: boolean;
-}): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
-  const consistencyOptions = { consistency: { waitUpToMs: 0 } };
+export async function getProcessInstance(
+	key: string,
+	options: {
+		profile?: string;
+		variables?: boolean;
+	},
+): Promise<void> {
+	const logger = getLogger();
+	const client = createClient(options.profile);
+	const consistencyOptions = { consistency: { waitUpToMs: 0 } };
 
-  try {
-    const result = await client.getProcessInstance({ processInstanceKey: ProcessInstanceKey.assumeExists(key) }, consistencyOptions);
-    
-    // Fetch variables if requested
-    if (options.variables) {
-      try {
-        const variablesResult = await client.searchVariables(
-          {
-            filter: {
-              processInstanceKey: ProcessInstanceKey.assumeExists(key),
-            },
-            truncateValues: false,  // Get full variable values
-          },
-          consistencyOptions
-        );
-        
-        // Add variables to the result
-        const resultWithVariables = {
-          ...result,
-          variables: variablesResult.items || [],
-        };
-        logger.json(resultWithVariables);
-      } catch (varError) {
-        handleCommandError(logger, `Failed to fetch variables for process instance ${key}. The process instance was found, but variables could not be retrieved.`, varError);
-      }
-    } else {
-      logger.json(result);
-    }
-  } catch (error) {
-    handleCommandError(logger, `Failed to get process instance ${key}`, error);
-  }
+	try {
+		const result = await client.getProcessInstance(
+			{ processInstanceKey: ProcessInstanceKey.assumeExists(key) },
+			consistencyOptions,
+		);
+
+		// Fetch variables if requested
+		if (options.variables) {
+			try {
+				const variablesResult = await client.searchVariables(
+					{
+						filter: {
+							processInstanceKey: ProcessInstanceKey.assumeExists(key),
+						},
+						truncateValues: false, // Get full variable values
+					},
+					consistencyOptions,
+				);
+
+				// Add variables to the result
+				const resultWithVariables = {
+					...result,
+					variables: variablesResult.items || [],
+				};
+				logger.json(resultWithVariables);
+			} catch (varError) {
+				handleCommandError(
+					logger,
+					`Failed to fetch variables for process instance ${key}. The process instance was found, but variables could not be retrieved.`,
+					varError,
+				);
+			}
+		} else {
+			logger.json(result);
+		}
+	} catch (error) {
+		handleCommandError(logger, `Failed to get process instance ${key}`, error);
+	}
 }
 
 /**
  * Create process instance
  */
 export async function createProcessInstance(options: {
-  profile?: string;
-  processDefinitionId?: string;
-  version?: number;
-  variables?: string;
-  awaitCompletion?: boolean;
-  fetchVariables?: boolean;
-  requestTimeout?: number;
-}): Promise<{
-  processInstanceKey: string | number;
-  variables?: Record<string, unknown>;
-  [key: string]: unknown;
-} | undefined> {
-  const logger = getLogger();
+	profile?: string;
+	processDefinitionId?: string;
+	version?: number;
+	variables?: string;
+	awaitCompletion?: boolean;
+	fetchVariables?: boolean;
+	requestTimeout?: number;
+}): Promise<
+	| {
+			processInstanceKey: string | number;
+			variables?: Record<string, unknown>;
+			[key: string]: unknown;
+	  }
+	| undefined
+> {
+	const logger = getLogger();
 
-  if (!options.processDefinitionId) {
-    logger.error('processDefinitionId is required. Use --processDefinitionId or --bpmnProcessId or --id flag');
-    process.exit(1);
-  }
+	if (!options.processDefinitionId) {
+		logger.error(
+			"processDefinitionId is required. Use --processDefinitionId or --bpmnProcessId or --id flag",
+		);
+		process.exit(1);
+	}
 
-  const tenantId = resolveTenantId(options.profile);
+	const tenantId = resolveTenantId(options.profile);
 
-  // Dry-run: emit the would-be API request without executing
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    const body: Record<string, unknown> = {
-      processDefinitionId: options.processDefinitionId,
-      tenantId,
-    };
-    if (options.version !== undefined) body.processDefinitionVersion = options.version;
-    if (options.variables) body.variables = JSON.parse(options.variables);
-    if (options.awaitCompletion) body.awaitCompletion = true;
-    if (options.requestTimeout !== undefined) body.requestTimeout = options.requestTimeout;
-    logger.json({
-      dryRun: true,
-      command: 'create process-instance',
-      method: 'POST',
-      url: `${config.baseUrl}/process-instances`,
-      body,
-    });
-    return;
-  }
+	// Dry-run: emit the would-be API request without executing
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		const body: Record<string, unknown> = {
+			processDefinitionId: options.processDefinitionId,
+			tenantId,
+		};
+		if (options.version !== undefined)
+			body.processDefinitionVersion = options.version;
+		if (options.variables) body.variables = JSON.parse(options.variables);
+		if (options.awaitCompletion) body.awaitCompletion = true;
+		if (options.requestTimeout !== undefined)
+			body.requestTimeout = options.requestTimeout;
+		logger.json({
+			dryRun: true,
+			command: "create process-instance",
+			method: "POST",
+			url: `${config.baseUrl}/process-instances`,
+			body,
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
+	const client = createClient(options.profile);
 
-  // Validate: fetchVariables requires awaitCompletion
-  if (options.fetchVariables && !options.awaitCompletion) {
-    logger.error('--fetchVariables can only be used with --awaitCompletion');
-    process.exit(1);
-  }
+	// Validate: fetchVariables requires awaitCompletion
+	if (options.fetchVariables && !options.awaitCompletion) {
+		logger.error("--fetchVariables can only be used with --awaitCompletion");
+		process.exit(1);
+	}
 
-  // Note: fetchVariables parameter is reserved for future API enhancement
-  // The orchestration-cluster-api currently does not support filtering variables
-  // The API returns all variables by default when awaitCompletion is true
-  if (options.fetchVariables) {
-    logger.info('Note: --fetchVariables is not yet supported by the API. All variables will be returned.');
-  }
+	// Note: fetchVariables parameter is reserved for future API enhancement
+	// The orchestration-cluster-api currently does not support filtering variables
+	// The API returns all variables by default when awaitCompletion is true
+	if (options.fetchVariables) {
+		logger.info(
+			"Note: --fetchVariables is not yet supported by the API. All variables will be returned.",
+		);
+	}
 
-  try {
-    // Build the request with properly branded types
-    const request: {
-      processDefinitionId: ReturnType<typeof ProcessDefinitionId.assumeExists>;
-      tenantId: ReturnType<typeof TenantId.assumeExists>;
-      processDefinitionVersion?: number;
-      variables?: Record<string, unknown>;
-      awaitCompletion?: boolean;
-      requestTimeout?: number;
-    } = {
-      processDefinitionId: ProcessDefinitionId.assumeExists(options.processDefinitionId),
-      tenantId: TenantId.assumeExists(tenantId),
-    };
+	try {
+		// Build the request with properly branded types
+		const request: {
+			processDefinitionId: ReturnType<typeof ProcessDefinitionId.assumeExists>;
+			tenantId: ReturnType<typeof TenantId.assumeExists>;
+			processDefinitionVersion?: number;
+			variables?: Record<string, unknown>;
+			awaitCompletion?: boolean;
+			requestTimeout?: number;
+		} = {
+			processDefinitionId: ProcessDefinitionId.assumeExists(
+				options.processDefinitionId,
+			),
+			tenantId: TenantId.assumeExists(tenantId),
+		};
 
-    if (options.version !== undefined) {
-      request.processDefinitionVersion = options.version;
-    }
+		if (options.version !== undefined) {
+			request.processDefinitionVersion = options.version;
+		}
 
-    if (options.variables) {
-      try {
-        request.variables = JSON.parse(options.variables);
-      } catch (error) {
-        handleCommandError(logger, 'Invalid JSON for variables', error);
-      }
-    }
+		if (options.variables) {
+			try {
+				request.variables = JSON.parse(options.variables);
+			} catch (error) {
+				handleCommandError(logger, "Invalid JSON for variables", error);
+			}
+		}
 
-    // Use the API's built-in awaitCompletion parameter
-    if (options.awaitCompletion) {
-      request.awaitCompletion = true;
-      logger.info('Waiting for process instance to complete...');
-    }
+		// Use the API's built-in awaitCompletion parameter
+		if (options.awaitCompletion) {
+			request.awaitCompletion = true;
+			logger.info("Waiting for process instance to complete...");
+		}
 
-    // Set requestTimeout if provided
-    if (options.requestTimeout !== undefined) {
-      request.requestTimeout = options.requestTimeout;
-    }
+		// Set requestTimeout if provided
+		if (options.requestTimeout !== undefined) {
+			request.requestTimeout = options.requestTimeout;
+		}
 
-    const result = await client.createProcessInstance(request);
-    
-    if (options.awaitCompletion) {
-      // When awaitCompletion is true, the API returns the completed process instance with variables
-      logger.success('Process instance completed', result.processInstanceKey);
-      logger.json(result);
-    } else {
-      // When awaitCompletion is false, just show the process instance key
-      logger.success('Process instance created', result.processInstanceKey);
-    }
-    
-    return result as {
-      processInstanceKey: string | number;
-      variables?: Record<string, unknown>;
-      [key: string]: unknown;
-    };
-  } catch (error) {
-    handleCommandError(logger, 'Failed to create process instance', error);
-  }
+		const result = await client.createProcessInstance(request);
+
+		if (options.awaitCompletion) {
+			// When awaitCompletion is true, the API returns the completed process instance with variables
+			logger.success("Process instance completed", result.processInstanceKey);
+			logger.json(result);
+		} else {
+			// When awaitCompletion is false, just show the process instance key
+			logger.success("Process instance created", result.processInstanceKey);
+		}
+
+		return result;
+	} catch (error) {
+		handleCommandError(logger, "Failed to create process instance", error);
+	}
 }
 
 /**
  * Cancel process instance
  */
-export async function cancelProcessInstance(key: string, options: {
-  profile?: string;
-}): Promise<void> {
-  const logger = getLogger();
+export async function cancelProcessInstance(
+	key: string,
+	options: {
+		profile?: string;
+	},
+): Promise<void> {
+	const logger = getLogger();
 
-  // Dry-run: emit the would-be API request without executing
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    logger.json({
-      dryRun: true,
-      command: 'cancel process-instance',
-      method: 'POST',
-      url: `${config.baseUrl}/process-instances/${key}/cancellation`,
-      body: {},
-    });
-    return;
-  }
+	// Dry-run: emit the would-be API request without executing
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		logger.json({
+			dryRun: true,
+			command: "cancel process-instance",
+			method: "POST",
+			url: `${config.baseUrl}/process-instances/${key}/cancellation`,
+			body: {},
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
+	const client = createClient(options.profile);
 
-  try {
-    await client.cancelProcessInstance({ processInstanceKey: ProcessInstanceKey.assumeExists(key) });
-    logger.success(`Process instance ${key} cancelled`);
-  } catch (error) {
-    handleCommandError(logger, `Failed to cancel process instance ${key}`, error);
-  }
+	try {
+		await client.cancelProcessInstance({
+			processInstanceKey: ProcessInstanceKey.assumeExists(key),
+		});
+		logger.success(`Process instance ${key} cancelled`);
+	} catch (error) {
+		handleCommandError(
+			logger,
+			`Failed to cancel process instance ${key}`,
+			error,
+		);
+	}
 }

--- a/src/commands/profiles.ts
+++ b/src/commands/profiles.ts
@@ -4,236 +4,254 @@
  * Modeler connections are read from settings.json (read-only) with "modeler:" prefix
  */
 
-import { getLogger } from '../logger.ts';
-import { c8ctl } from '../runtime.ts';
-import { readFileSync, existsSync } from 'node:fs';
+import { existsSync, readFileSync } from "node:fs";
 import {
-  getAllProfiles,
-  getProfile,
-  getProfileOrModeler,
-  addProfile as addProfileConfig,
-  removeProfile as removeProfileConfig,
-  parseEnvFile,
-  envVarsToProfile,
-  hasCamundaEnvVars,
-  DEFAULT_PROFILE,
-  MODELER_PREFIX,
-  type Profile,
-} from '../config.ts';
+	addProfile as addProfileConfig,
+	DEFAULT_PROFILE,
+	envVarsToProfile,
+	getAllProfiles,
+	getProfileOrModeler,
+	hasCamundaEnvVars,
+	MODELER_PREFIX,
+	type Profile,
+	parseEnvFile,
+	removeProfile as removeProfileConfig,
+} from "../config.ts";
+import { getLogger } from "../logger.ts";
+import { c8ctl } from "../runtime.ts";
 
 /**
  * List all profiles (c8ctl + Modeler)
  */
 export function listProfiles(): void {
-  const logger = getLogger();
-  const profiles = getAllProfiles();
+	const logger = getLogger();
+	const profiles = getAllProfiles();
 
-  if (profiles.length === 0) {
-    logger.info('No profiles configured');
-    logger.info('');
-    logger.info('Add a profile with: c8ctl profiles add <name> --url <cluster-url>');
-    logger.info('Or configure connections in Camunda Modeler and they will appear with "modeler:" prefix.');
-    return;
-  }
+	if (profiles.length === 0) {
+		logger.info("No profiles configured");
+		logger.info("");
+		logger.info(
+			"Add a profile with: c8ctl profiles add <name> --url <cluster-url>",
+		);
+		logger.info(
+			'Or configure connections in Camunda Modeler and they will appear with "modeler:" prefix.',
+		);
+		return;
+	}
 
-  interface ProfileTableRow {
-    Name: string;
-    URL: string;
-    Tenant: string;
-    Source: string;
-  }
+	interface ProfileTableRow {
+		Name: string;
+		URL: string;
+		Tenant: string;
+		Source: string;
+	}
 
-  const activeProfile = c8ctl.activeProfile;
-  const tableData: ProfileTableRow[] = profiles.map(profile => {
-    const isModeler = profile.name.startsWith(MODELER_PREFIX);
-    
-    return {
-      Name: profile.name === activeProfile ? `* ${profile.name}` : profile.name,
-      URL: profile.baseUrl || '(not set)',
-      Tenant: profile.defaultTenantId || '<default>',
-      Source: isModeler ? 'Modeler' : 'c8ctl',
-    };
-  });
+	const activeProfile = c8ctl.activeProfile;
+	const tableData: ProfileTableRow[] = profiles.map((profile) => {
+		const isModeler = profile.name.startsWith(MODELER_PREFIX);
 
-  logger.table(tableData);
-  
-  // Show hint about read-only Modeler profiles
-  const hasModelerProfiles = profiles.some(p => p.name.startsWith(MODELER_PREFIX));
-  if (hasModelerProfiles) {
-    logger.info('');
-    logger.info(`Note: Modeler profiles (prefixed with "${MODELER_PREFIX}") are read-only. Manage them in Camunda Modeler.`);
-  }
+		return {
+			Name: profile.name === activeProfile ? `* ${profile.name}` : profile.name,
+			URL: profile.baseUrl || "(not set)",
+			Tenant: profile.defaultTenantId || "<default>",
+			Source: isModeler ? "Modeler" : "c8ctl",
+		};
+	});
+
+	logger.table(tableData);
+
+	// Show hint about read-only Modeler profiles
+	const hasModelerProfiles = profiles.some((p) =>
+		p.name.startsWith(MODELER_PREFIX),
+	);
+	if (hasModelerProfiles) {
+		logger.info("");
+		logger.info(
+			`Note: Modeler profiles (prefixed with "${MODELER_PREFIX}") are read-only. Manage them in Camunda Modeler.`,
+		);
+	}
 }
 
 /**
  * Show profile details
  */
 export function showProfile(name: string): void {
-  const logger = getLogger();
-  const profile = getProfileOrModeler(name);
+	const logger = getLogger();
+	const profile = getProfileOrModeler(name);
 
-  if (!profile) {
-    logger.error(`Profile '${name}' not found`);
-    process.exit(1);
-  }
+	if (!profile) {
+		logger.error(`Profile '${name}' not found`);
+		process.exit(1);
+	}
 
-  const isModeler = profile.name.startsWith(MODELER_PREFIX);
-  
-  logger.info(`Profile: ${profile.name}`);
-  logger.info(`  Source: ${isModeler ? 'Camunda Modeler (read-only)' : 'c8ctl'}`);
-  logger.info(`  Base URL: ${profile.baseUrl}`);
-  
-  if (profile.username) {
-    logger.info(`  Username: ${profile.username}`);
-    logger.info(`  Password: ${profile.password ? '********' : '(not set)'}`);
-  }
-  
-  if (profile.clientId) {
-    logger.info(`  Client ID: ${profile.clientId}`);
-    logger.info(`  Client Secret: ${profile.clientSecret ? '********' : '(not set)'}`);
-  }
-  
-  if (profile.audience) {
-    logger.info(`  Audience: ${profile.audience}`);
-  }
-  
-  if (profile.oAuthUrl) {
-    logger.info(`  OAuth URL: ${profile.oAuthUrl}`);
-  }
-  
-  if (profile.defaultTenantId) {
-    logger.info(`  Default Tenant: ${profile.defaultTenantId}`);
-  }
+	const isModeler = profile.name.startsWith(MODELER_PREFIX);
+
+	logger.info(`Profile: ${profile.name}`);
+	logger.info(
+		`  Source: ${isModeler ? "Camunda Modeler (read-only)" : "c8ctl"}`,
+	);
+	logger.info(`  Base URL: ${profile.baseUrl}`);
+
+	if (profile.username) {
+		logger.info(`  Username: ${profile.username}`);
+		logger.info(`  Password: ${profile.password ? "********" : "(not set)"}`);
+	}
+
+	if (profile.clientId) {
+		logger.info(`  Client ID: ${profile.clientId}`);
+		logger.info(
+			`  Client Secret: ${profile.clientSecret ? "********" : "(not set)"}`,
+		);
+	}
+
+	if (profile.audience) {
+		logger.info(`  Audience: ${profile.audience}`);
+	}
+
+	if (profile.oAuthUrl) {
+		logger.info(`  OAuth URL: ${profile.oAuthUrl}`);
+	}
+
+	if (profile.defaultTenantId) {
+		logger.info(`  Default Tenant: ${profile.defaultTenantId}`);
+	}
 }
 
 export interface AddProfileOptions {
-  url?: string;
-  clientId?: string;
-  clientSecret?: string;
-  audience?: string;
-  oauthUrl?: string;
-  username?: string;
-  password?: string;
-  tenantId?: string;
-  envFile?: string;
-  fromEnv?: boolean;
+	url?: string;
+	clientId?: string;
+	clientSecret?: string;
+	audience?: string;
+	oauthUrl?: string;
+	username?: string;
+	password?: string;
+	tenantId?: string;
+	envFile?: string;
+	fromEnv?: boolean;
 }
 
 /**
  * Describe the auth type of a profile for user feedback.
  */
 function describeAuth(profile: Profile): string {
-  if (profile.clientId && profile.clientSecret) return 'OAuth (client credentials)';
-  if (profile.username && profile.password) return 'Basic auth';
-  return 'None';
+	if (profile.clientId && profile.clientSecret)
+		return "OAuth (client credentials)";
+	if (profile.username && profile.password) return "Basic auth";
+	return "None";
 }
 
 /**
  * Add a c8ctl profile
  */
 export function addProfile(name: string, options: AddProfileOptions): void {
-  const logger = getLogger();
+	const logger = getLogger();
 
-  // Prevent adding profiles with "modeler:" prefix
-  if (name.startsWith(MODELER_PREFIX)) {
-    logger.error(`Profile names cannot start with "${MODELER_PREFIX}" - this prefix is reserved for Camunda Modeler connections`);
-    logger.info('Please choose a different name or manage this profile in Camunda Modeler');
-    process.exit(1);
-  }
+	// Prevent adding profiles with "modeler:" prefix
+	if (name.startsWith(MODELER_PREFIX)) {
+		logger.error(
+			`Profile names cannot start with "${MODELER_PREFIX}" - this prefix is reserved for Camunda Modeler connections`,
+		);
+		logger.info(
+			"Please choose a different name or manage this profile in Camunda Modeler",
+		);
+		process.exit(1);
+	}
 
-  let profile: Profile;
+	let profile: Profile;
 
-  if (options.envFile && options.fromEnv) {
-    logger.error('Cannot use --from-file and --from-env together. Choose one.');
-    process.exit(1);
-  }
+	if (options.envFile && options.fromEnv) {
+		logger.error("Cannot use --from-file and --from-env together. Choose one.");
+		process.exit(1);
+	}
 
-  if (options.envFile) {
-    // --from-file: read a .env file and map CAMUNDA_* vars to profile fields
-    if (!existsSync(options.envFile)) {
-      logger.error(`File not found: ${options.envFile}`);
-      process.exit(1);
-    }
-    const content = readFileSync(options.envFile, 'utf-8');
-    const vars = parseEnvFile(content);
-    profile = envVarsToProfile(name, vars);
-    if (!profile.baseUrl) {
-      logger.error(`CAMUNDA_BASE_URL not found in ${options.envFile}`);
-      logger.info('The .env file must contain at least CAMUNDA_BASE_URL.');
-      process.exit(1);
-    }
-    addProfileConfig(profile);
-    logger.success(`Profile '${name}' added (from ${options.envFile})`);
-    logger.info(`  Base URL: ${profile.baseUrl}`);
-    logger.info(`  Auth: ${describeAuth(profile)}`);
-  } else if (options.fromEnv) {
-    // --from-env: read from current process environment
-    profile = envVarsToProfile(name, process.env);
-    if (!profile.baseUrl) {
-      logger.error('CAMUNDA_BASE_URL not set in environment');
-      logger.info('Set CAMUNDA_BASE_URL before using --from-env.');
-      process.exit(1);
-    }
-    addProfileConfig(profile);
-    logger.success(`Profile '${name}' added (from environment)`);
-    logger.info(`  Base URL: ${profile.baseUrl}`);
-    logger.info(`  Auth: ${describeAuth(profile)}`);
-  } else {
-    // Manual flags
-    profile = {
-      name,
-      baseUrl: options.url || 'http://localhost:8080/v2',
-      clientId: options.clientId,
-      clientSecret: options.clientSecret,
-      audience: options.audience,
-      oAuthUrl: options.oauthUrl,
-      username: options.username,
-      password: options.password,
-      defaultTenantId: options.tenantId,
-    };
-    addProfileConfig(profile);
-    logger.success(`Profile '${name}' added`);
-  }
+	if (options.envFile) {
+		// --from-file: read a .env file and map CAMUNDA_* vars to profile fields
+		if (!existsSync(options.envFile)) {
+			logger.error(`File not found: ${options.envFile}`);
+			process.exit(1);
+		}
+		const content = readFileSync(options.envFile, "utf-8");
+		const vars = parseEnvFile(content);
+		profile = envVarsToProfile(name, vars);
+		if (!profile.baseUrl) {
+			logger.error(`CAMUNDA_BASE_URL not found in ${options.envFile}`);
+			logger.info("The .env file must contain at least CAMUNDA_BASE_URL.");
+			process.exit(1);
+		}
+		addProfileConfig(profile);
+		logger.success(`Profile '${name}' added (from ${options.envFile})`);
+		logger.info(`  Base URL: ${profile.baseUrl}`);
+		logger.info(`  Auth: ${describeAuth(profile)}`);
+	} else if (options.fromEnv) {
+		// --from-env: read from current process environment
+		profile = envVarsToProfile(name, process.env);
+		if (!profile.baseUrl) {
+			logger.error("CAMUNDA_BASE_URL not set in environment");
+			logger.info("Set CAMUNDA_BASE_URL before using --from-env.");
+			process.exit(1);
+		}
+		addProfileConfig(profile);
+		logger.success(`Profile '${name}' added (from environment)`);
+		logger.info(`  Base URL: ${profile.baseUrl}`);
+		logger.info(`  Auth: ${describeAuth(profile)}`);
+	} else {
+		// Manual flags
+		profile = {
+			name,
+			baseUrl: options.url || "http://localhost:8080/v2",
+			clientId: options.clientId,
+			clientSecret: options.clientSecret,
+			audience: options.audience,
+			oAuthUrl: options.oauthUrl,
+			username: options.username,
+			password: options.password,
+			defaultTenantId: options.tenantId,
+		};
+		addProfileConfig(profile);
+		logger.success(`Profile '${name}' added`);
+	}
 }
 
 /**
  * Remove a c8ctl profile
  */
 export function removeProfile(name: string): void {
-  const logger = getLogger();
+	const logger = getLogger();
 
-  // Prevent removing Modeler profiles
-  if (name.startsWith(MODELER_PREFIX)) {
-    logger.error('Cannot remove Modeler profiles via c8ctl');
-    logger.info('Manage Modeler connections directly in Camunda Modeler');
-    process.exit(1);
-  }
+	// Prevent removing Modeler profiles
+	if (name.startsWith(MODELER_PREFIX)) {
+		logger.error("Cannot remove Modeler profiles via c8ctl");
+		logger.info("Manage Modeler connections directly in Camunda Modeler");
+		process.exit(1);
+	}
 
-  const removed = removeProfileConfig(name);
-  if (removed) {
-    logger.success(`Profile '${name}' removed`);
-  } else {
-    logger.error(`Profile '${name}' not found`);
-    process.exit(1);
-  }
+	const removed = removeProfileConfig(name);
+	if (removed) {
+		logger.success(`Profile '${name}' removed`);
+	} else {
+		logger.error(`Profile '${name}' not found`);
+		process.exit(1);
+	}
 }
 
 /**
  * Show which profile is currently active
  */
 export function whichProfile(): void {
-  const logger = getLogger();
-  const active = c8ctl.activeProfile;
-  if (!active) {
-    const hasBaseUrl = !!process.env.CAMUNDA_BASE_URL?.trim();
-    if (hasBaseUrl) {
-      logger.info('(none — CAMUNDA_* env vars will be used)');
-    } else if (hasCamundaEnvVars()) {
-      logger.info(`${DEFAULT_PROFILE} (default — CAMUNDA_* env vars detected but incomplete; set CAMUNDA_BASE_URL to use them)`);
-    } else {
-      logger.info(`${DEFAULT_PROFILE} (default)`);
-    }
-    return;
-  }
-  logger.info(active);
+	const logger = getLogger();
+	const active = c8ctl.activeProfile;
+	if (!active) {
+		const hasBaseUrl = !!process.env.CAMUNDA_BASE_URL?.trim();
+		if (hasBaseUrl) {
+			logger.info("(none — CAMUNDA_* env vars will be used)");
+		} else if (hasCamundaEnvVars()) {
+			logger.info(
+				`${DEFAULT_PROFILE} (default — CAMUNDA_* env vars detected but incomplete; set CAMUNDA_BASE_URL to use them)`,
+			);
+		} else {
+			logger.info(`${DEFAULT_PROFILE} (default)`);
+		}
+		return;
+	}
+	logger.info(active);
 }

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -3,6 +3,7 @@
  */
 
 import { readFileSync } from "node:fs";
+import { basename } from "node:path";
 import {
 	ProcessDefinitionId,
 	TenantId,
@@ -47,7 +48,7 @@ export async function run(
 		logger.info(`Deploying ${path}...`);
 
 		// Deploy the BPMN file - convert to File object with proper MIME type
-		const fileName = path.split("/").pop() || "process.bpmn";
+		const fileName = basename(path) || "process.bpmn";
 		const deployResult = await client.createDeployment({
 			tenantId: TenantId.assumeExists(tenantId),
 			resources: [

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -2,71 +2,82 @@
  * Run command - Deploy and create process instance in one step
  */
 
-import { getLogger } from '../logger.ts';
-import { createClient } from '../client.ts';
-import { resolveTenantId } from '../config.ts';
-import { TenantId } from '@camunda8/orchestration-cluster-api';
-import { readFileSync } from 'node:fs';
-import { handleCommandError } from '../errors.ts';
+import { readFileSync } from "node:fs";
+import {
+	ProcessDefinitionId,
+	TenantId,
+} from "@camunda8/orchestration-cluster-api";
+import { createClient } from "../client.ts";
+import { resolveTenantId } from "../config.ts";
+import { handleCommandError } from "../errors.ts";
+import { getLogger } from "../logger.ts";
 
 /**
  * Extract process ID from BPMN file
  */
 function extractProcessId(bpmnContent: string): string | null {
-  const match = bpmnContent.match(/process[^>]+id="([^"]+)"/);
-  return match ? match[1] : null;
+	const match = bpmnContent.match(/process[^>]+id="([^"]+)"/);
+	return match ? match[1] : null;
 }
 
 /**
  * Run - deploy and start process instance
  */
-export async function run(path: string, options: {
-  profile?: string;
-  variables?: string;
-}): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
-  const tenantId = resolveTenantId(options.profile);
+export async function run(
+	path: string,
+	options: {
+		profile?: string;
+		variables?: string;
+	},
+): Promise<void> {
+	const logger = getLogger();
+	const client = createClient(options.profile);
+	const tenantId = resolveTenantId(options.profile);
 
-  try {
-    // Read BPMN file
-    const content = readFileSync(path, 'utf-8');
-    const processId = extractProcessId(content);
+	try {
+		// Read BPMN file
+		const content = readFileSync(path, "utf-8");
+		const processId = extractProcessId(content);
 
-    if (!processId) {
-      logger.error('Could not extract process ID from BPMN file');
-      process.exit(1);
-    }
+		if (!processId) {
+			logger.error("Could not extract process ID from BPMN file");
+			process.exit(1);
+		}
 
-    logger.info(`Deploying ${path}...`);
+		logger.info(`Deploying ${path}...`);
 
-    // Deploy the BPMN file - convert to File object with proper MIME type
-    const fileName = path.split('/').pop() || 'process.bpmn';
-    const deployResult = await client.createDeployment({
-      tenantId: TenantId.assumeExists(tenantId),
-      resources: [new File([Buffer.from(content)], fileName, { type: 'application/xml' })],
-    });
-    logger.success('Deployment successful', deployResult.deploymentKey.toString());
+		// Deploy the BPMN file - convert to File object with proper MIME type
+		const fileName = path.split("/").pop() || "process.bpmn";
+		const deployResult = await client.createDeployment({
+			tenantId: TenantId.assumeExists(tenantId),
+			resources: [
+				new File([Buffer.from(content)], fileName, { type: "application/xml" }),
+			],
+		});
+		logger.success(
+			"Deployment successful",
+			deployResult.deploymentKey.toString(),
+		);
 
-    // Create process instance
-    logger.info(`Creating process instance for ${processId}...`);
+		// Create process instance
+		logger.info(`Creating process instance for ${processId}...`);
 
-    const createRequest: any = {
-      processDefinitionId: processId,
-      tenantId,
-    };
+		let variables: Record<string, unknown> | undefined;
+		if (options.variables) {
+			try {
+				variables = JSON.parse(options.variables);
+			} catch (error) {
+				handleCommandError(logger, "Invalid JSON for variables", error);
+			}
+		}
 
-    if (options.variables) {
-      try {
-        createRequest.variables = JSON.parse(options.variables);
-      } catch (error) {
-        handleCommandError(logger, 'Invalid JSON for variables', error);
-      }
-    }
-
-    const createResult = await client.createProcessInstance(createRequest);
-    logger.success('Process instance created', createResult.processInstanceKey);
-  } catch (error) {
-    handleCommandError(logger, 'Failed to run process', error);
-  }
+		const createResult = await client.createProcessInstance({
+			processDefinitionId: ProcessDefinitionId.assumeExists(processId),
+			tenantId: TenantId.assumeExists(tenantId),
+			...(variables !== undefined && { variables }),
+		});
+		logger.success("Process instance created", createResult.processInstanceKey);
+	} catch (error) {
+		handleCommandError(logger, "Failed to run process", error);
+	}
 }

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -283,7 +283,7 @@ export async function searchProcessDefinitions(options: {
       filter,
       ...(hasCiFilter ? [CI_PAGE_SIZE] as const : []),
     );
-    const result = { items: allItems } as any;
+    const result: { items: Record<string, unknown>[] } = { items: allItems as Record<string, unknown>[] };
 
     if (result.items?.length) {
       result.items = [...result.items].sort((left: any, right: any) => {
@@ -426,7 +426,7 @@ export async function searchProcessInstances(options: {
       filter,
       ...(hasCiFilter ? [CI_PAGE_SIZE] as const : []),
     );
-    const result = { items: allItems } as any;
+    const result: { items: Record<string, unknown>[] } = { items: allItems as Record<string, unknown>[] };
 
     if (hasCiFilter && result.items) {
       result.items = result.items.filter((pi: any) => {
@@ -548,7 +548,7 @@ export async function searchUserTasks(options: {
       filter,
       ...(hasCiFilter ? [CI_PAGE_SIZE] as const : []),
     );
-    const result = { items: allItems } as any;
+    const result: { items: Record<string, unknown>[] } = { items: allItems as Record<string, unknown>[] };
 
     if (hasCiFilter && result.items) {
       result.items = result.items.filter((task: any) => {
@@ -682,7 +682,7 @@ export async function searchIncidents(options: {
       filter,
       ...(hasCiFilter ? [CI_PAGE_SIZE] as const : []),
     );
-    const result = { items: allItems } as any;
+    const result: { items: Record<string, unknown>[] } = { items: allItems as Record<string, unknown>[] };
 
     if (hasCiFilter && result.items) {
       result.items = result.items.filter((incident: any) => {
@@ -799,7 +799,7 @@ export async function searchJobs(options: {
       filter,
       ...(hasCiFilter ? [CI_PAGE_SIZE] as const : []),
     );
-    const result = { items: allItems } as any;
+    const result: { items: Record<string, unknown>[] } = { items: allItems as Record<string, unknown>[] };
 
     if (hasCiFilter && result.items) {
       result.items = result.items.filter((job: any) => {
@@ -911,7 +911,7 @@ export async function searchVariables(options: {
       options.limit,
     );
 
-    let result = { items: allItems } as any;
+    let result: { items: Record<string, unknown>[] } = { items: allItems as Record<string, unknown>[] };
 
     if (hasCiFilter && result.items) {
       result.items = result.items.filter((variable: any) => {

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -278,12 +278,12 @@ export async function searchProcessDefinitions(options: {
       filter.filter.processDefinitionKey = options.key;
     }
 
-    const allItems = await fetchAllPages(
+    const allItems = await fetchAllPages<Record<string, unknown>>(
       (f, opts) => client.searchProcessDefinitions(f, opts),
       filter,
       ...(hasCiFilter ? [CI_PAGE_SIZE] as const : []),
     );
-    const result: { items: Record<string, unknown>[] } = { items: allItems as Record<string, unknown>[] };
+    const result: SearchResult = { items: allItems };
 
     if (result.items?.length) {
       result.items = [...result.items].sort((left: any, right: any) => {
@@ -321,7 +321,7 @@ export async function searchProcessDefinitions(options: {
       logNoResults(logger, 'process definitions', criteria.length > 0, options._unknownFlags);
     }
 
-    return result as SearchResult;
+    return result;
   } catch (error) {
     handleCommandError(logger, 'Failed to search process definitions', error);
   }
@@ -421,12 +421,12 @@ export async function searchProcessInstances(options: {
       }
     }
 
-    const allItems = await fetchAllPages(
+    const allItems = await fetchAllPages<Record<string, unknown>>(
       (f, opts) => client.searchProcessInstances(f, opts),
       filter,
       ...(hasCiFilter ? [CI_PAGE_SIZE] as const : []),
     );
-    const result: { items: Record<string, unknown>[] } = { items: allItems as Record<string, unknown>[] };
+    const result: SearchResult = { items: allItems };
 
     if (hasCiFilter && result.items) {
       result.items = result.items.filter((pi: any) => {
@@ -451,7 +451,7 @@ export async function searchProcessInstances(options: {
       logNoResults(logger, 'process instances', criteria.length > 0, options._unknownFlags);
     }
 
-    return result as SearchResult;
+    return result;
   } catch (error) {
     handleCommandError(logger, 'Failed to search process instances', error);
   }
@@ -543,12 +543,12 @@ export async function searchUserTasks(options: {
       }
     }
 
-    const allItems = await fetchAllPages(
+    const allItems = await fetchAllPages<Record<string, unknown>>(
       (f, opts) => client.searchUserTasks(f, opts),
       filter,
       ...(hasCiFilter ? [CI_PAGE_SIZE] as const : []),
     );
-    const result: { items: Record<string, unknown>[] } = { items: allItems as Record<string, unknown>[] };
+    const result: SearchResult = { items: allItems };
 
     if (hasCiFilter && result.items) {
       result.items = result.items.filter((task: any) => {
@@ -574,7 +574,7 @@ export async function searchUserTasks(options: {
       logNoResults(logger, 'user tasks', criteria.length > 0, options._unknownFlags);
     }
 
-    return result as SearchResult;
+    return result;
   } catch (error) {
     handleCommandError(logger, 'Failed to search user tasks', error);
   }
@@ -677,12 +677,12 @@ export async function searchIncidents(options: {
       }
     }
 
-    const allItems = await fetchAllPages(
+    const allItems = await fetchAllPages<Record<string, unknown>>(
       (f, opts) => client.searchIncidents(f, opts),
       filter,
       ...(hasCiFilter ? [CI_PAGE_SIZE] as const : []),
     );
-    const result: { items: Record<string, unknown>[] } = { items: allItems as Record<string, unknown>[] };
+    const result: SearchResult = { items: allItems };
 
     if (hasCiFilter && result.items) {
       result.items = result.items.filter((incident: any) => {
@@ -710,7 +710,7 @@ export async function searchIncidents(options: {
       logNoResults(logger, 'incidents', criteria.length > 0, options._unknownFlags);
     }
 
-    return result as SearchResult;
+    return result;
   } catch (error) {
     handleCommandError(logger, 'Failed to search incidents', error);
   }
@@ -794,12 +794,12 @@ export async function searchJobs(options: {
       }
     }
 
-    const allItems = await fetchAllPages(
+    const allItems = await fetchAllPages<Record<string, unknown>>(
       (f, opts) => client.searchJobs(f, opts),
       filter,
       ...(hasCiFilter ? [CI_PAGE_SIZE] as const : []),
     );
-    const result: { items: Record<string, unknown>[] } = { items: allItems as Record<string, unknown>[] };
+    const result: SearchResult = { items: allItems };
 
     if (hasCiFilter && result.items) {
       result.items = result.items.filter((job: any) => {
@@ -825,7 +825,7 @@ export async function searchJobs(options: {
       logNoResults(logger, 'jobs', criteria.length > 0, options._unknownFlags);
     }
 
-    return result as SearchResult;
+    return result;
   } catch (error) {
     handleCommandError(logger, 'Failed to search jobs', error);
   }
@@ -904,14 +904,14 @@ export async function searchVariables(options: {
     // By default, truncate values unless --fullValue is specified
     const truncateValues = !options.fullValue;
 
-    const allItems = await fetchAllPages(
+    const allItems = await fetchAllPages<Record<string, unknown>>(
       (f, opts) => client.searchVariables({ ...f, truncateValues }, opts),
       filter,
       hasCiFilter ? CI_PAGE_SIZE : DEFAULT_PAGE_SIZE,
       options.limit,
     );
 
-    let result: { items: Record<string, unknown>[] } = { items: allItems as Record<string, unknown>[] };
+    let result: SearchResult = { items: allItems };
 
     if (hasCiFilter && result.items) {
       result.items = result.items.filter((variable: any) => {
@@ -957,7 +957,7 @@ export async function searchVariables(options: {
       logNoResults(logger, 'variables', criteria.length > 0, options._unknownFlags);
     }
 
-    return result as SearchResult;
+    return result;
   } catch (error) {
     handleCommandError(logger, 'Failed to search variables', error);
   }

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -2,20 +2,26 @@
  * Search commands
  */
 
-import { getLogger, Logger, sortTableData, type SortOrder } from '../logger.ts';
-import { createClient, fetchAllPages, DEFAULT_PAGE_SIZE } from '../client.ts';
-import { resolveTenantId } from '../config.ts';
-import { parseBetween, buildDateFilter } from '../date-filter.ts';
-import { handleCommandError } from '../errors.ts';
+import { createClient, DEFAULT_PAGE_SIZE, fetchAllPages } from "../client.ts";
+import { resolveTenantId } from "../config.ts";
+import { buildDateFilter, parseBetween } from "../date-filter.ts";
+import { handleCommandError } from "../errors.ts";
+import {
+	getLogger,
+	type Logger,
+	type SortOrder,
+	sortTableData,
+} from "../logger.ts";
 
-export type SearchResult = { items: Array<Record<string, unknown>>; total?: number };
+export type SearchResult = {
+	items: Array<Record<string, unknown>>;
+	total?: number;
+};
 
 /**
  * CLI infrastructure flags — valid for every command, never passed to search APIs.
  */
-const CLI_FLAGS = new Set([
-  'profile', 'help', 'version',
-]);
+const CLI_FLAGS = new Set(["profile", "help", "version"]);
 
 /**
  * Search behavior flags consumed by shared infrastructure (fetchAllPages / buildDateFilter / sort)
@@ -25,7 +31,11 @@ const CLI_FLAGS = new Set([
  * If a flag is only relevant to some resources, put it in SEARCH_RESOURCE_FLAGS instead.
  */
 const SHARED_SEARCH_FLAGS = new Set([
-  'sortBy', 'asc', 'desc', 'between', 'dateField',
+	"sortBy",
+	"asc",
+	"desc",
+	"between",
+	"dateField",
 ]);
 
 /**
@@ -40,37 +50,103 @@ export const GLOBAL_FLAGS = new Set([...CLI_FLAGS, ...SHARED_SEARCH_FLAGS]);
  * for the specific resource, causing silent filter drops.
  */
 export const SEARCH_RESOURCE_FLAGS: Record<string, Set<string>> = {
-  'process-definition': new Set(['bpmnProcessId', 'id', 'processDefinitionId', 'name', 'key', 'iid', 'iname']),
-  'process-instance': new Set(['bpmnProcessId', 'id', 'processDefinitionId', 'processDefinitionKey', 'state', 'key', 'parentProcessInstanceKey', 'iid']),
-  'user-task': new Set(['state', 'assignee', 'processInstanceKey', 'processDefinitionKey', 'elementId', 'iassignee']),
-  'incident': new Set(['state', 'processInstanceKey', 'processDefinitionKey', 'bpmnProcessId', 'id', 'processDefinitionId', 'errorType', 'errorMessage', 'ierrorMessage', 'iid']),
-  'jobs': new Set(['state', 'type', 'processInstanceKey', 'processDefinitionKey', 'itype']),
-  'variable': new Set(['name', 'value', 'processInstanceKey', 'scopeKey', 'fullValue', 'iname', 'ivalue', 'limit']),
-  'user': new Set(['username', 'name', 'email', 'limit']),
-  'role': new Set(['roleId', 'name', 'limit']),
-  'group': new Set(['groupId', 'name', 'limit']),
-  'tenant': new Set(['tenantId', 'name', 'limit']),
-  'authorization': new Set(['ownerId', 'ownerType', 'resourceType', 'resourceId', 'limit']),
-  'mapping-rule': new Set(['mappingRuleId', 'name', 'claimName', 'claimValue', 'limit']),
+	"process-definition": new Set([
+		"bpmnProcessId",
+		"id",
+		"processDefinitionId",
+		"name",
+		"key",
+		"iid",
+		"iname",
+	]),
+	"process-instance": new Set([
+		"bpmnProcessId",
+		"id",
+		"processDefinitionId",
+		"processDefinitionKey",
+		"state",
+		"key",
+		"parentProcessInstanceKey",
+		"iid",
+	]),
+	"user-task": new Set([
+		"state",
+		"assignee",
+		"processInstanceKey",
+		"processDefinitionKey",
+		"elementId",
+		"iassignee",
+	]),
+	incident: new Set([
+		"state",
+		"processInstanceKey",
+		"processDefinitionKey",
+		"bpmnProcessId",
+		"id",
+		"processDefinitionId",
+		"errorType",
+		"errorMessage",
+		"ierrorMessage",
+		"iid",
+	]),
+	jobs: new Set([
+		"state",
+		"type",
+		"processInstanceKey",
+		"processDefinitionKey",
+		"itype",
+	]),
+	variable: new Set([
+		"name",
+		"value",
+		"processInstanceKey",
+		"scopeKey",
+		"fullValue",
+		"iname",
+		"ivalue",
+		"limit",
+	]),
+	user: new Set(["username", "name", "email", "limit"]),
+	role: new Set(["roleId", "name", "limit"]),
+	group: new Set(["groupId", "name", "limit"]),
+	tenant: new Set(["tenantId", "name", "limit"]),
+	authorization: new Set([
+		"ownerId",
+		"ownerType",
+		"resourceType",
+		"resourceId",
+		"limit",
+	]),
+	"mapping-rule": new Set([
+		"mappingRuleId",
+		"name",
+		"claimName",
+		"claimValue",
+		"limit",
+	]),
 };
 
 /**
  * Detect flags the user set that are not recognized for the given search resource.
  * Returns the list of unknown flag names (without the --prefix).
  */
-export function detectUnknownSearchFlags(values: Record<string, unknown>, normalizedResource: string): string[] {
-  const validFlags = SEARCH_RESOURCE_FLAGS[normalizedResource]
-    || SEARCH_RESOURCE_FLAGS[normalizedResource.replace(/s$/, '')];
-  if (!validFlags) return [];
+export function detectUnknownSearchFlags(
+	values: Record<string, unknown>,
+	normalizedResource: string,
+): string[] {
+	const validFlags =
+		SEARCH_RESOURCE_FLAGS[normalizedResource] ||
+		SEARCH_RESOURCE_FLAGS[normalizedResource.replace(/s$/, "")];
+	if (!validFlags) return [];
 
-  const unknown: string[] = [];
-  for (const [key, val] of Object.entries(values)) {
-    if (val === undefined || val === false) continue; // not set by the user
-    if (GLOBAL_FLAGS.has(key)) continue;
-    if (validFlags.has(key)) continue;
-    unknown.push(key);
-  }
-  return unknown;
+	const unknown: string[] = [];
+	for (const [key, val] of Object.entries(values)) {
+		if (val === undefined || val === false) continue; // not set by the user
+		if (GLOBAL_FLAGS.has(key)) continue;
+		if (validFlags.has(key)) continue;
+		unknown.push(key);
+	}
+	return unknown;
 }
 
 /**
@@ -83,56 +159,69 @@ export function detectUnknownSearchFlags(values: Record<string, unknown>, normal
  *   Escape with backslash: \* or \?
  */
 export const hasUnescapedWildcard = (value: string): boolean =>
-  /(?<!\\)[*?]/.test(value);
+	/(?<!\\)[*?]/.test(value);
 
 export const toStringFilter = (value: string): string | { $like: string } =>
-  hasUnescapedWildcard(value) ? { $like: value } : value;
+	hasUnescapedWildcard(value) ? { $like: value } : value;
 
 /**
  * Convert a wildcard pattern (* and ?) to a case-insensitive RegExp.
  * Handles escaped wildcards (\* and \?).
  */
-export const wildcardToRegex = (pattern: string, caseInsensitive = true): RegExp => {
-  let regex = '';
-  for (let i = 0; i < pattern.length; i++) {
-    if (pattern[i] === '\\' && i + 1 < pattern.length && (pattern[i + 1] === '*' || pattern[i + 1] === '?')) {
-      regex += pattern[i + 1] === '*' ? '\\*' : '\\?';
-      i++;
-    } else if (pattern[i] === '*') {
-      regex += '.*';
-    } else if (pattern[i] === '?') {
-      regex += '.';
-    } else {
-      regex += pattern[i].replace(/[[\]{}()+.,\\^$|#]/g, '\\$&');
-    }
-  }
-  return new RegExp(`^${regex}$`, caseInsensitive ? 'i' : '');
+export const wildcardToRegex = (
+	pattern: string,
+	caseInsensitive = true,
+): RegExp => {
+	let regex = "";
+	for (let i = 0; i < pattern.length; i++) {
+		if (
+			pattern[i] === "\\" &&
+			i + 1 < pattern.length &&
+			(pattern[i + 1] === "*" || pattern[i + 1] === "?")
+		) {
+			regex += pattern[i + 1] === "*" ? "\\*" : "\\?";
+			i++;
+		} else if (pattern[i] === "*") {
+			regex += ".*";
+		} else if (pattern[i] === "?") {
+			regex += ".";
+		} else {
+			regex += pattern[i].replace(/[[\]{}()+.,\\^$|#]/g, "\\$&");
+		}
+	}
+	return new RegExp(`^${regex}$`, caseInsensitive ? "i" : "");
 };
 
 /**
  * Test if a value matches a wildcard pattern case-insensitively.
  * Without wildcards, performs exact case-insensitive match.
  */
-export const matchesCaseInsensitive = (value: string | undefined | null, pattern: string): boolean => {
-  if (value == null) return false;
-  return wildcardToRegex(pattern).test(value);
+export const matchesCaseInsensitive = (
+	value: unknown,
+	pattern: string,
+): boolean => {
+	if (value == null || typeof value !== "string") return false;
+	return wildcardToRegex(pattern).test(value);
 };
 
 /**
  * Test if a value matches a wildcard pattern case-sensitively.
  * Without wildcards, performs exact case-sensitive match.
  */
-export const matchesCaseSensitive = (value: string | undefined | null, pattern: string): boolean => {
-  if (value == null) return false;
-  return wildcardToRegex(pattern, false).test(value);
+export const matchesCaseSensitive = (
+	value: unknown,
+	pattern: string,
+): boolean => {
+	if (value == null || typeof value !== "string") return false;
+	return wildcardToRegex(pattern, false).test(value);
 };
 
 const toBigIntSafe = (value: unknown): bigint => {
-  try {
-    return BigInt(String(value));
-  } catch {
-    return 0n;
-  }
+	try {
+		return BigInt(String(value));
+	} catch {
+		return 0n;
+	}
 };
 
 /** Default page size the Camunda REST API uses when no explicit limit is set */
@@ -143,29 +232,33 @@ const CI_PAGE_SIZE = 1000;
 
 /**
  * Build a human-readable description of a filter criterion.
- * 
+ *
  * @param fieldLabel - Human-readable name of the field being searched
  * @param value - The filter value
  * @param isCaseInsensitive - Whether this is a case-insensitive search
  * @returns A formatted string describing the criterion
  */
-function formatCriterion(fieldLabel: string, value: string | number | boolean, isCaseInsensitive: boolean = false): string {
-  if (typeof value === 'boolean') {
-    return `'${fieldLabel}' = ${value}`;
-  }
-  
-  if (typeof value === 'number') {
-    return `'${fieldLabel}' = ${value}`;
-  }
-  
-  const hasWildcard = hasUnescapedWildcard(value);
-  const prefix = isCaseInsensitive ? '(case-insensitive) ' : '';
-  
-  if (hasWildcard) {
-    return `${prefix}'${fieldLabel}' matching "${value}"`;
-  } else {
-    return `${prefix}'${fieldLabel}' = "${value}"`;
-  }
+function formatCriterion(
+	fieldLabel: string,
+	value: string | number | boolean,
+	isCaseInsensitive: boolean = false,
+): string {
+	if (typeof value === "boolean") {
+		return `'${fieldLabel}' = ${value}`;
+	}
+
+	if (typeof value === "number") {
+		return `'${fieldLabel}' = ${value}`;
+	}
+
+	const hasWildcard = hasUnescapedWildcard(value);
+	const prefix = isCaseInsensitive ? "(case-insensitive) " : "";
+
+	if (hasWildcard) {
+		return `${prefix}'${fieldLabel}' matching "${value}"`;
+	} else {
+		return `${prefix}'${fieldLabel}' = "${value}"`;
+	}
 }
 
 /**
@@ -176,789 +269,1014 @@ function formatCriterion(fieldLabel: string, value: string | number | boolean, i
  * @param resourceName - Human-readable name of the resource type being searched
  * @param criteria - Array of criterion strings describing the filters
  */
-function logSearchCriteria(logger: Logger, resourceName: string, criteria: string[]): void {
-  if (criteria.length === 0) {
-    logger.info(`Searching ${resourceName} (no filters)`);
-  } else if (criteria.length === 1) {
-    logger.info(`Searching ${resourceName} where ${criteria[0]}`);
-  } else {
-    logger.info(`Searching ${resourceName} where ${criteria.join(' AND ')}`);
-  }
+function logSearchCriteria(
+	logger: Logger,
+	resourceName: string,
+	criteria: string[],
+): void {
+	if (criteria.length === 0) {
+		logger.info(`Searching ${resourceName} (no filters)`);
+	} else if (criteria.length === 1) {
+		logger.info(`Searching ${resourceName} where ${criteria[0]}`);
+	} else {
+		logger.info(`Searching ${resourceName} where ${criteria.join(" AND ")}`);
+	}
 }
 
 /**
  * Log a "no results" message with 🕳️ emoji and contextual hint.
  */
-export function logNoResults(logger: Logger, resourceName: string, hasFilters: boolean, unknownFlags?: string[]): void {
-  if (unknownFlags && unknownFlags.length > 0) {
-    const flagList = unknownFlags.map(f => `--${f}`).join(', ');
-    logger.info(`🕳️ No ${resourceName} found matching the criteria (ignored unknown flag(s): ${flagList})`);
-  } else {
-    logger.info(`🕳️ No ${resourceName} found matching the criteria`);
-  }
-  if (!hasFilters) {
-    logger.info('No filters were applied. Use "c8ctl help search" to see available filter flags.');
-  }
+export function logNoResults(
+	logger: Logger,
+	resourceName: string,
+	hasFilters: boolean,
+	unknownFlags?: string[],
+): void {
+	if (unknownFlags && unknownFlags.length > 0) {
+		const flagList = unknownFlags.map((f) => `--${f}`).join(", ");
+		logger.info(
+			`🕳️ No ${resourceName} found matching the criteria (ignored unknown flag(s): ${flagList})`,
+		);
+	} else {
+		logger.info(`🕳️ No ${resourceName} found matching the criteria`);
+	}
+	if (!hasFilters) {
+		logger.info(
+			'No filters were applied. Use "c8ctl help search" to see available filter flags.',
+		);
+	}
 }
 
 /**
  * Log the result count with a truncation warning when the count matches the API default page size.
  */
-export function logResultCount(logger: Logger, count: number, resourceName: string, hasFilters: boolean): void {
-  logger.info(`Found ${count} ${resourceName}`);
-  if (count === API_DEFAULT_PAGE_SIZE && !hasFilters) {
-    logger.warn(`Showing first ${API_DEFAULT_PAGE_SIZE} results (API default page size). More results may exist — add filters to narrow down.`);
-  } else if (count === API_DEFAULT_PAGE_SIZE) {
-    logger.warn(`Result count equals the API default page size (${API_DEFAULT_PAGE_SIZE}). There may be more results.`);
-  }
+export function logResultCount(
+	logger: Logger,
+	count: number,
+	resourceName: string,
+	hasFilters: boolean,
+): void {
+	logger.info(`Found ${count} ${resourceName}`);
+	if (count === API_DEFAULT_PAGE_SIZE && !hasFilters) {
+		logger.warn(
+			`Showing first ${API_DEFAULT_PAGE_SIZE} results (API default page size). More results may exist — add filters to narrow down.`,
+		);
+	} else if (count === API_DEFAULT_PAGE_SIZE) {
+		logger.warn(
+			`Result count equals the API default page size (${API_DEFAULT_PAGE_SIZE}). There may be more results.`,
+		);
+	}
 }
 
 /**
  * Search process definitions
  */
 export async function searchProcessDefinitions(options: {
-  profile?: string;
-  processDefinitionId?: string;
-  name?: string;
-  version?: number;
-  key?: string;
-  iProcessDefinitionId?: string;
-  iName?: string;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  _unknownFlags?: string[];
+	profile?: string;
+	processDefinitionId?: string;
+	name?: string;
+	version?: number;
+	key?: string;
+	iProcessDefinitionId?: string;
+	iName?: string;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	_unknownFlags?: string[];
 }): Promise<SearchResult | undefined> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
-  const tenantId = resolveTenantId(options.profile);
-  const hasCiFilter = !!(options.iProcessDefinitionId || options.iName);
+	const logger = getLogger();
+	const client = createClient(options.profile);
+	const tenantId = resolveTenantId(options.profile);
+	const hasCiFilter = !!(options.iProcessDefinitionId || options.iName);
 
-  // Build search criteria description for user feedback
-  const criteria: string[] = [];
-  if (options.processDefinitionId) {
-    criteria.push(formatCriterion('Process Definition ID', options.processDefinitionId));
-  }
-  if (options.name) {
-    criteria.push(formatCriterion('name', options.name));
-  }
-  if (options.version !== undefined) {
-    criteria.push(formatCriterion('version', options.version));
-  }
-  if (options.key) {
-    criteria.push(formatCriterion('key', options.key));
-  }
-  if (options.iProcessDefinitionId) {
-    criteria.push(formatCriterion('Process Definition ID', options.iProcessDefinitionId, true));
-  }
-  if (options.iName) {
-    criteria.push(formatCriterion('name', options.iName, true));
-  }
-  logSearchCriteria(logger, 'Process Definitions', criteria);
+	// Build search criteria description for user feedback
+	const criteria: string[] = [];
+	if (options.processDefinitionId) {
+		criteria.push(
+			formatCriterion("Process Definition ID", options.processDefinitionId),
+		);
+	}
+	if (options.name) {
+		criteria.push(formatCriterion("name", options.name));
+	}
+	if (options.version !== undefined) {
+		criteria.push(formatCriterion("version", options.version));
+	}
+	if (options.key) {
+		criteria.push(formatCriterion("key", options.key));
+	}
+	if (options.iProcessDefinitionId) {
+		criteria.push(
+			formatCriterion(
+				"Process Definition ID",
+				options.iProcessDefinitionId,
+				true,
+			),
+		);
+	}
+	if (options.iName) {
+		criteria.push(formatCriterion("name", options.iName, true));
+	}
+	logSearchCriteria(logger, "Process Definitions", criteria);
 
-  try {
-    const filter: any = {
-      filter: {
-        tenantId,
-      },
-    };
+	try {
+		const filter: { filter: Record<string, unknown> } = {
+			filter: {
+				tenantId,
+			},
+		};
 
-    if (options.processDefinitionId) {
-      filter.filter.processDefinitionId = toStringFilter(options.processDefinitionId);
-    }
+		if (options.processDefinitionId) {
+			filter.filter.processDefinitionId = toStringFilter(
+				options.processDefinitionId,
+			);
+		}
 
-    if (options.name) {
-      filter.filter.name = toStringFilter(options.name);
-    }
+		if (options.name) {
+			filter.filter.name = toStringFilter(options.name);
+		}
 
-    if (options.version !== undefined) {
-      filter.filter.version = options.version;
-    }
+		if (options.version !== undefined) {
+			filter.filter.version = options.version;
+		}
 
-    if (options.key) {
-      filter.filter.processDefinitionKey = options.key;
-    }
+		if (options.key) {
+			filter.filter.processDefinitionKey = options.key;
+		}
 
-    const allItems = await fetchAllPages<Record<string, unknown>>(
-      (f, opts) => client.searchProcessDefinitions(f, opts),
-      filter,
-      ...(hasCiFilter ? [CI_PAGE_SIZE] as const : []),
-    );
-    const result: SearchResult = { items: allItems };
+		const allItems = await fetchAllPages<Record<string, unknown>>(
+			(f, opts) => client.searchProcessDefinitions(f, opts),
+			filter,
+			...(hasCiFilter ? ([CI_PAGE_SIZE] as const) : []),
+		);
+		const result: SearchResult = { items: allItems };
 
-    if (result.items?.length) {
-      result.items = [...result.items].sort((left: any, right: any) => {
-        const versionDelta = (Number(right.version) || 0) - (Number(left.version) || 0);
-        if (versionDelta !== 0) return versionDelta;
+		if (result.items?.length) {
+			result.items = [...result.items].sort((left, right) => {
+				const versionDelta =
+					(Number(right.version) || 0) - (Number(left.version) || 0);
+				if (versionDelta !== 0) return versionDelta;
 
-        const leftKey = toBigIntSafe(left.processDefinitionKey ?? left.key);
-        const rightKey = toBigIntSafe(right.processDefinitionKey ?? right.key);
-        if (leftKey === rightKey) return 0;
-        return rightKey > leftKey ? 1 : -1;
-      });
-    }
+				const leftKey = toBigIntSafe(left.processDefinitionKey ?? left.key);
+				const rightKey = toBigIntSafe(right.processDefinitionKey ?? right.key);
+				if (leftKey === rightKey) return 0;
+				return rightKey > leftKey ? 1 : -1;
+			});
+		}
 
-    // Client-side case-insensitive post-filtering
-    if (hasCiFilter && result.items) {
-      result.items = result.items.filter((pd: any) => {
-        if (options.iProcessDefinitionId && !matchesCaseInsensitive(pd.processDefinitionId, options.iProcessDefinitionId)) return false;
-        if (options.iName && !matchesCaseInsensitive(pd.name, options.iName)) return false;
-        return true;
-      });
-    }
-    
-    if (result.items && result.items.length > 0) {
-      let tableData = result.items.map((pd: any) => ({
-        Key: pd.processDefinitionKey || pd.key,
-        'Process ID': pd.processDefinitionId,
-        Name: pd.name || '-',
-        Version: pd.version,
-        'Tenant ID': pd.tenantId,
-      }));
-      tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-      logger.table(tableData);
-      logResultCount(logger, result.items.length, 'process definition(s)', criteria.length > 0);
-    } else {
-      logNoResults(logger, 'process definitions', criteria.length > 0, options._unknownFlags);
-    }
+		// Client-side case-insensitive post-filtering
+		if (hasCiFilter && result.items) {
+			result.items = result.items.filter((pd) => {
+				if (
+					options.iProcessDefinitionId &&
+					!matchesCaseInsensitive(
+						pd.processDefinitionId,
+						options.iProcessDefinitionId,
+					)
+				)
+					return false;
+				if (options.iName && !matchesCaseInsensitive(pd.name, options.iName))
+					return false;
+				return true;
+			});
+		}
 
-    return result;
-  } catch (error) {
-    handleCommandError(logger, 'Failed to search process definitions', error);
-  }
+		if (result.items && result.items.length > 0) {
+			let tableData = result.items.map((pd) => ({
+				Key: pd.processDefinitionKey || pd.key,
+				"Process ID": pd.processDefinitionId,
+				Name: pd.name || "-",
+				Version: pd.version,
+				"Tenant ID": pd.tenantId,
+			}));
+			tableData = sortTableData(
+				tableData,
+				options.sortBy,
+				logger,
+				options.sortOrder,
+			);
+			logger.table(tableData);
+			logResultCount(
+				logger,
+				result.items.length,
+				"process definition(s)",
+				criteria.length > 0,
+			);
+		} else {
+			logNoResults(
+				logger,
+				"process definitions",
+				criteria.length > 0,
+				options._unknownFlags,
+			);
+		}
+
+		return result;
+	} catch (error) {
+		handleCommandError(logger, "Failed to search process definitions", error);
+	}
 }
 
 /**
  * Search process instances
  */
 export async function searchProcessInstances(options: {
-  profile?: string;
-  processDefinitionId?: string;
-  processDefinitionKey?: string;
-  version?: number;
-  state?: string;
-  key?: string;
-  parentProcessInstanceKey?: string;
-  iProcessDefinitionId?: string;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  _unknownFlags?: string[];
-  between?: string;
-  dateField?: string;
+	profile?: string;
+	processDefinitionId?: string;
+	processDefinitionKey?: string;
+	version?: number;
+	state?: string;
+	key?: string;
+	parentProcessInstanceKey?: string;
+	iProcessDefinitionId?: string;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	_unknownFlags?: string[];
+	between?: string;
+	dateField?: string;
 }): Promise<SearchResult | undefined> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
-  const tenantId = resolveTenantId(options.profile);
-  const hasCiFilter = !!options.iProcessDefinitionId;
+	const logger = getLogger();
+	const client = createClient(options.profile);
+	const tenantId = resolveTenantId(options.profile);
+	const hasCiFilter = !!options.iProcessDefinitionId;
 
-  // Build search criteria description for user feedback
-  const criteria: string[] = [];
-  if (options.processDefinitionId) {
-    criteria.push(formatCriterion('Process Definition ID', options.processDefinitionId));
-  }
-  if (options.processDefinitionKey) {
-    criteria.push(formatCriterion('Process Definition Key', options.processDefinitionKey));
-  }
-  if (options.state) {
-    criteria.push(formatCriterion('state', options.state));
-  }
-  if (options.version !== undefined) {
-    criteria.push(formatCriterion('version', options.version));
-  }
-  if (options.key) {
-    criteria.push(formatCriterion('key', options.key));
-  }
-  if (options.parentProcessInstanceKey) {
-    criteria.push(formatCriterion('Parent Process Instance Key', options.parentProcessInstanceKey));
-  }
-  if (options.iProcessDefinitionId) {
-    criteria.push(formatCriterion('Process Definition ID', options.iProcessDefinitionId, true));
-  }
-  if (options.between) {
-    const field = options.dateField ?? 'startDate';
-    criteria.push(`'${field}' between "${options.between}"`);
-  }
-  logSearchCriteria(logger, 'Process Instances', criteria);
+	// Build search criteria description for user feedback
+	const criteria: string[] = [];
+	if (options.processDefinitionId) {
+		criteria.push(
+			formatCriterion("Process Definition ID", options.processDefinitionId),
+		);
+	}
+	if (options.processDefinitionKey) {
+		criteria.push(
+			formatCriterion("Process Definition Key", options.processDefinitionKey),
+		);
+	}
+	if (options.state) {
+		criteria.push(formatCriterion("state", options.state));
+	}
+	if (options.version !== undefined) {
+		criteria.push(formatCriterion("version", options.version));
+	}
+	if (options.key) {
+		criteria.push(formatCriterion("key", options.key));
+	}
+	if (options.parentProcessInstanceKey) {
+		criteria.push(
+			formatCriterion(
+				"Parent Process Instance Key",
+				options.parentProcessInstanceKey,
+			),
+		);
+	}
+	if (options.iProcessDefinitionId) {
+		criteria.push(
+			formatCriterion(
+				"Process Definition ID",
+				options.iProcessDefinitionId,
+				true,
+			),
+		);
+	}
+	if (options.between) {
+		const field = options.dateField ?? "startDate";
+		criteria.push(`'${field}' between "${options.between}"`);
+	}
+	logSearchCriteria(logger, "Process Instances", criteria);
 
-  try {
-    const filter: any = {
-      filter: {
-        tenantId,
-      },
-    };
+	try {
+		const filter: { filter: Record<string, unknown> } = {
+			filter: {
+				tenantId,
+			},
+		};
 
-    if (options.processDefinitionId) {
-      filter.filter.processDefinitionId = toStringFilter(options.processDefinitionId);
-    }
+		if (options.processDefinitionId) {
+			filter.filter.processDefinitionId = toStringFilter(
+				options.processDefinitionId,
+			);
+		}
 
-    if (options.processDefinitionKey) {
-      filter.filter.processDefinitionKey = options.processDefinitionKey;
-    }
+		if (options.processDefinitionKey) {
+			filter.filter.processDefinitionKey = options.processDefinitionKey;
+		}
 
-    if (options.version !== undefined) {
-      filter.filter.processDefinitionVersion = options.version;
-    }
+		if (options.version !== undefined) {
+			filter.filter.processDefinitionVersion = options.version;
+		}
 
-    if (options.state) {
-      filter.filter.state = options.state;
-    }
+		if (options.state) {
+			filter.filter.state = options.state;
+		}
 
-    if (options.key) {
-      filter.filter.processInstanceKey = options.key;
-    }
+		if (options.key) {
+			filter.filter.processInstanceKey = options.key;
+		}
 
-    if (options.parentProcessInstanceKey) {
-      filter.filter.parentProcessInstanceKey = options.parentProcessInstanceKey;
-    }
+		if (options.parentProcessInstanceKey) {
+			filter.filter.parentProcessInstanceKey = options.parentProcessInstanceKey;
+		}
 
-    if (options.between) {
-      const parsed = parseBetween(options.between);
-      if (parsed) {
-        const field = options.dateField ?? 'startDate';
-        filter.filter[field] = buildDateFilter(parsed.from, parsed.to);
-      } else {
-        logger.error('Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)');
-        process.exit(1);
-      }
-    }
+		if (options.between) {
+			const parsed = parseBetween(options.between);
+			if (parsed) {
+				const field = options.dateField ?? "startDate";
+				filter.filter[field] = buildDateFilter(parsed.from, parsed.to);
+			} else {
+				logger.error(
+					"Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)",
+				);
+				process.exit(1);
+			}
+		}
 
-    const allItems = await fetchAllPages<Record<string, unknown>>(
-      (f, opts) => client.searchProcessInstances(f, opts),
-      filter,
-      ...(hasCiFilter ? [CI_PAGE_SIZE] as const : []),
-    );
-    const result: SearchResult = { items: allItems };
+		const allItems = await fetchAllPages<Record<string, unknown>>(
+			(f, opts) => client.searchProcessInstances(f, opts),
+			filter,
+			...(hasCiFilter ? ([CI_PAGE_SIZE] as const) : []),
+		);
+		const result: SearchResult = { items: allItems };
 
-    if (hasCiFilter && result.items) {
-      result.items = result.items.filter((pi: any) => {
-        if (options.iProcessDefinitionId && !matchesCaseInsensitive(pi.processDefinitionId, options.iProcessDefinitionId)) return false;
-        return true;
-      });
-    }
-    
-    if (result.items && result.items.length > 0) {
-      let tableData = result.items.map((pi: any) => ({
-        Key: pi.processInstanceKey || pi.key,
-        'Process ID': pi.processDefinitionId,
-        State: pi.state,
-        Version: pi.processDefinitionVersion || pi.version,
-        'Start Date': pi.startDate || '-',
-        'Tenant ID': pi.tenantId,
-      }));
-      tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-      logger.table(tableData);
-      logResultCount(logger, result.items.length, 'process instance(s)', criteria.length > 0);
-    } else {
-      logNoResults(logger, 'process instances', criteria.length > 0, options._unknownFlags);
-    }
+		if (hasCiFilter && result.items) {
+			result.items = result.items.filter((pi) => {
+				if (
+					options.iProcessDefinitionId &&
+					!matchesCaseInsensitive(
+						pi.processDefinitionId,
+						options.iProcessDefinitionId,
+					)
+				)
+					return false;
+				return true;
+			});
+		}
 
-    return result;
-  } catch (error) {
-    handleCommandError(logger, 'Failed to search process instances', error);
-  }
+		if (result.items && result.items.length > 0) {
+			let tableData = result.items.map((pi) => ({
+				Key: pi.processInstanceKey || pi.key,
+				"Process ID": pi.processDefinitionId,
+				State: pi.state,
+				Version: pi.processDefinitionVersion || pi.version,
+				"Start Date": pi.startDate || "-",
+				"Tenant ID": pi.tenantId,
+			}));
+			tableData = sortTableData(
+				tableData,
+				options.sortBy,
+				logger,
+				options.sortOrder,
+			);
+			logger.table(tableData);
+			logResultCount(
+				logger,
+				result.items.length,
+				"process instance(s)",
+				criteria.length > 0,
+			);
+		} else {
+			logNoResults(
+				logger,
+				"process instances",
+				criteria.length > 0,
+				options._unknownFlags,
+			);
+		}
+
+		return result;
+	} catch (error) {
+		handleCommandError(logger, "Failed to search process instances", error);
+	}
 }
 
 /**
  * Search user tasks
  */
 export async function searchUserTasks(options: {
-  profile?: string;
-  state?: string;
-  assignee?: string;
-  processInstanceKey?: string;
-  processDefinitionKey?: string;
-  elementId?: string;
-  iAssignee?: string;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  _unknownFlags?: string[];
-  between?: string;
-  dateField?: string;
+	profile?: string;
+	state?: string;
+	assignee?: string;
+	processInstanceKey?: string;
+	processDefinitionKey?: string;
+	elementId?: string;
+	iAssignee?: string;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	_unknownFlags?: string[];
+	between?: string;
+	dateField?: string;
 }): Promise<SearchResult | undefined> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
-  const tenantId = resolveTenantId(options.profile);
-  const hasCiFilter = !!options.iAssignee;
+	const logger = getLogger();
+	const client = createClient(options.profile);
+	const tenantId = resolveTenantId(options.profile);
+	const hasCiFilter = !!options.iAssignee;
 
-  // Build search criteria description for user feedback
-  const criteria: string[] = [];
-  if (options.state) {
-    criteria.push(formatCriterion('state', options.state));
-  }
-  if (options.assignee) {
-    criteria.push(formatCriterion('assignee', options.assignee));
-  }
-  if (options.processInstanceKey) {
-    criteria.push(formatCriterion('Process Instance Key', options.processInstanceKey));
-  }
-  if (options.processDefinitionKey) {
-    criteria.push(formatCriterion('Process Definition Key', options.processDefinitionKey));
-  }
-  if (options.elementId) {
-    criteria.push(formatCriterion('Element ID', options.elementId));
-  }
-  if (options.iAssignee) {
-    criteria.push(formatCriterion('assignee', options.iAssignee, true));
-  }
-  if (options.between) {
-    const field = options.dateField ?? 'creationDate';
-    criteria.push(`'${field}' between "${options.between}"`);
-  }
-  logSearchCriteria(logger, 'User Tasks', criteria);
+	// Build search criteria description for user feedback
+	const criteria: string[] = [];
+	if (options.state) {
+		criteria.push(formatCriterion("state", options.state));
+	}
+	if (options.assignee) {
+		criteria.push(formatCriterion("assignee", options.assignee));
+	}
+	if (options.processInstanceKey) {
+		criteria.push(
+			formatCriterion("Process Instance Key", options.processInstanceKey),
+		);
+	}
+	if (options.processDefinitionKey) {
+		criteria.push(
+			formatCriterion("Process Definition Key", options.processDefinitionKey),
+		);
+	}
+	if (options.elementId) {
+		criteria.push(formatCriterion("Element ID", options.elementId));
+	}
+	if (options.iAssignee) {
+		criteria.push(formatCriterion("assignee", options.iAssignee, true));
+	}
+	if (options.between) {
+		const field = options.dateField ?? "creationDate";
+		criteria.push(`'${field}' between "${options.between}"`);
+	}
+	logSearchCriteria(logger, "User Tasks", criteria);
 
-  try {
-    const filter: any = {
-      filter: {
-        tenantId,
-      },
-    };
+	try {
+		const filter: { filter: Record<string, unknown> } = {
+			filter: {
+				tenantId,
+			},
+		};
 
-    if (options.state) {
-      filter.filter.state = options.state;
-    }
+		if (options.state) {
+			filter.filter.state = options.state;
+		}
 
-    if (options.assignee) {
-      filter.filter.assignee = toStringFilter(options.assignee);
-    }
+		if (options.assignee) {
+			filter.filter.assignee = toStringFilter(options.assignee);
+		}
 
-    if (options.processInstanceKey) {
-      filter.filter.processInstanceKey = options.processInstanceKey;
-    }
+		if (options.processInstanceKey) {
+			filter.filter.processInstanceKey = options.processInstanceKey;
+		}
 
-    if (options.processDefinitionKey) {
-      filter.filter.processDefinitionKey = options.processDefinitionKey;
-    }
+		if (options.processDefinitionKey) {
+			filter.filter.processDefinitionKey = options.processDefinitionKey;
+		}
 
-    if (options.elementId) {
-      filter.filter.elementId = options.elementId;
-    }
+		if (options.elementId) {
+			filter.filter.elementId = options.elementId;
+		}
 
-    if (options.between) {
-      const parsed = parseBetween(options.between);
-      if (parsed) {
-        const field = options.dateField ?? 'creationDate';
-        filter.filter[field] = buildDateFilter(parsed.from, parsed.to);
-      } else {
-        logger.error('Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)');
-        process.exit(1);
-      }
-    }
+		if (options.between) {
+			const parsed = parseBetween(options.between);
+			if (parsed) {
+				const field = options.dateField ?? "creationDate";
+				filter.filter[field] = buildDateFilter(parsed.from, parsed.to);
+			} else {
+				logger.error(
+					"Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)",
+				);
+				process.exit(1);
+			}
+		}
 
-    const allItems = await fetchAllPages<Record<string, unknown>>(
-      (f, opts) => client.searchUserTasks(f, opts),
-      filter,
-      ...(hasCiFilter ? [CI_PAGE_SIZE] as const : []),
-    );
-    const result: SearchResult = { items: allItems };
+		const allItems = await fetchAllPages<Record<string, unknown>>(
+			(f, opts) => client.searchUserTasks(f, opts),
+			filter,
+			...(hasCiFilter ? ([CI_PAGE_SIZE] as const) : []),
+		);
+		const result: SearchResult = { items: allItems };
 
-    if (hasCiFilter && result.items) {
-      result.items = result.items.filter((task: any) => {
-        if (options.iAssignee && !matchesCaseInsensitive(task.assignee, options.iAssignee)) return false;
-        return true;
-      });
-    }
-    
-    if (result.items && result.items.length > 0) {
-      let tableData = result.items.map((task: any) => ({
-        Key: task.userTaskKey || task.key,
-        Name: task.name || task.elementId,
-        State: task.state,
-        Assignee: task.assignee || '(unassigned)',
-        Created: task.creationDate || '-',
-        'Process Instance': task.processInstanceKey,
-        'Tenant ID': task.tenantId,
-      }));
-      tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-      logger.table(tableData);
-      logResultCount(logger, result.items.length, 'user task(s)', criteria.length > 0);
-    } else {
-      logNoResults(logger, 'user tasks', criteria.length > 0, options._unknownFlags);
-    }
+		if (hasCiFilter && result.items) {
+			result.items = result.items.filter((task) => {
+				if (
+					options.iAssignee &&
+					!matchesCaseInsensitive(task.assignee, options.iAssignee)
+				)
+					return false;
+				return true;
+			});
+		}
 
-    return result;
-  } catch (error) {
-    handleCommandError(logger, 'Failed to search user tasks', error);
-  }
+		if (result.items && result.items.length > 0) {
+			let tableData = result.items.map((task) => ({
+				Key: task.userTaskKey || task.key,
+				Name: task.name || task.elementId,
+				State: task.state,
+				Assignee: task.assignee || "(unassigned)",
+				Created: task.creationDate || "-",
+				"Process Instance": task.processInstanceKey,
+				"Tenant ID": task.tenantId,
+			}));
+			tableData = sortTableData(
+				tableData,
+				options.sortBy,
+				logger,
+				options.sortOrder,
+			);
+			logger.table(tableData);
+			logResultCount(
+				logger,
+				result.items.length,
+				"user task(s)",
+				criteria.length > 0,
+			);
+		} else {
+			logNoResults(
+				logger,
+				"user tasks",
+				criteria.length > 0,
+				options._unknownFlags,
+			);
+		}
+
+		return result;
+	} catch (error) {
+		handleCommandError(logger, "Failed to search user tasks", error);
+	}
 }
 
 /**
  * Search incidents
  */
 export async function searchIncidents(options: {
-  profile?: string;
-  state?: string;
-  processInstanceKey?: string;
-  processDefinitionKey?: string;
-  processDefinitionId?: string;
-  errorType?: string;
-  errorMessage?: string;
-  iErrorMessage?: string;
-  iProcessDefinitionId?: string;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  _unknownFlags?: string[];
-  between?: string;
+	profile?: string;
+	state?: string;
+	processInstanceKey?: string;
+	processDefinitionKey?: string;
+	processDefinitionId?: string;
+	errorType?: string;
+	errorMessage?: string;
+	iErrorMessage?: string;
+	iProcessDefinitionId?: string;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	_unknownFlags?: string[];
+	between?: string;
 }): Promise<SearchResult | undefined> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
-  const tenantId = resolveTenantId(options.profile);
-  // The incident API does not support a $like filter for errorMessage; fall back to client-side filtering for wildcard patterns
-  const errorMessageHasWildcard = !!(options.errorMessage && hasUnescapedWildcard(options.errorMessage));
-  const hasCiFilter = !!(options.iErrorMessage || options.iProcessDefinitionId || errorMessageHasWildcard);
+	const logger = getLogger();
+	const client = createClient(options.profile);
+	const tenantId = resolveTenantId(options.profile);
+	// The incident API does not support a $like filter for errorMessage; fall back to client-side filtering for wildcard patterns
+	const errorMessageHasWildcard = !!(
+		options.errorMessage && hasUnescapedWildcard(options.errorMessage)
+	);
+	const hasCiFilter = !!(
+		options.iErrorMessage ||
+		options.iProcessDefinitionId ||
+		errorMessageHasWildcard
+	);
 
-  // Build search criteria description for user feedback
-  const criteria: string[] = [];
-  if (options.state) {
-    criteria.push(formatCriterion('state', options.state));
-  }
-  if (options.processInstanceKey) {
-    criteria.push(formatCriterion('Process Instance Key', options.processInstanceKey));
-  }
-  if (options.processDefinitionKey) {
-    criteria.push(formatCriterion('Process Definition Key', options.processDefinitionKey));
-  }
-  if (options.errorType) {
-    criteria.push(formatCriterion('Error Type', options.errorType));
-  }
-  if (options.errorMessage) {
-    criteria.push(formatCriterion('Error Message', options.errorMessage));
-  }
-  if (options.processDefinitionId) {
-    criteria.push(formatCriterion('Process Definition ID', options.processDefinitionId));
-  }
-  if (options.iErrorMessage) {
-    criteria.push(formatCriterion('Error Message', options.iErrorMessage, true));
-  }
-  if (options.iProcessDefinitionId) {
-    criteria.push(formatCriterion('Process Definition ID', options.iProcessDefinitionId, true));
-  }
-  if (options.between) {
-    criteria.push(`'creationTime' between "${options.between}"`);
-  }
-  logSearchCriteria(logger, 'Incidents', criteria);
+	// Build search criteria description for user feedback
+	const criteria: string[] = [];
+	if (options.state) {
+		criteria.push(formatCriterion("state", options.state));
+	}
+	if (options.processInstanceKey) {
+		criteria.push(
+			formatCriterion("Process Instance Key", options.processInstanceKey),
+		);
+	}
+	if (options.processDefinitionKey) {
+		criteria.push(
+			formatCriterion("Process Definition Key", options.processDefinitionKey),
+		);
+	}
+	if (options.errorType) {
+		criteria.push(formatCriterion("Error Type", options.errorType));
+	}
+	if (options.errorMessage) {
+		criteria.push(formatCriterion("Error Message", options.errorMessage));
+	}
+	if (options.processDefinitionId) {
+		criteria.push(
+			formatCriterion("Process Definition ID", options.processDefinitionId),
+		);
+	}
+	if (options.iErrorMessage) {
+		criteria.push(
+			formatCriterion("Error Message", options.iErrorMessage, true),
+		);
+	}
+	if (options.iProcessDefinitionId) {
+		criteria.push(
+			formatCriterion(
+				"Process Definition ID",
+				options.iProcessDefinitionId,
+				true,
+			),
+		);
+	}
+	if (options.between) {
+		criteria.push(`'creationTime' between "${options.between}"`);
+	}
+	logSearchCriteria(logger, "Incidents", criteria);
 
-  try {
-    const filter: any = {
-      filter: {
-        tenantId,
-      },
-    };
+	try {
+		const filter: { filter: Record<string, unknown> } = {
+			filter: {
+				tenantId,
+			},
+		};
 
-    if (options.state) {
-      filter.filter.state = options.state;
-    }
+		if (options.state) {
+			filter.filter.state = options.state;
+		}
 
-    if (options.processInstanceKey) {
-      filter.filter.processInstanceKey = options.processInstanceKey;
-    }
+		if (options.processInstanceKey) {
+			filter.filter.processInstanceKey = options.processInstanceKey;
+		}
 
-    if (options.processDefinitionKey) {
-      filter.filter.processDefinitionKey = options.processDefinitionKey;
-    }
+		if (options.processDefinitionKey) {
+			filter.filter.processDefinitionKey = options.processDefinitionKey;
+		}
 
-    if (options.errorType) {
-      filter.filter.errorType = options.errorType;
-    }
+		if (options.errorType) {
+			filter.filter.errorType = options.errorType;
+		}
 
-    if (options.errorMessage && !errorMessageHasWildcard) {
-      filter.filter.errorMessage = options.errorMessage;
-    }
+		if (options.errorMessage && !errorMessageHasWildcard) {
+			filter.filter.errorMessage = options.errorMessage;
+		}
 
-    if (options.processDefinitionId) {
-      filter.filter.processDefinitionId = toStringFilter(options.processDefinitionId);
-    }
+		if (options.processDefinitionId) {
+			filter.filter.processDefinitionId = toStringFilter(
+				options.processDefinitionId,
+			);
+		}
 
-    if (options.between) {
-      const parsed = parseBetween(options.between);
-      if (parsed) {
-        filter.filter.creationTime = buildDateFilter(parsed.from, parsed.to);
-      } else {
-        logger.error('Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)');
-        process.exit(1);
-      }
-    }
+		if (options.between) {
+			const parsed = parseBetween(options.between);
+			if (parsed) {
+				filter.filter.creationTime = buildDateFilter(parsed.from, parsed.to);
+			} else {
+				logger.error(
+					"Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)",
+				);
+				process.exit(1);
+			}
+		}
 
-    const allItems = await fetchAllPages<Record<string, unknown>>(
-      (f, opts) => client.searchIncidents(f, opts),
-      filter,
-      ...(hasCiFilter ? [CI_PAGE_SIZE] as const : []),
-    );
-    const result: SearchResult = { items: allItems };
+		const allItems = await fetchAllPages<Record<string, unknown>>(
+			(f, opts) => client.searchIncidents(f, opts),
+			filter,
+			...(hasCiFilter ? ([CI_PAGE_SIZE] as const) : []),
+		);
+		const result: SearchResult = { items: allItems };
 
-    if (hasCiFilter && result.items) {
-      result.items = result.items.filter((incident: any) => {
-        if (options.iErrorMessage && !matchesCaseInsensitive(incident.errorMessage, options.iErrorMessage)) return false;
-        if (options.iProcessDefinitionId && !matchesCaseInsensitive(incident.processDefinitionId, options.iProcessDefinitionId)) return false;
-        if (errorMessageHasWildcard && options.errorMessage && !matchesCaseSensitive(incident.errorMessage, options.errorMessage)) return false;
-        return true;
-      });
-    }
-    
-    if (result.items && result.items.length > 0) {
-      let tableData = result.items.map((incident: any) => ({
-        Key: incident.incidentKey || incident.key,
-        Type: incident.errorType,
-        Message: incident.errorMessage?.substring(0, 50) || '',
-        State: incident.state,
-        Created: incident.creationTime || '-',
-        'Process Instance': incident.processInstanceKey,
-        'Tenant ID': incident.tenantId,
-      }));
-      tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-      logger.table(tableData);
-      logResultCount(logger, result.items.length, 'incident(s)', criteria.length > 0);
-    } else {
-      logNoResults(logger, 'incidents', criteria.length > 0, options._unknownFlags);
-    }
+		if (hasCiFilter && result.items) {
+			result.items = result.items.filter((incident) => {
+				if (
+					options.iErrorMessage &&
+					!matchesCaseInsensitive(incident.errorMessage, options.iErrorMessage)
+				)
+					return false;
+				if (
+					options.iProcessDefinitionId &&
+					!matchesCaseInsensitive(
+						incident.processDefinitionId,
+						options.iProcessDefinitionId,
+					)
+				)
+					return false;
+				if (
+					errorMessageHasWildcard &&
+					options.errorMessage &&
+					!matchesCaseSensitive(incident.errorMessage, options.errorMessage)
+				)
+					return false;
+				return true;
+			});
+		}
 
-    return result;
-  } catch (error) {
-    handleCommandError(logger, 'Failed to search incidents', error);
-  }
+		if (result.items && result.items.length > 0) {
+			let tableData = result.items.map((incident) => ({
+				Key: incident.incidentKey || incident.key,
+				Type: incident.errorType,
+				Message:
+					typeof incident.errorMessage === "string"
+						? incident.errorMessage.substring(0, 50)
+						: "",
+				State: incident.state,
+				Created: incident.creationTime || "-",
+				"Process Instance": incident.processInstanceKey,
+				"Tenant ID": incident.tenantId,
+			}));
+			tableData = sortTableData(
+				tableData,
+				options.sortBy,
+				logger,
+				options.sortOrder,
+			);
+			logger.table(tableData);
+			logResultCount(
+				logger,
+				result.items.length,
+				"incident(s)",
+				criteria.length > 0,
+			);
+		} else {
+			logNoResults(
+				logger,
+				"incidents",
+				criteria.length > 0,
+				options._unknownFlags,
+			);
+		}
+
+		return result;
+	} catch (error) {
+		handleCommandError(logger, "Failed to search incidents", error);
+	}
 }
 
 /**
  * Search jobs
  */
 export async function searchJobs(options: {
-  profile?: string;
-  state?: string;
-  type?: string;
-  processInstanceKey?: string;
-  processDefinitionKey?: string;
-  iType?: string;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  _unknownFlags?: string[];
-  between?: string;
-  dateField?: string;
+	profile?: string;
+	state?: string;
+	type?: string;
+	processInstanceKey?: string;
+	processDefinitionKey?: string;
+	iType?: string;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	_unknownFlags?: string[];
+	between?: string;
+	dateField?: string;
 }): Promise<SearchResult | undefined> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
-  const tenantId = resolveTenantId(options.profile);
-  const hasCiFilter = !!options.iType;
+	const logger = getLogger();
+	const client = createClient(options.profile);
+	const tenantId = resolveTenantId(options.profile);
+	const hasCiFilter = !!options.iType;
 
-  // Build search criteria description for user feedback
-  const criteria: string[] = [];
-  if (options.state) {
-    criteria.push(formatCriterion('state', options.state));
-  }
-  if (options.type) {
-    criteria.push(formatCriterion('type', options.type));
-  }
-  if (options.processInstanceKey) {
-    criteria.push(formatCriterion('Process Instance Key', options.processInstanceKey));
-  }
-  if (options.processDefinitionKey) {
-    criteria.push(formatCriterion('Process Definition Key', options.processDefinitionKey));
-  }
-  if (options.iType) {
-    criteria.push(formatCriterion('type', options.iType, true));
-  }
-  if (options.between) {
-    const field = options.dateField ?? 'creationTime';
-    criteria.push(`'${field}' between "${options.between}"`);
-  }
-  logSearchCriteria(logger, 'Jobs', criteria);
+	// Build search criteria description for user feedback
+	const criteria: string[] = [];
+	if (options.state) {
+		criteria.push(formatCriterion("state", options.state));
+	}
+	if (options.type) {
+		criteria.push(formatCriterion("type", options.type));
+	}
+	if (options.processInstanceKey) {
+		criteria.push(
+			formatCriterion("Process Instance Key", options.processInstanceKey),
+		);
+	}
+	if (options.processDefinitionKey) {
+		criteria.push(
+			formatCriterion("Process Definition Key", options.processDefinitionKey),
+		);
+	}
+	if (options.iType) {
+		criteria.push(formatCriterion("type", options.iType, true));
+	}
+	if (options.between) {
+		const field = options.dateField ?? "creationTime";
+		criteria.push(`'${field}' between "${options.between}"`);
+	}
+	logSearchCriteria(logger, "Jobs", criteria);
 
-  try {
-    const filter: any = {
-      filter: {
-        tenantId,
-      },
-    };
+	try {
+		const filter: { filter: Record<string, unknown> } = {
+			filter: {
+				tenantId,
+			},
+		};
 
-    if (options.state) {
-      filter.filter.state = options.state;
-    }
+		if (options.state) {
+			filter.filter.state = options.state;
+		}
 
-    if (options.type) {
-      filter.filter.type = toStringFilter(options.type);
-    }
+		if (options.type) {
+			filter.filter.type = toStringFilter(options.type);
+		}
 
-    if (options.processInstanceKey) {
-      filter.filter.processInstanceKey = options.processInstanceKey;
-    }
+		if (options.processInstanceKey) {
+			filter.filter.processInstanceKey = options.processInstanceKey;
+		}
 
-    if (options.processDefinitionKey) {
-      filter.filter.processDefinitionKey = options.processDefinitionKey;
-    }
+		if (options.processDefinitionKey) {
+			filter.filter.processDefinitionKey = options.processDefinitionKey;
+		}
 
-    if (options.between) {
-      const parsed = parseBetween(options.between);
-      if (parsed) {
-        const field = options.dateField ?? 'creationTime';
-        filter.filter[field] = buildDateFilter(parsed.from, parsed.to);
-      } else {
-        logger.error('Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)');
-        process.exit(1);
-      }
-    }
+		if (options.between) {
+			const parsed = parseBetween(options.between);
+			if (parsed) {
+				const field = options.dateField ?? "creationTime";
+				filter.filter[field] = buildDateFilter(parsed.from, parsed.to);
+			} else {
+				logger.error(
+					"Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)",
+				);
+				process.exit(1);
+			}
+		}
 
-    const allItems = await fetchAllPages<Record<string, unknown>>(
-      (f, opts) => client.searchJobs(f, opts),
-      filter,
-      ...(hasCiFilter ? [CI_PAGE_SIZE] as const : []),
-    );
-    const result: SearchResult = { items: allItems };
+		const allItems = await fetchAllPages<Record<string, unknown>>(
+			(f, opts) => client.searchJobs(f, opts),
+			filter,
+			...(hasCiFilter ? ([CI_PAGE_SIZE] as const) : []),
+		);
+		const result: SearchResult = { items: allItems };
 
-    if (hasCiFilter && result.items) {
-      result.items = result.items.filter((job: any) => {
-        if (options.iType && !matchesCaseInsensitive(job.type, options.iType)) return false;
-        return true;
-      });
-    }
-    
-    if (result.items && result.items.length > 0) {
-      let tableData = result.items.map((job: any) => ({
-        Key: job.jobKey || job.key,
-        Type: job.type,
-        State: job.state,
-        Retries: job.retries,
-        Created: job.creationTime || '-',
-        'Process Instance': job.processInstanceKey,
-        'Tenant ID': job.tenantId,
-      }));
-      tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-      logger.table(tableData);
-      logResultCount(logger, result.items.length, 'job(s)', criteria.length > 0);
-    } else {
-      logNoResults(logger, 'jobs', criteria.length > 0, options._unknownFlags);
-    }
+		if (hasCiFilter && result.items) {
+			result.items = result.items.filter((job) => {
+				if (options.iType && !matchesCaseInsensitive(job.type, options.iType))
+					return false;
+				return true;
+			});
+		}
 
-    return result;
-  } catch (error) {
-    handleCommandError(logger, 'Failed to search jobs', error);
-  }
+		if (result.items && result.items.length > 0) {
+			let tableData = result.items.map((job) => ({
+				Key: job.jobKey || job.key,
+				Type: job.type,
+				State: job.state,
+				Retries: job.retries,
+				Created: job.creationTime || "-",
+				"Process Instance": job.processInstanceKey,
+				"Tenant ID": job.tenantId,
+			}));
+			tableData = sortTableData(
+				tableData,
+				options.sortBy,
+				logger,
+				options.sortOrder,
+			);
+			logger.table(tableData);
+			logResultCount(
+				logger,
+				result.items.length,
+				"job(s)",
+				criteria.length > 0,
+			);
+		} else {
+			logNoResults(logger, "jobs", criteria.length > 0, options._unknownFlags);
+		}
+
+		return result;
+	} catch (error) {
+		handleCommandError(logger, "Failed to search jobs", error);
+	}
 }
 
 /**
  * Search variables
  */
 export async function searchVariables(options: {
-  profile?: string;
-  name?: string;
-  value?: string;
-  processInstanceKey?: string;
-  scopeKey?: string;
-  fullValue?: boolean;
-  iName?: string;
-  iValue?: string;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  limit?: number;
-  _unknownFlags?: string[];
+	profile?: string;
+	name?: string;
+	value?: string;
+	processInstanceKey?: string;
+	scopeKey?: string;
+	fullValue?: boolean;
+	iName?: string;
+	iValue?: string;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	limit?: number;
+	_unknownFlags?: string[];
 }): Promise<SearchResult | undefined> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
-  const tenantId = resolveTenantId(options.profile);
-  const hasCiFilter = !!(options.iName || options.iValue);
+	const logger = getLogger();
+	const client = createClient(options.profile);
+	const tenantId = resolveTenantId(options.profile);
+	const hasCiFilter = !!(options.iName || options.iValue);
 
-  // Build search criteria description for user feedback
-  const criteria: string[] = [];
-  if (options.name) {
-    criteria.push(formatCriterion('name', options.name));
-  }
-  if (options.value) {
-    criteria.push(formatCriterion('value', options.value));
-  }
-  if (options.processInstanceKey) {
-    criteria.push(formatCriterion('Process Instance Key', options.processInstanceKey));
-  }
-  if (options.scopeKey) {
-    criteria.push(formatCriterion('Scope Key', options.scopeKey));
-  }
-  if (options.iName) {
-    criteria.push(formatCriterion('name', options.iName, true));
-  }
-  if (options.iValue) {
-    criteria.push(formatCriterion('value', options.iValue, true));
-  }
-  if (options.fullValue) {
-    criteria.push(formatCriterion('fullValue', true));
-  }
-  logSearchCriteria(logger, 'Variables', criteria);
+	// Build search criteria description for user feedback
+	const criteria: string[] = [];
+	if (options.name) {
+		criteria.push(formatCriterion("name", options.name));
+	}
+	if (options.value) {
+		criteria.push(formatCriterion("value", options.value));
+	}
+	if (options.processInstanceKey) {
+		criteria.push(
+			formatCriterion("Process Instance Key", options.processInstanceKey),
+		);
+	}
+	if (options.scopeKey) {
+		criteria.push(formatCriterion("Scope Key", options.scopeKey));
+	}
+	if (options.iName) {
+		criteria.push(formatCriterion("name", options.iName, true));
+	}
+	if (options.iValue) {
+		criteria.push(formatCriterion("value", options.iValue, true));
+	}
+	if (options.fullValue) {
+		criteria.push(formatCriterion("fullValue", true));
+	}
+	logSearchCriteria(logger, "Variables", criteria);
 
-  try {
-    const filter: any = {
-      filter: {
-        tenantId,
-      },
-    };
+	try {
+		const filter: { filter: Record<string, unknown> } = {
+			filter: {
+				tenantId,
+			},
+		};
 
-    if (options.name) {
-      filter.filter.name = toStringFilter(options.name);
-    }
+		if (options.name) {
+			filter.filter.name = toStringFilter(options.name);
+		}
 
-    if (options.value) {
-      filter.filter.value = toStringFilter(options.value);
-    }
+		if (options.value) {
+			filter.filter.value = toStringFilter(options.value);
+		}
 
-    if (options.processInstanceKey) {
-      filter.filter.processInstanceKey = options.processInstanceKey;
-    }
+		if (options.processInstanceKey) {
+			filter.filter.processInstanceKey = options.processInstanceKey;
+		}
 
-    if (options.scopeKey) {
-      filter.filter.scopeKey = options.scopeKey;
-    }
+		if (options.scopeKey) {
+			filter.filter.scopeKey = options.scopeKey;
+		}
 
-    // By default, truncate values unless --fullValue is specified
-    const truncateValues = !options.fullValue;
+		// By default, truncate values unless --fullValue is specified
+		const truncateValues = !options.fullValue;
 
-    const allItems = await fetchAllPages<Record<string, unknown>>(
-      (f, opts) => client.searchVariables({ ...f, truncateValues }, opts),
-      filter,
-      hasCiFilter ? CI_PAGE_SIZE : DEFAULT_PAGE_SIZE,
-      options.limit,
-    );
+		const allItems = await fetchAllPages<Record<string, unknown>>(
+			(f, opts) => client.searchVariables({ ...f, truncateValues }, opts),
+			filter,
+			hasCiFilter ? CI_PAGE_SIZE : DEFAULT_PAGE_SIZE,
+			options.limit,
+		);
 
-    let result: SearchResult = { items: allItems };
+		const result: SearchResult = { items: allItems };
 
-    if (hasCiFilter && result.items) {
-      result.items = result.items.filter((variable: any) => {
-        if (options.iName && !matchesCaseInsensitive(variable.name, options.iName)) return false;
-        if (options.iValue) {
-          // Variable values come JSON-encoded from the API (e.g., '"PendingReview"').
-          // Unwrap the JSON string for comparison so users can match the actual value.
-          let rawValue = variable.value;
-          try {
-            const parsed = JSON.parse(rawValue);
-            if (typeof parsed === 'string') rawValue = parsed;
-          } catch { /* keep original value */ }
-          if (!matchesCaseInsensitive(rawValue, options.iValue)) return false;
-        }
-        return true;
-      });
-    }
-    
-    if (result.items && result.items.length > 0) {
-      let tableData = result.items.map((variable: any) => {
-        const row: any = {
-          Name: variable.name,
-          Value: variable.value || '',
-          'Process Instance': variable.processInstanceKey,
-          'Scope Key': variable.scopeKey,
-          'Tenant ID': variable.tenantId,
-        };
-        
-        if (variable.isTruncated) {
-          row['Truncated'] = '✓';
-        }
-        
-        return row;
-      });
-      tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-      logger.table(tableData);
-      logResultCount(logger, result.items.length, 'variable(s)', criteria.length > 0);
-      
-      if (!options.fullValue && result.items.some((v: any) => v.isTruncated)) {
-        logger.info('Some values are truncated. Use --fullValue to see full values.');
-      }
-    } else {
-      logNoResults(logger, 'variables', criteria.length > 0, options._unknownFlags);
-    }
+		if (hasCiFilter && result.items) {
+			result.items = result.items.filter((variable) => {
+				if (
+					options.iName &&
+					!matchesCaseInsensitive(variable.name, options.iName)
+				)
+					return false;
+				if (options.iValue) {
+					// Variable values come JSON-encoded from the API (e.g., '"PendingReview"').
+					// Unwrap the JSON string for comparison so users can match the actual value.
+					let rawValue =
+						typeof variable.value === "string"
+							? variable.value
+							: String(variable.value ?? "");
+					try {
+						const parsed = JSON.parse(rawValue);
+						if (typeof parsed === "string") rawValue = parsed;
+					} catch {
+						/* keep original value */
+					}
+					if (!matchesCaseInsensitive(rawValue, options.iValue)) return false;
+				}
+				return true;
+			});
+		}
 
-    return result;
-  } catch (error) {
-    handleCommandError(logger, 'Failed to search variables', error);
-  }
+		if (result.items && result.items.length > 0) {
+			let tableData = result.items.map((variable) => {
+				const row: Record<string, unknown> = {
+					Name: variable.name,
+					Value: variable.value || "",
+					"Process Instance": variable.processInstanceKey,
+					"Scope Key": variable.scopeKey,
+					"Tenant ID": variable.tenantId,
+				};
+
+				if (variable.isTruncated) {
+					row.Truncated = "✓";
+				}
+
+				return row;
+			});
+			tableData = sortTableData(
+				tableData,
+				options.sortBy,
+				logger,
+				options.sortOrder,
+			);
+			logger.table(tableData);
+			logResultCount(
+				logger,
+				result.items.length,
+				"variable(s)",
+				criteria.length > 0,
+			);
+
+			if (!options.fullValue && result.items.some((v) => v.isTruncated)) {
+				logger.info(
+					"Some values are truncated. Use --fullValue to see full values.",
+				);
+			}
+		} else {
+			logNoResults(
+				logger,
+				"variables",
+				criteria.length > 0,
+				options._unknownFlags,
+			);
+		}
+
+		return result;
+	} catch (error) {
+		handleCommandError(logger, "Failed to search variables", error);
+	}
 }

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -2,78 +2,77 @@
  * Session management commands (use profile, use tenant, output mode)
  */
 
-import { getLogger } from '../logger.ts';
 import {
-  setActiveProfile,
-  setActiveTenant,
-  setOutputMode,
-  getProfileOrModeler,
-  clearActiveProfile,
-} from '../config.ts';
-import { c8ctl } from '../runtime.ts';
-import type { OutputMode } from '../logger.ts';
+	clearActiveProfile,
+	getProfileOrModeler,
+	setActiveProfile,
+	setActiveTenant,
+	setOutputMode,
+} from "../config.ts";
+import { getLogger } from "../logger.ts";
+import { c8ctl } from "../runtime.ts";
 
 /**
  * Set active profile
  */
 export function useProfile(name: string): void {
-  const logger = getLogger();
-  
-  // Handle --none to clear profile
-  if (name === '--none') {
-    clearActiveProfile();
-    logger.success('Session profile cleared');
-    return;
-  }
+	const logger = getLogger();
 
-  // Verify profile exists (checks both c8ctl and Modeler profiles)
-  const profile = getProfileOrModeler(name);
-  if (!profile) {
-    logger.error(`Profile '${name}' not found`);
-    process.exit(1);
-  }
+	// Handle --none to clear profile
+	if (name === "--none") {
+		clearActiveProfile();
+		logger.success("Session profile cleared");
+		return;
+	}
 
-  setActiveProfile(name);
-  logger.success(`Now using profile: ${name}`);
+	// Verify profile exists (checks both c8ctl and Modeler profiles)
+	const profile = getProfileOrModeler(name);
+	if (!profile) {
+		logger.error(`Profile '${name}' not found`);
+		process.exit(1);
+	}
+
+	setActiveProfile(name);
+	logger.success(`Now using profile: ${name}`);
 }
 
 /**
  * Set active tenant
  */
 export function useTenant(tenantId: string): void {
-  const logger = getLogger();
-  setActiveTenant(tenantId);
-  logger.success(`Now using tenant: ${tenantId}`);
+	const logger = getLogger();
+	setActiveTenant(tenantId);
+	logger.success(`Now using tenant: ${tenantId}`);
 }
 
 /**
  * Set output mode
  */
 export function setOutputFormat(mode: string): void {
-  const logger = getLogger();
-  
-  if (mode !== 'json' && mode !== 'text') {
-    logger.error(`Invalid output mode: ${mode}. Must be 'json' or 'text'`);
-    process.exit(1);
-  }
+	const logger = getLogger();
 
-  setOutputMode(mode as OutputMode);
-  
-  // Update logger immediately
-  logger.mode = mode as OutputMode;
-  
-  logger.success(`Output mode set to: ${mode}`);
+	if (mode !== "json" && mode !== "text") {
+		logger.error(`Invalid output mode: ${mode}. Must be 'json' or 'text'`);
+		process.exit(1);
+	}
+
+	setOutputMode(mode);
+
+	// Update logger immediately
+	logger.mode = mode;
+
+	logger.success(`Output mode set to: ${mode}`);
 }
 
 /**
  * Show current session state
  */
 export function showSessionState(): void {
-  const logger = getLogger();
-  
-  logger.info('\nCurrent Session State:');
-  logger.info(`  Active Profile: ${c8ctl.activeProfile || '(none)'}`);
-  logger.info(`  Active Tenant: ${c8ctl.activeTenant || '(none)'}`);
-  logger.info(`  Output Mode: ${c8ctl.outputMode}`);
-  logger.info('');
+	const logger = getLogger();
+
+	logger.info("\nCurrent Session State:");
+	logger.info(`  Active Profile: ${c8ctl.activeProfile || "(none)"}`);
+	logger.info(`  Active Tenant: ${c8ctl.activeTenant || "(none)"}`);
+	logger.info(`  Output Mode: ${c8ctl.outputMode}`);
+	logger.info("");
 }

--- a/src/commands/topology.ts
+++ b/src/commands/topology.ts
@@ -2,23 +2,23 @@
  * Topology commands
  */
 
-import { getLogger } from '../logger.ts';
-import { createClient } from '../client.ts';
-import { handleCommandError } from '../errors.ts';
+import { createClient } from "../client.ts";
+import { handleCommandError } from "../errors.ts";
+import { getLogger } from "../logger.ts";
 
 /**
  * Get cluster topology
  */
 export async function getTopology(options: {
-  profile?: string;
+	profile?: string;
 }): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
+	const logger = getLogger();
+	const client = createClient(options.profile);
 
-  try {
-    const result = await client.getTopology();
-    logger.json(result);
-  } catch (error) {
-    handleCommandError(logger, 'Failed to get topology', error);
-  }
+	try {
+		const result = await client.getTopology();
+		logger.json(result);
+	} catch (error) {
+		handleCommandError(logger, "Failed to get topology", error);
+	}
 }

--- a/src/commands/user-tasks.ts
+++ b/src/commands/user-tasks.ts
@@ -121,9 +121,15 @@ export async function completeUserTask(
 	const client = createClient(options.profile);
 
 	try {
-		const variables = options.variables
-			? JSON.parse(options.variables)
-			: undefined;
+		let variables: Record<string, unknown> | undefined;
+		if (options.variables) {
+			try {
+				variables = JSON.parse(options.variables);
+			} catch (error) {
+				handleCommandError(logger, "Invalid JSON for variables", error);
+				return;
+			}
+		}
 		await client.completeUserTask({
 			userTaskKey: UserTaskKey.assumeExists(key),
 			...(variables !== undefined && { variables }),

--- a/src/commands/user-tasks.ts
+++ b/src/commands/user-tasks.ts
@@ -2,130 +2,134 @@
  * User task commands
  */
 
-import { getLogger } from '../logger.ts';
-import { sortTableData, type SortOrder } from '../logger.ts';
-import { createClient, fetchAllPages } from '../client.ts';
-import { resolveTenantId, resolveClusterConfig } from '../config.ts';
-import { parseBetween, buildDateFilter } from '../date-filter.ts';
-import { c8ctl } from '../runtime.ts';
-import { handleCommandError } from '../errors.ts';
+import { UserTaskKey } from "@camunda8/orchestration-cluster-api";
+import { createClient, fetchAllPages } from "../client.ts";
+import { resolveClusterConfig, resolveTenantId } from "../config.ts";
+import { buildDateFilter, parseBetween } from "../date-filter.ts";
+import { handleCommandError } from "../errors.ts";
+import { getLogger, type SortOrder, sortTableData } from "../logger.ts";
+import { c8ctl } from "../runtime.ts";
 
 /**
  * List user tasks
  */
 export async function listUserTasks(options: {
-  profile?: string;
-  state?: string;
-  assignee?: string;
-  all?: boolean;
-  sortBy?: string;
-  sortOrder?: SortOrder;
-  limit?: number;
-  between?: string;
-  dateField?: string;
+	profile?: string;
+	state?: string;
+	assignee?: string;
+	all?: boolean;
+	sortBy?: string;
+	sortOrder?: SortOrder;
+	limit?: number;
+	between?: string;
+	dateField?: string;
 }): Promise<void> {
-  const logger = getLogger();
-  const client = createClient(options.profile);
-  const tenantId = resolveTenantId(options.profile);
+	const logger = getLogger();
+	const client = createClient(options.profile);
+	const tenantId = resolveTenantId(options.profile);
 
-  try {
-    const filter: any = {
-      filter: {
-        tenantId,
-      },
-    };
+	try {
+		const filter: { filter: Record<string, unknown> } = {
+			filter: {
+				tenantId,
+			},
+		};
 
-    if (options.state) {
-      filter.filter.state = options.state;
-    } else if (!options.all) {
-      // By default, exclude COMPLETED tasks unless --all is specified
-      filter.filter.state = 'CREATED';
-    }
+		if (options.state) {
+			filter.filter.state = options.state;
+		} else if (!options.all) {
+			// By default, exclude COMPLETED tasks unless --all is specified
+			filter.filter.state = "CREATED";
+		}
 
-    if (options.assignee) {
-      filter.filter.assignee = options.assignee;
-    }
+		if (options.assignee) {
+			filter.filter.assignee = options.assignee;
+		}
 
-    if (options.between) {
-      const parsed = parseBetween(options.between);
-      if (parsed) {
-        const field = options.dateField ?? 'creationDate';
-        filter.filter[field] = buildDateFilter(parsed.from, parsed.to);
-      } else {
-        logger.error('Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)');
-        process.exit(1);
-      }
-    }
+		if (options.between) {
+			const parsed = parseBetween(options.between);
+			if (parsed) {
+				const field = options.dateField ?? "creationDate";
+				filter.filter[field] = buildDateFilter(parsed.from, parsed.to);
+			} else {
+				logger.error(
+					"Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)",
+				);
+				process.exit(1);
+			}
+		}
 
-    const allItems = await fetchAllPages(
-      (f, opts) => client.searchUserTasks(f, opts),
-      filter,
-      undefined,
-      options.limit,
-    );
-    
-    if (allItems.length > 0) {
-      let tableData = allItems.map((task: any) => ({
-        Key: task.userTaskKey || task.key,
-        Name: task.name || task.elementId,
-        State: task.state,
-        Assignee: task.assignee || '(unassigned)',
-        Created: task.creationDate || '-',
-        'Process Instance': task.processInstanceKey,
-        'Tenant ID': task.tenantId,
-      }));
-      tableData = sortTableData(tableData, options.sortBy, logger, options.sortOrder);
-      logger.table(tableData);
-    } else {
-      logger.info('No user tasks found');
-    }
-  } catch (error) {
-    handleCommandError(logger, 'Failed to list user tasks', error);
-  }
+		const allItems = await fetchAllPages(
+			(f, opts) => client.searchUserTasks(f, opts),
+			filter,
+			undefined,
+			options.limit,
+		);
+
+		if (allItems.length > 0) {
+			let tableData = allItems.map((task) => ({
+				Key: task.userTaskKey,
+				Name: task.name || task.elementId,
+				State: task.state,
+				Assignee: task.assignee || "(unassigned)",
+				Created: task.creationDate || "-",
+				"Process Instance": task.processInstanceKey,
+				"Tenant ID": task.tenantId,
+			}));
+			tableData = sortTableData(
+				tableData,
+				options.sortBy,
+				logger,
+				options.sortOrder,
+			);
+			logger.table(tableData);
+		} else {
+			logger.info("No user tasks found");
+		}
+	} catch (error) {
+		handleCommandError(logger, "Failed to list user tasks", error);
+	}
 }
 
 /**
  * Complete user task
  */
-export async function completeUserTask(key: string, options: {
-  profile?: string;
-  variables?: string;
-}): Promise<void> {
-  const logger = getLogger();
+export async function completeUserTask(
+	key: string,
+	options: {
+		profile?: string;
+		variables?: string;
+	},
+): Promise<void> {
+	const logger = getLogger();
 
-  // Dry-run: emit the would-be API request without executing
-  if (c8ctl.dryRun) {
-    const config = resolveClusterConfig(options.profile);
-    const body: Record<string, unknown> = {};
-    if (options.variables) body.variables = JSON.parse(options.variables);
-    logger.json({
-      dryRun: true,
-      command: 'complete user-task',
-      method: 'POST',
-      url: `${config.baseUrl}/user-tasks/${key}/completion`,
-      body,
-    });
-    return;
-  }
+	// Dry-run: emit the would-be API request without executing
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		const body: Record<string, unknown> = {};
+		if (options.variables) body.variables = JSON.parse(options.variables);
+		logger.json({
+			dryRun: true,
+			command: "complete user-task",
+			method: "POST",
+			url: `${config.baseUrl}/user-tasks/${key}/completion`,
+			body,
+		});
+		return;
+	}
 
-  const client = createClient(options.profile);
+	const client = createClient(options.profile);
 
-  try {
-    const request: any = {
-      userTaskKey: key,
-    };
-
-    if (options.variables) {
-      try {
-        request.variables = JSON.parse(options.variables);
-      } catch (error) {
-        handleCommandError(logger, 'Invalid JSON for variables', error);
-      }
-    }
-
-    await client.completeUserTask(request);
-    logger.success(`User task ${key} completed`);
-  } catch (error) {
-    handleCommandError(logger, `Failed to complete user task ${key}`, error);
-  }
+	try {
+		const variables = options.variables
+			? JSON.parse(options.variables)
+			: undefined;
+		await client.completeUserTask({
+			userTaskKey: UserTaskKey.assumeExists(key),
+			...(variables !== undefined && { variables }),
+		});
+		logger.success(`User task ${key} completed`);
+	} catch (error) {
+		handleCommandError(logger, `Failed to complete user task ${key}`, error);
+	}
 }

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -2,118 +2,138 @@
  * Watch command - monitor files for changes and auto-deploy
  */
 
-import { watch } from 'node:fs';
-import { resolve, extname, basename } from 'node:path';
-import { existsSync, statSync } from 'node:fs';
-import { getLogger } from '../logger.ts';
-import { deploy } from './deployments.ts';
-import { loadIgnoreRules, isIgnored } from '../ignore.ts';
+import { existsSync, statSync, watch } from "node:fs";
+import { basename, extname, resolve } from "node:path";
+import { isIgnored, loadIgnoreRules } from "../ignore.ts";
+import { getLogger } from "../logger.ts";
+import { deploy } from "./deployments.ts";
 
-const WATCHED_EXTENSIONS = ['.bpmn', '.dmn', '.form'];
+const WATCHED_EXTENSIONS = [".bpmn", ".dmn", ".form"];
 export const DEPLOY_COOLDOWN = 1000; // 1 second cooldown
 const DEBOUNCE_DELAY = 200; // ms to wait after last fs event before deploying
 
 /**
  * Watch for file changes and auto-deploy
  */
-export async function watchFiles(paths: string[], options: {
-  profile?: string;
-  force?: boolean;
-}): Promise<void> {
-  const logger = getLogger();
-  
-  if (!paths || paths.length === 0) {
-    paths = ['.'];
-  }
+export async function watchFiles(
+	paths: string[],
+	options: {
+		profile?: string;
+		force?: boolean;
+	},
+): Promise<void> {
+	const logger = getLogger();
 
-  // Resolve all paths
-  const resolvedPaths = paths.map(p => resolve(p));
-  
-  // Validate paths exist
-  for (const path of resolvedPaths) {
-    if (!existsSync(path)) {
-      logger.error(`Path does not exist: ${path}`);
-      process.exit(1);
-    }
-  }
+	if (!paths || paths.length === 0) {
+		paths = ["."];
+	}
 
-  // Load .c8ignore rules from the working directory
-  const ignoreBaseDir = resolve(process.cwd());
-  const ig = loadIgnoreRules(ignoreBaseDir);
+	// Resolve all paths
+	const resolvedPaths = paths.map((p) => resolve(p));
 
-  logger.info(`👁️  Watching for changes in: ${resolvedPaths.join(', ')}`);
-  logger.info(`📋 Monitoring extensions: ${WATCHED_EXTENSIONS.join(', ')}`);
-  if (options.force) {
-    logger.info('🔒 Force mode: will continue watching after deployment errors');
-  }
-  logger.info('Press Ctrl+C to stop watching\n');
+	// Validate paths exist
+	for (const path of resolvedPaths) {
+		if (!existsSync(path)) {
+			logger.error(`Path does not exist: ${path}`);
+			process.exit(1);
+		}
+	}
 
-  // Keep track of recently deployed files to avoid duplicate deploys
-  const recentlyDeployed = new Map<string, number>();
-  // Debounce timers per file to let writes settle before deploying
-  const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+	// Load .c8ignore rules from the working directory
+	const ignoreBaseDir = resolve(process.cwd());
+	const ig = loadIgnoreRules(ignoreBaseDir);
 
-  // Watch each path
-  for (const path of resolvedPaths) {
-    const stats = statSync(path);
-    const isDirectory = stats.isDirectory();
+	logger.info(`👁️  Watching for changes in: ${resolvedPaths.join(", ")}`);
+	logger.info(`📋 Monitoring extensions: ${WATCHED_EXTENSIONS.join(", ")}`);
+	if (options.force) {
+		logger.info(
+			"🔒 Force mode: will continue watching after deployment errors",
+		);
+	}
+	logger.info("Press Ctrl+C to stop watching\n");
 
-    const watcher = watch(path, { recursive: isDirectory }, (eventType, filename) => {
-      if (!filename) return;
+	// Keep track of recently deployed files to avoid duplicate deploys
+	const recentlyDeployed = new Map<string, number>();
+	// Debounce timers per file to let writes settle before deploying
+	const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
-      const ext = extname(filename);
-      if (!WATCHED_EXTENSIONS.includes(ext)) {
-        return;
-      }
+	// Watch each path
+	for (const path of resolvedPaths) {
+		const stats = statSync(path);
+		const isDirectory = stats.isDirectory();
 
-      const fullPath = isDirectory ? resolve(path, filename) : path;
+		const watcher = watch(
+			path,
+			{ recursive: isDirectory },
+			(_eventType, filename) => {
+				if (!filename) return;
 
-      // Skip files matching .c8ignore rules
-      if (isIgnored(ig, fullPath, ignoreBaseDir)) {
-        return;
-      }
+				const file = filename;
 
-      // Clear any pending debounce for this file and restart the timer.
-      // This ensures we wait until the file system is quiet before reading.
-      const existing = debounceTimers.get(fullPath);
-      if (existing) clearTimeout(existing);
+				const ext = extname(filename);
+				if (!WATCHED_EXTENSIONS.includes(ext)) {
+					return;
+				}
 
-      debounceTimers.set(fullPath, setTimeout(async () => {
-        debounceTimers.delete(fullPath);
+				const fullPath = isDirectory ? resolve(path, filename) : path;
 
-        // Check cooldown to prevent duplicate deploys
-        const lastDeploy = recentlyDeployed.get(fullPath);
-        const now = Date.now();
-        if (lastDeploy && (now - lastDeploy) < DEPLOY_COOLDOWN) {
-          return;
-        }
+				// Skip files matching .c8ignore rules
+				if (isIgnored(ig, fullPath, ignoreBaseDir)) {
+					return;
+				}
 
-        // Check if file still exists (might have been deleted)
-        if (!existsSync(fullPath)) {
-          logger.info(`⚠️  File deleted, skipping: ${basename(filename!)}`);
-          return;
-        }
+				// Clear any pending debounce for this file and restart the timer.
+				// This ensures we wait until the file system is quiet before reading.
+				const existing = debounceTimers.get(fullPath);
+				if (existing) clearTimeout(existing);
 
-        logger.info(`\n🔄 Change detected: ${basename(filename!)}`);
-        recentlyDeployed.set(fullPath, Date.now());
+				debounceTimers.set(
+					fullPath,
+					setTimeout(async () => {
+						debounceTimers.delete(fullPath);
 
-        try {
-          await deploy([fullPath], { profile: options.profile, continueOnError: options.force, continueOnUserError: true });
-        } catch (error) {
-          logger.error(`Failed to deploy ${basename(filename!)}`, error as Error);
-        }
-      }, DEBOUNCE_DELAY));
-    });
+						// Check cooldown to prevent duplicate deploys
+						const lastDeploy = recentlyDeployed.get(fullPath);
+						const now = Date.now();
+						if (lastDeploy && now - lastDeploy < DEPLOY_COOLDOWN) {
+							return;
+						}
 
-    // Handle watcher errors
-    watcher.on('error', (error) => {
-      logger.error('Watcher error', error);
-    });
-  }
+						// Check if file still exists (might have been deleted)
+						if (!existsSync(fullPath)) {
+							logger.info(`⚠️  File deleted, skipping: ${basename(file)}`);
+							return;
+						}
 
-  // Keep process alive
-  process.on('SIGINT', () => {
-    logger.info('\n\n🍹 - bottoms up.');
-    process.exit(0);
-  });
+						logger.info(`\n🔄 Change detected: ${basename(file)}`);
+						recentlyDeployed.set(fullPath, Date.now());
+
+						try {
+							await deploy([fullPath], {
+								profile: options.profile,
+								continueOnError: options.force,
+								continueOnUserError: true,
+							});
+						} catch (error) {
+							logger.error(
+								`Failed to deploy ${basename(file)}`,
+								error instanceof Error ? error : new Error(String(error)),
+							);
+						}
+					}, DEBOUNCE_DELAY),
+				);
+			},
+		);
+
+		// Handle watcher errors
+		watcher.on("error", (error) => {
+			logger.error("Watcher error", error);
+		});
+	}
+
+	// Keep process alive
+	process.on("SIGINT", () => {
+		logger.info("\n\n🍹 - bottoms up.");
+		process.exit(0);
+	});
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -737,7 +737,7 @@ export function envVarsToProfile(name: string, vars: Record<string, string | und
   for (const [envKey, profileField] of Object.entries(ENV_VAR_PROFILE_MAP)) {
     const value = vars[envKey];
     if (value) {
-      (profile as any)[profileField] = value;
+      (profile as Record<string, string>)[profileField] = value;
     }
   }
   return profile;

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,32 +5,31 @@
  * Modeler connections are read from settings.json (read-only) with "modeler:" prefix
  */
 
-import { homedir, platform } from 'node:os';
-import { join } from 'node:path';
-import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
-import { randomUUID } from 'node:crypto';
-import type { OutputMode } from './logger.ts';
-import { getLogger } from './logger.ts';
-import { c8ctl } from './runtime.ts';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+import type { OutputMode } from "./logger.ts";
+import { getLogger } from "./logger.ts";
+import { c8ctl } from "./runtime.ts";
 
 // ============================================================================
 // Constants - matching Camunda Modeler exactly
 // ============================================================================
 
 export const TARGET_TYPES = {
-  CAMUNDA_CLOUD: 'camundaCloud',
-  SELF_HOSTED: 'selfHosted',
+	CAMUNDA_CLOUD: "camundaCloud",
+	SELF_HOSTED: "selfHosted",
 } as const;
 
-export type TargetType = typeof TARGET_TYPES[keyof typeof TARGET_TYPES];
+export type TargetType = (typeof TARGET_TYPES)[keyof typeof TARGET_TYPES];
 
 export const AUTH_TYPES = {
-  NONE: 'none',
-  BASIC: 'basic',
-  OAUTH: 'oauth',
+	NONE: "none",
+	BASIC: "basic",
+	OAUTH: "oauth",
 } as const;
 
-export type AuthType = typeof AUTH_TYPES[keyof typeof AUTH_TYPES];
+export type AuthType = (typeof AUTH_TYPES)[keyof typeof AUTH_TYPES];
 
 // ============================================================================
 // Connection Types - matching Camunda Modeler's connection-manager-plugin
@@ -41,41 +40,41 @@ export type AuthType = typeof AUTH_TYPES[keyof typeof AUTH_TYPES];
  * @see https://github.com/camunda/camunda-modeler/blob/main/client/src/plugins/zeebe-plugin/connection-manager-plugin/ConnectionManagerSettingsProperties.js
  */
 export interface Connection {
-  /** Unique identifier (UUID) */
-  id: string;
-  /** Human-readable connection name */
-  name?: string;
-  /** Target environment type */
-  targetType: TargetType;
+	/** Unique identifier (UUID) */
+	id: string;
+	/** Human-readable connection name */
+	name?: string;
+	/** Target environment type */
+	targetType: TargetType;
 
-  // Camunda Cloud (SaaS) properties
-  /** Camunda Cloud cluster URL (e.g., https://xxx.bru-2.zeebe.camunda.io/xxx) */
-  camundaCloudClusterUrl?: string;
-  /** Camunda Cloud client ID */
-  camundaCloudClientId?: string;
-  /** Camunda Cloud client secret */
-  camundaCloudClientSecret?: string;
+	// Camunda Cloud (SaaS) properties
+	/** Camunda Cloud cluster URL (e.g., https://xxx.bru-2.zeebe.camunda.io/xxx) */
+	camundaCloudClusterUrl?: string;
+	/** Camunda Cloud client ID */
+	camundaCloudClientId?: string;
+	/** Camunda Cloud client secret */
+	camundaCloudClientSecret?: string;
 
-  // Self-Hosted properties
-  /** Self-hosted cluster URL (e.g., http://localhost:8080/v2) */
-  contactPoint?: string;
-  /** Authentication type for self-hosted */
-  authType?: AuthType;
-  /** Tenant ID (optional) */
-  tenantId?: string;
-  /** Operate URL (optional) */
-  operateUrl?: string;
+	// Self-Hosted properties
+	/** Self-hosted cluster URL (e.g., http://localhost:8080/v2) */
+	contactPoint?: string;
+	/** Authentication type for self-hosted */
+	authType?: AuthType;
+	/** Tenant ID (optional) */
+	tenantId?: string;
+	/** Operate URL (optional) */
+	operateUrl?: string;
 
-  // Basic Auth (self-hosted)
-  basicAuthUsername?: string;
-  basicAuthPassword?: string;
+	// Basic Auth (self-hosted)
+	basicAuthUsername?: string;
+	basicAuthPassword?: string;
 
-  // OAuth (self-hosted)
-  clientId?: string;
-  clientSecret?: string;
-  oauthURL?: string;
-  audience?: string;
-  scope?: string;
+	// OAuth (self-hosted)
+	clientId?: string;
+	clientSecret?: string;
+	oauthURL?: string;
+	audience?: string;
+	scope?: string;
 }
 
 /**
@@ -83,31 +82,31 @@ export interface Connection {
  * This is c8ctl's native profile format
  */
 export interface Profile {
-  name: string;
-  baseUrl: string;
-  clientId?: string;
-  clientSecret?: string;
-  audience?: string;
-  oAuthUrl?: string;
-  username?: string;
-  password?: string;
-  defaultTenantId?: string;
+	name: string;
+	baseUrl: string;
+	clientId?: string;
+	clientSecret?: string;
+	audience?: string;
+	oAuthUrl?: string;
+	username?: string;
+	password?: string;
+	defaultTenantId?: string;
 }
 
 export interface SessionState {
-  activeProfile?: string;
-  activeTenant?: string;
-  outputMode: OutputMode;
+	activeProfile?: string;
+	activeTenant?: string;
+	outputMode: OutputMode;
 }
 
 export interface ClusterConfig {
-  baseUrl: string;
-  clientId?: string;
-  clientSecret?: string;
-  audience?: string;
-  oAuthUrl?: string;
-  username?: string;
-  password?: string;
+	baseUrl: string;
+	clientId?: string;
+	clientSecret?: string;
+	audience?: string;
+	oAuthUrl?: string;
+	username?: string;
+	password?: string;
 }
 
 // ============================================================================
@@ -115,8 +114,9 @@ export interface ClusterConfig {
 // ============================================================================
 
 const VALIDATION_PATTERNS = {
-  URL: /^https?:\/\//,
-  CAMUNDA_CLOUD_REST_URL: /^https:\/\/[a-z]+-\d+\.zeebe\.camunda\.io(:443|)\/[a-z\d-]+\/?$/,
+	URL: /^https?:\/\//,
+	CAMUNDA_CLOUD_REST_URL:
+		/^https:\/\/[a-z]+-\d+\.zeebe\.camunda\.io(:443|)\/[a-z\d-]+\/?$/,
 };
 
 // Cloud URLs must be REST URLs (HTTP-based)
@@ -127,67 +127,67 @@ const CAMUNDA_CLOUD_URL_PATTERN = VALIDATION_PATTERNS.CAMUNDA_CLOUD_REST_URL;
  * Returns array of error messages (empty if valid)
  */
 export function validateConnection(conn: Partial<Connection>): string[] {
-  const errors: string[] = [];
+	const errors: string[] = [];
 
-  if (!conn) {
-    errors.push('Connection configuration is required');
-    return errors;
-  }
+	if (!conn) {
+		errors.push("Connection configuration is required");
+		return errors;
+	}
 
-  if (!conn.id) {
-    errors.push('Connection must have an ID');
-  }
+	if (!conn.id) {
+		errors.push("Connection must have an ID");
+	}
 
-  if (!conn.targetType) {
-    errors.push('Target type is required (camundaCloud or selfHosted)');
-    return errors;
-  }
+	if (!conn.targetType) {
+		errors.push("Target type is required (camundaCloud or selfHosted)");
+		return errors;
+	}
 
-  if (conn.targetType === TARGET_TYPES.CAMUNDA_CLOUD) {
-    if (!conn.camundaCloudClusterUrl) {
-      errors.push('Cluster URL is required for Camunda Cloud');
-    } else if (!CAMUNDA_CLOUD_URL_PATTERN.test(conn.camundaCloudClusterUrl)) {
-      errors.push('Cluster URL must be a valid Camunda 8 SaaS URL');
-    }
-    if (!conn.camundaCloudClientId) {
-      errors.push('Client ID is required for Camunda Cloud');
-    }
-    if (!conn.camundaCloudClientSecret) {
-      errors.push('Client Secret is required for Camunda Cloud');
-    }
-  } else if (conn.targetType === TARGET_TYPES.SELF_HOSTED) {
-    if (!conn.contactPoint) {
-      errors.push('Cluster URL (contactPoint) is required for Self-Hosted');
-    } else if (!VALIDATION_PATTERNS.URL.test(conn.contactPoint)) {
-      errors.push('Cluster URL must start with http:// or https://');
-    }
+	if (conn.targetType === TARGET_TYPES.CAMUNDA_CLOUD) {
+		if (!conn.camundaCloudClusterUrl) {
+			errors.push("Cluster URL is required for Camunda Cloud");
+		} else if (!CAMUNDA_CLOUD_URL_PATTERN.test(conn.camundaCloudClusterUrl)) {
+			errors.push("Cluster URL must be a valid Camunda 8 SaaS URL");
+		}
+		if (!conn.camundaCloudClientId) {
+			errors.push("Client ID is required for Camunda Cloud");
+		}
+		if (!conn.camundaCloudClientSecret) {
+			errors.push("Client Secret is required for Camunda Cloud");
+		}
+	} else if (conn.targetType === TARGET_TYPES.SELF_HOSTED) {
+		if (!conn.contactPoint) {
+			errors.push("Cluster URL (contactPoint) is required for Self-Hosted");
+		} else if (!VALIDATION_PATTERNS.URL.test(conn.contactPoint)) {
+			errors.push("Cluster URL must start with http:// or https://");
+		}
 
-    if (conn.authType === AUTH_TYPES.BASIC) {
-      if (!conn.basicAuthUsername) {
-        errors.push('Username is required for Basic authentication');
-      }
-      if (!conn.basicAuthPassword) {
-        errors.push('Password is required for Basic authentication');
-      }
-    } else if (conn.authType === AUTH_TYPES.OAUTH) {
-      if (!conn.clientId) {
-        errors.push('Client ID is required for OAuth authentication');
-      }
-      if (!conn.clientSecret) {
-        errors.push('Client Secret is required for OAuth authentication');
-      }
-      if (!conn.oauthURL) {
-        errors.push('OAuth URL is required for OAuth authentication');
-      }
-      if (!conn.audience) {
-        errors.push('Audience is required for OAuth authentication');
-      }
-    }
-  } else {
-    errors.push(`Unknown target type: ${conn.targetType}`);
-  }
+		if (conn.authType === AUTH_TYPES.BASIC) {
+			if (!conn.basicAuthUsername) {
+				errors.push("Username is required for Basic authentication");
+			}
+			if (!conn.basicAuthPassword) {
+				errors.push("Password is required for Basic authentication");
+			}
+		} else if (conn.authType === AUTH_TYPES.OAUTH) {
+			if (!conn.clientId) {
+				errors.push("Client ID is required for OAuth authentication");
+			}
+			if (!conn.clientSecret) {
+				errors.push("Client Secret is required for OAuth authentication");
+			}
+			if (!conn.oauthURL) {
+				errors.push("OAuth URL is required for OAuth authentication");
+			}
+			if (!conn.audience) {
+				errors.push("Audience is required for OAuth authentication");
+			}
+		}
+	} else {
+		errors.push(`Unknown target type: ${conn.targetType}`);
+	}
 
-  return errors;
+	return errors;
 }
 
 // ============================================================================
@@ -198,21 +198,27 @@ export function validateConnection(conn: Partial<Connection>): string[] {
  * Get platform-specific user data directory for c8ctl
  */
 export function getUserDataDir(): string {
-  if (process.env.C8CTL_DATA_DIR) {
-    return process.env.C8CTL_DATA_DIR;
-  }
+	if (process.env.C8CTL_DATA_DIR) {
+		return process.env.C8CTL_DATA_DIR;
+	}
 
-  const plat = platform();
-  const home = homedir();
+	const plat = platform();
+	const home = homedir();
 
-  switch (plat) {
-    case 'win32':
-      return join(process.env.APPDATA || join(home, 'AppData', 'Roaming'), 'c8ctl');
-    case 'darwin':
-      return join(home, 'Library', 'Application Support', 'c8ctl');
-    default:
-      return join(process.env.XDG_CONFIG_HOME || join(home, '.config'), 'c8ctl');
-  }
+	switch (plat) {
+		case "win32":
+			return join(
+				process.env.APPDATA || join(home, "AppData", "Roaming"),
+				"c8ctl",
+			);
+		case "darwin":
+			return join(home, "Library", "Application Support", "c8ctl");
+		default:
+			return join(
+				process.env.XDG_CONFIG_HOME || join(home, ".config"),
+				"c8ctl",
+			);
+	}
 }
 
 /**
@@ -220,30 +226,36 @@ export function getUserDataDir(): string {
  * Modeler stores connections in settings.json
  */
 export function getModelerDataDir(): string {
-  // Allow override for testing
-  if (process.env.C8CTL_MODELER_DIR) {
-    return process.env.C8CTL_MODELER_DIR;
-  }
+	// Allow override for testing
+	if (process.env.C8CTL_MODELER_DIR) {
+		return process.env.C8CTL_MODELER_DIR;
+	}
 
-  const plat = platform();
-  const home = homedir();
+	const plat = platform();
+	const home = homedir();
 
-  switch (plat) {
-    case 'win32':
-      return join(process.env.APPDATA || join(home, 'AppData', 'Roaming'), 'camunda-modeler');
-    case 'darwin':
-      return join(home, 'Library', 'Application Support', 'camunda-modeler');
-    default:
-      return join(process.env.XDG_CONFIG_HOME || join(home, '.config'), 'camunda-modeler');
-  }
+	switch (plat) {
+		case "win32":
+			return join(
+				process.env.APPDATA || join(home, "AppData", "Roaming"),
+				"camunda-modeler",
+			);
+		case "darwin":
+			return join(home, "Library", "Application Support", "camunda-modeler");
+		default:
+			return join(
+				process.env.XDG_CONFIG_HOME || join(home, ".config"),
+				"camunda-modeler",
+			);
+	}
 }
 
 function ensureUserDataDir(): string {
-  const dir = getUserDataDir();
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
-  }
-  return dir;
+	const dir = getUserDataDir();
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true });
+	}
+	return dir;
 }
 
 /**
@@ -251,30 +263,30 @@ function ensureUserDataDir(): string {
  * This is where plugins are installed globally, independent of any project
  */
 export function getPluginsDir(): string {
-  return join(getUserDataDir(), 'plugins');
+	return join(getUserDataDir(), "plugins");
 }
 
 /**
  * Ensure plugins directory exists
  */
 export function ensurePluginsDir(): string {
-  const dir = getPluginsDir();
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
-  }
-  return dir;
+	const dir = getPluginsDir();
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true });
+	}
+	return dir;
 }
 
 function getSessionStatePath(): string {
-  return join(ensureUserDataDir(), 'session.json');
+	return join(ensureUserDataDir(), "session.json");
 }
 
 function getProfilesPath(): string {
-  return join(ensureUserDataDir(), 'profiles.json');
+	return join(ensureUserDataDir(), "profiles.json");
 }
 
 function getModelerSettingsPath(): string {
-  return join(getModelerDataDir(), 'settings.json');
+	return join(getModelerDataDir(), "settings.json");
 }
 
 // ============================================================================
@@ -282,86 +294,86 @@ function getModelerSettingsPath(): string {
 // ============================================================================
 
 interface ProfilesFile {
-  profiles: Profile[];
+	profiles: Profile[];
 }
 
 /**
  * Load c8ctl profiles from profiles.json
  */
 export function loadProfiles(): Profile[] {
-  const profilesPath = getProfilesPath();
+	const profilesPath = getProfilesPath();
 
-  if (!existsSync(profilesPath)) {
-    return [];
-  }
+	if (!existsSync(profilesPath)) {
+		return [];
+	}
 
-  try {
-    const data = readFileSync(profilesPath, 'utf-8');
-    const profilesFile: ProfilesFile = JSON.parse(data);
-    return profilesFile.profiles || [];
-  } catch {
-    return [];
-  }
+	try {
+		const data = readFileSync(profilesPath, "utf-8");
+		const profilesFile: ProfilesFile = JSON.parse(data);
+		return profilesFile.profiles || [];
+	} catch {
+		return [];
+	}
 }
 
 /**
  * Save c8ctl profiles to profiles.json
  */
 export function saveProfiles(profiles: Profile[]): void {
-  const profilesPath = getProfilesPath();
-  const profilesFile: ProfilesFile = { profiles };
-  writeFileSync(profilesPath, JSON.stringify(profilesFile, null, 2), 'utf-8');
+	const profilesPath = getProfilesPath();
+	const profilesFile: ProfilesFile = { profiles };
+	writeFileSync(profilesPath, JSON.stringify(profilesFile, null, 2), "utf-8");
 }
 
 /**
  * Get a c8ctl profile by name
  */
 export function getProfile(name: string): Profile | undefined {
-  const profiles = loadProfiles();
-  return profiles.find(p => p.name === name);
+	const profiles = loadProfiles();
+	return profiles.find((p) => p.name === name);
 }
 
 /**
  * Add a c8ctl profile
  */
 export function addProfile(profile: Profile): void {
-  const profiles = loadProfiles();
-  
-  // Check if profile already exists
-  const existingIndex = profiles.findIndex(p => p.name === profile.name);
-  if (existingIndex >= 0) {
-    profiles[existingIndex] = profile;
-  } else {
-    profiles.push(profile);
-  }
-  
-  saveProfiles(profiles);
+	const profiles = loadProfiles();
+
+	// Check if profile already exists
+	const existingIndex = profiles.findIndex((p) => p.name === profile.name);
+	if (existingIndex >= 0) {
+		profiles[existingIndex] = profile;
+	} else {
+		profiles.push(profile);
+	}
+
+	saveProfiles(profiles);
 }
 
 /**
  * Remove a c8ctl profile by name
  */
 export function removeProfile(name: string): boolean {
-  const profiles = loadProfiles();
-  const filtered = profiles.filter(p => p.name !== name);
-  
-  if (filtered.length === profiles.length) {
-    return false;
-  }
-  
-  saveProfiles(filtered);
-  return true;
+	const profiles = loadProfiles();
+	const filtered = profiles.filter((p) => p.name !== name);
+
+	if (filtered.length === profiles.length) {
+		return false;
+	}
+
+	saveProfiles(filtered);
+	return true;
 }
 
 // ============================================================================
 // Modeler Connection Management - READ-ONLY from settings.json
 // ============================================================================
 
-export const MODELER_PREFIX = 'modeler:';
+export const MODELER_PREFIX = "modeler:";
 
 interface ModelerSettingsFile {
-  'connectionManagerPlugin.c8connections'?: Connection[];
-  [key: string]: unknown;
+	"connectionManagerPlugin.c8connections"?: Connection[];
+	[key: string]: unknown;
 }
 
 /**
@@ -369,26 +381,26 @@ interface ModelerSettingsFile {
  * These are NOT modified by c8ctl
  */
 export function loadModelerConnections(): Connection[] {
-  const settingsPath = getModelerSettingsPath();
+	const settingsPath = getModelerSettingsPath();
 
-  if (!existsSync(settingsPath)) {
-    return [];
-  }
+	if (!existsSync(settingsPath)) {
+		return [];
+	}
 
-  try {
-    const data = readFileSync(settingsPath, 'utf-8');
-    const settings: ModelerSettingsFile = JSON.parse(data);
-    const connections = settings['connectionManagerPlugin.c8connections'];
+	try {
+		const data = readFileSync(settingsPath, "utf-8");
+		const settings: ModelerSettingsFile = JSON.parse(data);
+		const connections = settings["connectionManagerPlugin.c8connections"];
 
-    if (!connections || !Array.isArray(connections)) {
-      return [];
-    }
+		if (!connections || !Array.isArray(connections)) {
+			return [];
+		}
 
-    // Filter out invalid connections (must have id)
-    return connections.filter(c => c && c.id);
-  } catch {
-    return [];
-  }
+		// Filter out invalid connections (must have id)
+		return connections.filter((c) => c?.id);
+	} catch {
+		return [];
+	}
 }
 
 /**
@@ -396,16 +408,18 @@ export function loadModelerConnections(): Connection[] {
  * Modeler connections are prefixed with "modeler:"
  */
 export function getAllProfiles(): Profile[] {
-  const c8ctlProfiles = loadProfiles();
-  const modelerConnections = loadModelerConnections();
-  
-  // Convert Modeler connections to Profile format with "modeler:" prefix
-  const modelerProfiles = modelerConnections.map(connectionToProfile).map(p => ({
-    ...p,
-    name: `${MODELER_PREFIX}${p.name}`,
-  }));
-  
-  return [...c8ctlProfiles, ...modelerProfiles];
+	const c8ctlProfiles = loadProfiles();
+	const modelerConnections = loadModelerConnections();
+
+	// Convert Modeler connections to Profile format with "modeler:" prefix
+	const modelerProfiles = modelerConnections
+		.map(connectionToProfile)
+		.map((p) => ({
+			...p,
+			name: `${MODELER_PREFIX}${p.name}`,
+		}));
+
+	return [...c8ctlProfiles, ...modelerProfiles];
 }
 
 /**
@@ -413,28 +427,30 @@ export function getAllProfiles(): Profile[] {
  * For Modeler profiles, accepts name with or without "modeler:" prefix
  */
 export function getProfileOrModeler(name: string): Profile | undefined {
-  // Try c8ctl profiles first
-  const c8ctlProfile = getProfile(name);
-  if (c8ctlProfile) {
-    return c8ctlProfile;
-  }
-  
-  // Try Modeler connections (with or without prefix)
-  const modelerName = name.startsWith(MODELER_PREFIX) ? name.slice(MODELER_PREFIX.length) : name;
-  const modelerConnections = loadModelerConnections();
-  const modelerConnection = modelerConnections.find(
-    c => c.name === modelerName || c.id === modelerName
-  );
-  
-  if (modelerConnection) {
-    const profile = connectionToProfile(modelerConnection);
-    return {
-      ...profile,
-      name: `${MODELER_PREFIX}${profile.name}`,
-    };
-  }
-  
-  return undefined;
+	// Try c8ctl profiles first
+	const c8ctlProfile = getProfile(name);
+	if (c8ctlProfile) {
+		return c8ctlProfile;
+	}
+
+	// Try Modeler connections (with or without prefix)
+	const modelerName = name.startsWith(MODELER_PREFIX)
+		? name.slice(MODELER_PREFIX.length)
+		: name;
+	const modelerConnections = loadModelerConnections();
+	const modelerConnection = modelerConnections.find(
+		(c) => c.name === modelerName || c.id === modelerName,
+	);
+
+	if (modelerConnection) {
+		const profile = connectionToProfile(modelerConnection);
+		return {
+			...profile,
+			name: `${MODELER_PREFIX}${profile.name}`,
+		};
+	}
+
+	return undefined;
 }
 
 // ============================================================================
@@ -445,35 +461,35 @@ export function getProfileOrModeler(name: string): Profile | undefined {
  * Convert a Connection to ClusterConfig for API client use
  */
 export function connectionToClusterConfig(conn: Connection): ClusterConfig {
-  if (conn.targetType === TARGET_TYPES.CAMUNDA_CLOUD) {
-    const audience = conn.audience?.trim();
-    const oAuthUrl = conn.oauthURL?.trim();
+	if (conn.targetType === TARGET_TYPES.CAMUNDA_CLOUD) {
+		const audience = conn.audience?.trim();
+		const oAuthUrl = conn.oauthURL?.trim();
 
-    return {
-      baseUrl: conn.camundaCloudClusterUrl || '',
-      clientId: conn.camundaCloudClientId,
-      clientSecret: conn.camundaCloudClientSecret,
-      audience: audience || undefined,
-      oAuthUrl: oAuthUrl || 'https://login.cloud.camunda.io/oauth/token',
-    };
-  }
+		return {
+			baseUrl: conn.camundaCloudClusterUrl || "",
+			clientId: conn.camundaCloudClientId,
+			clientSecret: conn.camundaCloudClientSecret,
+			audience: audience || undefined,
+			oAuthUrl: oAuthUrl || "https://login.cloud.camunda.io/oauth/token",
+		};
+	}
 
-  // Self-hosted
-  const config: ClusterConfig = {
-    baseUrl: conn.contactPoint || 'http://localhost:8080/v2',
-  };
+	// Self-hosted
+	const config: ClusterConfig = {
+		baseUrl: conn.contactPoint || "http://localhost:8080/v2",
+	};
 
-  if (conn.authType === AUTH_TYPES.BASIC) {
-    config.username = conn.basicAuthUsername;
-    config.password = conn.basicAuthPassword;
-  } else if (conn.authType === AUTH_TYPES.OAUTH) {
-    config.clientId = conn.clientId;
-    config.clientSecret = conn.clientSecret;
-    config.oAuthUrl = conn.oauthURL;
-    config.audience = conn.audience;
-  }
+	if (conn.authType === AUTH_TYPES.BASIC) {
+		config.username = conn.basicAuthUsername;
+		config.password = conn.basicAuthPassword;
+	} else if (conn.authType === AUTH_TYPES.OAUTH) {
+		config.clientId = conn.clientId;
+		config.clientSecret = conn.clientSecret;
+		config.oAuthUrl = conn.oauthURL;
+		config.audience = conn.audience;
+	}
 
-  return config;
+	return config;
 }
 
 /**
@@ -481,78 +497,78 @@ export function connectionToClusterConfig(conn: Connection): ClusterConfig {
  * Used to convert read-only Modeler connections to c8ctl Profile format
  */
 export function connectionToProfile(conn: Connection): Profile {
-  const config = connectionToClusterConfig(conn);
+	const config = connectionToClusterConfig(conn);
 
-  return {
-    name: conn.name || conn.id,
-    baseUrl: config.baseUrl,
-    clientId: config.clientId,
-    clientSecret: config.clientSecret,
-    audience: config.audience,
-    oAuthUrl: config.oAuthUrl,
-    username: config.username,
-    password: config.password,
-    defaultTenantId: conn.tenantId,
-  };
+	return {
+		name: conn.name || conn.id,
+		baseUrl: config.baseUrl,
+		clientId: config.clientId,
+		clientSecret: config.clientSecret,
+		audience: config.audience,
+		oAuthUrl: config.oAuthUrl,
+		username: config.username,
+		password: config.password,
+		defaultTenantId: conn.tenantId,
+	};
 }
 
 /**
  * Convert Profile to ClusterConfig for API client use
  */
 export function profileToClusterConfig(profile: Profile): ClusterConfig {
-  return {
-    baseUrl: profile.baseUrl,
-    clientId: profile.clientId,
-    clientSecret: profile.clientSecret,
-    audience: profile.audience,
-    oAuthUrl: profile.oAuthUrl,
-    username: profile.username,
-    password: profile.password,
-  };
+	return {
+		baseUrl: profile.baseUrl,
+		clientId: profile.clientId,
+		clientSecret: profile.clientSecret,
+		audience: profile.audience,
+		oAuthUrl: profile.oAuthUrl,
+		username: profile.username,
+		password: profile.password,
+	};
 }
 
 /**
  * Get display label for a connection
  */
 export function getConnectionLabel(conn: Connection): string {
-  if (conn.name) {
-    return conn.name;
-  }
+	if (conn.name) {
+		return conn.name;
+	}
 
-  // Fallback to URL-based label like Modeler does
-  const url = conn.targetType === TARGET_TYPES.CAMUNDA_CLOUD
-    ? conn.camundaCloudClusterUrl
-    : conn.contactPoint;
+	// Fallback to URL-based label like Modeler does
+	const url =
+		conn.targetType === TARGET_TYPES.CAMUNDA_CLOUD
+			? conn.camundaCloudClusterUrl
+			: conn.contactPoint;
 
-  return url ? `Unnamed (${url})` : 'Unnamed connection';
+	return url ? `Unnamed (${url})` : "Unnamed connection";
 }
 
 /**
  * Get auth type label for display
  */
 export function getAuthTypeLabel(conn: Connection): string {
-  if (conn.targetType === TARGET_TYPES.CAMUNDA_CLOUD) {
-    return 'OAuth (Cloud)';
-  }
+	if (conn.targetType === TARGET_TYPES.CAMUNDA_CLOUD) {
+		return "OAuth (Cloud)";
+	}
 
-  switch (conn.authType) {
-    case AUTH_TYPES.BASIC:
-      return 'Basic';
-    case AUTH_TYPES.OAUTH:
-      return 'OAuth';
-    case AUTH_TYPES.NONE:
-    default:
-      return 'None';
-  }
+	switch (conn.authType) {
+		case AUTH_TYPES.BASIC:
+			return "Basic";
+		case AUTH_TYPES.OAUTH:
+			return "OAuth";
+		default:
+			return "None";
+	}
 }
 
 /**
  * Get target type label for display
  */
 export function getTargetTypeLabel(conn: Connection): string {
-  return conn.targetType === TARGET_TYPES.CAMUNDA_CLOUD
-    ? 'Camunda Cloud'
-    : 'Self-Hosted';
+	return conn.targetType === TARGET_TYPES.CAMUNDA_CLOUD
+		? "Camunda Cloud"
+		: "Self-Hosted";
 }
 
 // ============================================================================
@@ -560,14 +576,14 @@ export function getTargetTypeLabel(conn: Connection): string {
 // ============================================================================
 
 /** The default profile used when no profile has been explicitly selected */
-export const DEFAULT_PROFILE = 'local';
+export const DEFAULT_PROFILE = "local";
 
 /** The default profile configuration that matches the previous localhost fallback */
 export const DEFAULT_PROFILE_CONFIG: Profile = {
-  name: DEFAULT_PROFILE,
-  baseUrl: 'http://localhost:8080/v2',
-  username: 'demo',
-  password: 'demo',
+	name: DEFAULT_PROFILE,
+	baseUrl: "http://localhost:8080/v2",
+	username: "demo",
+	password: "demo",
 };
 
 /**
@@ -575,10 +591,10 @@ export const DEFAULT_PROFILE_CONFIG: Profile = {
  * If no 'local' profile is configured, creates one with the localhost defaults.
  */
 export function ensureDefaultProfile(): void {
-  const existing = getProfile(DEFAULT_PROFILE);
-  if (!existing) {
-    addProfile({ ...DEFAULT_PROFILE_CONFIG });
-  }
+	const existing = getProfile(DEFAULT_PROFILE);
+	if (!existing) {
+		addProfile({ ...DEFAULT_PROFILE_CONFIG });
+	}
 }
 
 /**
@@ -589,87 +605,93 @@ export function ensureDefaultProfile(): void {
  * through to env vars before using the default 'local' profile.
  */
 export function loadSessionState(): SessionState {
-  // Always make sure the 'local' profile exists in profiles.json
-  ensureDefaultProfile();
+	// Always make sure the 'local' profile exists in profiles.json
+	ensureDefaultProfile();
 
-  const path = getSessionStatePath();
+	const path = getSessionStatePath();
 
-  if (!existsSync(path)) {
-    return {
-      activeProfile: c8ctl.activeProfile,
-      activeTenant: c8ctl.activeTenant,
-      outputMode: c8ctl.outputMode,
-    };
-  }
+	if (!existsSync(path)) {
+		return {
+			activeProfile: c8ctl.activeProfile,
+			activeTenant: c8ctl.activeTenant,
+			outputMode: c8ctl.outputMode,
+		};
+	}
 
-  try {
-    const data = readFileSync(path, 'utf-8');
-    const state = JSON.parse(data) as SessionState;
+	try {
+		const data = readFileSync(path, "utf-8");
+		const state: Record<string, unknown> = JSON.parse(data);
 
-    c8ctl.activeProfile = state.activeProfile ?? undefined;
-    c8ctl.activeTenant = state.activeTenant === null ? undefined : state.activeTenant;
-    c8ctl.outputMode = state.outputMode || 'text';
+		c8ctl.activeProfile =
+			typeof state.activeProfile === "string" ? state.activeProfile : undefined;
+		c8ctl.activeTenant =
+			typeof state.activeTenant === "string" ? state.activeTenant : undefined;
+		c8ctl.outputMode = state.outputMode === "json" ? "json" : "text";
 
-    return {
-      activeProfile: c8ctl.activeProfile,
-      activeTenant: c8ctl.activeTenant,
-      outputMode: c8ctl.outputMode,
-    };
-  } catch {
-    return {
-      activeProfile: c8ctl.activeProfile,
-      activeTenant: c8ctl.activeTenant,
-      outputMode: c8ctl.outputMode,
-    };
-  }
+		return {
+			activeProfile: c8ctl.activeProfile,
+			activeTenant: c8ctl.activeTenant,
+			outputMode: c8ctl.outputMode,
+		};
+	} catch {
+		return {
+			activeProfile: c8ctl.activeProfile,
+			activeTenant: c8ctl.activeTenant,
+			outputMode: c8ctl.outputMode,
+		};
+	}
 }
 
 /**
  * Save session state from c8ctl runtime object to disk
  */
 export function saveSessionState(state?: SessionState): void {
-  const stateToSave: SessionState = {
-    activeProfile: state?.activeProfile ?? c8ctl.activeProfile,
-    activeTenant: state?.activeTenant ?? c8ctl.activeTenant,
-    outputMode: state?.outputMode ?? c8ctl.outputMode,
-  };
+	const stateToSave: SessionState = {
+		activeProfile: state?.activeProfile ?? c8ctl.activeProfile,
+		activeTenant: state?.activeTenant ?? c8ctl.activeTenant,
+		outputMode: state?.outputMode ?? c8ctl.outputMode,
+	};
 
-  if (state) {
-    c8ctl.activeProfile = state.activeProfile;
-    c8ctl.activeTenant = state.activeTenant;
-    c8ctl.outputMode = state.outputMode;
-  }
+	if (state) {
+		c8ctl.activeProfile = state.activeProfile;
+		c8ctl.activeTenant = state.activeTenant;
+		c8ctl.outputMode = state.outputMode;
+	}
 
-  const path = getSessionStatePath();
-  writeFileSync(
-    path,
-    JSON.stringify(stateToSave, (_, value) => (value === undefined ? null : value), 2),
-    'utf-8'
-  );
+	const path = getSessionStatePath();
+	writeFileSync(
+		path,
+		JSON.stringify(
+			stateToSave,
+			(_, value) => (value === undefined ? null : value),
+			2,
+		),
+		"utf-8",
+	);
 }
 
 /**
  * Set active profile/connection in session and persist to disk
  */
 export function setActiveProfile(name: string): void {
-  c8ctl.activeProfile = name;
-  saveSessionState();
+	c8ctl.activeProfile = name;
+	saveSessionState();
 }
 
 /**
  * Set active tenant in session and persist to disk
  */
 export function setActiveTenant(tenantId: string): void {
-  c8ctl.activeTenant = tenantId;
-  saveSessionState();
+	c8ctl.activeTenant = tenantId;
+	saveSessionState();
 }
 
 /**
  * Set output mode in session and persist to disk
  */
 export function setOutputMode(mode: OutputMode): void {
-  c8ctl.outputMode = mode;
-  saveSessionState();
+	c8ctl.outputMode = mode;
+	saveSessionState();
 }
 
 // ============================================================================
@@ -680,27 +702,27 @@ export function setOutputMode(mode: OutputMode): void {
  * Check whether CAMUNDA_* credential env vars are set in the current environment.
  */
 export function hasCamundaEnvVars(): boolean {
-  return !!(
-    process.env.CAMUNDA_BASE_URL ||
-    process.env.CAMUNDA_CLIENT_ID ||
-    process.env.CAMUNDA_CLIENT_SECRET ||
-    process.env.CAMUNDA_USERNAME ||
-    process.env.CAMUNDA_PASSWORD
-  );
+	return !!(
+		process.env.CAMUNDA_BASE_URL ||
+		process.env.CAMUNDA_CLIENT_ID ||
+		process.env.CAMUNDA_CLIENT_SECRET ||
+		process.env.CAMUNDA_USERNAME ||
+		process.env.CAMUNDA_PASSWORD
+	);
 }
 
 /**
  * The env var → profile field mapping used by --from-file and --from-env.
  */
 export const ENV_VAR_PROFILE_MAP: Record<string, keyof Profile> = {
-  CAMUNDA_BASE_URL: 'baseUrl',
-  CAMUNDA_CLIENT_ID: 'clientId',
-  CAMUNDA_CLIENT_SECRET: 'clientSecret',
-  CAMUNDA_OAUTH_URL: 'oAuthUrl',
-  CAMUNDA_TOKEN_AUDIENCE: 'audience',
-  CAMUNDA_USERNAME: 'username',
-  CAMUNDA_PASSWORD: 'password',
-  CAMUNDA_DEFAULT_TENANT_ID: 'defaultTenantId',
+	CAMUNDA_BASE_URL: "baseUrl",
+	CAMUNDA_CLIENT_ID: "clientId",
+	CAMUNDA_CLIENT_SECRET: "clientSecret",
+	CAMUNDA_OAUTH_URL: "oAuthUrl",
+	CAMUNDA_TOKEN_AUDIENCE: "audience",
+	CAMUNDA_USERNAME: "username",
+	CAMUNDA_PASSWORD: "password",
+	CAMUNDA_DEFAULT_TENANT_ID: "defaultTenantId",
 };
 
 /**
@@ -708,48 +730,53 @@ export const ENV_VAR_PROFILE_MAP: Record<string, keyof Profile> = {
  * Handles # comments, blank lines, optional `export` prefix, single/double quotes.
  */
 export function parseEnvFile(content: string): Record<string, string> {
-  const result: Record<string, string> = {};
-  for (const raw of content.split('\n')) {
-    const line = raw.trim();
-    if (!line || line.startsWith('#')) continue;
-    // Strip optional `export ` prefix
-    const stripped = line.startsWith('export ') ? line.slice(7) : line;
-    const eqIdx = stripped.indexOf('=');
-    if (eqIdx === -1) continue;
-    const key = stripped.slice(0, eqIdx).trim();
-    let value = stripped.slice(eqIdx + 1).trim();
-    // Strip surrounding quotes
-    if ((value.startsWith('"') && value.endsWith('"')) ||
-        (value.startsWith("'") && value.endsWith("'"))) {
-      value = value.slice(1, -1);
-    }
-    result[key] = value;
-  }
-  return result;
+	const result: Record<string, string> = {};
+	for (const raw of content.split("\n")) {
+		const line = raw.trim();
+		if (!line || line.startsWith("#")) continue;
+		// Strip optional `export ` prefix
+		const stripped = line.startsWith("export ") ? line.slice(7) : line;
+		const eqIdx = stripped.indexOf("=");
+		if (eqIdx === -1) continue;
+		const key = stripped.slice(0, eqIdx).trim();
+		let value = stripped.slice(eqIdx + 1).trim();
+		// Strip surrounding quotes
+		if (
+			(value.startsWith('"') && value.endsWith('"')) ||
+			(value.startsWith("'") && value.endsWith("'"))
+		) {
+			value = value.slice(1, -1);
+		}
+		result[key] = value;
+	}
+	return result;
 }
 
 /**
  * Build a partial Profile from an env-var map (either from a .env file or process.env).
  * Only keys present in ENV_VAR_PROFILE_MAP are considered.
  */
-export function envVarsToProfile(name: string, vars: Record<string, string | undefined>): Profile {
-  const profile: Profile = { name, baseUrl: '' };
-  for (const envKey of Object.keys(ENV_VAR_PROFILE_MAP)) {
-    const profileField = ENV_VAR_PROFILE_MAP[envKey];
-    const value = vars[envKey];
-    if (value) {
-      profile[profileField] = value;
-    }
-  }
-  return profile;
+export function envVarsToProfile(
+	name: string,
+	vars: Record<string, string | undefined>,
+): Profile {
+	const profile: Profile = { name, baseUrl: "" };
+	for (const envKey of Object.keys(ENV_VAR_PROFILE_MAP)) {
+		const profileField = ENV_VAR_PROFILE_MAP[envKey];
+		const value = vars[envKey];
+		if (value) {
+			profile[profileField] = value;
+		}
+	}
+	return profile;
 }
 
 /**
  * Clear the active session profile and persist to disk.
  */
 export function clearActiveProfile(): void {
-  c8ctl.activeProfile = undefined;
-  saveSessionState();
+	c8ctl.activeProfile = undefined;
+	saveSessionState();
 }
 
 /**
@@ -757,70 +784,74 @@ export function clearActiveProfile(): void {
  * Priority: profileFlag → session profile → env vars → default 'local' profile
  */
 export function resolveClusterConfig(profileFlag?: string): ClusterConfig {
-  const config = _resolveClusterConfig(profileFlag);
-  c8ctl.resolvedBaseUrl = config.baseUrl;
-  return config;
+	const config = _resolveClusterConfig(profileFlag);
+	c8ctl.resolvedBaseUrl = config.baseUrl;
+	return config;
 }
 
 function _resolveClusterConfig(profileFlag?: string): ClusterConfig {
-  // 1. Try profile flag (profile name, including modeler: prefix)
-  if (profileFlag) {
-    const profile = getProfileOrModeler(profileFlag);
-    if (profile) {
-      return profileToClusterConfig(profile);
-    }
-  }
+	// 1. Try profile flag (profile name, including modeler: prefix)
+	if (profileFlag) {
+		const profile = getProfileOrModeler(profileFlag);
+		if (profile) {
+			return profileToClusterConfig(profile);
+		}
+	}
 
-  // 2. Try session profile (only when user explicitly selected one)
-  if (c8ctl.activeProfile) {
-    const profile = getProfileOrModeler(c8ctl.activeProfile);
-    if (profile) {
-      // Warn when env vars are also present — avoids silent surprise
-      // Only warn when CAMUNDA_BASE_URL is set, since resolveClusterConfig
-      // only uses env vars when CAMUNDA_BASE_URL is present
-      if (process.env.CAMUNDA_BASE_URL?.trim()) {
-        const logger = getLogger();
-        logger.warn(`Active profile '${c8ctl.activeProfile}' is overriding CAMUNDA_* environment variables.`);
-        logger.info('  To use env vars instead, run: c8 use profile --none');
-        logger.info('  To create a profile from env vars: c8 add profile <name> --from-env');
-      }
-      return profileToClusterConfig(profile);
-    }
-  }
+	// 2. Try session profile (only when user explicitly selected one)
+	if (c8ctl.activeProfile) {
+		const profile = getProfileOrModeler(c8ctl.activeProfile);
+		if (profile) {
+			// Warn when env vars are also present — avoids silent surprise
+			// Only warn when CAMUNDA_BASE_URL is set, since resolveClusterConfig
+			// only uses env vars when CAMUNDA_BASE_URL is present
+			if (process.env.CAMUNDA_BASE_URL?.trim()) {
+				const logger = getLogger();
+				logger.warn(
+					`Active profile '${c8ctl.activeProfile}' is overriding CAMUNDA_* environment variables.`,
+				);
+				logger.info("  To use env vars instead, run: c8 use profile --none");
+				logger.info(
+					"  To create a profile from env vars: c8 add profile <name> --from-env",
+				);
+			}
+			return profileToClusterConfig(profile);
+		}
+	}
 
-  // 3. Try environment variables
-  const baseUrl = process.env.CAMUNDA_BASE_URL;
-  const clientId = process.env.CAMUNDA_CLIENT_ID;
-  const clientSecret = process.env.CAMUNDA_CLIENT_SECRET;
-  const audience = process.env.CAMUNDA_TOKEN_AUDIENCE;
-  const oAuthUrl = process.env.CAMUNDA_OAUTH_URL;
-  const username = process.env.CAMUNDA_USERNAME;
-  const password = process.env.CAMUNDA_PASSWORD;
+	// 3. Try environment variables
+	const baseUrl = process.env.CAMUNDA_BASE_URL;
+	const clientId = process.env.CAMUNDA_CLIENT_ID;
+	const clientSecret = process.env.CAMUNDA_CLIENT_SECRET;
+	const audience = process.env.CAMUNDA_TOKEN_AUDIENCE;
+	const oAuthUrl = process.env.CAMUNDA_OAUTH_URL;
+	const username = process.env.CAMUNDA_USERNAME;
+	const password = process.env.CAMUNDA_PASSWORD;
 
-  if (baseUrl) {
-    return {
-      baseUrl,
-      clientId,
-      clientSecret,
-      audience,
-      oAuthUrl,
-      username,
-      password,
-    };
-  }
+	if (baseUrl) {
+		return {
+			baseUrl,
+			clientId,
+			clientSecret,
+			audience,
+			oAuthUrl,
+			username,
+			password,
+		};
+	}
 
-  // 4. Default 'local' profile (manifested by ensureDefaultProfile at startup)
-  const localProfile = getProfile(DEFAULT_PROFILE);
-  if (localProfile) {
-    return profileToClusterConfig(localProfile);
-  }
+	// 4. Default 'local' profile (manifested by ensureDefaultProfile at startup)
+	const localProfile = getProfile(DEFAULT_PROFILE);
+	if (localProfile) {
+		return profileToClusterConfig(localProfile);
+	}
 
-  // 5. Hardcoded fallback (safety net, should not be reached)
-  return {
-    baseUrl: 'http://localhost:8080/v2',
-    username: 'demo',
-    password: 'demo',
-  };
+	// 5. Hardcoded fallback (safety net, should not be reached)
+	return {
+		baseUrl: "http://localhost:8080/v2",
+		username: "demo",
+		password: "demo",
+	};
 }
 
 /**
@@ -828,26 +859,26 @@ function _resolveClusterConfig(profileFlag?: string): ClusterConfig {
  * Priority: session tenant → profile tenant → env var → '<default>'
  */
 export function resolveTenantId(profileFlag?: string): string {
-  // 1. Try session tenant
-  if (c8ctl.activeTenant) {
-    return c8ctl.activeTenant;
-  }
+	// 1. Try session tenant
+	if (c8ctl.activeTenant) {
+		return c8ctl.activeTenant;
+	}
 
-  // 2. Try profile default tenant (from flag or session)
-  const profileName = profileFlag || c8ctl.activeProfile;
-  if (profileName) {
-    const profile = getProfileOrModeler(profileName);
-    if (profile?.defaultTenantId) {
-      return profile.defaultTenantId;
-    }
-  }
+	// 2. Try profile default tenant (from flag or session)
+	const profileName = profileFlag || c8ctl.activeProfile;
+	if (profileName) {
+		const profile = getProfileOrModeler(profileName);
+		if (profile?.defaultTenantId) {
+			return profile.defaultTenantId;
+		}
+	}
 
-  // 3. Try environment variable
-  const envTenant = process.env.CAMUNDA_DEFAULT_TENANT_ID;
-  if (envTenant) {
-    return envTenant;
-  }
+	// 3. Try environment variable
+	const envTenant = process.env.CAMUNDA_DEFAULT_TENANT_ID;
+	if (envTenant) {
+		return envTenant;
+	}
 
-  // 4. Default tenant
-  return '<default>';
+	// 4. Default tenant
+	return "<default>";
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -734,10 +734,11 @@ export function parseEnvFile(content: string): Record<string, string> {
  */
 export function envVarsToProfile(name: string, vars: Record<string, string | undefined>): Profile {
   const profile: Profile = { name, baseUrl: '' };
-  for (const [envKey, profileField] of Object.entries(ENV_VAR_PROFILE_MAP)) {
+  for (const envKey of Object.keys(ENV_VAR_PROFILE_MAP)) {
+    const profileField = ENV_VAR_PROFILE_MAP[envKey];
     const value = vars[envKey];
     if (value) {
-      (profile as Record<string, string>)[profileField] = value;
+      profile[profileField] = value;
     }
   }
   return profile;

--- a/src/date-filter.ts
+++ b/src/date-filter.ts
@@ -12,20 +12,24 @@
  * Returns `{ from?, to? }` as ISO 8601 strings, or null on parse failure.
  * Returns null if the separator `..` is absent or if both sides are empty.
  */
-export function parseBetween(value: string): { from?: string; to?: string } | null {
-  const separatorIndex = value.indexOf('..');
-  if (separatorIndex < 0) return null;
+export function parseBetween(
+	value: string,
+): { from?: string; to?: string } | null {
+	const separatorIndex = value.indexOf("..");
+	if (separatorIndex < 0) return null;
 
-  const rawFrom = value.slice(0, separatorIndex).trim();
-  const rawTo = value.slice(separatorIndex + 2).trim();
-  if (!rawFrom && !rawTo) return null;
+	const rawFrom = value.slice(0, separatorIndex).trim();
+	const rawTo = value.slice(separatorIndex + 2).trim();
+	if (!rawFrom && !rawTo) return null;
 
-  const from = rawFrom ? expandDate(rawFrom, 'start') ?? undefined : undefined;
-  const to = rawTo ? expandDate(rawTo, 'end') ?? undefined : undefined;
-  if (rawFrom && !from) return null;
-  if (rawTo && !to) return null;
+	const from = rawFrom
+		? (expandDate(rawFrom, "start") ?? undefined)
+		: undefined;
+	const to = rawTo ? (expandDate(rawTo, "end") ?? undefined) : undefined;
+	if (rawFrom && !from) return null;
+	if (rawTo && !to) return null;
 
-  return { from, to };
+	return { from, to };
 }
 
 /**
@@ -33,11 +37,14 @@ export function parseBetween(value: string): { from?: string; to?: string } | nu
  * Only includes `$gte`/`$lte` fields when the corresponding bound is provided,
  * supporting open-ended ranges.
  */
-export function buildDateFilter(from?: string, to?: string): { $gte?: string; $lte?: string } {
-  const filter: { $gte?: string; $lte?: string } = {};
-  if (from) filter.$gte = from;
-  if (to) filter.$lte = to;
-  return filter;
+export function buildDateFilter(
+	from?: string,
+	to?: string,
+): { $gte?: string; $lte?: string } {
+	const filter: { $gte?: string; $lte?: string } = {};
+	if (from) filter.$gte = from;
+	if (to) filter.$lte = to;
+	return filter;
 }
 
 /**
@@ -47,20 +54,20 @@ export function buildDateFilter(from?: string, to?: string): { $gte?: string; $l
  *   - 'start' boundary: T00:00:00.000Z
  *   - 'end' boundary: T23:59:59.999Z
  */
-function expandDate(value: string, boundary: 'start' | 'end'): string | null {
-  if (value.includes('T')) {
-    // Validate as a datetime
-    const d = new Date(value);
-    if (isNaN(d.getTime())) return null;
-    return value;
-  }
+function expandDate(value: string, boundary: "start" | "end"): string | null {
+	if (value.includes("T")) {
+		// Validate as a datetime
+		const d = new Date(value);
+		if (Number.isNaN(d.getTime())) return null;
+		return value;
+	}
 
-  // Expect YYYY-MM-DD
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
-  const d = new Date(value + 'T00:00:00.000Z');
-  if (isNaN(d.getTime())) return null;
+	// Expect YYYY-MM-DD
+	if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return null;
+	const d = new Date(`${value}T00:00:00.000Z`);
+	if (Number.isNaN(d.getTime())) return null;
 
-  return boundary === 'start'
-    ? `${value}T00:00:00.000Z`
-    : `${value}T23:59:59.999Z`;
+	return boundary === "start"
+		? `${value}T00:00:00.000Z`
+		: `${value}T23:59:59.999Z`;
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -6,8 +6,8 @@
  * the process exits with a non-zero code, with a hint about using --verbose.
  */
 
-import { c8ctl } from './runtime.ts';
-import type { Logger } from './logger.ts';
+import type { Logger } from "./logger.ts";
+import { c8ctl } from "./runtime.ts";
 
 /**
  * Handle a command error in a consistent way across the codebase.
@@ -19,23 +19,24 @@ import type { Logger } from './logger.ts';
  *   The process exits with code 1.
  */
 export function handleCommandError(
-  logger: Logger,
-  message: string,
-  error: unknown,
-  additionalHints?: string[],
+	logger: Logger,
+	message: string,
+	error: unknown,
+	additionalHints?: string[],
 ): never {
-  const normalizedError = error instanceof Error ? error : new Error(String(error));
+	const normalizedError =
+		error instanceof Error ? error : new Error(String(error));
 
-  if (c8ctl.verbose) {
-    throw normalizedError;
-  }
+	if (c8ctl.verbose) {
+		throw normalizedError;
+	}
 
-  logger.error(message, normalizedError);
-  if (additionalHints) {
-    for (const hint of additionalHints) {
-      logger.info(hint);
-    }
-  }
-  logger.info('For more details on the error, run with the --verbose flag');
-  process.exit(1);
+	logger.error(message, normalizedError);
+	if (additionalHints) {
+		for (const hint of additionalHints) {
+			logger.info(hint);
+		}
+	}
+	logger.info("For more details on the error, run with the --verbose flag");
+	process.exit(1);
 }

--- a/src/ignore.ts
+++ b/src/ignore.ts
@@ -9,32 +9,28 @@
  * Users can override or extend via a `.c8ignore` file in the working directory.
  */
 
-import ignore, { type Ignore } from 'ignore';
-import { readFileSync, existsSync } from 'node:fs';
-import { join, relative, sep } from 'node:path';
+import { existsSync, readFileSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+import ignore, { type Ignore } from "ignore";
 
-const DEFAULT_PATTERNS = [
-  'node_modules/',
-  'target/',
-  '.git/',
-];
+const DEFAULT_PATTERNS = ["node_modules/", "target/", ".git/"];
 
-const C8IGNORE_FILENAME = '.c8ignore';
+const C8IGNORE_FILENAME = ".c8ignore";
 
 /**
  * Load ignore rules from the `.c8ignore` file in `baseDir` (if present)
  * merged with built-in default patterns.
  */
 export function loadIgnoreRules(baseDir: string): Ignore {
-  const ig = ignore().add(DEFAULT_PATTERNS);
+	const ig = ignore().add(DEFAULT_PATTERNS);
 
-  const ignoreFilePath = join(baseDir, C8IGNORE_FILENAME);
-  if (existsSync(ignoreFilePath)) {
-    const content = readFileSync(ignoreFilePath, 'utf-8');
-    ig.add(content);
-  }
+	const ignoreFilePath = join(baseDir, C8IGNORE_FILENAME);
+	if (existsSync(ignoreFilePath)) {
+		const content = readFileSync(ignoreFilePath, "utf-8");
+		ig.add(content);
+	}
 
-  return ig;
+	return ig;
 }
 
 /**
@@ -45,15 +41,19 @@ export function loadIgnoreRules(baseDir: string): Ignore {
  *
  * Returns `true` when the path matches an ignore rule.
  */
-export function isIgnored(ig: Ignore, filePath: string, baseDir: string): boolean {
-  let rel = relative(baseDir, filePath);
-  // `ignore` expects forward-slash separators
-  if (sep !== '/') {
-    rel = rel.split(sep).join('/');
-  }
-  // Paths outside baseDir can't be ignored
-  if (rel === '' || rel === '..' || rel.startsWith('../')) {
-    return false;
-  }
-  return ig.ignores(rel);
+export function isIgnored(
+	ig: Ignore,
+	filePath: string,
+	baseDir: string,
+): boolean {
+	let rel = relative(baseDir, filePath);
+	// `ignore` expects forward-slash separators
+	if (sep !== "/") {
+		rel = rel.split(sep).join("/");
+	}
+	// Paths outside baseDir can't be ignored
+	if (rel === "" || rel === ".." || rel.startsWith("../")) {
+		return false;
+	}
+	return ig.ignores(rel);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,1169 +4,1435 @@
  * Main entry point
  */
 
-import { realpathSync } from 'node:fs';
-import { parseArgs } from 'node:util';
-import { fileURLToPath } from 'node:url';
-import { getLogger, type SortOrder } from './logger.ts';
-import { c8ctl } from './runtime.ts';
-import { loadSessionState } from './config.ts';
-import { showHelp, showVersion, showVerbResources, showCommandHelp } from './commands/help.ts';
-import { useProfile, useTenant, setOutputFormat } from './commands/session.ts';
-import { listProfiles, addProfile, removeProfile, whichProfile } from './commands/profiles.ts';
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+import { showCompletion } from "./commands/completion.ts";
+import { deploy } from "./commands/deployments.ts";
+import { getForm, getStartForm, getUserTaskForm } from "./commands/forms.ts";
 import {
-  listProcessInstances,
-  getProcessInstance,
-  createProcessInstance,
-  cancelProcessInstance,
-} from './commands/process-instances.ts';
+	showCommandHelp,
+	showHelp,
+	showVerbResources,
+	showVersion,
+} from "./commands/help.ts";
 import {
-  listProcessDefinitions,
-  getProcessDefinition,
-} from './commands/process-definitions.ts';
+	createIdentityAuthorization,
+	createIdentityGroup,
+	createIdentityMappingRule,
+	createIdentityRole,
+	createIdentityTenant,
+	createIdentityUser,
+	deleteIdentityAuthorization,
+	deleteIdentityGroup,
+	deleteIdentityMappingRule,
+	deleteIdentityRole,
+	deleteIdentityTenant,
+	deleteIdentityUser,
+	getIdentityAuthorization,
+	getIdentityGroup,
+	getIdentityMappingRule,
+	getIdentityRole,
+	getIdentityTenant,
+	getIdentityUser,
+	handleAssign,
+	handleUnassign,
+	listAuthorizations,
+	listGroups,
+	listMappingRules,
+	listRoles,
+	listTenants,
+	listUsers,
+	searchIdentityAuthorizations,
+	searchIdentityGroups,
+	searchIdentityMappingRules,
+	searchIdentityRoles,
+	searchIdentityTenants,
+	searchIdentityUsers,
+} from "./commands/identity.ts";
 import {
-  searchProcessDefinitions,
-  searchProcessInstances,
-  searchUserTasks,
-  searchIncidents,
-  searchJobs,
-  searchVariables,
-  detectUnknownSearchFlags,
-} from './commands/search.ts';
-import { listUserTasks, completeUserTask } from './commands/user-tasks.ts';
-import { listIncidents, getIncident, resolveIncident } from './commands/incidents.ts';
-import { listJobs, activateJobs, completeJob, failJob } from './commands/jobs.ts';
-import { publishMessage, correlateMessage } from './commands/messages.ts';
-import { getTopology } from './commands/topology.ts';
-import { deploy } from './commands/deployments.ts';
-import { run } from './commands/run.ts';
-import { watchFiles } from './commands/watch.ts';
-import { loadPlugin, unloadPlugin, listPlugins, syncPlugins, upgradePlugin, downgradePlugin, initPlugin } from './commands/plugins.ts';
-import { showCompletion } from './commands/completion.ts';
-import { getUserTaskForm, getStartForm, getForm } from './commands/forms.ts';
-import { 
-  loadInstalledPlugins, 
-  executePluginCommand
-} from './plugin-loader.ts';
-import { mcpProxy } from './commands/mcp-proxy.ts';
-import { openApp, openUrl } from './commands/open.ts';
+	getIncident,
+	listIncidents,
+	resolveIncident,
+} from "./commands/incidents.ts";
 import {
-  listUsers, searchIdentityUsers, getIdentityUser, createIdentityUser, deleteIdentityUser,
-  listRoles, searchIdentityRoles, getIdentityRole, createIdentityRole, deleteIdentityRole,
-  listGroups, searchIdentityGroups, getIdentityGroup, createIdentityGroup, deleteIdentityGroup,
-  listTenants, searchIdentityTenants, getIdentityTenant, createIdentityTenant, deleteIdentityTenant,
-  listAuthorizations, searchIdentityAuthorizations, getIdentityAuthorization, createIdentityAuthorization, deleteIdentityAuthorization,
-  listMappingRules, searchIdentityMappingRules, getIdentityMappingRule, createIdentityMappingRule, deleteIdentityMappingRule,
-  handleAssign, handleUnassign,
-} from './commands/identity.ts';
+	activateJobs,
+	completeJob,
+	failJob,
+	listJobs,
+} from "./commands/jobs.ts";
+import { mcpProxy } from "./commands/mcp-proxy.ts";
+import { correlateMessage, publishMessage } from "./commands/messages.ts";
+import { openApp, openUrl } from "./commands/open.ts";
+import {
+	downgradePlugin,
+	initPlugin,
+	listPlugins,
+	loadPlugin,
+	syncPlugins,
+	unloadPlugin,
+	upgradePlugin,
+} from "./commands/plugins.ts";
+import {
+	getProcessDefinition,
+	listProcessDefinitions,
+} from "./commands/process-definitions.ts";
+import {
+	cancelProcessInstance,
+	createProcessInstance,
+	getProcessInstance,
+	listProcessInstances,
+} from "./commands/process-instances.ts";
+import {
+	addProfile,
+	listProfiles,
+	removeProfile,
+	whichProfile,
+} from "./commands/profiles.ts";
+import { run } from "./commands/run.ts";
+import {
+	detectUnknownSearchFlags,
+	searchIncidents,
+	searchJobs,
+	searchProcessDefinitions,
+	searchProcessInstances,
+	searchUserTasks,
+	searchVariables,
+} from "./commands/search.ts";
+import { setOutputFormat, useProfile, useTenant } from "./commands/session.ts";
+import { getTopology } from "./commands/topology.ts";
+import { completeUserTask, listUserTasks } from "./commands/user-tasks.ts";
+import { watchFiles } from "./commands/watch.ts";
+import { loadSessionState } from "./config.ts";
+import { getLogger, type SortOrder } from "./logger.ts";
+import { executePluginCommand, loadInstalledPlugins } from "./plugin-loader.ts";
+import { c8ctl } from "./runtime.ts";
 
 /**
  * Normalize resource aliases
  */
 function normalizeResource(resource: string): string {
-  const aliases: Record<string, string> = {
-    pi: 'process-instance',
-    pd: 'process-definition',
-    ut: 'user-task',
-    inc: 'incident',
-    msg: 'message',
-    vars: 'variable',
-    profile: 'profile',
-    profiles: 'profile',
-    plugin: 'plugin',
-    plugins: 'plugin',
-    auth: 'authorization',
-    authorizations: 'authorization',
-    mr: 'mapping-rule',
-    'mapping-rules': 'mapping-rule',
-    users: 'user',
-    roles: 'role',
-    groups: 'group',
-    tenants: 'tenant',
-  };
-  return aliases[resource] || resource;
+	const aliases: Record<string, string> = {
+		pi: "process-instance",
+		pd: "process-definition",
+		ut: "user-task",
+		inc: "incident",
+		msg: "message",
+		vars: "variable",
+		profile: "profile",
+		profiles: "profile",
+		plugin: "plugin",
+		plugins: "plugin",
+		auth: "authorization",
+		authorizations: "authorization",
+		mr: "mapping-rule",
+		"mapping-rules": "mapping-rule",
+		users: "user",
+		roles: "role",
+		groups: "group",
+		tenants: "tenant",
+	};
+	return aliases[resource] || resource;
+}
+
+/**
+ * Type guard: extract a string value from parseArgs values, or undefined.
+ * parseArgs with strict:false returns values typed as string | boolean | (string|boolean)[] | undefined.
+ * This narrows to string | undefined safely, without type assertions.
+ */
+function str(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Type guard: extract a boolean value from parseArgs values, or undefined.
+ */
+function bool(value: unknown): boolean | undefined {
+	return typeof value === "boolean" ? value : undefined;
+}
+
+/**
+ * Type guard: narrow unknown to Record<string, unknown>.
+ */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+	return value != null && typeof value === "object";
 }
 
 /**
  * Parse --version flag value into a number, or undefined if not set.
  */
 function parseVersionFlag(values: Record<string, unknown>): number | undefined {
-  return (values.version && typeof values.version === 'string') ? parseInt(values.version) : undefined;
+	return values.version && typeof values.version === "string"
+		? parseInt(values.version, 10)
+		: undefined;
 }
 
 /**
  * Parse command line arguments
  */
 function parseCliArgs() {
-  try {
-    const { values, positionals } = parseArgs({
-      args: process.argv.slice(2),
-      options: {
-        help: { type: 'boolean', short: 'h' },
-        version: { type: 'string', short: 'v' },
-        all: { type: 'boolean' },
-        xml: { type: 'boolean' },
-        profile: { type: 'string' },
-        bpmnProcessId: { type: 'string' },
-        id: { type: 'string' },
-        processDefinitionId: { type: 'string' },
-        processInstanceKey: { type: 'string' },
-        processDefinitionKey: { type: 'string' },
-        parentProcessInstanceKey: { type: 'string' },
-        variables: { type: 'string' },
-        state: { type: 'string' },
-        assignee: { type: 'string' },
-        type: { type: 'string' },
-        correlationKey: { type: 'string' },
-        timeToLive: { type: 'string' },
-        maxJobsToActivate: { type: 'string' },
-        timeout: { type: 'string' },
-        worker: { type: 'string' },
-        retries: { type: 'string' },
-        errorMessage: { type: 'string' },
-        baseUrl: { type: 'string' },
-        clientId: { type: 'string' },
-        clientSecret: { type: 'string' },
-        audience: { type: 'string' },
-        oAuthUrl: { type: 'string' },
-        defaultTenantId: { type: 'string' },
-        from: { type: 'string' },
-        name: { type: 'string' },
-        key: { type: 'string' },
-        elementId: { type: 'string' },
-        errorType: { type: 'string' },
-        awaitCompletion: { type: 'boolean' },
-        fetchVariables: { type: 'boolean' },
-        requestTimeout: { type: 'string' },
-        value: { type: 'string' },
-        scopeKey: { type: 'string' },
-        fullValue: { type: 'boolean' },
-        userTask: { type: 'boolean' },
-        processDefinition: { type: 'boolean' },
-        iname: { type: 'string' },
-        iid: { type: 'string' },
-        iassignee: { type: 'string' },
-        ierrorMessage: { type: 'string' },
-        itype: { type: 'string' },
-        ivalue: { type: 'string' },
-        sortBy: { type: 'string' },
-        asc: { type: 'boolean' },
-        desc: { type: 'boolean' },
-        limit: { type: 'string' },
-        between: { type: 'string' },
-        dateField: { type: 'string' },
-        fields: { type: 'string' },
-        'dry-run': { type: 'boolean' },
-        verbose: { type: 'boolean' },
-        force: { type: 'boolean' },
-        none: { type: 'boolean' },
-        'from-file': { type: 'string' },
-        'from-env': { type: 'boolean' },
-        username: { type: 'string' },
-        email: { type: 'string' },
-        password: { type: 'string' },
-        ownerId: { type: 'string' },
-        ownerType: { type: 'string' },
-        resourceType: { type: 'string' },
-        resourceId: { type: 'string' },
-        permissions: { type: 'string' },
-        roleId: { type: 'string' },
-        groupId: { type: 'string' },
-        tenantId: { type: 'string' },
-        claimName: { type: 'string' },
-        claimValue: { type: 'string' },
-        mappingRuleId: { type: 'string' },
-        'to-user': { type: 'string' },
-        'to-group': { type: 'string' },
-        'to-tenant': { type: 'string' },
-        'to-mapping-rule': { type: 'string' },
-        'from-user': { type: 'string' },
-        'from-group': { type: 'string' },
-        'from-tenant': { type: 'string' },
-        'from-mapping-rule': { type: 'string' },
-      },
-      allowPositionals: true,
-      strict: false,
-    });
+	try {
+		const { values, positionals } = parseArgs({
+			args: process.argv.slice(2),
+			options: {
+				help: { type: "boolean", short: "h" },
+				version: { type: "string", short: "v" },
+				all: { type: "boolean" },
+				xml: { type: "boolean" },
+				profile: { type: "string" },
+				bpmnProcessId: { type: "string" },
+				id: { type: "string" },
+				processDefinitionId: { type: "string" },
+				processInstanceKey: { type: "string" },
+				processDefinitionKey: { type: "string" },
+				parentProcessInstanceKey: { type: "string" },
+				variables: { type: "string" },
+				state: { type: "string" },
+				assignee: { type: "string" },
+				type: { type: "string" },
+				correlationKey: { type: "string" },
+				timeToLive: { type: "string" },
+				maxJobsToActivate: { type: "string" },
+				timeout: { type: "string" },
+				worker: { type: "string" },
+				retries: { type: "string" },
+				errorMessage: { type: "string" },
+				baseUrl: { type: "string" },
+				clientId: { type: "string" },
+				clientSecret: { type: "string" },
+				audience: { type: "string" },
+				oAuthUrl: { type: "string" },
+				defaultTenantId: { type: "string" },
+				from: { type: "string" },
+				name: { type: "string" },
+				key: { type: "string" },
+				elementId: { type: "string" },
+				errorType: { type: "string" },
+				awaitCompletion: { type: "boolean" },
+				fetchVariables: { type: "boolean" },
+				requestTimeout: { type: "string" },
+				value: { type: "string" },
+				scopeKey: { type: "string" },
+				fullValue: { type: "boolean" },
+				userTask: { type: "boolean" },
+				processDefinition: { type: "boolean" },
+				iname: { type: "string" },
+				iid: { type: "string" },
+				iassignee: { type: "string" },
+				ierrorMessage: { type: "string" },
+				itype: { type: "string" },
+				ivalue: { type: "string" },
+				sortBy: { type: "string" },
+				asc: { type: "boolean" },
+				desc: { type: "boolean" },
+				limit: { type: "string" },
+				between: { type: "string" },
+				dateField: { type: "string" },
+				fields: { type: "string" },
+				"dry-run": { type: "boolean" },
+				verbose: { type: "boolean" },
+				force: { type: "boolean" },
+				none: { type: "boolean" },
+				"from-file": { type: "string" },
+				"from-env": { type: "boolean" },
+				username: { type: "string" },
+				email: { type: "string" },
+				password: { type: "string" },
+				ownerId: { type: "string" },
+				ownerType: { type: "string" },
+				resourceType: { type: "string" },
+				resourceId: { type: "string" },
+				permissions: { type: "string" },
+				roleId: { type: "string" },
+				groupId: { type: "string" },
+				tenantId: { type: "string" },
+				claimName: { type: "string" },
+				claimValue: { type: "string" },
+				mappingRuleId: { type: "string" },
+				"to-user": { type: "string" },
+				"to-group": { type: "string" },
+				"to-tenant": { type: "string" },
+				"to-mapping-rule": { type: "string" },
+				"from-user": { type: "string" },
+				"from-group": { type: "string" },
+				"from-tenant": { type: "string" },
+				"from-mapping-rule": { type: "string" },
+			},
+			allowPositionals: true,
+			strict: false,
+		});
 
-    return { values, positionals };
-  } catch (error: any) {
-    console.error(`Error parsing arguments: ${error.message}`);
-    process.exit(1);
-  }
+		return { values, positionals };
+	} catch (error: unknown) {
+		const message = error instanceof Error ? error.message : String(error);
+		console.error(`Error parsing arguments: ${message}`);
+		process.exit(1);
+	}
 }
 
 /**
  * Resolve process definition ID from --id, --processDefinitionId, or --bpmnProcessId flag
  */
-export function resolveProcessDefinitionId(values: any): string | undefined {
-  return (values.id || values.processDefinitionId || values.bpmnProcessId) as string | undefined;
+export function resolveProcessDefinitionId(
+	values: Record<string, unknown>,
+): string | undefined {
+	return (
+		str(values.id) ||
+		str(values.processDefinitionId) ||
+		str(values.bpmnProcessId)
+	);
 }
 
 /**
  * Warn about unrecognized flags for a search resource.
  */
-function warnUnknownSearchFlags(logger: ReturnType<typeof getLogger>, unknownFlags: string[], resource: string): void {
-  if (unknownFlags.length === 0) return;
-  const flagList = unknownFlags.map(f => `--${f}`).join(', ');
-  logger.warn(
-    `Flag(s) ${flagList} not recognized for 'search ${resource}'. They will be ignored. Run "c8ctl help search" for valid options.`,
-  );
+function warnUnknownSearchFlags(
+	logger: ReturnType<typeof getLogger>,
+	unknownFlags: string[],
+	resource: string,
+): void {
+	if (unknownFlags.length === 0) return;
+	const flagList = unknownFlags.map((f) => `--${f}`).join(", ");
+	logger.warn(
+		`Flag(s) ${flagList} not recognized for 'search ${resource}'. They will be ignored. Run "c8ctl help search" for valid options.`,
+	);
 }
 
 /**
  * Main CLI handler
  */
 async function main() {
-  // Load session state from disk at startup
-  loadSessionState();
-  
-  const { values, positionals } = parseCliArgs();
-
-  // Initialize logger with current output mode from c8ctl runtime
-  const logger = getLogger(c8ctl.outputMode);
-
-  // Resolve sort order from --asc / --desc flags (default: asc)
-  const sortOrder: SortOrder = values.desc ? 'desc' : 'asc';
-  if (values.asc && values.desc) {
-    logger.error('Cannot specify both --asc and --desc. Use one or the other.');
-    process.exit(1);
-  }
-
-  // Resolve --limit flag (max items to fetch)
-  const limit = values.limit ? parseInt(values.limit as string, 10) : undefined;
-  if (limit !== undefined && (isNaN(limit) || limit < 1)) {
-    logger.error('--limit must be a positive integer.');
-    process.exit(1);
-  }
-
-  // Resolve --fields flag (agent feature: filter output keys)
-  if (values.fields && typeof values.fields === 'string') {
-    c8ctl.fields = values.fields.split(',').map(f => f.trim()).filter(Boolean);
-  }
-
-  // Resolve --dry-run flag (agent feature: emit API request without executing)
-  if (values['dry-run']) {
-    c8ctl.dryRun = true;
-  }
-
-  // Resolve --verbose flag (enable SDK trace logging and surface raw errors)
-  if (values.verbose) {
-    c8ctl.verbose = true;
-  }
-
-  // Load installed plugins
-  await loadInstalledPlugins();
-
-  // Extract command and resource
-  const [verb, resource, ...args] = positionals;
-
-  // Handle global --version flag (only when no verb/command is provided)
-  if (values.version && !verb) {
-    showVersion();
-    return;
-  }
-
-  if (values.help && positionals.length === 0) {
-    showHelp();
-    return;
-  }
-
-  if (!verb) {
-    showHelp();
-    return;
-  }
-
-  // Handle help command
-  if (verb === 'help' || verb === 'menu' || verb === '--help' || verb === '-h') {
-    // Check if user wants help for a specific command
-    if (resource) {
-      showCommandHelp(resource);
-    } else {
-      showHelp();
-    }
-    return;
-  }
-
-  // Handle completion command
-  if (verb === 'completion') {
-    showCompletion(resource);
-    return;
-  }
-
-  // Normalize resource
-  const normalizedResource = resource ? normalizeResource(resource) : '';
-
-  // Handle session commands
-  if (verb === 'use') {
-    if (normalizedResource === 'profile') {
-      if (values.none) {
-        useProfile('--none');
-        return;
-      }
-      if (!args[0]) {
-        logger.error('Profile name required. Usage: c8 use profile <name>');
-        process.exit(1);
-      }
-      useProfile(args[0]);
-      return;
-    }
-    if (normalizedResource === 'tenant') {
-      if (!args[0]) {
-        logger.error('Tenant ID required. Usage: c8 use tenant <id>');
-        process.exit(1);
-      }
-      useTenant(args[0]);
-      return;
-    }
-    showVerbResources('use');
-    return;
-  }
-
-  if (verb === 'output') {
-    if (!resource) {
-      logger.info(`Current output mode: ${c8ctl.outputMode}`);
-      if (c8ctl.outputMode === 'text') {
-        logger.info('');
-      }
-      logger.info('Available modes: json|text');
-      return;
-    }
-    setOutputFormat(resource);
-    return;
-  }
-
-  // Handle profile commands
-  if (verb === 'list' && normalizedResource === 'profile') {
-    listProfiles();
-    return;
-  }
-
-  if (verb === 'add' && normalizedResource === 'profile') {
-    if (!args[0]) {
-      logger.error('Profile name required. Usage: c8 add profile <name> --baseUrl=<url>');
-      process.exit(1);
-    }
-    const envFile = typeof values['from-file'] === 'string' ? values['from-file'] : undefined;
-    const fromEnv = values['from-env'] === true;
-    addProfile(args[0], {
-      url: typeof values.baseUrl === 'string' ? values.baseUrl : undefined,
-      clientId: typeof values.clientId === 'string' ? values.clientId : undefined,
-      clientSecret: typeof values.clientSecret === 'string' ? values.clientSecret : undefined,
-      audience: typeof values.audience === 'string' ? values.audience : undefined,
-      oauthUrl: typeof values.oAuthUrl === 'string' ? values.oAuthUrl : undefined,
-      tenantId: typeof values.defaultTenantId === 'string' ? values.defaultTenantId : undefined,
-      envFile,
-      fromEnv,
-    });
-    return;
-  }
-
-  if ((verb === 'remove' || verb === 'rm') && normalizedResource === 'profile') {
-    if (!args[0]) {
-      logger.error('Profile name required. Usage: c8 remove profile <name>');
-      process.exit(1);
-    }
-    removeProfile(args[0]);
-    return;
-  }
-
-  if (verb === 'which' && normalizedResource === 'profile') {
-    whichProfile();
-    return;
-  }
-
-  // Handle plugin commands
-  if (verb === 'list' && normalizedResource === 'plugin') {
-    listPlugins();
-    return;
-  }
-
-  if (verb === 'load' && normalizedResource === 'plugin') {
-    const fromUrl = values.from as string | undefined;
-    const packageName = args[0];
-    await loadPlugin(packageName, fromUrl);
-    return;
-  }
-
-  if ((verb === 'unload' || verb === 'remove' || verb === 'rm') && normalizedResource === 'plugin') {
-    if (!args[0]) {
-      logger.error('Package name required. Usage: c8 unload plugin <package-name>');
-      process.exit(1);
-    }
-    await unloadPlugin(args[0], { force: values.force as boolean | undefined });
-    return;
-  }
-
-  if (verb === 'sync' && normalizedResource === 'plugin') {
-    await syncPlugins();
-    return;
-  }
-
-  if (verb === 'upgrade' && normalizedResource === 'plugin') {
-    if (!args[0]) {
-      logger.error('Package name required. Usage: c8 upgrade plugin <package-name> [version]');
-      process.exit(1);
-    }
-    await upgradePlugin(args[0], args[1]);
-    return;
-  }
-
-  if (verb === 'downgrade' && normalizedResource === 'plugin') {
-    if (!args[0] || !args[1]) {
-      logger.error('Package name and version required. Usage: c8 downgrade plugin <package-name> <version>');
-      process.exit(1);
-    }
-    await downgradePlugin(args[0], args[1]);
-    return;
-  }
-
-  if (verb === 'init' && normalizedResource === 'plugin') {
-    await initPlugin(args[0]);
-    return;
-  }
-
-  // Handle process instance commands
-  if (verb === 'list' && (normalizedResource === 'process-instance' || normalizedResource === 'process-instances')) {
-    await listProcessInstances({
-      profile: values.profile as string | undefined,
-      processDefinitionId: resolveProcessDefinitionId(values),
-      version: parseVersionFlag(values),
-      state: values.state as string | undefined,
-      all: values.all as boolean | undefined,
-      sortBy: values.sortBy as string | undefined,
-      sortOrder,
-      limit,
-      between: values.between as string | undefined,
-      dateField: values.dateField as string | undefined,
-    });
-    return;
-  }
-
-  if (verb === 'get' && normalizedResource === 'process-instance') {
-    if (!args[0]) {
-      logger.error('Process instance key required. Usage: c8 get pi <key>');
-      process.exit(1);
-    }
-    // Check if --variables flag is present (for get command, it's a boolean flag)
-    const includeVariables = process.argv.includes('--variables');
-    await getProcessInstance(args[0], {
-      profile: values.profile as string | undefined,
-      variables: includeVariables,
-    });
-    return;
-  }
-
-  if (verb === 'create' && normalizedResource === 'process-instance') {
-    await createProcessInstance({
-      profile: values.profile as string | undefined,
-      processDefinitionId: resolveProcessDefinitionId(values),
-      version: parseVersionFlag(values),
-      variables: values.variables as string | undefined,
-      awaitCompletion: values.awaitCompletion as boolean | undefined,
-      fetchVariables: values.fetchVariables as boolean | undefined,
-      requestTimeout: (values.requestTimeout && typeof values.requestTimeout === 'string') ? parseInt(values.requestTimeout) : undefined,
-    });
-    return;
-  }
-
-  if (verb === 'cancel' && normalizedResource === 'process-instance') {
-    if (!args[0]) {
-      logger.error('Process instance key required. Usage: c8 cancel pi <key>');
-      process.exit(1);
-    }
-    await cancelProcessInstance(args[0], {
-      profile: values.profile as string | undefined,
-    });
-    return;
-  }
-
-  // Handle await command - alias for create with awaitCompletion
-  if (verb === 'await' && normalizedResource === 'process-instance') {
-    // await pi is an alias for create pi with --awaitCompletion
-    // It supports the same flags as create (id, variables, version, etc.)
-    await createProcessInstance({
-      profile: values.profile as string | undefined,
-      processDefinitionId: resolveProcessDefinitionId(values),
-      version: parseVersionFlag(values),
-      variables: values.variables as string | undefined,
-      awaitCompletion: true,  // Always true for await command
-      fetchVariables: values.fetchVariables as boolean | undefined,
-      requestTimeout: (values.requestTimeout && typeof values.requestTimeout === 'string') ? parseInt(values.requestTimeout) : undefined,
-    });
-    return;
-  }
-
-  // Handle process definition commands
-  if (verb === 'list' && (normalizedResource === 'process-definition' || normalizedResource === 'process-definitions')) {
-    await listProcessDefinitions({
-      profile: values.profile as string | undefined,
-      sortBy: values.sortBy as string | undefined,
-      sortOrder,
-      limit,
-    });
-    return;
-  }
-
-  if (verb === 'get' && normalizedResource === 'process-definition') {
-    if (!args[0]) {
-      logger.error('Process definition key required. Usage: c8 get pd <key>');
-      process.exit(1);
-    }
-    await getProcessDefinition(args[0], {
-      profile: values.profile as string | undefined,
-      xml: values.xml as boolean | undefined,
-    });
-    return;
-  }
-
-  // Handle user task commands
-  if (verb === 'list' && (normalizedResource === 'user-task' || normalizedResource === 'user-tasks')) {
-    await listUserTasks({
-      profile: values.profile as string | undefined,
-      state: values.state as string | undefined,
-      assignee: values.assignee as string | undefined,
-      all: values.all as boolean | undefined,
-      sortBy: values.sortBy as string | undefined,
-      sortOrder,
-      limit,
-      between: values.between as string | undefined,
-      dateField: values.dateField as string | undefined,
-    });
-    return;
-  }
-
-  if (verb === 'complete' && normalizedResource === 'user-task') {
-    if (!args[0]) {
-      logger.error('User task key required. Usage: c8 complete ut <key>');
-      process.exit(1);
-    }
-    await completeUserTask(args[0], {
-      profile: values.profile as string | undefined,
-      variables: values.variables as string | undefined,
-    });
-    return;
-  }
-
-  // Handle incident commands
-  if (verb === 'list' && (normalizedResource === 'incident' || normalizedResource === 'incidents')) {
-    await listIncidents({
-      profile: values.profile as string | undefined,
-      state: values.state as string | undefined,
-      processInstanceKey: values.processInstanceKey as string | undefined,
-      sortBy: values.sortBy as string | undefined,
-      sortOrder,
-      limit,
-      between: values.between as string | undefined,
-    });
-    return;
-  }
-
-  if (verb === 'get' && normalizedResource === 'incident') {
-    if (!args[0]) {
-      logger.error('Incident key required. Usage: c8 get inc <key>');
-      process.exit(1);
-    }
-    await getIncident(args[0], {
-      profile: values.profile as string | undefined,
-    });
-    return;
-  }
-
-  if (verb === 'resolve' && normalizedResource === 'incident') {
-    if (!args[0]) {
-      logger.error('Incident key required. Usage: c8 resolve inc <key>');
-      process.exit(1);
-    }
-    await resolveIncident(args[0], {
-      profile: values.profile as string | undefined,
-    });
-    return;
-  }
-
-  // Handle job commands
-  if (verb === 'list' && normalizedResource === 'jobs') {
-    await listJobs({
-      profile: values.profile as string | undefined,
-      state: values.state as string | undefined,
-      type: values.type as string | undefined,
-      sortBy: values.sortBy as string | undefined,
-      sortOrder,
-      limit,
-      between: values.between as string | undefined,
-      dateField: values.dateField as string | undefined,
-    });
-    return;
-  }
-
-  if (verb === 'activate' && normalizedResource === 'jobs') {
-    if (!args[0]) {
-      logger.error('Job type required. Usage: c8 activate jobs <type>');
-      process.exit(1);
-    }
-    await activateJobs(args[0], {
-      profile: values.profile as string | undefined,
-      maxJobsToActivate: (values.maxJobsToActivate && typeof values.maxJobsToActivate === 'string') ? parseInt(values.maxJobsToActivate) : undefined,
-      timeout: (values.timeout && typeof values.timeout === 'string') ? parseInt(values.timeout) : undefined,
-      worker: values.worker as string | undefined,
-    });
-    return;
-  }
-
-  if (verb === 'complete' && normalizedResource === 'job') {
-    if (!args[0]) {
-      logger.error('Job key required. Usage: c8 complete job <key>');
-      process.exit(1);
-    }
-    await completeJob(args[0], {
-      profile: values.profile as string | undefined,
-      variables: values.variables as string | undefined,
-    });
-    return;
-  }
-
-  if (verb === 'fail' && normalizedResource === 'job') {
-    if (!args[0]) {
-      logger.error('Job key required. Usage: c8 fail job <key>');
-      process.exit(1);
-    }
-    await failJob(args[0], {
-      profile: values.profile as string | undefined,
-      retries: (values.retries && typeof values.retries === 'string') ? parseInt(values.retries) : undefined,
-      errorMessage: values.errorMessage as string | undefined,
-    });
-    return;
-  }
-
-  // Handle message commands
-  if (verb === 'publish' && normalizedResource === 'message') {
-    if (!args[0]) {
-      logger.error('Message name required. Usage: c8 publish msg <name>');
-      process.exit(1);
-    }
-    await publishMessage(args[0], {
-      profile: values.profile as string | undefined,
-      correlationKey: values.correlationKey as string | undefined,
-      variables: values.variables as string | undefined,
-      timeToLive: (values.timeToLive && typeof values.timeToLive === 'string') ? parseInt(values.timeToLive) : undefined,
-    });
-    return;
-  }
-
-  if (verb === 'correlate' && normalizedResource === 'message') {
-    if (!args[0]) {
-      logger.error('Message name required. Usage: c8 correlate msg <name>');
-      process.exit(1);
-    }
-    await correlateMessage(args[0], {
-      profile: values.profile as string | undefined,
-      correlationKey: values.correlationKey as string | undefined,
-      variables: values.variables as string | undefined,
-      timeToLive: (values.timeToLive && typeof values.timeToLive === 'string') ? parseInt(values.timeToLive) : undefined,
-    });
-    return;
-  }
-
-  // Handle topology command
-  if (verb === 'get' && normalizedResource === 'topology') {
-    await getTopology({
-      profile: values.profile as string | undefined,
-    });
-    return;
-  }
-
-  // Handle form commands
-  if (verb === 'get' && normalizedResource === 'form') {
-    if (!args[0]) {
-      logger.error('Key required. Usage: c8 get form <key> [--userTask|--ut] [--processDefinition|--pd]');
-      process.exit(1);
-    }
-    
-    // Check for flags and their aliases
-    const isUserTask = process.argv.includes('--userTask') || process.argv.includes('--ut');
-    const isProcessDefinition = process.argv.includes('--processDefinition') || process.argv.includes('--pd');
-    
-    // If both flags specified, error
-    if (isUserTask && isProcessDefinition) {
-      logger.error('Cannot specify both --userTask|--ut and --processDefinition|--pd. Use one or the other, or omit both to search both types.');
-      process.exit(1);
-    }
-    
-    // If specific flag provided, use that API
-    if (isUserTask) {
-      await getUserTaskForm(args[0], {
-        profile: values.profile as string | undefined,
-      });
-    } else if (isProcessDefinition) {
-      await getStartForm(args[0], {
-        profile: values.profile as string | undefined,
-      });
-    } else {
-      // No flag provided - try both
-      await getForm(args[0], {
-        profile: values.profile as string | undefined,
-      });
-    }
-    return;
-  }
-
-  // Handle deploy command
-  if (verb === 'deploy') {
-    const paths = resource ? [resource, ...args] : (args.length > 0 ? args : ['.']);
-    await deploy(paths, {
-      profile: values.profile as string | undefined,
-    });
-    return;
-  }
-
-  // Handle run command
-  if (verb === 'run') {
-    if (!resource) {
-      logger.error('BPMN file path required. Usage: c8 run <path>');
-      process.exit(1);
-    }
-    await run(resource, {
-      profile: values.profile as string | undefined,
-      variables: values.variables as string | undefined,
-    });
-    return;
-  }
-
-  // Handle watch command
-  if (verb === 'watch' || verb === 'w') {
-    const paths = resource ? [resource, ...args] : (args.length > 0 ? args : ['.']);
-    await watchFiles(paths, {
-      profile: values.profile as string | undefined,
-      force: values.force as boolean | undefined,
-    });
-    return;
-  }
-
-  // Handle open command
-  if (verb === 'open') {
-    await openApp(resource, {
-      profile: values.profile as string | undefined,
-      dryRun: values['dry-run'] as boolean | undefined,
-    });
-    return;
-  }
-
-  // Handle feedback command
-  if (verb === 'feedback') {
-    const logger = getLogger();
-    const url = 'https://github.com/camunda/c8ctl/issues';
-    logger.info(`Opening feedback page: ${url}`);
-    openUrl(url);
-    return;
-  }
-
-  // Handle mcp-proxy command
-  if (verb === 'mcp-proxy') {
-    await mcpProxy(positionals.slice(1), {
-      profile: values.profile as string | undefined,
-    });
-    return;
-  }
-
-  // Handle search commands
-  if (verb === 'search') {
-    if (!resource) {
-      showVerbResources('search');
-      return;
-    }
-    const normalizedSearchResource = normalizeResource(resource);
-    const unknownFlags = detectUnknownSearchFlags(values as Record<string, unknown>, normalizedSearchResource);
-    warnUnknownSearchFlags(logger, unknownFlags, resource);
-    
-    if (normalizedSearchResource === 'process-definition' || normalizedSearchResource === 'process-definitions') {
-      await searchProcessDefinitions({
-        profile: values.profile as string | undefined,
-        processDefinitionId: resolveProcessDefinitionId(values),
-        name: values.name as string | undefined,
-        version: parseVersionFlag(values),
-        key: values.key as string | undefined,
-        iProcessDefinitionId: values.iid as string | undefined,
-        iName: values.iname as string | undefined,
-        sortBy: values.sortBy as string | undefined,
-        sortOrder,
-        _unknownFlags: unknownFlags,
-      });
-      return;
-    }
-
-    if (normalizedSearchResource === 'process-instance' || normalizedSearchResource === 'process-instances') {
-      await searchProcessInstances({
-        profile: values.profile as string | undefined,
-        processDefinitionId: resolveProcessDefinitionId(values),
-        processDefinitionKey: values.processDefinitionKey as string | undefined,
-        version: parseVersionFlag(values),
-        state: values.state as string | undefined,
-        key: values.key as string | undefined,
-        parentProcessInstanceKey: values.parentProcessInstanceKey as string | undefined,
-        iProcessDefinitionId: values.iid as string | undefined,
-        sortBy: values.sortBy as string | undefined,
-        sortOrder,
-        _unknownFlags: unknownFlags,
-        between: values.between as string | undefined,
-        dateField: values.dateField as string | undefined,
-      });
-      return;
-    }
-
-    if (normalizedSearchResource === 'user-task' || normalizedSearchResource === 'user-tasks') {
-      await searchUserTasks({
-        profile: values.profile as string | undefined,
-        state: values.state as string | undefined,
-        assignee: values.assignee as string | undefined,
-        processInstanceKey: values.processInstanceKey as string | undefined,
-        processDefinitionKey: values.processDefinitionKey as string | undefined,
-        elementId: values.elementId as string | undefined,
-        iAssignee: values.iassignee as string | undefined,
-        sortBy: values.sortBy as string | undefined,
-        sortOrder,
-        _unknownFlags: unknownFlags,
-        between: values.between as string | undefined,
-        dateField: values.dateField as string | undefined,
-      });
-      return;
-    }
-
-    if (normalizedSearchResource === 'incident' || normalizedSearchResource === 'incidents') {
-      await searchIncidents({
-        profile: values.profile as string | undefined,
-        state: values.state as string | undefined,
-        processInstanceKey: values.processInstanceKey as string | undefined,
-        processDefinitionKey: values.processDefinitionKey as string | undefined,
-        processDefinitionId: resolveProcessDefinitionId(values),
-        errorType: values.errorType as string | undefined,
-        errorMessage: values.errorMessage as string | undefined,
-        iErrorMessage: values.ierrorMessage as string | undefined,
-        iProcessDefinitionId: values.iid as string | undefined,
-        sortBy: values.sortBy as string | undefined,
-        sortOrder,
-        _unknownFlags: unknownFlags,
-        between: values.between as string | undefined,
-      });
-      return;
-    }
-
-    if (normalizedSearchResource === 'jobs') {
-      await searchJobs({
-        profile: values.profile as string | undefined,
-        state: values.state as string | undefined,
-        type: values.type as string | undefined,
-        processInstanceKey: values.processInstanceKey as string | undefined,
-        processDefinitionKey: values.processDefinitionKey as string | undefined,
-        iType: values.itype as string | undefined,
-        sortBy: values.sortBy as string | undefined,
-        sortOrder,
-        _unknownFlags: unknownFlags,
-        between: values.between as string | undefined,
-        dateField: values.dateField as string | undefined,
-      });
-      return;
-    }
-
-    if (normalizedSearchResource === 'variable' || normalizedSearchResource === 'variables') {
-      await searchVariables({
-        profile: values.profile as string | undefined,
-        name: values.name as string | undefined,
-        value: values.value as string | undefined,
-        processInstanceKey: values.processInstanceKey as string | undefined,
-        scopeKey: values.scopeKey as string | undefined,
-        fullValue: values.fullValue as boolean | undefined,
-        iName: values.iname as string | undefined,
-        iValue: values.ivalue as string | undefined,
-        sortBy: values.sortBy as string | undefined,
-        sortOrder,
-        limit,
-        _unknownFlags: unknownFlags,
-      });
-      return;
-    }
-
-    if (normalizedSearchResource === 'user') {
-      await searchIdentityUsers({
-        profile: values.profile as string | undefined,
-        username: values.username as string | undefined,
-        name: values.name as string | undefined,
-        email: values.email as string | undefined,
-        sortBy: values.sortBy as string | undefined,
-        sortOrder,
-        limit,
-      });
-      return;
-    }
-
-    if (normalizedSearchResource === 'role') {
-      await searchIdentityRoles({
-        profile: values.profile as string | undefined,
-        roleId: values.roleId as string | undefined,
-        name: values.name as string | undefined,
-        sortBy: values.sortBy as string | undefined,
-        sortOrder,
-        limit,
-      });
-      return;
-    }
-
-    if (normalizedSearchResource === 'group') {
-      await searchIdentityGroups({
-        profile: values.profile as string | undefined,
-        groupId: values.groupId as string | undefined,
-        name: values.name as string | undefined,
-        sortBy: values.sortBy as string | undefined,
-        sortOrder,
-        limit,
-      });
-      return;
-    }
-
-    if (normalizedSearchResource === 'tenant') {
-      await searchIdentityTenants({
-        profile: values.profile as string | undefined,
-        name: values.name as string | undefined,
-        tenantId: values.tenantId as string | undefined,
-        sortBy: values.sortBy as string | undefined,
-        sortOrder,
-        limit,
-      });
-      return;
-    }
-
-    if (normalizedSearchResource === 'authorization') {
-      await searchIdentityAuthorizations({
-        profile: values.profile as string | undefined,
-        ownerId: values.ownerId as string | undefined,
-        ownerType: values.ownerType as string | undefined,
-        resourceType: values.resourceType as string | undefined,
-        resourceId: values.resourceId as string | undefined,
-        sortBy: values.sortBy as string | undefined,
-        sortOrder,
-        limit,
-      });
-      return;
-    }
-
-    if (normalizedSearchResource === 'mapping-rule') {
-      await searchIdentityMappingRules({
-        profile: values.profile as string | undefined,
-        mappingRuleId: values.mappingRuleId as string | undefined,
-        name: values.name as string | undefined,
-        claimName: values.claimName as string | undefined,
-        claimValue: values.claimValue as string | undefined,
-        sortBy: values.sortBy as string | undefined,
-        sortOrder,
-        limit,
-      });
-      return;
-    }
-
-    // If resource not recognized for search, show available resources
-    showVerbResources('search');
-    return;
-  }
-
-  // Handle identity list commands
-  if (verb === 'list' && normalizedResource === 'user') {
-    await listUsers({ profile: values.profile as string | undefined, sortBy: values.sortBy as string | undefined, sortOrder, limit });
-    return;
-  }
-  if (verb === 'list' && normalizedResource === 'role') {
-    await listRoles({ profile: values.profile as string | undefined, sortBy: values.sortBy as string | undefined, sortOrder, limit });
-    return;
-  }
-  if (verb === 'list' && normalizedResource === 'group') {
-    await listGroups({ profile: values.profile as string | undefined, sortBy: values.sortBy as string | undefined, sortOrder, limit });
-    return;
-  }
-  if (verb === 'list' && normalizedResource === 'tenant') {
-    await listTenants({ profile: values.profile as string | undefined, sortBy: values.sortBy as string | undefined, sortOrder, limit });
-    return;
-  }
-  if (verb === 'list' && normalizedResource === 'authorization') {
-    await listAuthorizations({ profile: values.profile as string | undefined, sortBy: values.sortBy as string | undefined, sortOrder, limit });
-    return;
-  }
-  if (verb === 'list' && normalizedResource === 'mapping-rule') {
-    await listMappingRules({ profile: values.profile as string | undefined, sortBy: values.sortBy as string | undefined, sortOrder, limit });
-    return;
-  }
-
-  // Handle identity get commands
-  if (verb === 'get' && normalizedResource === 'user') {
-    if (!args[0]) { logger.error('Username required. Usage: c8 get user <username>'); process.exit(1); }
-    await getIdentityUser(args[0], { profile: values.profile as string | undefined });
-    return;
-  }
-  if (verb === 'get' && normalizedResource === 'role') {
-    if (!args[0]) { logger.error('Role ID required. Usage: c8 get role <roleId>'); process.exit(1); }
-    await getIdentityRole(args[0], { profile: values.profile as string | undefined });
-    return;
-  }
-  if (verb === 'get' && normalizedResource === 'group') {
-    if (!args[0]) { logger.error('Group ID required. Usage: c8 get group <groupId>'); process.exit(1); }
-    await getIdentityGroup(args[0], { profile: values.profile as string | undefined });
-    return;
-  }
-  if (verb === 'get' && normalizedResource === 'tenant') {
-    if (!args[0]) { logger.error('Tenant ID required. Usage: c8 get tenant <tenantId>'); process.exit(1); }
-    await getIdentityTenant(args[0], { profile: values.profile as string | undefined });
-    return;
-  }
-  if (verb === 'get' && normalizedResource === 'authorization') {
-    if (!args[0]) { logger.error('Authorization key required. Usage: c8 get auth <key>'); process.exit(1); }
-    await getIdentityAuthorization(args[0], { profile: values.profile as string | undefined });
-    return;
-  }
-  if (verb === 'get' && normalizedResource === 'mapping-rule') {
-    if (!args[0]) { logger.error('Mapping rule ID required. Usage: c8 get mapping-rule <id>'); process.exit(1); }
-    await getIdentityMappingRule(args[0], { profile: values.profile as string | undefined });
-    return;
-  }
-
-  // Handle identity create commands
-  if (verb === 'create' && normalizedResource === 'user') {
-    await createIdentityUser({
-      profile: values.profile as string | undefined,
-      username: values.username as string | undefined,
-      name: values.name as string | undefined,
-      email: values.email as string | undefined,
-      password: values.password as string | undefined,
-    });
-    return;
-  }
-  if (verb === 'create' && normalizedResource === 'role') {
-    await createIdentityRole({
-      profile: values.profile as string | undefined,
-      roleId: values.roleId as string | undefined,
-      name: values.name as string | undefined,
-    });
-    return;
-  }
-  if (verb === 'create' && normalizedResource === 'group') {
-    await createIdentityGroup({
-      profile: values.profile as string | undefined,
-      groupId: values.groupId as string | undefined,
-      name: values.name as string | undefined,
-    });
-    return;
-  }
-  if (verb === 'create' && normalizedResource === 'tenant') {
-    await createIdentityTenant({
-      profile: values.profile as string | undefined,
-      tenantId: values.tenantId as string | undefined,
-      name: values.name as string | undefined,
-    });
-    return;
-  }
-  if (verb === 'create' && normalizedResource === 'authorization') {
-    await createIdentityAuthorization({
-      profile: values.profile as string | undefined,
-      ownerId: values.ownerId as string | undefined,
-      ownerType: values.ownerType as string | undefined,
-      resourceType: values.resourceType as string | undefined,
-      resourceId: values.resourceId as string | undefined,
-      permissions: values.permissions as string | undefined,
-    });
-    return;
-  }
-  if (verb === 'create' && normalizedResource === 'mapping-rule') {
-    await createIdentityMappingRule({
-      profile: values.profile as string | undefined,
-      mappingRuleId: values.mappingRuleId as string | undefined,
-      name: values.name as string | undefined,
-      claimName: values.claimName as string | undefined,
-      claimValue: values.claimValue as string | undefined,
-    });
-    return;
-  }
-
-  // Handle identity delete commands
-  if (verb === 'delete' && normalizedResource === 'user') {
-    if (!args[0]) { logger.error('Username required. Usage: c8 delete user <username>'); process.exit(1); }
-    await deleteIdentityUser(args[0], { profile: values.profile as string | undefined });
-    return;
-  }
-  if (verb === 'delete' && normalizedResource === 'role') {
-    if (!args[0]) { logger.error('Role ID required. Usage: c8 delete role <roleId>'); process.exit(1); }
-    await deleteIdentityRole(args[0], { profile: values.profile as string | undefined });
-    return;
-  }
-  if (verb === 'delete' && normalizedResource === 'group') {
-    if (!args[0]) { logger.error('Group ID required. Usage: c8 delete group <groupId>'); process.exit(1); }
-    await deleteIdentityGroup(args[0], { profile: values.profile as string | undefined });
-    return;
-  }
-  if (verb === 'delete' && normalizedResource === 'tenant') {
-    if (!args[0]) { logger.error('Tenant ID required. Usage: c8 delete tenant <tenantId>'); process.exit(1); }
-    await deleteIdentityTenant(args[0], { profile: values.profile as string | undefined });
-    return;
-  }
-  if (verb === 'delete' && normalizedResource === 'authorization') {
-    if (!args[0]) { logger.error('Authorization key required. Usage: c8 delete auth <key>'); process.exit(1); }
-    await deleteIdentityAuthorization(args[0], { profile: values.profile as string | undefined });
-    return;
-  }
-  if (verb === 'delete' && normalizedResource === 'mapping-rule') {
-    if (!args[0]) { logger.error('Mapping rule ID required. Usage: c8 delete mapping-rule <id>'); process.exit(1); }
-    await deleteIdentityMappingRule(args[0], { profile: values.profile as string | undefined });
-    return;
-  }
-
-  // Handle assign/unassign commands
-  if (verb === 'assign') {
-    if (!normalizedResource) {
-      showVerbResources('assign');
-      return;
-    }
-    if (!args[0]) {
-      logger.error(`ID required. Usage: c8 assign ${normalizedResource} <id> --to-<target>=<targetId>`);
-      process.exit(1);
-    }
-    await handleAssign(normalizedResource, args[0], values as Record<string, unknown>, { profile: values.profile as string | undefined });
-    return;
-  }
-
-  if (verb === 'unassign') {
-    if (!normalizedResource) {
-      showVerbResources('unassign');
-      return;
-    }
-    if (!args[0]) {
-      logger.error(`ID required. Usage: c8 unassign ${normalizedResource} <id> --from-<target>=<targetId>`);
-      process.exit(1);
-    }
-    await handleUnassign(normalizedResource, args[0], values as Record<string, unknown>, { profile: values.profile as string | undefined });
-    return;
-  }
-
-  // Try to execute plugin command (before verb-only check)
-  if (await executePluginCommand(verb, resource ? [resource, ...args] : args)) {
-    return;
-  }
-
-  // Handle verb-only invocations (show available resources)
-  if (!resource) {
-    showVerbResources(verb);
-    return;
-  }
-
-  // Unknown command
-  logger.error(`Unknown command: ${verb} ${resource}`);
-  logger.info('Run "c8 help" for usage information');
-  process.exit(1);
+	// Load session state from disk at startup
+	loadSessionState();
+
+	const { values, positionals } = parseCliArgs();
+
+	// Initialize logger with current output mode from c8ctl runtime
+	const logger = getLogger(c8ctl.outputMode);
+
+	// Resolve sort order from --asc / --desc flags (default: asc)
+	const sortOrder: SortOrder = values.desc ? "desc" : "asc";
+	if (values.asc && values.desc) {
+		logger.error("Cannot specify both --asc and --desc. Use one or the other.");
+		process.exit(1);
+	}
+
+	// Resolve --limit flag (max items to fetch)
+	const limitStr = str(values.limit);
+	const limit = limitStr ? parseInt(limitStr, 10) : undefined;
+	if (limit !== undefined && (Number.isNaN(limit) || limit < 1)) {
+		logger.error("--limit must be a positive integer.");
+		process.exit(1);
+	}
+
+	// Resolve --fields flag (agent feature: filter output keys)
+	if (values.fields && typeof values.fields === "string") {
+		c8ctl.fields = values.fields
+			.split(",")
+			.map((f) => f.trim())
+			.filter(Boolean);
+	}
+
+	// Resolve --dry-run flag (agent feature: emit API request without executing)
+	if (values["dry-run"]) {
+		c8ctl.dryRun = true;
+	}
+
+	// Resolve --verbose flag (enable SDK trace logging and surface raw errors)
+	if (values.verbose) {
+		c8ctl.verbose = true;
+	}
+
+	// Load installed plugins
+	await loadInstalledPlugins();
+
+	// Extract command and resource
+	const [verb, resource, ...args] = positionals;
+
+	// Handle global --version flag (only when no verb/command is provided)
+	if (values.version && !verb) {
+		showVersion();
+		return;
+	}
+
+	if (values.help && positionals.length === 0) {
+		showHelp();
+		return;
+	}
+
+	if (!verb) {
+		showHelp();
+		return;
+	}
+
+	// Handle help command
+	if (
+		verb === "help" ||
+		verb === "menu" ||
+		verb === "--help" ||
+		verb === "-h"
+	) {
+		// Check if user wants help for a specific command
+		if (resource) {
+			showCommandHelp(resource);
+		} else {
+			showHelp();
+		}
+		return;
+	}
+
+	// Handle completion command
+	if (verb === "completion") {
+		showCompletion(resource);
+		return;
+	}
+
+	// Normalize resource
+	const normalizedResource = resource ? normalizeResource(resource) : "";
+
+	// Handle session commands
+	if (verb === "use") {
+		if (normalizedResource === "profile") {
+			if (values.none) {
+				useProfile("--none");
+				return;
+			}
+			if (!args[0]) {
+				logger.error("Profile name required. Usage: c8 use profile <name>");
+				process.exit(1);
+			}
+			useProfile(args[0]);
+			return;
+		}
+		if (normalizedResource === "tenant") {
+			if (!args[0]) {
+				logger.error("Tenant ID required. Usage: c8 use tenant <id>");
+				process.exit(1);
+			}
+			useTenant(args[0]);
+			return;
+		}
+		showVerbResources("use");
+		return;
+	}
+
+	if (verb === "output") {
+		if (!resource) {
+			logger.info(`Current output mode: ${c8ctl.outputMode}`);
+			if (c8ctl.outputMode === "text") {
+				logger.info("");
+			}
+			logger.info("Available modes: json|text");
+			return;
+		}
+		setOutputFormat(resource);
+		return;
+	}
+
+	// Handle profile commands
+	if (verb === "list" && normalizedResource === "profile") {
+		listProfiles();
+		return;
+	}
+
+	if (verb === "add" && normalizedResource === "profile") {
+		if (!args[0]) {
+			logger.error(
+				"Profile name required. Usage: c8 add profile <name> --baseUrl=<url>",
+			);
+			process.exit(1);
+		}
+		const envFile =
+			typeof values["from-file"] === "string" ? values["from-file"] : undefined;
+		const fromEnv = values["from-env"] === true;
+		addProfile(args[0], {
+			url: typeof values.baseUrl === "string" ? values.baseUrl : undefined,
+			clientId:
+				typeof values.clientId === "string" ? values.clientId : undefined,
+			clientSecret:
+				typeof values.clientSecret === "string"
+					? values.clientSecret
+					: undefined,
+			audience:
+				typeof values.audience === "string" ? values.audience : undefined,
+			oauthUrl:
+				typeof values.oAuthUrl === "string" ? values.oAuthUrl : undefined,
+			tenantId:
+				typeof values.defaultTenantId === "string"
+					? values.defaultTenantId
+					: undefined,
+			envFile,
+			fromEnv,
+		});
+		return;
+	}
+
+	if (
+		(verb === "remove" || verb === "rm") &&
+		normalizedResource === "profile"
+	) {
+		if (!args[0]) {
+			logger.error("Profile name required. Usage: c8 remove profile <name>");
+			process.exit(1);
+		}
+		removeProfile(args[0]);
+		return;
+	}
+
+	if (verb === "which" && normalizedResource === "profile") {
+		whichProfile();
+		return;
+	}
+
+	// Handle plugin commands
+	if (verb === "list" && normalizedResource === "plugin") {
+		listPlugins();
+		return;
+	}
+
+	if (verb === "load" && normalizedResource === "plugin") {
+		const fromUrl = str(values.from);
+		const packageName = args[0];
+		await loadPlugin(packageName, fromUrl);
+		return;
+	}
+
+	if (
+		(verb === "unload" || verb === "remove" || verb === "rm") &&
+		normalizedResource === "plugin"
+	) {
+		if (!args[0]) {
+			logger.error(
+				"Package name required. Usage: c8 unload plugin <package-name>",
+			);
+			process.exit(1);
+		}
+		await unloadPlugin(args[0], { force: bool(values.force) });
+		return;
+	}
+
+	if (verb === "sync" && normalizedResource === "plugin") {
+		await syncPlugins();
+		return;
+	}
+
+	if (verb === "upgrade" && normalizedResource === "plugin") {
+		if (!args[0]) {
+			logger.error(
+				"Package name required. Usage: c8 upgrade plugin <package-name> [version]",
+			);
+			process.exit(1);
+		}
+		await upgradePlugin(args[0], args[1]);
+		return;
+	}
+
+	if (verb === "downgrade" && normalizedResource === "plugin") {
+		if (!args[0] || !args[1]) {
+			logger.error(
+				"Package name and version required. Usage: c8 downgrade plugin <package-name> <version>",
+			);
+			process.exit(1);
+		}
+		await downgradePlugin(args[0], args[1]);
+		return;
+	}
+
+	if (verb === "init" && normalizedResource === "plugin") {
+		await initPlugin(args[0]);
+		return;
+	}
+
+	// Handle process instance commands
+	if (
+		verb === "list" &&
+		(normalizedResource === "process-instance" ||
+			normalizedResource === "process-instances")
+	) {
+		await listProcessInstances({
+			profile: str(values.profile),
+			processDefinitionId: resolveProcessDefinitionId(values),
+			version: parseVersionFlag(values),
+			state: str(values.state),
+			all: bool(values.all),
+			sortBy: str(values.sortBy),
+			sortOrder,
+			limit,
+			between: str(values.between),
+			dateField: str(values.dateField),
+		});
+		return;
+	}
+
+	if (verb === "get" && normalizedResource === "process-instance") {
+		if (!args[0]) {
+			logger.error("Process instance key required. Usage: c8 get pi <key>");
+			process.exit(1);
+		}
+		// Check if --variables flag is present (for get command, it's a boolean flag)
+		const includeVariables = process.argv.includes("--variables");
+		await getProcessInstance(args[0], {
+			profile: str(values.profile),
+			variables: includeVariables,
+		});
+		return;
+	}
+
+	if (verb === "create" && normalizedResource === "process-instance") {
+		await createProcessInstance({
+			profile: str(values.profile),
+			processDefinitionId: resolveProcessDefinitionId(values),
+			version: parseVersionFlag(values),
+			variables: str(values.variables),
+			awaitCompletion: bool(values.awaitCompletion),
+			fetchVariables: bool(values.fetchVariables),
+			requestTimeout:
+				values.requestTimeout && typeof values.requestTimeout === "string"
+					? parseInt(values.requestTimeout, 10)
+					: undefined,
+		});
+		return;
+	}
+
+	if (verb === "cancel" && normalizedResource === "process-instance") {
+		if (!args[0]) {
+			logger.error("Process instance key required. Usage: c8 cancel pi <key>");
+			process.exit(1);
+		}
+		await cancelProcessInstance(args[0], {
+			profile: str(values.profile),
+		});
+		return;
+	}
+
+	// Handle await command - alias for create with awaitCompletion
+	if (verb === "await" && normalizedResource === "process-instance") {
+		// await pi is an alias for create pi with --awaitCompletion
+		// It supports the same flags as create (id, variables, version, etc.)
+		await createProcessInstance({
+			profile: str(values.profile),
+			processDefinitionId: resolveProcessDefinitionId(values),
+			version: parseVersionFlag(values),
+			variables: str(values.variables),
+			awaitCompletion: true, // Always true for await command
+			fetchVariables: bool(values.fetchVariables),
+			requestTimeout:
+				values.requestTimeout && typeof values.requestTimeout === "string"
+					? parseInt(values.requestTimeout, 10)
+					: undefined,
+		});
+		return;
+	}
+
+	// Handle process definition commands
+	if (
+		verb === "list" &&
+		(normalizedResource === "process-definition" ||
+			normalizedResource === "process-definitions")
+	) {
+		await listProcessDefinitions({
+			profile: str(values.profile),
+			sortBy: str(values.sortBy),
+			sortOrder,
+			limit,
+		});
+		return;
+	}
+
+	if (verb === "get" && normalizedResource === "process-definition") {
+		if (!args[0]) {
+			logger.error("Process definition key required. Usage: c8 get pd <key>");
+			process.exit(1);
+		}
+		await getProcessDefinition(args[0], {
+			profile: str(values.profile),
+			xml: bool(values.xml),
+		});
+		return;
+	}
+
+	// Handle user task commands
+	if (
+		verb === "list" &&
+		(normalizedResource === "user-task" || normalizedResource === "user-tasks")
+	) {
+		await listUserTasks({
+			profile: str(values.profile),
+			state: str(values.state),
+			assignee: str(values.assignee),
+			all: bool(values.all),
+			sortBy: str(values.sortBy),
+			sortOrder,
+			limit,
+			between: str(values.between),
+			dateField: str(values.dateField),
+		});
+		return;
+	}
+
+	if (verb === "complete" && normalizedResource === "user-task") {
+		if (!args[0]) {
+			logger.error("User task key required. Usage: c8 complete ut <key>");
+			process.exit(1);
+		}
+		await completeUserTask(args[0], {
+			profile: str(values.profile),
+			variables: str(values.variables),
+		});
+		return;
+	}
+
+	// Handle incident commands
+	if (
+		verb === "list" &&
+		(normalizedResource === "incident" || normalizedResource === "incidents")
+	) {
+		await listIncidents({
+			profile: str(values.profile),
+			state: str(values.state),
+			processInstanceKey: str(values.processInstanceKey),
+			sortBy: str(values.sortBy),
+			sortOrder,
+			limit,
+			between: str(values.between),
+		});
+		return;
+	}
+
+	if (verb === "get" && normalizedResource === "incident") {
+		if (!args[0]) {
+			logger.error("Incident key required. Usage: c8 get inc <key>");
+			process.exit(1);
+		}
+		await getIncident(args[0], {
+			profile: str(values.profile),
+		});
+		return;
+	}
+
+	if (verb === "resolve" && normalizedResource === "incident") {
+		if (!args[0]) {
+			logger.error("Incident key required. Usage: c8 resolve inc <key>");
+			process.exit(1);
+		}
+		await resolveIncident(args[0], {
+			profile: str(values.profile),
+		});
+		return;
+	}
+
+	// Handle job commands
+	if (verb === "list" && normalizedResource === "jobs") {
+		await listJobs({
+			profile: str(values.profile),
+			state: str(values.state),
+			type: str(values.type),
+			sortBy: str(values.sortBy),
+			sortOrder,
+			limit,
+			between: str(values.between),
+			dateField: str(values.dateField),
+		});
+		return;
+	}
+
+	if (verb === "activate" && normalizedResource === "jobs") {
+		if (!args[0]) {
+			logger.error("Job type required. Usage: c8 activate jobs <type>");
+			process.exit(1);
+		}
+		await activateJobs(args[0], {
+			profile: str(values.profile),
+			maxJobsToActivate:
+				values.maxJobsToActivate && typeof values.maxJobsToActivate === "string"
+					? parseInt(values.maxJobsToActivate, 10)
+					: undefined,
+			timeout:
+				values.timeout && typeof values.timeout === "string"
+					? parseInt(values.timeout, 10)
+					: undefined,
+			worker: str(values.worker),
+		});
+		return;
+	}
+
+	if (verb === "complete" && normalizedResource === "job") {
+		if (!args[0]) {
+			logger.error("Job key required. Usage: c8 complete job <key>");
+			process.exit(1);
+		}
+		await completeJob(args[0], {
+			profile: str(values.profile),
+			variables: str(values.variables),
+		});
+		return;
+	}
+
+	if (verb === "fail" && normalizedResource === "job") {
+		if (!args[0]) {
+			logger.error("Job key required. Usage: c8 fail job <key>");
+			process.exit(1);
+		}
+		await failJob(args[0], {
+			profile: str(values.profile),
+			retries:
+				values.retries && typeof values.retries === "string"
+					? parseInt(values.retries, 10)
+					: undefined,
+			errorMessage: str(values.errorMessage),
+		});
+		return;
+	}
+
+	// Handle message commands
+	if (verb === "publish" && normalizedResource === "message") {
+		if (!args[0]) {
+			logger.error("Message name required. Usage: c8 publish msg <name>");
+			process.exit(1);
+		}
+		await publishMessage(args[0], {
+			profile: str(values.profile),
+			correlationKey: str(values.correlationKey),
+			variables: str(values.variables),
+			timeToLive:
+				values.timeToLive && typeof values.timeToLive === "string"
+					? parseInt(values.timeToLive, 10)
+					: undefined,
+		});
+		return;
+	}
+
+	if (verb === "correlate" && normalizedResource === "message") {
+		if (!args[0]) {
+			logger.error("Message name required. Usage: c8 correlate msg <name>");
+			process.exit(1);
+		}
+		await correlateMessage(args[0], {
+			profile: str(values.profile),
+			correlationKey: str(values.correlationKey),
+			variables: str(values.variables),
+			timeToLive:
+				values.timeToLive && typeof values.timeToLive === "string"
+					? parseInt(values.timeToLive, 10)
+					: undefined,
+		});
+		return;
+	}
+
+	// Handle topology command
+	if (verb === "get" && normalizedResource === "topology") {
+		await getTopology({
+			profile: str(values.profile),
+		});
+		return;
+	}
+
+	// Handle form commands
+	if (verb === "get" && normalizedResource === "form") {
+		if (!args[0]) {
+			logger.error(
+				"Key required. Usage: c8 get form <key> [--userTask|--ut] [--processDefinition|--pd]",
+			);
+			process.exit(1);
+		}
+
+		// Check for flags and their aliases
+		const isUserTask =
+			process.argv.includes("--userTask") || process.argv.includes("--ut");
+		const isProcessDefinition =
+			process.argv.includes("--processDefinition") ||
+			process.argv.includes("--pd");
+
+		// If both flags specified, error
+		if (isUserTask && isProcessDefinition) {
+			logger.error(
+				"Cannot specify both --userTask|--ut and --processDefinition|--pd. Use one or the other, or omit both to search both types.",
+			);
+			process.exit(1);
+		}
+
+		// If specific flag provided, use that API
+		if (isUserTask) {
+			await getUserTaskForm(args[0], {
+				profile: str(values.profile),
+			});
+		} else if (isProcessDefinition) {
+			await getStartForm(args[0], {
+				profile: str(values.profile),
+			});
+		} else {
+			// No flag provided - try both
+			await getForm(args[0], {
+				profile: str(values.profile),
+			});
+		}
+		return;
+	}
+
+	// Handle deploy command
+	if (verb === "deploy") {
+		const paths = resource
+			? [resource, ...args]
+			: args.length > 0
+				? args
+				: ["."];
+		await deploy(paths, {
+			profile: str(values.profile),
+		});
+		return;
+	}
+
+	// Handle run command
+	if (verb === "run") {
+		if (!resource) {
+			logger.error("BPMN file path required. Usage: c8 run <path>");
+			process.exit(1);
+		}
+		await run(resource, {
+			profile: str(values.profile),
+			variables: str(values.variables),
+		});
+		return;
+	}
+
+	// Handle watch command
+	if (verb === "watch" || verb === "w") {
+		const paths = resource
+			? [resource, ...args]
+			: args.length > 0
+				? args
+				: ["."];
+		await watchFiles(paths, {
+			profile: str(values.profile),
+			force: bool(values.force),
+		});
+		return;
+	}
+
+	// Handle open command
+	if (verb === "open") {
+		await openApp(resource, {
+			profile: str(values.profile),
+			dryRun: bool(values["dry-run"]),
+		});
+		return;
+	}
+
+	// Handle feedback command
+	if (verb === "feedback") {
+		const logger = getLogger();
+		const url = "https://github.com/camunda/c8ctl/issues";
+		logger.info(`Opening feedback page: ${url}`);
+		openUrl(url);
+		return;
+	}
+
+	// Handle mcp-proxy command
+	if (verb === "mcp-proxy") {
+		await mcpProxy(positionals.slice(1), {
+			profile: str(values.profile),
+		});
+		return;
+	}
+
+	// Handle search commands
+	if (verb === "search") {
+		if (!resource) {
+			showVerbResources("search");
+			return;
+		}
+		const normalizedSearchResource = normalizeResource(resource);
+		const unknownFlags = detectUnknownSearchFlags(
+			values,
+			normalizedSearchResource,
+		);
+		warnUnknownSearchFlags(logger, unknownFlags, resource);
+
+		if (
+			normalizedSearchResource === "process-definition" ||
+			normalizedSearchResource === "process-definitions"
+		) {
+			await searchProcessDefinitions({
+				profile: str(values.profile),
+				processDefinitionId: resolveProcessDefinitionId(values),
+				name: str(values.name),
+				version: parseVersionFlag(values),
+				key: str(values.key),
+				iProcessDefinitionId: str(values.iid),
+				iName: str(values.iname),
+				sortBy: str(values.sortBy),
+				sortOrder,
+				_unknownFlags: unknownFlags,
+			});
+			return;
+		}
+
+		if (
+			normalizedSearchResource === "process-instance" ||
+			normalizedSearchResource === "process-instances"
+		) {
+			await searchProcessInstances({
+				profile: str(values.profile),
+				processDefinitionId: resolveProcessDefinitionId(values),
+				processDefinitionKey: str(values.processDefinitionKey),
+				version: parseVersionFlag(values),
+				state: str(values.state),
+				key: str(values.key),
+				parentProcessInstanceKey: str(values.parentProcessInstanceKey),
+				iProcessDefinitionId: str(values.iid),
+				sortBy: str(values.sortBy),
+				sortOrder,
+				_unknownFlags: unknownFlags,
+				between: str(values.between),
+				dateField: str(values.dateField),
+			});
+			return;
+		}
+
+		if (
+			normalizedSearchResource === "user-task" ||
+			normalizedSearchResource === "user-tasks"
+		) {
+			await searchUserTasks({
+				profile: str(values.profile),
+				state: str(values.state),
+				assignee: str(values.assignee),
+				processInstanceKey: str(values.processInstanceKey),
+				processDefinitionKey: str(values.processDefinitionKey),
+				elementId: str(values.elementId),
+				iAssignee: str(values.iassignee),
+				sortBy: str(values.sortBy),
+				sortOrder,
+				_unknownFlags: unknownFlags,
+				between: str(values.between),
+				dateField: str(values.dateField),
+			});
+			return;
+		}
+
+		if (
+			normalizedSearchResource === "incident" ||
+			normalizedSearchResource === "incidents"
+		) {
+			await searchIncidents({
+				profile: str(values.profile),
+				state: str(values.state),
+				processInstanceKey: str(values.processInstanceKey),
+				processDefinitionKey: str(values.processDefinitionKey),
+				processDefinitionId: resolveProcessDefinitionId(values),
+				errorType: str(values.errorType),
+				errorMessage: str(values.errorMessage),
+				iErrorMessage: str(values.ierrorMessage),
+				iProcessDefinitionId: str(values.iid),
+				sortBy: str(values.sortBy),
+				sortOrder,
+				_unknownFlags: unknownFlags,
+				between: str(values.between),
+			});
+			return;
+		}
+
+		if (normalizedSearchResource === "jobs") {
+			await searchJobs({
+				profile: str(values.profile),
+				state: str(values.state),
+				type: str(values.type),
+				processInstanceKey: str(values.processInstanceKey),
+				processDefinitionKey: str(values.processDefinitionKey),
+				iType: str(values.itype),
+				sortBy: str(values.sortBy),
+				sortOrder,
+				_unknownFlags: unknownFlags,
+				between: str(values.between),
+				dateField: str(values.dateField),
+			});
+			return;
+		}
+
+		if (
+			normalizedSearchResource === "variable" ||
+			normalizedSearchResource === "variables"
+		) {
+			await searchVariables({
+				profile: str(values.profile),
+				name: str(values.name),
+				value: str(values.value),
+				processInstanceKey: str(values.processInstanceKey),
+				scopeKey: str(values.scopeKey),
+				fullValue: bool(values.fullValue),
+				iName: str(values.iname),
+				iValue: str(values.ivalue),
+				sortBy: str(values.sortBy),
+				sortOrder,
+				limit,
+				_unknownFlags: unknownFlags,
+			});
+			return;
+		}
+
+		if (normalizedSearchResource === "user") {
+			await searchIdentityUsers({
+				profile: str(values.profile),
+				username: str(values.username),
+				name: str(values.name),
+				email: str(values.email),
+				sortBy: str(values.sortBy),
+				sortOrder,
+				limit,
+			});
+			return;
+		}
+
+		if (normalizedSearchResource === "role") {
+			await searchIdentityRoles({
+				profile: str(values.profile),
+				roleId: str(values.roleId),
+				name: str(values.name),
+				sortBy: str(values.sortBy),
+				sortOrder,
+				limit,
+			});
+			return;
+		}
+
+		if (normalizedSearchResource === "group") {
+			await searchIdentityGroups({
+				profile: str(values.profile),
+				groupId: str(values.groupId),
+				name: str(values.name),
+				sortBy: str(values.sortBy),
+				sortOrder,
+				limit,
+			});
+			return;
+		}
+
+		if (normalizedSearchResource === "tenant") {
+			await searchIdentityTenants({
+				profile: str(values.profile),
+				name: str(values.name),
+				tenantId: str(values.tenantId),
+				sortBy: str(values.sortBy),
+				sortOrder,
+				limit,
+			});
+			return;
+		}
+
+		if (normalizedSearchResource === "authorization") {
+			await searchIdentityAuthorizations({
+				profile: str(values.profile),
+				ownerId: str(values.ownerId),
+				ownerType: str(values.ownerType),
+				resourceType: str(values.resourceType),
+				resourceId: str(values.resourceId),
+				sortBy: str(values.sortBy),
+				sortOrder,
+				limit,
+			});
+			return;
+		}
+
+		if (normalizedSearchResource === "mapping-rule") {
+			await searchIdentityMappingRules({
+				profile: str(values.profile),
+				mappingRuleId: str(values.mappingRuleId),
+				name: str(values.name),
+				claimName: str(values.claimName),
+				claimValue: str(values.claimValue),
+				sortBy: str(values.sortBy),
+				sortOrder,
+				limit,
+			});
+			return;
+		}
+
+		// If resource not recognized for search, show available resources
+		showVerbResources("search");
+		return;
+	}
+
+	// Handle identity list commands
+	if (verb === "list" && normalizedResource === "user") {
+		await listUsers({
+			profile: str(values.profile),
+			sortBy: str(values.sortBy),
+			sortOrder,
+			limit,
+		});
+		return;
+	}
+	if (verb === "list" && normalizedResource === "role") {
+		await listRoles({
+			profile: str(values.profile),
+			sortBy: str(values.sortBy),
+			sortOrder,
+			limit,
+		});
+		return;
+	}
+	if (verb === "list" && normalizedResource === "group") {
+		await listGroups({
+			profile: str(values.profile),
+			sortBy: str(values.sortBy),
+			sortOrder,
+			limit,
+		});
+		return;
+	}
+	if (verb === "list" && normalizedResource === "tenant") {
+		await listTenants({
+			profile: str(values.profile),
+			sortBy: str(values.sortBy),
+			sortOrder,
+			limit,
+		});
+		return;
+	}
+	if (verb === "list" && normalizedResource === "authorization") {
+		await listAuthorizations({
+			profile: str(values.profile),
+			sortBy: str(values.sortBy),
+			sortOrder,
+			limit,
+		});
+		return;
+	}
+	if (verb === "list" && normalizedResource === "mapping-rule") {
+		await listMappingRules({
+			profile: str(values.profile),
+			sortBy: str(values.sortBy),
+			sortOrder,
+			limit,
+		});
+		return;
+	}
+
+	// Handle identity get commands
+	if (verb === "get" && normalizedResource === "user") {
+		if (!args[0]) {
+			logger.error("Username required. Usage: c8 get user <username>");
+			process.exit(1);
+		}
+		await getIdentityUser(args[0], { profile: str(values.profile) });
+		return;
+	}
+	if (verb === "get" && normalizedResource === "role") {
+		if (!args[0]) {
+			logger.error("Role ID required. Usage: c8 get role <roleId>");
+			process.exit(1);
+		}
+		await getIdentityRole(args[0], { profile: str(values.profile) });
+		return;
+	}
+	if (verb === "get" && normalizedResource === "group") {
+		if (!args[0]) {
+			logger.error("Group ID required. Usage: c8 get group <groupId>");
+			process.exit(1);
+		}
+		await getIdentityGroup(args[0], { profile: str(values.profile) });
+		return;
+	}
+	if (verb === "get" && normalizedResource === "tenant") {
+		if (!args[0]) {
+			logger.error("Tenant ID required. Usage: c8 get tenant <tenantId>");
+			process.exit(1);
+		}
+		await getIdentityTenant(args[0], { profile: str(values.profile) });
+		return;
+	}
+	if (verb === "get" && normalizedResource === "authorization") {
+		if (!args[0]) {
+			logger.error("Authorization key required. Usage: c8 get auth <key>");
+			process.exit(1);
+		}
+		await getIdentityAuthorization(args[0], { profile: str(values.profile) });
+		return;
+	}
+	if (verb === "get" && normalizedResource === "mapping-rule") {
+		if (!args[0]) {
+			logger.error("Mapping rule ID required. Usage: c8 get mapping-rule <id>");
+			process.exit(1);
+		}
+		await getIdentityMappingRule(args[0], { profile: str(values.profile) });
+		return;
+	}
+
+	// Handle identity create commands
+	if (verb === "create" && normalizedResource === "user") {
+		await createIdentityUser({
+			profile: str(values.profile),
+			username: str(values.username),
+			name: str(values.name),
+			email: str(values.email),
+			password: str(values.password),
+		});
+		return;
+	}
+	if (verb === "create" && normalizedResource === "role") {
+		await createIdentityRole({
+			profile: str(values.profile),
+			roleId: str(values.roleId),
+			name: str(values.name),
+		});
+		return;
+	}
+	if (verb === "create" && normalizedResource === "group") {
+		await createIdentityGroup({
+			profile: str(values.profile),
+			groupId: str(values.groupId),
+			name: str(values.name),
+		});
+		return;
+	}
+	if (verb === "create" && normalizedResource === "tenant") {
+		await createIdentityTenant({
+			profile: str(values.profile),
+			tenantId: str(values.tenantId),
+			name: str(values.name),
+		});
+		return;
+	}
+	if (verb === "create" && normalizedResource === "authorization") {
+		await createIdentityAuthorization({
+			profile: str(values.profile),
+			ownerId: str(values.ownerId),
+			ownerType: str(values.ownerType),
+			resourceType: str(values.resourceType),
+			resourceId: str(values.resourceId),
+			permissions: str(values.permissions),
+		});
+		return;
+	}
+	if (verb === "create" && normalizedResource === "mapping-rule") {
+		await createIdentityMappingRule({
+			profile: str(values.profile),
+			mappingRuleId: str(values.mappingRuleId),
+			name: str(values.name),
+			claimName: str(values.claimName),
+			claimValue: str(values.claimValue),
+		});
+		return;
+	}
+
+	// Handle identity delete commands
+	if (verb === "delete" && normalizedResource === "user") {
+		if (!args[0]) {
+			logger.error("Username required. Usage: c8 delete user <username>");
+			process.exit(1);
+		}
+		await deleteIdentityUser(args[0], { profile: str(values.profile) });
+		return;
+	}
+	if (verb === "delete" && normalizedResource === "role") {
+		if (!args[0]) {
+			logger.error("Role ID required. Usage: c8 delete role <roleId>");
+			process.exit(1);
+		}
+		await deleteIdentityRole(args[0], { profile: str(values.profile) });
+		return;
+	}
+	if (verb === "delete" && normalizedResource === "group") {
+		if (!args[0]) {
+			logger.error("Group ID required. Usage: c8 delete group <groupId>");
+			process.exit(1);
+		}
+		await deleteIdentityGroup(args[0], { profile: str(values.profile) });
+		return;
+	}
+	if (verb === "delete" && normalizedResource === "tenant") {
+		if (!args[0]) {
+			logger.error("Tenant ID required. Usage: c8 delete tenant <tenantId>");
+			process.exit(1);
+		}
+		await deleteIdentityTenant(args[0], { profile: str(values.profile) });
+		return;
+	}
+	if (verb === "delete" && normalizedResource === "authorization") {
+		if (!args[0]) {
+			logger.error("Authorization key required. Usage: c8 delete auth <key>");
+			process.exit(1);
+		}
+		await deleteIdentityAuthorization(args[0], {
+			profile: str(values.profile),
+		});
+		return;
+	}
+	if (verb === "delete" && normalizedResource === "mapping-rule") {
+		if (!args[0]) {
+			logger.error(
+				"Mapping rule ID required. Usage: c8 delete mapping-rule <id>",
+			);
+			process.exit(1);
+		}
+		await deleteIdentityMappingRule(args[0], { profile: str(values.profile) });
+		return;
+	}
+
+	// Handle assign/unassign commands
+	if (verb === "assign") {
+		if (!normalizedResource) {
+			showVerbResources("assign");
+			return;
+		}
+		if (!args[0]) {
+			logger.error(
+				`ID required. Usage: c8 assign ${normalizedResource} <id> --to-<target>=<targetId>`,
+			);
+			process.exit(1);
+		}
+		await handleAssign(normalizedResource, args[0], values, {
+			profile: str(values.profile),
+		});
+		return;
+	}
+
+	if (verb === "unassign") {
+		if (!normalizedResource) {
+			showVerbResources("unassign");
+			return;
+		}
+		if (!args[0]) {
+			logger.error(
+				`ID required. Usage: c8 unassign ${normalizedResource} <id> --from-<target>=<targetId>`,
+			);
+			process.exit(1);
+		}
+		await handleUnassign(normalizedResource, args[0], values, {
+			profile: str(values.profile),
+		});
+		return;
+	}
+
+	// Try to execute plugin command (before verb-only check)
+	if (await executePluginCommand(verb, resource ? [resource, ...args] : args)) {
+		return;
+	}
+
+	// Handle verb-only invocations (show available resources)
+	if (!resource) {
+		showVerbResources(verb);
+		return;
+	}
+
+	// Unknown command
+	logger.error(`Unknown command: ${verb} ${resource}`);
+	logger.info('Run "c8 help" for usage information');
+	process.exit(1);
 }
 
 // Run the CLI only when invoked directly (not when imported)
 // Use realpathSync to resolve symlinks (e.g. when installed globally via npm link)
 try {
-  if (realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
-    main().catch((error) => {
-      if (c8ctl.verbose) {
-        throw error;
-      }
-      console.error('Unexpected error:', error);
-      process.exit(1);
-    });
-  }
-} catch { /* not invoked directly */ }
+	if (realpathSync(process.argv[1]) === fileURLToPath(import.meta.url)) {
+		main().catch((error) => {
+			if (c8ctl.verbose) {
+				throw error;
+			}
+			console.error("Unexpected error:", error);
+			process.exit(1);
+		});
+	}
+} catch {
+	/* not invoked directly */
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1038,6 +1038,7 @@ async function main() {
   if (verb === 'create' && normalizedResource === 'role') {
     await createIdentityRole({
       profile: values.profile as string | undefined,
+      roleId: values.roleId as string | undefined,
       name: values.name as string | undefined,
     });
     return;
@@ -1045,6 +1046,7 @@ async function main() {
   if (verb === 'create' && normalizedResource === 'group') {
     await createIdentityGroup({
       profile: values.profile as string | undefined,
+      groupId: values.groupId as string | undefined,
       name: values.name as string | undefined,
     });
     return;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -3,9 +3,10 @@
  * Handles output in multiple modes (text, json) based on session state
  */
 
-import { c8ctl } from './runtime.ts';
+import { isRecord } from "./index.ts";
+import { c8ctl } from "./runtime.ts";
 
-export type OutputMode = 'text' | 'json';
+export type OutputMode = "text" | "json";
 
 /**
  * Fields that contain genuine credentials and must be redacted before logging.
@@ -15,12 +16,12 @@ export type OutputMode = 'text' | 'json';
  * are intentionally excluded from this set.
  */
 const SENSITIVE_LOG_FIELDS = new Set([
-  'password',
-  'passwd',
-  'clientSecret',
-  'basicAuthPassword',
-  'camundaCloudClientSecret',
-  'secret',
+	"password",
+	"passwd",
+	"clientSecret",
+	"basicAuthPassword",
+	"camundaCloudClientSecret",
+	"secret",
 ]);
 
 /**
@@ -28,47 +29,59 @@ const SENSITIVE_LOG_FIELDS = new Set([
  * Only fields in SENSITIVE_LOG_FIELDS are redacted; all others pass through.
  */
 export function sanitizeForLogging(data: unknown): unknown {
-  if (Array.isArray(data)) {
-    return data.map(sanitizeForLogging);
-  }
-  if (data instanceof Error) {
-    const sanitized: Record<string, unknown> = {
-      name: data.name,
-      message: data.message,
-      stack: data.stack,
-    };
-    if (data.cause !== undefined) {
-      sanitized.cause = sanitizeForLogging(data.cause);
-    }
-    // Preserve enumerable fields (e.g. code) with sanitization
-    for (const [key, value] of Object.entries(data)) {
-      sanitized[key] = SENSITIVE_LOG_FIELDS.has(key) ? '[REDACTED]' : sanitizeForLogging(value);
-    }
-    return sanitized;
-  }
-  // Preserve common built-in types that have no useful enumerable properties
-  if (data instanceof Date || data instanceof RegExp || data instanceof URL) {
-    return data;
-  }
-  if (data !== null && typeof data === 'object') {
-    const result: Record<string, unknown> = {};
-    for (const [key, value] of Object.entries(data as Record<string, unknown>)) {
-      result[key] = SENSITIVE_LOG_FIELDS.has(key) ? '[REDACTED]' : sanitizeForLogging(value);
-    }
-    return result;
-  }
-  return data;
+	if (Array.isArray(data)) {
+		return data.map(sanitizeForLogging);
+	}
+	if (data instanceof Error) {
+		const sanitized: Record<string, unknown> = {
+			name: data.name,
+			message: data.message,
+			stack: data.stack,
+		};
+		if (data.cause !== undefined) {
+			sanitized.cause = sanitizeForLogging(data.cause);
+		}
+		// Preserve enumerable fields (e.g. code) with sanitization
+		for (const [key, value] of Object.entries(data)) {
+			sanitized[key] = SENSITIVE_LOG_FIELDS.has(key)
+				? "[REDACTED]"
+				: sanitizeForLogging(value);
+		}
+		return sanitized;
+	}
+	// Preserve common built-in types that have no useful enumerable properties
+	if (data instanceof Date || data instanceof RegExp || data instanceof URL) {
+		return data;
+	}
+	if (data !== null && typeof data === "object") {
+		const result: Record<string, unknown> = {};
+		for (const [key, value] of Object.entries(
+			// biome-ignore lint/plugin: data is narrowed to object, safe widening for Object.entries
+			data as Record<string, unknown>,
+		)) {
+			result[key] = SENSITIVE_LOG_FIELDS.has(key)
+				? "[REDACTED]"
+				: sanitizeForLogging(value);
+		}
+		return result;
+	}
+	return data;
 }
 
 /**
  * Filter a single object to only include the specified fields.
  * Field matching is case-insensitive.
  */
-function filterObjectFields(obj: Record<string, unknown>, fields: string[]): Record<string, unknown> {
-  const lowerFields = fields.map(f => f.toLowerCase());
-  return Object.fromEntries(
-    Object.entries(obj).filter(([key]) => lowerFields.includes(key.toLowerCase()))
-  );
+function filterObjectFields(
+	obj: Record<string, unknown>,
+	fields: string[],
+): Record<string, unknown> {
+	const lowerFields = fields.map((f) => f.toLowerCase());
+	return Object.fromEntries(
+		Object.entries(obj).filter(([key]) =>
+			lowerFields.includes(key.toLowerCase()),
+		),
+	);
 }
 
 /**
@@ -77,21 +90,21 @@ function filterObjectFields(obj: Record<string, unknown>, fields: string[]): Rec
  * - Object: filter object keys
  * - Primitive: return as-is
  */
-function filterFields(data: any, fields: string[]): any {
-  if (Array.isArray(data)) {
-    return data.map(item =>
-      item && typeof item === 'object' ? filterObjectFields(item as Record<string, unknown>, fields) : item
-    );
-  }
-  if (data && typeof data === 'object') {
-    return filterObjectFields(data as Record<string, unknown>, fields);
-  }
-  return data;
+function filterFields(data: unknown, fields: string[]): unknown {
+	if (Array.isArray(data)) {
+		return data.map((item) =>
+			isRecord(item) ? filterObjectFields(item, fields) : item,
+		);
+	}
+	if (isRecord(data)) {
+		return filterObjectFields(data, fields);
+	}
+	return data;
 }
 
 export type LogWriter = {
-  log(...data: any[]): void;
-  error(...data: any[]): void;
+	log(...data: unknown[]): void;
+	error(...data: unknown[]): void;
 };
 
 /**
@@ -99,281 +112,317 @@ export type LogWriter = {
  * and return an actionable hint for the user if so.
  */
 function getLocalClusterHint(error?: Error): string | undefined {
-  if (!error) return undefined;
+	if (!error) return undefined;
 
-  // Only emit the hint when the active profile is 'local' (the default) or not set
-  // and no CAMUNDA_* env vars are configured (env vars point elsewhere)
-  if (c8ctl.activeProfile !== undefined && c8ctl.activeProfile !== 'local') return undefined;
-  if (!c8ctl.activeProfile && process.env.CAMUNDA_BASE_URL) return undefined;
+	// Only emit the hint when the active profile is 'local' (the default) or not set
+	// and no CAMUNDA_* env vars are configured (env vars point elsewhere)
+	if (c8ctl.activeProfile !== undefined && c8ctl.activeProfile !== "local")
+		return undefined;
+	if (!c8ctl.activeProfile && process.env.CAMUNDA_BASE_URL) return undefined;
 
-  const isConnectionError = isNetworkError(error);
-  if (!isConnectionError) return undefined;
+	const isConnectionError = isNetworkError(error);
+	if (!isConnectionError) return undefined;
 
-  return 'Hint: Is the local cluster running? Start it with: c8ctl start c8-cluster';
+	return "Hint: Is the local cluster running? Start it with: c8ctl start c8-cluster";
 }
 
 /**
  * Return true when the error indicates that a TCP connection could not be established.
  */
 function isNetworkError(error: Error): boolean {
-  const message = error.message || '';
-  // Node.js native fetch surfaces this when the TCP connection is refused
-  if (message.toLowerCase().includes('fetch failed')) return true;
+	const message = error.message || "";
+	// Node.js native fetch surfaces this when the TCP connection is refused
+	if (message.toLowerCase().includes("fetch failed")) return true;
 
-  const anyErr = error as unknown as { code?: string; cause?: { code?: string } };
-  const code = anyErr.code ?? anyErr.cause?.code;
-  if (code) {
-    return ['ECONNREFUSED', 'ENOTFOUND', 'EHOSTUNREACH', 'ECONNRESET', 'ETIMEDOUT'].includes(code);
-  }
-  // Fetch abort (timeout) is also a connectivity issue
-  if (error.name === 'AbortError') return true;
+	// Check for Node.js system error codes (e.g. ECONNREFUSED)
+	// biome-ignore lint/plugin: Error subclasses have .code/.cause not declared on base Error
+	const errRecord = error as unknown as Record<string, unknown>;
+	const code =
+		typeof errRecord.code === "string"
+			? errRecord.code
+			: isRecord(errRecord.cause) && typeof errRecord.cause.code === "string"
+				? errRecord.cause.code
+				: undefined;
+	if (code) {
+		return [
+			"ECONNREFUSED",
+			"ENOTFOUND",
+			"EHOSTUNREACH",
+			"ECONNRESET",
+			"ETIMEDOUT",
+		].includes(code);
+	}
+	// Fetch abort (timeout) is also a connectivity issue
+	if (error.name === "AbortError") return true;
 
-  return false;
+	return false;
 }
 
 const defaultLogWriter: LogWriter = {
-  log(...data: any[]): void {
-    console.log(...data); // codeql[js/clear-text-logging] - oAuthUrl is a token-endpoint URL, not a credential; structured data is sanitized via sanitizeForLogging at call sites (json/table/debug)
-  },
-  error(...data: any[]): void {
-    console.error(...data); // codeql[js/clear-text-logging] - oAuthUrl is a token-endpoint URL, not a credential; structured data is sanitized via sanitizeForLogging at call sites (json/table/debug)
-  },
+	log(...data: unknown[]): void {
+		console.log(...data); // codeql[js/clear-text-logging] - oAuthUrl is a token-endpoint URL, not a credential; structured data is sanitized via sanitizeForLogging at call sites (json/table/debug)
+	},
+	error(...data: unknown[]): void {
+		console.error(...data); // codeql[js/clear-text-logging] - oAuthUrl is a token-endpoint URL, not a credential; structured data is sanitized via sanitizeForLogging at call sites (json/table/debug)
+	},
 };
 
 export class Logger {
-  private _debugEnabled: boolean = false;
-  private _logWriter: LogWriter;
+	private _debugEnabled: boolean = false;
+	private _logWriter: LogWriter;
 
-  constructor(logWriter: LogWriter = defaultLogWriter) {
-    this._logWriter = logWriter;
+	constructor(logWriter: LogWriter = defaultLogWriter) {
+		this._logWriter = logWriter;
 
-    // Enable debug mode if DEBUG or C8CTL_DEBUG env var is set
-    this._debugEnabled = process.env.DEBUG === '1' || 
-                         process.env.DEBUG === 'true' || 
-                         process.env.C8CTL_DEBUG === '1' ||
-                         process.env.C8CTL_DEBUG === 'true';
-  }
+		// Enable debug mode if DEBUG or C8CTL_DEBUG env var is set
+		this._debugEnabled =
+			process.env.DEBUG === "1" ||
+			process.env.DEBUG === "true" ||
+			process.env.C8CTL_DEBUG === "1" ||
+			process.env.C8CTL_DEBUG === "true";
+	}
 
-  get mode(): OutputMode {
-    // Always get the mode from c8ctl runtime to ensure it reflects current session state
-    return c8ctl.outputMode;
-  }
+	get mode(): OutputMode {
+		// Always get the mode from c8ctl runtime to ensure it reflects current session state
+		return c8ctl.outputMode;
+	}
 
-  set mode(mode: OutputMode) {
-    // Update the c8ctl runtime when mode is set directly on logger
-    c8ctl.outputMode = mode;
-  }
+	set mode(mode: OutputMode) {
+		// Update the c8ctl runtime when mode is set directly on logger
+		c8ctl.outputMode = mode;
+	}
 
-  get debugEnabled(): boolean {
-    return this._debugEnabled;
-  }
+	get debugEnabled(): boolean {
+		return this._debugEnabled;
+	}
 
-  set debugEnabled(enabled: boolean) {
-    this._debugEnabled = enabled;
-  }
+	set debugEnabled(enabled: boolean) {
+		this._debugEnabled = enabled;
+	}
 
-  private _writeLog(...data: any[]): void {
-    this._logWriter.log(...data);
-  }
+	private _writeLog(...data: unknown[]): void {
+		this._logWriter.log(...data);
+	}
 
-  private _writeError(...data: any[]): void {
-    this._logWriter.error(...data);
-  }
+	private _writeError(...data: unknown[]): void {
+		this._logWriter.error(...data);
+	}
 
-  info(message: string): void {
-    if (this.mode === 'text') {
-      this._writeLog(message);
-    } else {
-    
-      // unix convention suggest: info and warning messages should go to stderr, while only the main output goes to stdout
-      this._writeError(JSON.stringify({ status: 'info', message }));
-    }
-  }
+	info(message: string): void {
+		if (this.mode === "text") {
+			this._writeLog(message);
+		} else {
+			// unix convention suggest: info and warning messages should go to stderr, while only the main output goes to stdout
+			this._writeError(JSON.stringify({ status: "info", message }));
+		}
+	}
 
-  warn(message: string): void {
-    if (this.mode === 'text') {
-      this._writeError(`⚠ ${message}`);
-    } else {
-      this._writeError(JSON.stringify({ status: 'warning', message }));
-    }
-  }
+	warn(message: string): void {
+		if (this.mode === "text") {
+			this._writeError(`⚠ ${message}`);
+		} else {
+			this._writeError(JSON.stringify({ status: "warning", message }));
+		}
+	}
 
-  debug(message: string, ...args: any[]): void {
-    if (this._debugEnabled) {
-      const sanitizedArgs = args.map(a => sanitizeForLogging(a));
-      if (this.mode === 'text') {
-        const timestamp = new Date().toISOString();
-        this._writeError(`[DEBUG ${timestamp}] ${message}`, ...sanitizedArgs);
-      } else {
-        this._writeError(JSON.stringify({
-          level: 'debug',
-          message,
-          timestamp: new Date().toISOString(),
-          args: sanitizedArgs
-        }));
-      }
-    }
-  }
+	debug(message: string, ...args: unknown[]): void {
+		if (this._debugEnabled) {
+			const sanitizedArgs = args.map((a) => sanitizeForLogging(a));
+			if (this.mode === "text") {
+				const timestamp = new Date().toISOString();
+				this._writeError(`[DEBUG ${timestamp}] ${message}`, ...sanitizedArgs);
+			} else {
+				this._writeError(
+					JSON.stringify({
+						level: "debug",
+						message,
+						timestamp: new Date().toISOString(),
+						args: sanitizedArgs,
+					}),
+				);
+			}
+		}
+	}
 
-  success(message: string, key?: string | number): void {
-    if (this.mode === 'text') {
-      if (key !== undefined) {
-        this._writeLog(`✓ ${message} [Key: ${key}]`);
-      } else {
-        this._writeLog(`✓ ${message}`);
-      }
-    } else {
-      if (key !== undefined) {
-        this._writeError(JSON.stringify({ status: 'success', message, key }));
-      } else {
-        this._writeError(JSON.stringify({ status: 'success', message }));
-      }
-    }
-  }
+	success(message: string, key?: string | number): void {
+		if (this.mode === "text") {
+			if (key !== undefined) {
+				this._writeLog(`✓ ${message} [Key: ${key}]`);
+			} else {
+				this._writeLog(`✓ ${message}`);
+			}
+		} else {
+			if (key !== undefined) {
+				this._writeError(JSON.stringify({ status: "success", message, key }));
+			} else {
+				this._writeError(JSON.stringify({ status: "success", message }));
+			}
+		}
+	}
 
-  error(message: string, error?: Error): void {
-    if (this.mode === 'text') {
-      this._writeError(`✗ ${message}`);
-      if (error) {
-        const urlInfo = isNetworkError(error) && c8ctl.resolvedBaseUrl
-          ? ` (${c8ctl.resolvedBaseUrl})`
-          : '';
-        this._writeError(`  ${error.message}${urlInfo}`);
-      }
-      const hint = getLocalClusterHint(error);
-      if (hint) {
-        this._writeError(`  ${hint}`);
-      }
-    } else {
-      const output: any = { status: 'error', message };
-      if (error) {
-        output.error = error.message;
-        if (isNetworkError(error) && c8ctl.resolvedBaseUrl) {
-          output.url = c8ctl.resolvedBaseUrl;
-        }
-        if (error.stack) {
-          output.stack = error.stack;
-        }
-      }
-      const hint = getLocalClusterHint(error);
-      if (hint) {
-        output.hint = hint;
-      }
-      this._writeError(JSON.stringify(output));
-    }
-  }
+	error(message: string, error?: Error): void {
+		if (this.mode === "text") {
+			this._writeError(`✗ ${message}`);
+			if (error) {
+				const urlInfo =
+					isNetworkError(error) && c8ctl.resolvedBaseUrl
+						? ` (${c8ctl.resolvedBaseUrl})`
+						: "";
+				this._writeError(`  ${error.message}${urlInfo}`);
+			}
+			const hint = getLocalClusterHint(error);
+			if (hint) {
+				this._writeError(`  ${hint}`);
+			}
+		} else {
+			const output: Record<string, unknown> = { status: "error", message };
+			if (error) {
+				output.error = error.message;
+				if (isNetworkError(error) && c8ctl.resolvedBaseUrl) {
+					output.url = c8ctl.resolvedBaseUrl;
+				}
+				if (error.stack) {
+					output.stack = error.stack;
+				}
+			}
+			const hint = getLocalClusterHint(error);
+			if (hint) {
+				output.hint = hint;
+			}
+			this._writeError(JSON.stringify(output));
+		}
+	}
 
-  table(data: any[]): void {
-    const fields = c8ctl.fields;
-    // Apply --fields filtering when set (only for object elements)
-    const filtered = fields && fields.length > 0
-      ? data.map(obj => (obj && typeof obj === 'object' ? filterObjectFields(obj as Record<string, unknown>, fields) : obj))
-      : data;
-    // Redact credentials before rendering
-    const filteredData = sanitizeForLogging(filtered) as Record<string, unknown>[];
+	table(data: unknown[]): void {
+		const fields = c8ctl.fields;
+		// Apply --fields filtering when set (only for object elements)
+		const filtered =
+			fields && fields.length > 0
+				? data.map((obj) =>
+						isRecord(obj) ? filterObjectFields(obj, fields) : obj,
+					)
+				: data;
+		// Redact credentials before rendering
+		// biome-ignore lint/plugin: sanitizeForLogging returns unknown, safe widening for table rendering
+		const filteredData = sanitizeForLogging(filtered) as Record<
+			string,
+			unknown
+		>[];
 
-    if (this.mode === 'text') {
-      if (filteredData.length === 0) {
-        this._writeLog('No data to display');
-        return;
-      }
+		if (this.mode === "text") {
+			if (filteredData.length === 0) {
+				this._writeLog("No data to display");
+				return;
+			}
 
-      // Get all unique keys from all objects
-      const keys = Array.from(new Set(filteredData.flatMap(obj => Object.keys(obj))));
+			// Get all unique keys from all objects
+			const keys = Array.from(
+				new Set(filteredData.flatMap((obj) => Object.keys(obj))),
+			);
 
-      // Calculate column widths
-      const widths: Record<string, number> = {};
-      keys.forEach(key => {
-        widths[key] = Math.max(
-          key.length,
-          ...filteredData.map(obj => String(obj[key] ?? '').length)
-        );
-      });
+			// Calculate column widths
+			const widths: Record<string, number> = {};
+			keys.forEach((key) => {
+				widths[key] = Math.max(
+					key.length,
+					...filteredData.map((obj) => String(obj[key] ?? "").length),
+				);
+			});
 
-      // Print header
-      const header = keys.map(key => key.padEnd(widths[key])).join(' | ');
-      this._writeLog(header);
-      this._writeLog(keys.map(key => '-'.repeat(widths[key])).join('-+-'));
+			// Print header
+			const header = keys.map((key) => key.padEnd(widths[key])).join(" | ");
+			this._writeLog(header);
+			this._writeLog(keys.map((key) => "-".repeat(widths[key])).join("-+-"));
 
-      // Print rows
-      filteredData.forEach(obj => {
-        const row = keys.map(key => String(obj[key] ?? '').padEnd(widths[key])).join(' | ');
-        this._writeLog(row);
-      });
-    } else {
-      this._writeLog(JSON.stringify(filteredData, null, 2));
-    }
-  }
+			// Print rows
+			filteredData.forEach((obj) => {
+				const row = keys
+					.map((key) => String(obj[key] ?? "").padEnd(widths[key]))
+					.join(" | ");
+				this._writeLog(row);
+			});
+		} else {
+			this._writeLog(JSON.stringify(filteredData, null, 2));
+		}
+	}
 
-  json(data: any): void {
-    const fields = c8ctl.fields;
-    // Apply --fields filtering when set
-    const filtered = fields && fields.length > 0 ? filterFields(data, fields) : data;
-    // Redact credentials before serialisation
-    const filteredData = sanitizeForLogging(filtered);
+	json(data: unknown): void {
+		const fields = c8ctl.fields;
+		// Apply --fields filtering when set
+		const filtered =
+			fields && fields.length > 0 ? filterFields(data, fields) : data;
+		// Redact credentials before serialisation
+		const filteredData = sanitizeForLogging(filtered);
 
-    if (this.mode === 'text') {
-      this._writeLog(JSON.stringify(filteredData, null, 2));
-    } else {
-      this._writeLog(JSON.stringify(filteredData));
-    }
-  }
+		if (this.mode === "text") {
+			this._writeLog(JSON.stringify(filteredData, null, 2));
+		} else {
+			this._writeLog(JSON.stringify(filteredData));
+		}
+	}
 
-  /**
-   * Write primary command output to stdout as-is, regardless of output mode.
-   * Use this for non-structured content (e.g. XML, plain text). 
-   */
-  output(content: string): void {
-    this._writeLog(content);
-  }
+	/**
+	 * Write primary command output to stdout as-is, regardless of output mode.
+	 * Use this for non-structured content (e.g. XML, plain text).
+	 */
+	output(content: string): void {
+		this._writeLog(content);
+	}
 }
 
 /**
  * Sort table data by a given column name.
  * If the column doesn't exist, a warning is logged and the original data is returned unchanged.
  */
-export type SortOrder = 'asc' | 'desc';
+export type SortOrder = "asc" | "desc";
 
-export function sortTableData<T extends Record<string, unknown>>(data: T[], sortBy: string | undefined, logger: Logger, sortOrder: SortOrder = 'asc'): T[] {
-  if (!sortBy || data.length === 0) return data;
+export function sortTableData<T extends Record<string, unknown>>(
+	data: T[],
+	sortBy: string | undefined,
+	logger: Logger,
+	sortOrder: SortOrder = "asc",
+): T[] {
+	if (!sortBy || data.length === 0) return data;
 
-  // Find actual key using case-insensitive match
-  const keys = Object.keys(data[0]);
-  const matchedKey = keys.find(k => k.toLowerCase() === sortBy.toLowerCase());
+	// Find actual key using case-insensitive match
+	const keys = Object.keys(data[0]);
+	const matchedKey = keys.find((k) => k.toLowerCase() === sortBy.toLowerCase());
 
-  if (!matchedKey) {
-    logger.warn(`Column '${sortBy}' not found in output. Available columns: ${keys.join(', ')}`);
-    return data;
-  }
+	if (!matchedKey) {
+		logger.warn(
+			`Column '${sortBy}' not found in output. Available columns: ${keys.join(", ")}`,
+		);
+		return data;
+	}
 
-  const direction = sortOrder === 'desc' ? -1 : 1;
+	const direction = sortOrder === "desc" ? -1 : 1;
 
-  return [...data].sort((a, b) => {
-    const va = a[matchedKey];
-    const vb = b[matchedKey];
-    if (va === undefined || va === null) return 1;
-    if (vb === undefined || vb === null) return -1;
-    const sa = String(va);
-    const sb = String(vb);
-    // Use numeric comparison when both values are numeric strings
-    const na = Number(sa);
-    const nb = Number(sb);
-    if (!isNaN(na) && !isNaN(nb)) return (na - nb) * direction;
-    return (sa < sb ? -1 : sa > sb ? 1 : 0) * direction;
-  });
+	return [...data].sort((a, b) => {
+		const va = a[matchedKey];
+		const vb = b[matchedKey];
+		if (va === undefined || va === null) return 1;
+		if (vb === undefined || vb === null) return -1;
+		const sa = String(va);
+		const sb = String(vb);
+		// Use numeric comparison when both values are numeric strings
+		const na = Number(sa);
+		const nb = Number(sb);
+		if (!Number.isNaN(na) && !Number.isNaN(nb)) return (na - nb) * direction;
+		return (sa < sb ? -1 : sa > sb ? 1 : 0) * direction;
+	});
 }
 
 // Singleton instance to be used across the CLI
 let loggerInstance: Logger | null = null;
 
 export function getLogger(mode?: OutputMode): Logger {
-  if (!loggerInstance) {
-    loggerInstance = new Logger();
-  }
-  // Note: mode parameter is deprecated - logger now always reflects c8ctl.outputMode
-  // If mode is provided, update c8ctl.outputMode for backwards compatibility
-  if (mode !== undefined) {
-    c8ctl.outputMode = mode;
-  }
-  return loggerInstance;
+	if (!loggerInstance) {
+		loggerInstance = new Logger();
+	}
+	// Note: mode parameter is deprecated - logger now always reflects c8ctl.outputMode
+	// If mode is provided, update c8ctl.outputMode for backwards compatibility
+	if (mode !== undefined) {
+		c8ctl.outputMode = mode;
+	}
+	return loggerInstance;
 }

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -2,32 +2,32 @@
  * Plugin loader for dynamic command loading
  */
 
-import { existsSync, readdirSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { getLogger } from './logger.ts';
-import { c8ctl, type C8ctlPluginRuntime } from './runtime.ts';
-import { ensurePluginsDir, resolveTenantId } from './config.ts';
-import { createClient } from './client.ts';
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { createClient } from "./client.ts";
+import { ensurePluginsDir, resolveTenantId } from "./config.ts";
+import { getLogger } from "./logger.ts";
+import { type C8ctlPluginRuntime, c8ctl } from "./runtime.ts";
 
 interface PluginCommands {
-  [commandName: string]: (args: string[]) => Promise<void>;
+	[commandName: string]: (args: string[]) => Promise<void>;
 }
 
 interface PluginMetadata {
-  name?: string;
-  description?: string;
-  commands?: {
-    [commandName: string]: {
-      description?: string;
-      examples?: { command: string; description: string }[];
-    };
-  };
+	name?: string;
+	description?: string;
+	commands?: {
+		[commandName: string]: {
+			description?: string;
+			examples?: { command: string; description: string }[];
+		};
+	};
 }
 
 interface LoadedPlugin {
-  name: string;
-  commands: PluginCommands;
-  metadata?: PluginMetadata;
+	name: string;
+	commands: PluginCommands;
+	metadata?: PluginMetadata;
 }
 
 const loadedPlugins = new Map<string, LoadedPlugin>();
@@ -36,282 +36,297 @@ const loadedPlugins = new Map<string, LoadedPlugin>();
  * Load default plugins bundled with c8ctl
  */
 async function loadDefaultPlugins(): Promise<void> {
-  const logger = getLogger();
-  const { fileURLToPath } = await import('node:url');
-  const { dirname } = await import('node:path');
-  
-  try {
-    // Get the directory where this file is located
-    const __filename = fileURLToPath(import.meta.url);
-    const __dirname = dirname(__filename);
-    
-    // Check both possible locations:
-    // In development: src/plugin-loader.ts -> ../default-plugins
-    // In production: dist/plugin-loader.js -> dist/default-plugins
-    const possiblePaths = [
-      join(__dirname, 'default-plugins'),  // Production path
-      join(__dirname, '..', 'default-plugins'),  // Development path
-    ];
-    
-    let defaultPluginsDir: string | null = null;
-    for (const path of possiblePaths) {
-      if (existsSync(path)) {
-        defaultPluginsDir = path;
-        break;
-      }
-    }
-    
-    if (!defaultPluginsDir) {
-      logger.debug('No default-plugins directory found');
-      return;
-    }
-    
-    const pluginDirs = readdirSync(defaultPluginsDir);
-    logger.debug(`Found ${pluginDirs.length} default plugin(s)`);
-    
-    for (const pluginDir of pluginDirs) {
-      const pluginPath = join(defaultPluginsDir, pluginDir);
-      const packageJsonPath = join(pluginPath, 'package.json');
-      
-      if (!existsSync(packageJsonPath)) {
-        logger.debug(`No package.json in default plugin: ${pluginDir}`);
-        continue;
-      }
-      
-      try {
-        // Check for c8ctl-plugin file
-        const pluginFileJs = join(pluginPath, 'c8ctl-plugin.js');
-        const pluginFileTs = join(pluginPath, 'c8ctl-plugin.ts');
-        
-        if (!existsSync(pluginFileJs) && !existsSync(pluginFileTs)) {
-          logger.debug(`No c8ctl-plugin.js/ts in default plugin: ${pluginDir}`);
-          continue;
-        }
-        
-        // Read package.json
-        const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
-        const pluginName = packageJson.name || `default-${pluginDir}`;
-        
-        const pluginFile = existsSync(pluginFileJs) ? pluginFileJs : pluginFileTs;
-        
-        // Use file:// protocol and add timestamp to bust cache
-        const pluginUrl = `file://${pluginFile}?t=${Date.now()}`;
-        logger.debug(`Loading default plugin from: ${pluginUrl}`);
-        const plugin = await import(pluginUrl);
-        
-        if (plugin.commands && typeof plugin.commands === 'object') {
-          loadedPlugins.set(pluginName, {
-            name: pluginName,
-            commands: plugin.commands,
-            metadata: plugin.metadata || {},
-          });
-          const commandNames = Object.keys(plugin.commands);
-          logger.debug(`Successfully loaded default plugin: ${pluginName} with ${commandNames.length} commands:`, commandNames);
-        }
-      } catch (error) {
-        logger.debug(`Failed to load default plugin ${pluginDir}:`, error);
-      }
-    }
-  } catch (error) {
-    logger.debug('Error loading default plugins:', error);
-  }
+	const logger = getLogger();
+	const { fileURLToPath } = await import("node:url");
+	const { dirname } = await import("node:path");
+
+	try {
+		// Get the directory where this file is located
+		const __filename = fileURLToPath(import.meta.url);
+		const __dirname = dirname(__filename);
+
+		// Check both possible locations:
+		// In development: src/plugin-loader.ts -> ../default-plugins
+		// In production: dist/plugin-loader.js -> dist/default-plugins
+		const possiblePaths = [
+			join(__dirname, "default-plugins"), // Production path
+			join(__dirname, "..", "default-plugins"), // Development path
+		];
+
+		let defaultPluginsDir: string | null = null;
+		for (const path of possiblePaths) {
+			if (existsSync(path)) {
+				defaultPluginsDir = path;
+				break;
+			}
+		}
+
+		if (!defaultPluginsDir) {
+			logger.debug("No default-plugins directory found");
+			return;
+		}
+
+		const pluginDirs = readdirSync(defaultPluginsDir);
+		logger.debug(`Found ${pluginDirs.length} default plugin(s)`);
+
+		for (const pluginDir of pluginDirs) {
+			const pluginPath = join(defaultPluginsDir, pluginDir);
+			const packageJsonPath = join(pluginPath, "package.json");
+
+			if (!existsSync(packageJsonPath)) {
+				logger.debug(`No package.json in default plugin: ${pluginDir}`);
+				continue;
+			}
+
+			try {
+				// Check for c8ctl-plugin file
+				const pluginFileJs = join(pluginPath, "c8ctl-plugin.js");
+				const pluginFileTs = join(pluginPath, "c8ctl-plugin.ts");
+
+				if (!existsSync(pluginFileJs) && !existsSync(pluginFileTs)) {
+					logger.debug(`No c8ctl-plugin.js/ts in default plugin: ${pluginDir}`);
+					continue;
+				}
+
+				// Read package.json
+				const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+				const pluginName = packageJson.name || `default-${pluginDir}`;
+
+				const pluginFile = existsSync(pluginFileJs)
+					? pluginFileJs
+					: pluginFileTs;
+
+				// Use file:// protocol and add timestamp to bust cache
+				const pluginUrl = `file://${pluginFile}?t=${Date.now()}`;
+				logger.debug(`Loading default plugin from: ${pluginUrl}`);
+				const plugin = await import(pluginUrl);
+
+				if (plugin.commands && typeof plugin.commands === "object") {
+					loadedPlugins.set(pluginName, {
+						name: pluginName,
+						commands: plugin.commands,
+						metadata: plugin.metadata || {},
+					});
+					const commandNames = Object.keys(plugin.commands);
+					logger.debug(
+						`Successfully loaded default plugin: ${pluginName} with ${commandNames.length} commands:`,
+						commandNames,
+					);
+				}
+			} catch (error) {
+				logger.debug(`Failed to load default plugin ${pluginDir}:`, error);
+			}
+		}
+	} catch (error) {
+		logger.debug("Error loading default plugins:", error);
+	}
 }
 
 /**
  * Load all installed plugins from global plugins directory
  */
 export async function loadInstalledPlugins(): Promise<void> {
-  const logger = getLogger();
-  
-  // Make c8ctl runtime available globally for plugins
-  const pluginRuntime = c8ctl as unknown as C8ctlPluginRuntime;
-  (pluginRuntime as any).createClient = createClient;
-  (pluginRuntime as any).resolveTenantId = resolveTenantId;
-  (pluginRuntime as any).getLogger = getLogger;
-  globalThis.c8ctl = pluginRuntime;
-  
-  // Load default plugins first
-  await loadDefaultPlugins();
-  
-  // Then load user-installed plugins
-  const pluginsDir = ensurePluginsDir();
-  const nodeModulesPath = join(pluginsDir, 'node_modules');
-  
-  if (!existsSync(nodeModulesPath)) {
-    logger.debug('Global plugins node_modules directory not found');
-    return;
-  }
-  
-  try {
-    const entries = readdirSync(nodeModulesPath);
-    logger.debug(`Scanning ${entries.length} entries in node_modules`);
-    
-    const packagesToScan: string[] = [];
-    
-    // Collect regular packages and scoped packages
-    for (const entry of entries) {
-      if (entry.startsWith('.')) {
-        continue;
-      }
-      
-      if (entry.startsWith('@')) {
-        // Scoped package - scan subdirectories
-        const scopePath = join(nodeModulesPath, entry);
-        try {
-          const scopedPackages = readdirSync(scopePath);
-          for (const scopedPkg of scopedPackages) {
-            if (!scopedPkg.startsWith('.')) {
-              packagesToScan.push(join(entry, scopedPkg));
-            }
-          }
-        } catch (error) {
-          logger.debug(`Failed to scan scoped package directory ${entry}:`, error);
-        }
-      } else {
-        // Regular package
-        packagesToScan.push(entry);
-      }
-    }
-    
-    logger.debug(`Found ${packagesToScan.length} packages to scan:`, packagesToScan);
-    
-    for (const packageName of packagesToScan) {
-      const packagePath = join(nodeModulesPath, packageName);
-      const packageJsonPath = join(packagePath, 'package.json');
-      
-      if (!existsSync(packageJsonPath)) {
-        logger.debug(`No package.json for ${packageName}`);
-        continue;
-      }
-      
-      try {
-        // Check for c8ctl-plugin entry point files first
-        const pluginFileJs = join(packagePath, 'c8ctl-plugin.js');
-        const pluginFileTs = join(packagePath, 'c8ctl-plugin.ts');
-        
-        if (!existsSync(pluginFileJs) && !existsSync(pluginFileTs)) {
-          logger.debug(`No c8ctl-plugin.js/ts found for ${packageName}`);
-          continue;
-        }
-        
-        // Read package.json to check keywords
-        const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
-        
-        // Plugin must have c8ctl or c8ctl-plugin in keywords
-        const isC8ctlPlugin = 
-          packageJson.keywords?.includes('c8ctl') ||
-          packageJson.keywords?.includes('c8ctl-plugin');
-        
-        if (!isC8ctlPlugin) {
-          logger.debug(`Package ${packageName} has c8ctl-plugin file but missing keywords (keywords: ${packageJson.keywords?.join(', ') || 'none'})`);
-          continue;
-        }
-        
-        logger.debug(`Found c8ctl plugin candidate: ${packageName}`);
-        
-        const pluginFile = existsSync(pluginFileJs) ? pluginFileJs : pluginFileTs;
-        
-        // Use file:// protocol and add timestamp to bust cache
-        const pluginUrl = `file://${pluginFile}?t=${Date.now()}`;
-        logger.debug(`Loading plugin from: ${pluginUrl}`);
-        const plugin = await import(pluginUrl);
-        
-        if (plugin.commands && typeof plugin.commands === 'object') {
-          loadedPlugins.set(packageName, {
-            name: packageName,
-            commands: plugin.commands,
-            metadata: plugin.metadata || {},
-          });
-          const commandNames = Object.keys(plugin.commands);
-          logger.debug(`Successfully loaded plugin: ${packageName} with ${commandNames.length} commands:`, commandNames);
-        }
-      } catch (error) {
-        logger.debug(`Failed to load plugin ${packageName}:`, error);
-      }
-    }
-    logger.debug(`Total plugins loaded: ${loadedPlugins.size}`);
-  } catch (error) {
-    logger.debug('Error scanning for plugins:', error);
-  }
+	const logger = getLogger();
+
+	// Make c8ctl runtime available globally for plugins
+	// biome-ignore lint/plugin: C8ctl uses prototype getters — Object.assign mutates in-place to preserve them (#219)
+	const pluginRuntime = c8ctl as unknown as C8ctlPluginRuntime;
+	Object.assign(pluginRuntime, { createClient, resolveTenantId, getLogger });
+	globalThis.c8ctl = pluginRuntime;
+
+	// Load default plugins first
+	await loadDefaultPlugins();
+
+	// Then load user-installed plugins
+	const pluginsDir = ensurePluginsDir();
+	const nodeModulesPath = join(pluginsDir, "node_modules");
+
+	if (!existsSync(nodeModulesPath)) {
+		logger.debug("Global plugins node_modules directory not found");
+		return;
+	}
+
+	try {
+		const entries = readdirSync(nodeModulesPath);
+		logger.debug(`Scanning ${entries.length} entries in node_modules`);
+
+		const packagesToScan: string[] = [];
+
+		// Collect regular packages and scoped packages
+		for (const entry of entries) {
+			if (entry.startsWith(".")) {
+				continue;
+			}
+
+			if (entry.startsWith("@")) {
+				// Scoped package - scan subdirectories
+				const scopePath = join(nodeModulesPath, entry);
+				try {
+					const scopedPackages = readdirSync(scopePath);
+					for (const scopedPkg of scopedPackages) {
+						if (!scopedPkg.startsWith(".")) {
+							packagesToScan.push(join(entry, scopedPkg));
+						}
+					}
+				} catch (error) {
+					logger.debug(
+						`Failed to scan scoped package directory ${entry}:`,
+						error,
+					);
+				}
+			} else {
+				// Regular package
+				packagesToScan.push(entry);
+			}
+		}
+
+		logger.debug(
+			`Found ${packagesToScan.length} packages to scan:`,
+			packagesToScan,
+		);
+
+		for (const packageName of packagesToScan) {
+			const packagePath = join(nodeModulesPath, packageName);
+			const packageJsonPath = join(packagePath, "package.json");
+
+			if (!existsSync(packageJsonPath)) {
+				logger.debug(`No package.json for ${packageName}`);
+				continue;
+			}
+
+			try {
+				// Check for c8ctl-plugin entry point files first
+				const pluginFileJs = join(packagePath, "c8ctl-plugin.js");
+				const pluginFileTs = join(packagePath, "c8ctl-plugin.ts");
+
+				if (!existsSync(pluginFileJs) && !existsSync(pluginFileTs)) {
+					logger.debug(`No c8ctl-plugin.js/ts found for ${packageName}`);
+					continue;
+				}
+
+				// Read package.json to check keywords
+				const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+
+				// Plugin must have c8ctl or c8ctl-plugin in keywords
+				const isC8ctlPlugin =
+					packageJson.keywords?.includes("c8ctl") ||
+					packageJson.keywords?.includes("c8ctl-plugin");
+
+				if (!isC8ctlPlugin) {
+					logger.debug(
+						`Package ${packageName} has c8ctl-plugin file but missing keywords (keywords: ${packageJson.keywords?.join(", ") || "none"})`,
+					);
+					continue;
+				}
+
+				logger.debug(`Found c8ctl plugin candidate: ${packageName}`);
+
+				const pluginFile = existsSync(pluginFileJs)
+					? pluginFileJs
+					: pluginFileTs;
+
+				// Use file:// protocol and add timestamp to bust cache
+				const pluginUrl = `file://${pluginFile}?t=${Date.now()}`;
+				logger.debug(`Loading plugin from: ${pluginUrl}`);
+				const plugin = await import(pluginUrl);
+
+				if (plugin.commands && typeof plugin.commands === "object") {
+					loadedPlugins.set(packageName, {
+						name: packageName,
+						commands: plugin.commands,
+						metadata: plugin.metadata || {},
+					});
+					const commandNames = Object.keys(plugin.commands);
+					logger.debug(
+						`Successfully loaded plugin: ${packageName} with ${commandNames.length} commands:`,
+						commandNames,
+					);
+				}
+			} catch (error) {
+				logger.debug(`Failed to load plugin ${packageName}:`, error);
+			}
+		}
+		logger.debug(`Total plugins loaded: ${loadedPlugins.size}`);
+	} catch (error) {
+		logger.debug("Error scanning for plugins:", error);
+	}
 }
 
 /**
  * Get all loaded plugin commands
  */
 export function getPluginCommands(): PluginCommands {
-  const allCommands: PluginCommands = {};
-  
-  for (const plugin of loadedPlugins.values()) {
-    Object.assign(allCommands, plugin.commands);
-  }
-  
-  return allCommands;
+	const allCommands: PluginCommands = {};
+
+	for (const plugin of loadedPlugins.values()) {
+		Object.assign(allCommands, plugin.commands);
+	}
+
+	return allCommands;
 }
 
 /**
  * Execute a plugin command if it exists
  */
 export async function executePluginCommand(
-  commandName: string,
-  args: string[]
+	commandName: string,
+	args: string[],
 ): Promise<boolean> {
-  const commands = getPluginCommands();
-  
-  if (commands[commandName]) {
-    await commands[commandName](args);
-    return true;
-  }
-  
-  return false;
+	const commands = getPluginCommands();
+
+	if (commands[commandName]) {
+		await commands[commandName](args);
+		return true;
+	}
+
+	return false;
 }
 
 /**
  * Check if a command is provided by a plugin
  */
 export function isPluginCommand(commandName: string): boolean {
-  const commands = getPluginCommands();
-  return commandName in commands;
+	const commands = getPluginCommands();
+	return commandName in commands;
 }
 
 /**
  * Get list of all plugin command names
  */
 export function getPluginCommandNames(): string[] {
-  return Object.keys(getPluginCommands());
+	return Object.keys(getPluginCommands());
 }
 
 /**
  * Get plugin information for help display
  */
 export interface PluginCommandInfo {
-  commandName: string;
-  pluginName: string;
-  description?: string;
-  examples?: { command: string; description: string }[];
+	commandName: string;
+	pluginName: string;
+	description?: string;
+	examples?: { command: string; description: string }[];
 }
 
 export function getPluginCommandsInfo(): PluginCommandInfo[] {
-  const infos: PluginCommandInfo[] = [];
-  
-  for (const plugin of loadedPlugins.values()) {
-    for (const commandName of Object.keys(plugin.commands)) {
-      infos.push({
-        commandName,
-        pluginName: plugin.name,
-        description: plugin.metadata?.commands?.[commandName]?.description,
-        examples: plugin.metadata?.commands?.[commandName]?.examples,
-      });
-    }
-  }
-  
-  return infos;
+	const infos: PluginCommandInfo[] = [];
+
+	for (const plugin of loadedPlugins.values()) {
+		for (const commandName of Object.keys(plugin.commands)) {
+			infos.push({
+				commandName,
+				pluginName: plugin.name,
+				description: plugin.metadata?.commands?.[commandName]?.description,
+				examples: plugin.metadata?.commands?.[commandName]?.examples,
+			});
+		}
+	}
+
+	return infos;
 }
 
 /**
  * Clear all loaded plugins (useful for testing and after uninstall)
  */
 export function clearLoadedPlugins(): void {
-  loadedPlugins.clear();
+	loadedPlugins.clear();
 }
-
-

--- a/src/plugin-registry.ts
+++ b/src/plugin-registry.ts
@@ -42,11 +42,19 @@ export function loadPluginRegistry(): PluginRegistry {
 
 	try {
 		const content = readFileSync(registryPath, "utf-8");
-		registryCache = JSON.parse(content);
-		if (registryCache === null) {
-			console.warn("⚠ Warning: Plugin registry file was unparseable.");
-			return { plugins: [] };
+		const parsed: unknown = JSON.parse(content);
+		if (
+			parsed &&
+			typeof parsed === "object" &&
+			!Array.isArray(parsed) &&
+			"plugins" in parsed &&
+			Array.isArray(parsed.plugins)
+		) {
+			registryCache = { plugins: parsed.plugins };
+			return registryCache;
 		}
+		console.warn("⚠ Warning: Plugin registry file was unparseable.");
+		registryCache = { plugins: [] };
 		return registryCache;
 	} catch (_error) {
 		// If registry is corrupted, start fresh and warn user

--- a/src/plugin-registry.ts
+++ b/src/plugin-registry.ts
@@ -2,18 +2,18 @@
  * Plugin registry for tracking loaded plugins independently of package.json
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { getUserDataDir } from './config.ts';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { getUserDataDir } from "./config.ts";
 
 export interface PluginEntry {
-  name: string;
-  source: string; // npm package name, git URL, file URL, etc.
-  installedAt: string; // ISO timestamp
+	name: string;
+	source: string; // npm package name, git URL, file URL, etc.
+	installedAt: string; // ISO timestamp
 }
 
 interface PluginRegistry {
-  plugins: PluginEntry[];
+	plugins: PluginEntry[];
 }
 
 let registryCache: PluginRegistry | null = null;
@@ -22,107 +22,113 @@ let registryCache: PluginRegistry | null = null;
  * Get the path to the plugin registry file
  */
 function getRegistryPath(): string {
-  return join(getUserDataDir(), 'plugins.json');
+	return join(getUserDataDir(), "plugins.json");
 }
 
 /**
  * Load the plugin registry from disk
  */
 export function loadPluginRegistry(): PluginRegistry {
-  if (registryCache) {
-    return registryCache;
-  }
+	if (registryCache) {
+		return registryCache;
+	}
 
-  const registryPath = getRegistryPath();
-  
-  if (!existsSync(registryPath)) {
-    registryCache = { plugins: [] };
-    return registryCache;
-  }
+	const registryPath = getRegistryPath();
 
-  try {
-    const content = readFileSync(registryPath, 'utf-8');
-    registryCache = JSON.parse(content);
-    return registryCache!;
-  } catch (error) {
-    // If registry is corrupted, start fresh and warn user
-    console.warn('⚠ Warning: Plugin registry file was corrupted and has been reset. Your plugins may need to be re-registered.');
-    registryCache = { plugins: [] };
-    return registryCache;
-  }
+	if (!existsSync(registryPath)) {
+		registryCache = { plugins: [] };
+		return registryCache;
+	}
+
+	try {
+		const content = readFileSync(registryPath, "utf-8");
+		registryCache = JSON.parse(content);
+		if (registryCache === null) {
+			console.warn("⚠ Warning: Plugin registry file was unparseable.");
+			return { plugins: [] };
+		}
+		return registryCache;
+	} catch (_error) {
+		// If registry is corrupted, start fresh and warn user
+		console.warn(
+			"⚠ Warning: Plugin registry file was corrupted and has been reset. Your plugins may need to be re-registered.",
+		);
+		registryCache = { plugins: [] };
+		return registryCache;
+	}
 }
 
 /**
  * Save the plugin registry to disk
  */
 export function savePluginRegistry(registry: PluginRegistry): void {
-  const registryPath = getRegistryPath();
-  const registryDir = dirname(registryPath);
+	const registryPath = getRegistryPath();
+	const registryDir = dirname(registryPath);
 
-  // Ensure config directory exists
-  if (!existsSync(registryDir)) {
-    mkdirSync(registryDir, { recursive: true });
-  }
+	// Ensure config directory exists
+	if (!existsSync(registryDir)) {
+		mkdirSync(registryDir, { recursive: true });
+	}
 
-  writeFileSync(registryPath, JSON.stringify(registry, null, 2), 'utf-8');
-  registryCache = registry;
+	writeFileSync(registryPath, JSON.stringify(registry, null, 2), "utf-8");
+	registryCache = registry;
 }
 
 /**
  * Add a plugin to the registry
  */
 export function addPluginToRegistry(name: string, source: string): void {
-  const registry = loadPluginRegistry();
-  
-  // Remove existing entry if present
-  registry.plugins = registry.plugins.filter(p => p.name !== name);
-  
-  // Add new entry
-  registry.plugins.push({
-    name,
-    source,
-    installedAt: new Date().toISOString(),
-  });
-  
-  savePluginRegistry(registry);
+	const registry = loadPluginRegistry();
+
+	// Remove existing entry if present
+	registry.plugins = registry.plugins.filter((p) => p.name !== name);
+
+	// Add new entry
+	registry.plugins.push({
+		name,
+		source,
+		installedAt: new Date().toISOString(),
+	});
+
+	savePluginRegistry(registry);
 }
 
 /**
  * Remove a plugin from the registry
  */
 export function removePluginFromRegistry(name: string): void {
-  const registry = loadPluginRegistry();
-  registry.plugins = registry.plugins.filter(p => p.name !== name);
-  savePluginRegistry(registry);
+	const registry = loadPluginRegistry();
+	registry.plugins = registry.plugins.filter((p) => p.name !== name);
+	savePluginRegistry(registry);
 }
 
 /**
  * Get all plugins from the registry
  */
 export function getRegisteredPlugins(): PluginEntry[] {
-  const registry = loadPluginRegistry();
-  return [...registry.plugins];
+	const registry = loadPluginRegistry();
+	return [...registry.plugins];
 }
 
 /**
  * Check if a plugin is in the registry
  */
 export function isPluginRegistered(name: string): boolean {
-  const registry = loadPluginRegistry();
-  return registry.plugins.some(p => p.name === name);
+	const registry = loadPluginRegistry();
+	return registry.plugins.some((p) => p.name === name);
 }
 
 /**
  * Get a specific plugin entry from the registry
  */
 export function getPluginEntry(name: string): PluginEntry | undefined {
-  const registry = loadPluginRegistry();
-  return registry.plugins.find(p => p.name === name);
+	const registry = loadPluginRegistry();
+	return registry.plugins.find((p) => p.name === name);
 }
 
 /**
  * Clear the registry cache (useful for testing)
  */
 export function clearRegistryCache(): void {
-  registryCache = null;
+	registryCache = null;
 }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -2,164 +2,171 @@
  * c8ctl runtime object with environment information and session state
  */
 
-import { readFileSync } from 'node:fs';
-import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import type { CamundaClient, CamundaOptions } from '@camunda8/orchestration-cluster-api';
-import type { Logger, OutputMode } from './logger.ts';
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type {
+	CamundaClient,
+	CamundaOptions,
+} from "@camunda8/orchestration-cluster-api";
+import type { Logger, OutputMode } from "./logger.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 export interface C8ctlEnv {
-  version: string;
-  nodeVersion: string;
-  platform: string;
-  arch: string;
-  cwd: string;
-  rootDir: string;
+	version: string;
+	nodeVersion: string;
+	platform: string;
+	arch: string;
+	cwd: string;
+	rootDir: string;
 }
 
 export interface C8ctlPluginRuntime {
-  readonly env: C8ctlEnv;
-  readonly version: string;
-  readonly nodeVersion: string;
-  readonly platform: string;
-  readonly arch: string;
-  readonly cwd: string;
-  activeProfile?: string;
-  activeTenant?: string;
-  outputMode: OutputMode;
-  /** Agent flag: comma-separated list of fields to include in output (applied at logger level) */
-  fields?: string[];
-  /** Agent flag: when true, mutating commands emit the would-be API request as JSON without executing it */
-  dryRun?: boolean;
-  /** When true, enables SDK trace logging and surfaces raw errors instead of user-friendly messages */
-  verbose?: boolean;
-  createClient(profileFlag?: string, additionalSdkConfig?: Partial<CamundaOptions>): CamundaClient;
-  resolveTenantId(profileFlag?: string): string;
-  getLogger(mode?: OutputMode): Logger;
+	readonly env: C8ctlEnv;
+	readonly version: string;
+	readonly nodeVersion: string;
+	readonly platform: string;
+	readonly arch: string;
+	readonly cwd: string;
+	activeProfile?: string;
+	activeTenant?: string;
+	outputMode: OutputMode;
+	/** Agent flag: comma-separated list of fields to include in output (applied at logger level) */
+	fields?: string[];
+	/** Agent flag: when true, mutating commands emit the would-be API request as JSON without executing it */
+	dryRun?: boolean;
+	/** When true, enables SDK trace logging and surfaces raw errors instead of user-friendly messages */
+	verbose?: boolean;
+	createClient(
+		profileFlag?: string,
+		additionalSdkConfig?: Partial<CamundaOptions>,
+	): CamundaClient;
+	resolveTenantId(profileFlag?: string): string;
+	getLogger(mode?: OutputMode): Logger;
 }
 
 declare global {
-  // c8ctl runtime exposed to plugins via globalThis
-  // eslint-disable-next-line no-var
-  var c8ctl: C8ctlPluginRuntime | undefined;
+	// c8ctl runtime exposed to plugins via globalThis
+	// eslint-disable-next-line no-var
+	var c8ctl: C8ctlPluginRuntime | undefined;
 }
 
 /**
  * Get c8ctl version from package.json
  */
 function getVersion(): string {
-  try {
-    const packageJsonPath = join(__dirname, '..', 'package.json');
-    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
-    return packageJson.version || '0.0.0';
-  } catch {
-    return '0.0.0';
-  }
+	try {
+		const packageJsonPath = join(__dirname, "..", "package.json");
+		const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+		return packageJson.version || "0.0.0";
+	} catch {
+		return "0.0.0";
+	}
 }
 
 /**
  * c8ctl runtime class with session state management
  */
 class C8ctl {
-  private _activeProfile?: string;
-  private _activeTenant?: string;
-  private _outputMode: OutputMode = 'text';
-  private _fields?: string[];
-  private _dryRun?: boolean;
-  private _verbose?: boolean;
-  private _resolvedBaseUrl?: string;
+	private _activeProfile?: string;
+	private _activeTenant?: string;
+	private _outputMode: OutputMode = "text";
+	private _fields?: string[];
+	private _dryRun?: boolean;
+	private _verbose?: boolean;
+	private _resolvedBaseUrl?: string;
 
-  readonly env: C8ctlEnv = {
-    version: getVersion(),
-    nodeVersion: process.version,
-    platform: process.platform,
-    arch: process.arch,
-    cwd: process.cwd(),
-    rootDir: join(__dirname, '..'),
-  };
+	readonly env: C8ctlEnv = {
+		version: getVersion(),
+		nodeVersion: process.version,
+		platform: process.platform,
+		arch: process.arch,
+		cwd: process.cwd(),
+		rootDir: join(__dirname, ".."),
+	};
 
-  // Expose env properties directly for plugin compatibility
-  get version(): string {
-    return this.env.version;
-  }
+	// Expose env properties directly for plugin compatibility
+	get version(): string {
+		return this.env.version;
+	}
 
-  get nodeVersion(): string {
-    return this.env.nodeVersion;
-  }
+	get nodeVersion(): string {
+		return this.env.nodeVersion;
+	}
 
-  get platform(): string {
-    return this.env.platform;
-  }
+	get platform(): string {
+		return this.env.platform;
+	}
 
-  get arch(): string {
-    return this.env.arch;
-  }
+	get arch(): string {
+		return this.env.arch;
+	}
 
-  get cwd(): string {
-    return this.env.cwd;
-  }
+	get cwd(): string {
+		return this.env.cwd;
+	}
 
-  get activeProfile(): string | undefined {
-    return this._activeProfile;
-  }
+	get activeProfile(): string | undefined {
+		return this._activeProfile;
+	}
 
-  set activeProfile(value: string | undefined) {
-    this._activeProfile = value;
-  }
+	set activeProfile(value: string | undefined) {
+		this._activeProfile = value;
+	}
 
-  get activeTenant(): string | undefined {
-    return this._activeTenant;
-  }
+	get activeTenant(): string | undefined {
+		return this._activeTenant;
+	}
 
-  set activeTenant(value: string | undefined) {
-    this._activeTenant = value;
-  }
+	set activeTenant(value: string | undefined) {
+		this._activeTenant = value;
+	}
 
-  get outputMode(): OutputMode {
-    return this._outputMode;
-  }
+	get outputMode(): OutputMode {
+		return this._outputMode;
+	}
 
-  set outputMode(value: OutputMode) {
-    this._outputMode = value;
-  }
+	set outputMode(value: OutputMode) {
+		this._outputMode = value;
+	}
 
-  get fields(): string[] | undefined {
-    return this._fields;
-  }
+	get fields(): string[] | undefined {
+		return this._fields;
+	}
 
-  set fields(value: string[] | undefined) {
-    this._fields = value;
-  }
+	set fields(value: string[] | undefined) {
+		this._fields = value;
+	}
 
-  get dryRun(): boolean | undefined {
-    return this._dryRun;
-  }
+	get dryRun(): boolean | undefined {
+		return this._dryRun;
+	}
 
-  set dryRun(value: boolean | undefined) {
-    this._dryRun = value;
-  }
+	set dryRun(value: boolean | undefined) {
+		this._dryRun = value;
+	}
 
-  get verbose(): boolean | undefined {
-    return this._verbose;
-  }
+	get verbose(): boolean | undefined {
+		return this._verbose;
+	}
 
-  set verbose(value: boolean | undefined) {
-    this._verbose = value;
-  }
+	set verbose(value: boolean | undefined) {
+		this._verbose = value;
+	}
 
-  get resolvedBaseUrl(): string | undefined {
-    return this._resolvedBaseUrl;
-  }
+	get resolvedBaseUrl(): string | undefined {
+		return this._resolvedBaseUrl;
+	}
 
-  set resolvedBaseUrl(value: string | undefined) {
-    this._resolvedBaseUrl = value;
-  }
+	set resolvedBaseUrl(value: string | undefined) {
+		this._resolvedBaseUrl = value;
+	}
 }
 
 /**
  * Global c8ctl runtime instance
  */
+// biome-ignore lint/suspicious/noRedeclare: intentional — module export shadows the globalThis declaration (#219)
 export const c8ctl = new C8ctl();

--- a/tests/integration/process-instances.test.ts
+++ b/tests/integration/process-instances.test.ts
@@ -94,22 +94,29 @@ describe('Process Instance Integration Tests (requires Camunda 8 at localhost:80
   });
 
   test('list process instances filters by version', async () => {
+    // Use a unique process ID so version numbering starts at 1 regardless of server state
+    const uniqueId = `version-test-${Date.now()}`;
+    const baseBpmn = readFileSync('tests/fixtures/simple.bpmn', 'utf8')
+      .replace('id="simple-process"', `id="${uniqueId}"`);
+
     // Deploy v1
-    await deploy(['tests/fixtures/simple.bpmn'], {});
-    await createProcessInstance({ processDefinitionId: 'simple-process' });
+    const v1Path = join(testDir, 'v1.bpmn');
+    writeFileSync(v1Path, baseBpmn);
+    await deploy([v1Path], {});
+    await createProcessInstance({ processDefinitionId: uniqueId });
 
     // Deploy v2 with a minimal change (different task name)
-    const v2Bpmn = readFileSync('tests/fixtures/simple.bpmn', 'utf8')
+    const v2Bpmn = baseBpmn
       .replace('name="Do Something"', 'name="Do Something v2"');
-    const v2Path = join(testDir, 'simple-v2.bpmn');
+    const v2Path = join(testDir, 'v2.bpmn');
     writeFileSync(v2Path, v2Bpmn);
     await deploy([v2Path], {});
-    await createProcessInstance({ processDefinitionId: 'simple-process' });
+    await createProcessInstance({ processDefinitionId: uniqueId });
 
     // Wait for both versions to be indexed
     const v1Indexed = await pollUntil(async () => {
       const result = await listProcessInstances({
-        processDefinitionId: 'simple-process',
+        processDefinitionId: uniqueId,
         version: 1,
         all: true,
       });
@@ -119,7 +126,7 @@ describe('Process Instance Integration Tests (requires Camunda 8 at localhost:80
 
     const v2Indexed = await pollUntil(async () => {
       const result = await listProcessInstances({
-        processDefinitionId: 'simple-process',
+        processDefinitionId: uniqueId,
         version: 2,
         all: true,
       });
@@ -129,7 +136,7 @@ describe('Process Instance Integration Tests (requires Camunda 8 at localhost:80
 
     // Verify version filtering is exclusive
     const v1Result = await listProcessInstances({
-      processDefinitionId: 'simple-process',
+      processDefinitionId: uniqueId,
       version: 1,
       all: true,
     });
@@ -141,7 +148,7 @@ describe('Process Instance Integration Tests (requires Camunda 8 at localhost:80
     );
 
     const v2Result = await listProcessInstances({
-      processDefinitionId: 'simple-process',
+      processDefinitionId: uniqueId,
       version: 2,
       all: true,
     });

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -160,21 +160,28 @@ describe('Search Command Integration Tests (requires Camunda 8 at localhost:8080
   });
 
   test('search process instances by version', async () => {
+    // Use a unique process ID so version numbering starts at 1 regardless of server state
+    const uniqueId = `version-pi-test-${Date.now()}`;
+    const baseBpmn = readFileSync('tests/fixtures/simple.bpmn', 'utf8')
+      .replace('id="simple-process"', `id="${uniqueId}"`);
+
     // Deploy v1
-    await cli('deploy', 'tests/fixtures/simple.bpmn');
-    await cli('create', 'pi', '--id=simple-process');
+    const v1Path = join(dataDir, 'v1-pi.bpmn');
+    writeFileSync(v1Path, baseBpmn);
+    await cli('deploy', v1Path);
+    await cli('create', 'pi', `--id=${uniqueId}`);
 
     // Deploy v2 with a minimal change (different task name)
-    const v2Bpmn = readFileSync('tests/fixtures/simple.bpmn', 'utf8')
+    const v2Bpmn = baseBpmn
       .replace('name="Do Something"', 'name="Do Something v2"');
-    const v2Path = join(dataDir, 'simple-v2.bpmn');
+    const v2Path = join(dataDir, 'v2-pi.bpmn');
     writeFileSync(v2Path, v2Bpmn);
     await cli('deploy', v2Path);
-    await cli('create', 'pi', '--id=simple-process');
+    await cli('create', 'pi', `--id=${uniqueId}`);
 
     // Wait until v1 instances are indexed
     const v1Found = await pollUntil(async () => {
-      const result = await cli('search', 'pi', '--id=simple-process', '--version=1');
+      const result = await cli('search', 'pi', `--id=${uniqueId}`, '--version=1');
       const items = parseItems<ProcessInstanceRow>(result.stdout);
       return items.length > 0;
     }, POLL_TIMEOUT_MS, POLL_INTERVAL_MS);
@@ -182,54 +189,61 @@ describe('Search Command Integration Tests (requires Camunda 8 at localhost:8080
 
     // Wait until v2 instances are indexed
     const v2Found = await pollUntil(async () => {
-      const result = await cli('search', 'pi', '--id=simple-process', '--version=2');
+      const result = await cli('search', 'pi', `--id=${uniqueId}`, '--version=2');
       const items = parseItems<ProcessInstanceRow>(result.stdout);
       return items.length > 0;
     }, POLL_TIMEOUT_MS, POLL_INTERVAL_MS);
     assert.ok(v2Found, 'Search should find process instances matching version 2');
 
     // Verify version filtering is exclusive
-    const v1Result = await cli('search', 'pi', '--id=simple-process', '--version=1');
+    const v1Result = await cli('search', 'pi', `--id=${uniqueId}`, '--version=1');
     const v1Items = parseItems<ProcessInstanceRow>(v1Result.stdout);
     assert.ok(v1Items.every(i => Number(i.Version) === 1), 'All version 1 results should be version 1');
 
-    const v2Result = await cli('search', 'pi', '--id=simple-process', '--version=2');
+    const v2Result = await cli('search', 'pi', `--id=${uniqueId}`, '--version=2');
     const v2Items = parseItems<ProcessInstanceRow>(v2Result.stdout);
     assert.ok(v2Items.every(i => Number(i.Version) === 2), 'All version 2 results should be version 2');
   });
 
   test('search process definitions by version', async () => {
+    // Use a unique process ID so version numbering starts at 1 regardless of server state
+    const uniqueId = `version-pd-test-${Date.now()}`;
+    const baseBpmn = readFileSync('tests/fixtures/simple.bpmn', 'utf8')
+      .replace('id="simple-process"', `id="${uniqueId}"`);
+
     // Deploy v1
-    await cli('deploy', 'tests/fixtures/simple.bpmn');
+    const v1Path = join(dataDir, 'v1-pd.bpmn');
+    writeFileSync(v1Path, baseBpmn);
+    await cli('deploy', v1Path);
 
     // Deploy v2 with a minimal change (different task name)
-    const v2Bpmn = readFileSync('tests/fixtures/simple.bpmn', 'utf8')
+    const v2Bpmn = baseBpmn
       .replace('name="Do Something"', 'name="Do Something v2"');
-    const v2Path = join(dataDir, 'simple-v2.bpmn');
+    const v2Path = join(dataDir, 'v2-pd.bpmn');
     writeFileSync(v2Path, v2Bpmn);
     await cli('deploy', v2Path);
 
     // Wait until both versions are indexed
     const v1Found = await pollUntil(async () => {
-      const result = await cli('search', 'pd', '--id=simple-process', '--version=1');
+      const result = await cli('search', 'pd', `--id=${uniqueId}`, '--version=1');
       const items = parseItems<ProcessDefinitionRow>(result.stdout);
       return items.length > 0;
     }, POLL_TIMEOUT_MS, POLL_INTERVAL_MS);
     assert.ok(v1Found, 'Search should find process definition version 1');
 
     const v2Found = await pollUntil(async () => {
-      const result = await cli('search', 'pd', '--id=simple-process', '--version=2');
+      const result = await cli('search', 'pd', `--id=${uniqueId}`, '--version=2');
       const items = parseItems<ProcessDefinitionRow>(result.stdout);
       return items.length > 0;
     }, POLL_TIMEOUT_MS, POLL_INTERVAL_MS);
     assert.ok(v2Found, 'Search should find process definition version 2');
 
     // Verify filtering is exclusive
-    const v1Result = await cli('search', 'pd', '--id=simple-process', '--version=1');
+    const v1Result = await cli('search', 'pd', `--id=${uniqueId}`, '--version=1');
     const v1Items = parseItems<ProcessDefinitionRow>(v1Result.stdout);
     assert.ok(v1Items.every(pd => Number(pd.Version) === 1), 'All version 1 results should be version 1');
 
-    const v2Result = await cli('search', 'pd', '--id=simple-process', '--version=2');
+    const v2Result = await cli('search', 'pd', `--id=${uniqueId}`, '--version=2');
     const v2Items = parseItems<ProcessDefinitionRow>(v2Result.stdout);
     assert.ok(v2Items.every(pd => Number(pd.Version) === 2), 'All version 2 results should be version 2');
   });

--- a/tests/unit/identity.test.ts
+++ b/tests/unit/identity.test.ts
@@ -96,9 +96,17 @@ describe('Identity Commands — required-flag validation', () => {
   });
 
   // createIdentityRole
+  test('createIdentityRole: errors when --roleId is missing', async () => {
+    await assert.rejects(
+      () => createIdentityRole({ name: 'admin' }),
+      /process\.exit\(1\)/,
+    );
+    assert.ok(errorSpy.some(l => l.includes('--roleId is required')));
+  });
+
   test('createIdentityRole: errors when --name is missing', async () => {
     await assert.rejects(
-      () => createIdentityRole({}),
+      () => createIdentityRole({ roleId: 'admin-role' }),
       /process\.exit\(1\)/,
     );
     assert.ok(errorSpy.some(l => l.includes('--name is required')));
@@ -204,13 +212,13 @@ describe('Identity Commands — dry-run output', () => {
   });
 
   test('createIdentityRole: emits POST to /roles with name in body', async () => {
-    await createIdentityRole({ name: 'admin' });
+    await createIdentityRole({ roleId: 'admin-role', name: 'admin' });
 
     const out = capturedJson();
     assert.strictEqual(out.dryRun, true);
     assert.strictEqual(out.method, 'POST');
     assert.ok((out.url as string).endsWith('/roles'), `expected URL to end with /roles, got: ${out.url}`);
-    assert.deepStrictEqual(out.body, { name: 'admin' });
+    assert.deepStrictEqual(out.body, { roleId: 'admin-role', name: 'admin' });
   });
 
   test('deleteIdentityRole: emits DELETE to /roles/:roleId', async () => {
@@ -487,7 +495,7 @@ describe('Dry-run schema — all mutating identity commands include body field',
   });
 
   test('createIdentityRole dry-run includes body object', async () => {
-    await createIdentityRole({ name: 'admin' });
+    await createIdentityRole({ roleId: 'admin-role', name: 'admin' });
     assertDryRunSchema(capturedJson(), 'createIdentityRole');
     assert.ok(typeof capturedJson().body === 'object' && capturedJson().body !== null);
   });


### PR DESCRIPTION
## Summary

Eliminates all `any` types and unsafe type assertions from the codebase, replaces ESLint with Biome + GritQL enforcement, and fixes security/correctness issues found during review. Resolves #210.

### Type safety

**Branded type params** — use `.assumeExists()` for validated path parameters:
- `ProcessInstanceKey`, `ProcessDefinitionKey`, `IncidentKey`, `UserTaskKey` (numeric branded types)
- `Username`, `TenantId`, `AuthorizationKey` (string branded types)

**Plain string params** — remove cast entirely (SDK already expects `string`):
- `roleId`, `groupId`, `mappingRuleId`

**Request bodies** — type with SDK input types:
- `createGroupInput`, `createRoleInput`, `createTenantInput`, `createUserInput`, `createMappingRuleInput`, `createAuthorizationInput`

**Search results** — replace `{ items: allItems } as any` with typed `{ items: Record[] }`

**Logger** — all `any` params replaced with `unknown`; `isRecord()` type guard added as shared utility

**Type guards added:**
- `isRecord()` — shared utility for safe runtime narrowing (used in deployments, forms, logger, mcp-proxy)
- `isAppName()` — validates CLI input against known app names
- `isExecFileError()` — narrows caught errors for npm subprocess handling

### Linting & enforcement

**Replaced ESLint with Biome 2.4.11:**
- `noExplicitAny`, `noImplicitAnyLet`, `noEvolvingTypes` — all set to `error`
- Auto-fixed ~34 additional lint issues (template literals, optional chaining, unused imports, `useConst`, etc.)

**GritQL plugin** (`plugins/no-unsafe-type-assertion.grit`):
- Bans all `as T` type assertions at the lint level
- Excludes `as const` and import renames (no false positives)

**CI integration:**
- Dedicated lint job runs `biome check src/ --fix` and auto-commits changes
- Unit/integration tests depend on the lint job

**DEVELOPMENT.md** updated with coding conventions for `any` and type assertion bans.

### Security fixes (from review)

- **Shell injection**: replaced all `execSync` with `execFileSync` in plugin commands — user-controlled `fromUrl`/`packageName` can no longer inject shell metacharacters
- **Cross-platform path**: replaced `path.split("/").pop()` with `basename()` in run.ts

### Bug fixes (from review)

- **Plugin registry cache**: fixed bug where `JSON.parse` returning `null` left `registryCache` unset, causing repeated re-reads. Now validates parsed shape (`"plugins" in parsed && Array.isArray`)
- **Template formatting**: excluded `src/templates/` from Biome scope (scaffolding output, not project source) — Biome was reformatting the plugin template, breaking integration tests that check generated file content

### Remaining suppressions (tracked in follow-up issues)

All `biome-ignore` suppressions reference the issue that will resolve them:

- **#218** — CLI string → SDK enum boundary validation (4 suppressions in `identity-authorizations.ts`, `open.ts`)
- **#219** — Make C8ctl implement C8ctlPluginRuntime directly (3 suppressions in `plugin-loader.ts`, `runtime.ts`)

### Bonus

Found and fixed 2 latent runtime defects — requests that would have caused HTTP 400 errors were masked by `as any` casts erasing the type system's ability to detect wrong parameter shapes.