### PR TITLE
refactor: make C8ctl implement C8ctlPluginRuntime directly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@
 import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
+import { createClient } from "./client.ts";
 import { showCompletion } from "./commands/completion.ts";
 import { deploy } from "./commands/deployments.ts";
 import { getForm, getStartForm, getUserTaskForm } from "./commands/forms.ts";
@@ -103,7 +104,7 @@ import { setOutputFormat, useProfile, useTenant } from "./commands/session.ts";
 import { getTopology } from "./commands/topology.ts";
 import { completeUserTask, listUserTasks } from "./commands/user-tasks.ts";
 import { watchFiles } from "./commands/watch.ts";
-import { loadSessionState } from "./config.ts";
+import { loadSessionState, resolveTenantId } from "./config.ts";
 import { getLogger, type SortOrder } from "./logger.ts";
 import { executePluginCommand, loadInstalledPlugins } from "./plugin-loader.ts";
 import { c8ctl } from "./runtime.ts";
@@ -342,6 +343,9 @@ async function main() {
 	if (values.verbose) {
 		c8ctl.verbose = true;
 	}
+
+	// Inject dependencies into the runtime (breaks circular imports)
+	c8ctl.init({ createClient, resolveTenantId, getLogger });
 
 	// Load installed plugins
 	await loadInstalledPlugins();

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -4,10 +4,9 @@
 
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { createClient } from "./client.ts";
-import { ensurePluginsDir, resolveTenantId } from "./config.ts";
+import { ensurePluginsDir } from "./config.ts";
 import { getLogger } from "./logger.ts";
-import { type C8ctlPluginRuntime, c8ctl } from "./runtime.ts";
+import { c8ctl } from "./runtime.ts";
 
 interface PluginCommands {
 	[commandName: string]: (args: string[]) => Promise<void>;
@@ -128,11 +127,9 @@ async function loadDefaultPlugins(): Promise<void> {
 export async function loadInstalledPlugins(): Promise<void> {
 	const logger = getLogger();
 
-	// Make c8ctl runtime available globally for plugins
-	// biome-ignore lint/plugin: C8ctl uses prototype getters — Object.assign mutates in-place to preserve them (#219)
-	const pluginRuntime = c8ctl as unknown as C8ctlPluginRuntime;
-	Object.assign(pluginRuntime, { createClient, resolveTenantId, getLogger });
-	globalThis.c8ctl = pluginRuntime;
+	// Expose the runtime to plugins via globalThis.
+	// C8ctl implements C8ctlPluginRuntime directly — no monkey-patching needed.
+	globalThis.c8ctl = c8ctl;
 
 	// Load default plugins first
 	await loadDefaultPlugins();

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -23,6 +23,20 @@ export interface C8ctlEnv {
 	rootDir: string;
 }
 
+/**
+ * Functions injected into the runtime via init() to break circular imports.
+ * client.ts, config.ts, and logger.ts all import c8ctl from this module,
+ * so this module cannot import from them at the top level.
+ */
+export interface C8ctlDeps {
+	createClient(
+		profileFlag?: string,
+		additionalSdkConfig?: Partial<CamundaOptions>,
+	): CamundaClient;
+	resolveTenantId(profileFlag?: string): string;
+	getLogger(mode?: OutputMode): Logger;
+}
+
 export interface C8ctlPluginRuntime {
 	readonly env: C8ctlEnv;
 	readonly version: string;
@@ -67,9 +81,10 @@ function getVersion(): string {
 }
 
 /**
- * c8ctl runtime class with session state management
+ * c8ctl runtime class with session state management.
+ * Implements C8ctlPluginRuntime directly — no monkey-patching required.
  */
-class C8ctl {
+class C8ctl implements C8ctlPluginRuntime {
 	private _activeProfile?: string;
 	private _activeTenant?: string;
 	private _outputMode: OutputMode = "text";
@@ -77,6 +92,7 @@ class C8ctl {
 	private _dryRun?: boolean;
 	private _verbose?: boolean;
 	private _resolvedBaseUrl?: string;
+	private _deps?: C8ctlDeps;
 
 	readonly env: C8ctlEnv = {
 		version: getVersion(),
@@ -86,6 +102,39 @@ class C8ctl {
 		cwd: process.cwd(),
 		rootDir: join(__dirname, ".."),
 	};
+
+	/**
+	 * Inject dependencies that cannot be imported at module level
+	 * due to circular imports. Must be called once during startup,
+	 * before any plugin or command accesses createClient/resolveTenantId/getLogger.
+	 */
+	init(deps: C8ctlDeps): void {
+		this._deps = deps;
+	}
+
+	createClient(
+		profileFlag?: string,
+		additionalSdkConfig?: Partial<CamundaOptions>,
+	): CamundaClient {
+		if (!this._deps) {
+			throw new Error("c8ctl.init() must be called before createClient()");
+		}
+		return this._deps.createClient(profileFlag, additionalSdkConfig);
+	}
+
+	resolveTenantId(profileFlag?: string): string {
+		if (!this._deps) {
+			throw new Error("c8ctl.init() must be called before resolveTenantId()");
+		}
+		return this._deps.resolveTenantId(profileFlag);
+	}
+
+	getLogger(mode?: OutputMode): Logger {
+		if (!this._deps) {
+			throw new Error("c8ctl.init() must be called before getLogger()");
+		}
+		return this._deps.getLogger(mode);
+	}
 
 	// Expose env properties directly for plugin compatibility
 	get version(): string {
@@ -168,5 +217,5 @@ class C8ctl {
 /**
  * Global c8ctl runtime instance
  */
-// biome-ignore lint/suspicious/noRedeclare: intentional — module export shadows the globalThis declaration (#219)
+// biome-ignore lint/suspicious/noRedeclare: intentional — module export shadows the globalThis declaration
 export const c8ctl = new C8ctl();

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -26,7 +26,8 @@ export interface C8ctlEnv {
 /**
  * Functions injected into the runtime via init() to break circular imports.
  * client.ts, config.ts, and logger.ts all import c8ctl from this module,
- * so this module cannot import from them at the top level.
+ * so this module cannot import runtime values from them at the top level
+ * (type-only imports are OK).
  */
 export interface C8ctlDeps {
 	createClient(
@@ -109,6 +110,9 @@ class C8ctl implements C8ctlPluginRuntime {
 	 * before any plugin or command accesses createClient/resolveTenantId/getLogger.
 	 */
 	init(deps: C8ctlDeps): void {
+		if (this._deps) {
+			throw new Error("c8ctl.init() must only be called once");
+		}
 		this._deps = deps;
 	}
 


### PR DESCRIPTION
## Problem

The `c8ctl` singleton (`src/runtime.ts`) is a `C8ctl` class instance that lacks the `createClient`, `resolveTenantId`, and `getLogger` methods required by the `C8ctlPluginRuntime` interface. These were monkey-patched on via `Object.assign` in `loadInstalledPlugins()`, requiring a `as unknown as C8ctlPluginRuntime` double cast.

The root cause is circular imports: `client.ts`, `logger.ts`, and `config.ts` all import `c8ctl` from `runtime.ts`, so `runtime.ts` cannot import from them at the top level.

## Solution

Dependency injection via `init()`:

1. **`C8ctl` now `implements C8ctlPluginRuntime` directly** — the class has real `createClient()`, `resolveTenantId()`, and `getLogger()` methods that delegate to injected functions.
2. **`init(deps)` method** accepts a `C8ctlDeps` object with the three functions, called once during startup before any plugin or command accesses them.
3. **No more `Object.assign`** — `plugin-loader.ts` just does `globalThis.c8ctl = c8ctl`.
4. **No more double cast** — the `as unknown as C8ctlPluginRuntime` and its `biome-ignore` suppression are eliminated.

## Changes

- `src/runtime.ts` — `C8ctl implements C8ctlPluginRuntime`, adds `C8ctlDeps` interface and `init()` method
- `src/plugin-loader.ts` — removes `createClient`/`resolveTenantId` imports, `Object.assign`, and type cast
- `src/index.ts` — calls `c8ctl.init({ createClient, resolveTenantId, getLogger })` before `loadInstalledPlugins()`

## Verification

- tsc: clean
- biome: clean
- 787 tests pass, 0 fail

Closes #219