### PR TITLE
refactor: extract command-validation layer for CLI boundary checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-semantically-released",
       "license": "MIT",
       "dependencies": {
-        "@camunda8/orchestration-cluster-api": "8.9.0-alpha.37",
+        "@camunda8/orchestration-cluster-api": "^8.9.0-alpha.38",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "ignore": "^7.0.5"
       },
@@ -269,9 +269,9 @@
       }
     },
     "node_modules/@camunda8/orchestration-cluster-api": {
-      "version": "8.9.0-alpha.37",
-      "resolved": "https://registry.npmjs.org/@camunda8/orchestration-cluster-api/-/orchestration-cluster-api-8.9.0-alpha.37.tgz",
-      "integrity": "sha512-ZkZPJV4GSd2wqjzDdOIic6sBgP6VoRRikQXbfZtqjPQDn6WJmrP2E5kRXJSLA0TpW1cuNCJJxpj4mKYSFmYVNQ==",
+      "version": "8.9.0-alpha.38",
+      "resolved": "https://registry.npmjs.org/@camunda8/orchestration-cluster-api/-/orchestration-cluster-api-8.9.0-alpha.38.tgz",
+      "integrity": "sha512-CS7Hxj3xpPi6seAQYFsF1SWGflpd88mhoXCBmGeoI/DSGXA9KCFhNNIPmEn5sLUkpJZlRaQ7bnUgHuptEav6MA==",
       "license": "Apache-2.0",
       "dependencies": {
         "typed-env": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@camunda8/orchestration-cluster-api": "8.9.0-alpha.37",
+    "@camunda8/orchestration-cluster-api": "^8.9.0-alpha.38",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "ignore": "^7.0.5"
   },

--- a/src/command-validation.ts
+++ b/src/command-validation.ts
@@ -88,3 +88,47 @@ export function requireCsvEnum<T extends string>(
 
 	return result;
 }
+
+/**
+ * Validate that a positional argument is present and non-empty.
+ * Unlike requireOption (for --flags), this uses a descriptive label
+ * in the error message.
+ * Exits with code 1 if missing.
+ */
+export function requirePositional(
+	value: string | undefined,
+	label: string,
+	hint?: string,
+): string {
+	if (!value) {
+		const logger = getLogger();
+		logger.error(`${label} is required`);
+		if (hint) logger.info(hint);
+		process.exit(1);
+	}
+	return value;
+}
+
+/**
+ * Validate that a string value is one of an allowed set.
+ * Works with readonly tuples (e.g. `OPEN_APPS as const`).
+ * Uses .find() so TypeScript narrows to T with no cast.
+ * Exits with code 1 if invalid, listing valid values.
+ */
+export function requireOneOf<T extends string>(
+	value: string,
+	allowed: readonly T[],
+	label: string,
+	hint?: string,
+): T {
+	const match = allowed.find((v) => v === value);
+	if (match === undefined) {
+		const logger = getLogger();
+		logger.error(
+			`Unknown ${label} '${value}'. Available: ${allowed.join(", ")}`,
+		);
+		if (hint) logger.info(hint);
+		process.exit(1);
+	}
+	return match;
+}

--- a/src/command-validation.ts
+++ b/src/command-validation.ts
@@ -68,6 +68,11 @@ export function requireCsvEnum<T extends string>(
 		.map((p) => p.trim())
 		.filter((p) => p.length > 0);
 
+	if (items.length === 0) {
+		getLogger().error(`--${flagName} is required`);
+		process.exit(1);
+	}
+
 	const result: T[] = [];
 	const invalid: string[] = [];
 	for (const item of items) {

--- a/src/command-validation.ts
+++ b/src/command-validation.ts
@@ -1,0 +1,90 @@
+/**
+ * CLI boundary validation utilities.
+ *
+ * These functions validate raw CLI string inputs and narrow them to
+ * SDK types. They exit with code 1 on invalid input, so callers
+ * receive only valid, typed values.
+ *
+ * This module is the single chokepoint for input validation — command
+ * handlers receive already-validated types and need no internal guards.
+ *
+ * Extension points for future issues:
+ * - #212: add validateAcceptedFlags(values, accepted, verb, resource)
+ * - #213: add requireResource(verb, resource, verbResourceMap)
+ */
+
+import { getLogger } from "./logger.ts";
+
+/**
+ * Validate that a required CLI option is present and non-empty.
+ * Exits with code 1 if missing.
+ */
+export function requireOption(
+	value: string | undefined,
+	flagName: string,
+): string {
+	if (!value) {
+		getLogger().error(`--${flagName} is required`);
+		process.exit(1);
+	}
+	return value;
+}
+
+/**
+ * Validate that a string value is a valid member of an SDK enum.
+ * Uses Object.values().find() so TypeScript narrows to T with no cast.
+ * Exits with code 1 if invalid, listing valid values.
+ */
+export function requireEnum<T extends string>(
+	value: string,
+	enumValues: Record<string, T>,
+	flagName: string,
+): T {
+	const validValues = Object.values(enumValues);
+	const match = validValues.find((v) => v === value);
+	if (match === undefined) {
+		getLogger().error(
+			`Invalid --${flagName} "${value}". Valid values: ${validValues.join(", ")}`,
+		);
+		process.exit(1);
+	}
+	return match;
+}
+
+/**
+ * Validate a comma-separated string where each element must be a
+ * valid member of an SDK enum. Splits on commas, trims whitespace,
+ * and filters empty strings before validation.
+ * Exits with code 1 if any element is invalid.
+ */
+export function requireCsvEnum<T extends string>(
+	value: string,
+	enumValues: Record<string, T>,
+	flagName: string,
+): T[] {
+	const validValues = Object.values(enumValues);
+	const items = value
+		.split(",")
+		.map((p) => p.trim())
+		.filter((p) => p.length > 0);
+
+	const result: T[] = [];
+	const invalid: string[] = [];
+	for (const item of items) {
+		const match = validValues.find((v) => v === item);
+		if (match !== undefined) {
+			result.push(match);
+		} else {
+			invalid.push(item);
+		}
+	}
+
+	if (invalid.length > 0) {
+		getLogger().error(
+			`Invalid --${flagName}: ${invalid.join(", ")}. Valid values: ${validValues.join(", ")}`,
+		);
+		process.exit(1);
+	}
+
+	return result;
+}

--- a/src/commands/identity-authorizations.ts
+++ b/src/commands/identity-authorizations.ts
@@ -11,23 +11,12 @@ import {
 	type ResourceTypeEnum,
 	ResourceTypeEnum as ResourceTypeValues,
 } from "@camunda8/orchestration-cluster-api";
-
-function isOwnerType(value: string): value is OwnerTypeEnum {
-	const values: readonly string[] = Object.values(OwnerTypeValues);
-	return values.includes(value);
-}
-
-function isResourceType(value: string): value is ResourceTypeEnum {
-	const values: readonly string[] = Object.values(ResourceTypeValues);
-	return values.includes(value);
-}
-
-function isPermissionType(value: string): value is PermissionTypeEnum {
-	const values: readonly string[] = Object.values(PermissionTypeValues);
-	return values.includes(value);
-}
-
 import { createClient, fetchAllPages } from "../client.ts";
+import {
+	requireCsvEnum,
+	requireEnum,
+	requireOption,
+} from "../command-validation.ts";
 import { resolveClusterConfig } from "../config.ts";
 import { handleCommandError } from "../errors.ts";
 import { getLogger, type SortOrder, sortTableData } from "../logger.ts";
@@ -167,77 +156,68 @@ export async function getIdentityAuthorization(
 }
 
 /**
- * Create a new authorization
+ * Validated inputs for creating an authorization.
+ * All fields are guaranteed present and type-narrowed by
+ * validateCreateAuthorizationOptions() before reaching the handler.
  */
-export async function createIdentityAuthorization(options: {
+export interface CreateAuthorizationInput {
+	profile?: string;
+	ownerId: string;
+	ownerType: OwnerTypeEnum;
+	resourceType: ResourceTypeEnum;
+	resourceId: string;
+	permissionTypes: PermissionTypeEnum[];
+}
+
+/**
+ * Validate raw CLI options for the create authorization command.
+ * Returns a fully validated and type-narrowed input object.
+ * Exits with code 1 on invalid input.
+ */
+export function validateCreateAuthorizationOptions(options: {
 	profile?: string;
 	ownerId?: string;
 	ownerType?: string;
 	resourceType?: string;
 	resourceId?: string;
 	permissions?: string;
-}): Promise<void> {
+}): CreateAuthorizationInput {
+	return {
+		profile: options.profile,
+		ownerId: requireOption(options.ownerId, "ownerId"),
+		ownerType: requireEnum(
+			requireOption(options.ownerType, "ownerType"),
+			OwnerTypeValues,
+			"ownerType",
+		),
+		resourceType: requireEnum(
+			requireOption(options.resourceType, "resourceType"),
+			ResourceTypeValues,
+			"resourceType",
+		),
+		resourceId: requireOption(options.resourceId, "resourceId"),
+		permissionTypes: requireCsvEnum(
+			requireOption(options.permissions, "permissions"),
+			PermissionTypeValues,
+			"permissions",
+		),
+	};
+}
+
+/**
+ * Create a new authorization
+ */
+export async function createIdentityAuthorization(
+	options: CreateAuthorizationInput,
+): Promise<void> {
 	const logger = getLogger();
-
-	if (!options.ownerId) {
-		logger.error("--ownerId is required");
-		process.exit(1);
-	}
-	if (!options.ownerType) {
-		logger.error("--ownerType is required");
-		process.exit(1);
-	}
-	const ownerTypeValues: readonly string[] = Object.values(OwnerTypeValues);
-	if (!isOwnerType(options.ownerType)) {
-		logger.error(
-			`Invalid --ownerType "${options.ownerType}". Valid values: ${ownerTypeValues.join(", ")}`,
-		);
-		process.exit(1);
-	}
-
-	if (!options.resourceType) {
-		logger.error("--resourceType is required");
-		process.exit(1);
-	}
-	const resourceTypeValues: readonly string[] =
-		Object.values(ResourceTypeValues);
-	if (!isResourceType(options.resourceType)) {
-		logger.error(
-			`Invalid --resourceType "${options.resourceType}". Valid values: ${resourceTypeValues.join(", ")}`,
-		);
-		process.exit(1);
-	}
-
-	if (!options.resourceId) {
-		logger.error("--resourceId is required");
-		process.exit(1);
-	}
-	if (!options.permissions) {
-		logger.error("--permissions is required");
-		process.exit(1);
-	}
-
-	const permissionTypeValues: readonly string[] =
-		Object.values(PermissionTypeValues);
-	const rawPermissions = options.permissions
-		.split(",")
-		.map((p) => p.trim())
-		.filter((p) => p.length > 0);
-	const invalidPermissions = rawPermissions.filter((p) => !isPermissionType(p));
-	if (invalidPermissions.length > 0) {
-		logger.error(
-			`Invalid --permissions: ${invalidPermissions.join(", ")}. Valid values: ${permissionTypeValues.join(", ")}`,
-		);
-		process.exit(1);
-	}
-	const permissionTypes = rawPermissions.filter(isPermissionType);
 
 	const body = {
 		ownerId: options.ownerId,
 		ownerType: options.ownerType,
 		resourceType: options.resourceType,
 		resourceId: options.resourceId,
-		permissionTypes,
+		permissionTypes: options.permissionTypes,
 	};
 
 	if (c8ctl.dryRun) {

--- a/src/commands/identity-authorizations.ts
+++ b/src/commands/identity-authorizations.ts
@@ -2,12 +2,31 @@
  * Identity authorization commands
  */
 
-import type {
-	OwnerTypeEnum,
-	PermissionTypeEnum,
-	ResourceTypeEnum,
+import {
+	AuthorizationKey,
+	type OwnerTypeEnum,
+	OwnerTypeEnum as OwnerTypeValues,
+	type PermissionTypeEnum,
+	PermissionTypeEnum as PermissionTypeValues,
+	type ResourceTypeEnum,
+	ResourceTypeEnum as ResourceTypeValues,
 } from "@camunda8/orchestration-cluster-api";
-import { AuthorizationKey } from "@camunda8/orchestration-cluster-api";
+
+function isOwnerType(value: string): value is OwnerTypeEnum {
+	const values: readonly string[] = Object.values(OwnerTypeValues);
+	return values.includes(value);
+}
+
+function isResourceType(value: string): value is ResourceTypeEnum {
+	const values: readonly string[] = Object.values(ResourceTypeValues);
+	return values.includes(value);
+}
+
+function isPermissionType(value: string): value is PermissionTypeEnum {
+	const values: readonly string[] = Object.values(PermissionTypeValues);
+	return values.includes(value);
+}
+
 import { createClient, fetchAllPages } from "../client.ts";
 import { resolveClusterConfig } from "../config.ts";
 import { handleCommandError } from "../errors.ts";
@@ -168,10 +187,27 @@ export async function createIdentityAuthorization(options: {
 		logger.error("--ownerType is required");
 		process.exit(1);
 	}
+	const ownerTypeValues: readonly string[] = Object.values(OwnerTypeValues);
+	if (!isOwnerType(options.ownerType)) {
+		logger.error(
+			`Invalid --ownerType "${options.ownerType}". Valid values: ${ownerTypeValues.join(", ")}`,
+		);
+		process.exit(1);
+	}
+
 	if (!options.resourceType) {
 		logger.error("--resourceType is required");
 		process.exit(1);
 	}
+	const resourceTypeValues: readonly string[] =
+		Object.values(ResourceTypeValues);
+	if (!isResourceType(options.resourceType)) {
+		logger.error(
+			`Invalid --resourceType "${options.resourceType}". Valid values: ${resourceTypeValues.join(", ")}`,
+		);
+		process.exit(1);
+	}
+
 	if (!options.resourceId) {
 		logger.error("--resourceId is required");
 		process.exit(1);
@@ -181,18 +217,27 @@ export async function createIdentityAuthorization(options: {
 		process.exit(1);
 	}
 
+	const permissionTypeValues: readonly string[] =
+		Object.values(PermissionTypeValues);
+	const rawPermissions = options.permissions
+		.split(",")
+		.map((p) => p.trim())
+		.filter((p) => p.length > 0);
+	const invalidPermissions = rawPermissions.filter((p) => !isPermissionType(p));
+	if (invalidPermissions.length > 0) {
+		logger.error(
+			`Invalid --permissions: ${invalidPermissions.join(", ")}. Valid values: ${permissionTypeValues.join(", ")}`,
+		);
+		process.exit(1);
+	}
+	const permissionTypes = rawPermissions.filter(isPermissionType);
+
 	const body = {
 		ownerId: options.ownerId,
-		// biome-ignore lint/plugin: CLI string → SDK enum, validated by API at runtime (#218)
-		ownerType: options.ownerType as OwnerTypeEnum,
-		// biome-ignore lint/plugin: CLI string → SDK enum, validated by API at runtime (#218)
-		resourceType: options.resourceType as ResourceTypeEnum,
+		ownerType: options.ownerType,
+		resourceType: options.resourceType,
 		resourceId: options.resourceId,
-		// biome-ignore lint/plugin: CLI strings → SDK enum, validated by API at runtime (#218)
-		permissionTypes: options.permissions
-			.split(",")
-			.map((p) => p.trim())
-			.filter((p) => p.length > 0) as PermissionTypeEnum[],
+		permissionTypes,
 	};
 
 	if (c8ctl.dryRun) {

--- a/src/commands/identity.ts
+++ b/src/commands/identity.ts
@@ -15,6 +15,7 @@ export {
 	getIdentityAuthorization,
 	listAuthorizations,
 	searchIdentityAuthorizations,
+	validateCreateAuthorizationOptions,
 } from "./identity-authorizations.ts";
 export {
 	createIdentityGroup,

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -4,6 +4,7 @@
 
 import { spawn } from "node:child_process";
 import { platform } from "node:os";
+import { requireOneOf, requirePositional } from "../command-validation.ts";
 import { resolveClusterConfig } from "../config.ts";
 import { getLogger } from "../logger.ts";
 
@@ -89,40 +90,57 @@ export function openUrl(url: string): void {
 }
 
 /**
- * Open a Camunda web application in the default browser.
+ * Validated inputs for the open command.
  */
-export async function openApp(
+export interface OpenAppInput {
+	app: AppName;
+	profile?: string;
+	dryRun?: boolean;
+}
+
+const OPEN_USAGE = "Usage: c8 open <app> [--profile <name>]";
+
+/**
+ * Validate raw CLI positional + options for the open command.
+ * Returns a fully validated and type-narrowed input object.
+ * Exits with code 1 on invalid input.
+ */
+export function validateOpenAppOptions(
 	app: string | undefined,
 	options: { profile?: string; dryRun?: boolean },
-): Promise<void> {
+): OpenAppInput {
+	return {
+		app: requireOneOf(
+			requirePositional(app, "Application", OPEN_USAGE),
+			OPEN_APPS,
+			"application",
+			OPEN_USAGE,
+		),
+		profile: options.profile,
+		dryRun: options.dryRun,
+	};
+}
+
+/**
+ * Open a Camunda web application in the default browser.
+ */
+export async function openApp(options: OpenAppInput): Promise<void> {
 	const logger = getLogger();
 
-	if (!app) {
-		logger.error(`Application required. Available: ${OPEN_APPS.join(", ")}`);
-		logger.info("Usage: c8 open <app> [--profile <name>]");
-		process.exit(1);
-	}
-
-	if (!isAppName(app)) {
-		logger.error(
-			`Unknown application '${app}'. Available: ${OPEN_APPS.join(", ")}`,
-		);
-		logger.info("Usage: c8 open <app> [--profile <name>]");
-		process.exit(1);
-	}
-
 	const config = resolveClusterConfig(options.profile);
-	const url = deriveAppUrl(config.baseUrl, app);
+	const url = deriveAppUrl(config.baseUrl, options.app);
 
 	if (!url) {
-		logger.error(`Cannot derive ${app} URL from base URL: ${config.baseUrl}`);
+		logger.error(
+			`Cannot derive ${options.app} URL from base URL: ${config.baseUrl}`,
+		);
 		logger.info(
 			"The open command is only supported for self-managed clusters whose base URL ends with /v<n> (e.g. http://localhost:8080/v2).",
 		);
 		process.exit(1);
 	}
 
-	logger.info(`Opening ${app} at: ${url}`);
+	logger.info(`Opening ${options.app} at: ${url}`);
 	if (!options.dryRun) {
 		openUrl(url);
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ import {
 } from "./commands/jobs.ts";
 import { mcpProxy } from "./commands/mcp-proxy.ts";
 import { correlateMessage, publishMessage } from "./commands/messages.ts";
-import { openApp, openUrl } from "./commands/open.ts";
+import { openApp, openUrl, validateOpenAppOptions } from "./commands/open.ts";
 import {
 	downgradePlugin,
 	initPlugin,
@@ -916,10 +916,11 @@ async function main() {
 
 	// Handle open command
 	if (verb === "open") {
-		await openApp(resource, {
+		const validated = validateOpenAppOptions(resource, {
 			profile: str(values.profile),
 			dryRun: bool(values["dry-run"]),
 		});
+		await openApp(validated);
 		return;
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ import {
 	searchIdentityRoles,
 	searchIdentityTenants,
 	searchIdentityUsers,
+	validateCreateAuthorizationOptions,
 } from "./commands/identity.ts";
 import {
 	getIncident,
@@ -1298,7 +1299,7 @@ async function main() {
 		return;
 	}
 	if (verb === "create" && normalizedResource === "authorization") {
-		await createIdentityAuthorization({
+		const validated = validateCreateAuthorizationOptions({
 			profile: str(values.profile),
 			ownerId: str(values.ownerId),
 			ownerType: str(values.ownerType),
@@ -1306,6 +1307,7 @@ async function main() {
 			resourceId: str(values.resourceId),
 			permissions: str(values.permissions),
 		});
+		await createIdentityAuthorization(validated);
 		return;
 	}
 	if (verb === "create" && normalizedResource === "mapping-rule") {

--- a/tests/unit/command-validation.test.ts
+++ b/tests/unit/command-validation.test.ts
@@ -7,7 +7,7 @@
 
 import { test, describe, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
-import { requireOption, requireEnum, requireCsvEnum } from '../../src/command-validation.ts';
+import { requireOption, requireEnum, requireCsvEnum, requirePositional, requireOneOf } from '../../src/command-validation.ts';
 
 // A minimal enum-like object matching the SDK pattern
 const ColorEnum = { RED: 'RED', GREEN: 'GREEN', BLUE: 'BLUE' } as const;
@@ -144,5 +144,87 @@ describe('requireCsvEnum', () => {
     );
     assert.ok(errorSpy.some(l => l.includes('PURPLE')));
     assert.ok(errorSpy.some(l => l.includes('YELLOW')));
+  });
+});
+
+// ─── requirePositional ──────────────────────────────────────────────────────
+
+describe('requirePositional', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  test('returns the value when present', () => {
+    assert.strictEqual(requirePositional('operate', 'Application'), 'operate');
+  });
+
+  test('exits when value is undefined', () => {
+    assert.throws(
+      () => requirePositional(undefined, 'Application'),
+      /process\.exit\(1\)/,
+    );
+    assert.ok(errorSpy.some(l => l.includes('Application is required')));
+  });
+
+  test('exits when value is empty string', () => {
+    assert.throws(
+      () => requirePositional('', 'Application'),
+      /process\.exit\(1\)/,
+    );
+    assert.ok(errorSpy.some(l => l.includes('Application is required')));
+  });
+
+  test('prints hint when provided', () => {
+    const logSpy: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: any[]) => { logSpy.push(args.join(' ')); };
+    try {
+      requirePositional(undefined, 'Application', 'Usage: c8 open <app>');
+    } catch { /* expected */ }
+    console.log = origLog;
+    assert.ok(logSpy.some(l => l.includes('Usage: c8 open <app>')));
+  });
+});
+
+// ─── requireOneOf ────────────────────────────────────────────────────────────
+
+const FRUITS = ['apple', 'banana', 'cherry'] as const;
+
+describe('requireOneOf', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  test('returns matched value for a valid item', () => {
+    assert.strictEqual(requireOneOf('apple', FRUITS, 'fruit'), 'apple');
+    assert.strictEqual(requireOneOf('banana', FRUITS, 'fruit'), 'banana');
+    assert.strictEqual(requireOneOf('cherry', FRUITS, 'fruit'), 'cherry');
+  });
+
+  test('exits on invalid value listing valid options', () => {
+    assert.throws(
+      () => requireOneOf('mango', FRUITS, 'fruit'),
+      /process\.exit\(1\)/,
+    );
+    assert.ok(errorSpy.some(l => l.includes("Unknown fruit 'mango'")));
+    assert.ok(errorSpy.some(l => l.includes('apple')));
+    assert.ok(errorSpy.some(l => l.includes('banana')));
+    assert.ok(errorSpy.some(l => l.includes('cherry')));
+  });
+
+  test('is case-sensitive', () => {
+    assert.throws(
+      () => requireOneOf('Apple', FRUITS, 'fruit'),
+      /process\.exit\(1\)/,
+    );
+  });
+
+  test('prints hint when provided', () => {
+    const logSpy: string[] = [];
+    const origLog = console.log;
+    console.log = (...args: any[]) => { logSpy.push(args.join(' ')); };
+    try {
+      requireOneOf('mango', FRUITS, 'fruit', 'Usage: pick a fruit');
+    } catch { /* expected */ }
+    console.log = origLog;
+    assert.ok(logSpy.some(l => l.includes('Usage: pick a fruit')));
   });
 });

--- a/tests/unit/command-validation.test.ts
+++ b/tests/unit/command-validation.test.ts
@@ -128,6 +128,14 @@ describe('requireCsvEnum', () => {
     assert.deepStrictEqual(result, ['RED', 'GREEN']);
   });
 
+  test('exits when input is only commas and whitespace', () => {
+    assert.throws(
+      () => requireCsvEnum(' , , ', ColorEnum, 'colors'),
+      /process\.exit\(1\)/,
+    );
+    assert.ok(errorSpy.some(l => l.includes('--colors is required')));
+  });
+
   test('exits on invalid value listing all invalid items', () => {
     assert.throws(
       () => requireCsvEnum('RED,PURPLE,YELLOW', ColorEnum, 'colors'),

--- a/tests/unit/command-validation.test.ts
+++ b/tests/unit/command-validation.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Unit tests for src/command-validation.ts
+ *
+ * Tests the validation utilities directly to catch regressions in
+ * the shared boundary-validation layer that all commands depend on.
+ */
+
+import { test, describe, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { requireOption, requireEnum, requireCsvEnum } from '../../src/command-validation.ts';
+
+// A minimal enum-like object matching the SDK pattern
+const ColorEnum = { RED: 'RED', GREEN: 'GREEN', BLUE: 'BLUE' } as const;
+type ColorEnum = (typeof ColorEnum)[keyof typeof ColorEnum];
+
+let errorSpy: string[];
+let originalError: typeof console.error;
+let originalExit: typeof process.exit;
+
+function setup() {
+  errorSpy = [];
+  originalError = console.error;
+  originalExit = process.exit;
+  console.error = (...args: any[]) => errorSpy.push(args.join(' '));
+  (process.exit as any) = (code: number) => { throw new Error(`process.exit(${code})`); };
+}
+
+function teardown() {
+  console.error = originalError;
+  process.exit = originalExit;
+}
+
+// ─── requireOption ───────────────────────────────────────────────────────────
+
+describe('requireOption', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  test('returns the value when present', () => {
+    assert.strictEqual(requireOption('hello', 'name'), 'hello');
+  });
+
+  test('exits when value is undefined', () => {
+    assert.throws(
+      () => requireOption(undefined, 'name'),
+      /process\.exit\(1\)/,
+    );
+    assert.ok(errorSpy.some(l => l.includes('--name is required')));
+  });
+
+  test('exits when value is empty string', () => {
+    assert.throws(
+      () => requireOption('', 'name'),
+      /process\.exit\(1\)/,
+    );
+    assert.ok(errorSpy.some(l => l.includes('--name is required')));
+  });
+});
+
+// ─── requireEnum ─────────────────────────────────────────────────────────────
+
+describe('requireEnum', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  test('returns the matched value for a valid enum member', () => {
+    const result = requireEnum('RED', ColorEnum, 'color');
+    assert.strictEqual(result, 'RED');
+  });
+
+  test('returns correctly typed value for each member', () => {
+    assert.strictEqual(requireEnum('GREEN', ColorEnum, 'color'), 'GREEN');
+    assert.strictEqual(requireEnum('BLUE', ColorEnum, 'color'), 'BLUE');
+  });
+
+  test('exits on invalid value with error listing valid values', () => {
+    assert.throws(
+      () => requireEnum('PURPLE', ColorEnum, 'color'),
+      /process\.exit\(1\)/,
+    );
+    assert.ok(errorSpy.some(l => l.includes('Invalid --color "PURPLE"')));
+    assert.ok(errorSpy.some(l => l.includes('RED')));
+    assert.ok(errorSpy.some(l => l.includes('GREEN')));
+    assert.ok(errorSpy.some(l => l.includes('BLUE')));
+  });
+
+  test('is case-sensitive', () => {
+    assert.throws(
+      () => requireEnum('red', ColorEnum, 'color'),
+      /process\.exit\(1\)/,
+    );
+  });
+});
+
+// ─── requireCsvEnum ──────────────────────────────────────────────────────────
+
+describe('requireCsvEnum', () => {
+  beforeEach(setup);
+  afterEach(teardown);
+
+  test('returns array of matched values for valid CSV', () => {
+    const result = requireCsvEnum('RED,GREEN', ColorEnum, 'colors');
+    assert.deepStrictEqual(result, ['RED', 'GREEN']);
+  });
+
+  test('handles single value (no commas)', () => {
+    const result = requireCsvEnum('BLUE', ColorEnum, 'colors');
+    assert.deepStrictEqual(result, ['BLUE']);
+  });
+
+  test('trims whitespace around values', () => {
+    const result = requireCsvEnum('RED , GREEN , BLUE', ColorEnum, 'colors');
+    assert.deepStrictEqual(result, ['RED', 'GREEN', 'BLUE']);
+  });
+
+  test('filters empty strings from trailing commas', () => {
+    const result = requireCsvEnum('RED,GREEN,', ColorEnum, 'colors');
+    assert.deepStrictEqual(result, ['RED', 'GREEN']);
+  });
+
+  test('filters empty strings from leading commas', () => {
+    const result = requireCsvEnum(',RED,GREEN', ColorEnum, 'colors');
+    assert.deepStrictEqual(result, ['RED', 'GREEN']);
+  });
+
+  test('filters whitespace-only items', () => {
+    const result = requireCsvEnum('RED, ,GREEN', ColorEnum, 'colors');
+    assert.deepStrictEqual(result, ['RED', 'GREEN']);
+  });
+
+  test('exits on invalid value listing all invalid items', () => {
+    assert.throws(
+      () => requireCsvEnum('RED,PURPLE,YELLOW', ColorEnum, 'colors'),
+      /process\.exit\(1\)/,
+    );
+    assert.ok(errorSpy.some(l => l.includes('Invalid --colors: PURPLE, YELLOW')));
+    assert.ok(errorSpy.some(l => l.includes('Valid values:')));
+  });
+
+  test('exits when all values are invalid', () => {
+    assert.throws(
+      () => requireCsvEnum('PURPLE,YELLOW', ColorEnum, 'colors'),
+      /process\.exit\(1\)/,
+    );
+    assert.ok(errorSpy.some(l => l.includes('PURPLE')));
+    assert.ok(errorSpy.some(l => l.includes('YELLOW')));
+  });
+});

--- a/tests/unit/identity-authorization-cli.test.ts
+++ b/tests/unit/identity-authorization-cli.test.ts
@@ -1,0 +1,170 @@
+/**
+ * CLI behavioral tests for identity authorization commands.
+ *
+ * These tests exercise the full dispatch path by spawning the CLI
+ * as a subprocess with --dry-run. They verify that CLI flags flow
+ * correctly through index.ts dispatch → validation → handler → JSON output.
+ *
+ * This catches wiring regressions in index.ts (e.g., missing str(values.X))
+ * that direct-call unit tests cannot detect.
+ */
+
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { asyncSpawn, type SpawnResult } from '../utils/spawn.ts';
+
+const CLI = 'src/index.ts';
+
+async function c8(...args: string[]): Promise<SpawnResult> {
+  return asyncSpawn('node', ['--experimental-strip-types', CLI, ...args], {
+    env: {
+      ...process.env,
+      CAMUNDA_BASE_URL: 'http://test-cluster/v2',
+      // Suppress any profile file lookup
+      HOME: '/tmp/c8ctl-test-nonexistent-home',
+    },
+  });
+}
+
+function parseJson(result: SpawnResult): Record<string, unknown> {
+  try {
+    return JSON.parse(result.stdout);
+  } catch {
+    throw new Error(`Failed to parse JSON from stdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  }
+}
+
+// ─── create authorization ────────────────────────────────────────────────────
+
+describe('CLI behavioral: create authorization', () => {
+
+  test('--dry-run emits correct JSON body shape with all fields', async () => {
+    const result = await c8(
+      'create', 'authorization',
+      '--dry-run',
+      '--ownerId', 'alice',
+      '--ownerType', 'USER',
+      '--resourceType', 'PROCESS_DEFINITION',
+      '--resourceId', 'my-process',
+      '--permissions', 'READ,UPDATE',
+    );
+
+    assert.strictEqual(result.status, 0, `CLI exited with ${result.status}\nstderr: ${result.stderr}`);
+    const out = parseJson(result);
+
+    assert.strictEqual(out.dryRun, true);
+    assert.strictEqual(out.method, 'POST');
+    assert.ok((out.url as string).endsWith('/authorizations'));
+
+    const body = out.body as Record<string, unknown>;
+    assert.strictEqual(body.ownerId, 'alice');
+    assert.strictEqual(body.ownerType, 'USER');
+    assert.strictEqual(body.resourceType, 'PROCESS_DEFINITION');
+    assert.strictEqual(body.resourceId, 'my-process');
+    assert.deepStrictEqual(body.permissionTypes, ['READ', 'UPDATE']);
+  });
+
+  test('--dry-run trims whitespace in permissions CSV', async () => {
+    const result = await c8(
+      'create', 'authorization',
+      '--dry-run',
+      '--ownerId', 'bob',
+      '--ownerType', 'CLIENT',
+      '--resourceType', 'DECISION_DEFINITION',
+      '--resourceId', '*',
+      '--permissions', ' READ , UPDATE , DELETE ',
+    );
+
+    assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+    const body = parseJson(result).body as Record<string, unknown>;
+    assert.deepStrictEqual(body.permissionTypes, ['READ', 'UPDATE', 'DELETE']);
+  });
+
+  test('rejects invalid --ownerType with exit code 1', async () => {
+    const result = await c8(
+      'create', 'authorization',
+      '--ownerId', 'alice',
+      '--ownerType', 'BOGUS',
+      '--resourceType', 'PROCESS_DEFINITION',
+      '--resourceId', 'r',
+      '--permissions', 'READ',
+    );
+
+    assert.strictEqual(result.status, 1);
+    assert.ok(result.stderr.includes('Invalid --ownerType "BOGUS"'), `stderr: ${result.stderr}`);
+    assert.ok(result.stderr.includes('Valid values:'), `stderr: ${result.stderr}`);
+  });
+
+  test('rejects invalid --resourceType with exit code 1', async () => {
+    const result = await c8(
+      'create', 'authorization',
+      '--ownerId', 'alice',
+      '--ownerType', 'USER',
+      '--resourceType', 'NOPE',
+      '--resourceId', 'r',
+      '--permissions', 'READ',
+    );
+
+    assert.strictEqual(result.status, 1);
+    assert.ok(result.stderr.includes('Invalid --resourceType "NOPE"'), `stderr: ${result.stderr}`);
+  });
+
+  test('rejects invalid --permissions with exit code 1', async () => {
+    const result = await c8(
+      'create', 'authorization',
+      '--ownerId', 'alice',
+      '--ownerType', 'USER',
+      '--resourceType', 'PROCESS_DEFINITION',
+      '--resourceId', 'r',
+      '--permissions', 'READ,BOGUS',
+    );
+
+    assert.strictEqual(result.status, 1);
+    assert.ok(result.stderr.includes('Invalid --permissions: BOGUS'), `stderr: ${result.stderr}`);
+  });
+
+  test('rejects missing --ownerId with exit code 1', async () => {
+    const result = await c8(
+      'create', 'authorization',
+      '--ownerType', 'USER',
+      '--resourceType', 'PROCESS_DEFINITION',
+      '--resourceId', 'r',
+      '--permissions', 'READ',
+    );
+
+    assert.strictEqual(result.status, 1);
+    assert.ok(result.stderr.includes('--ownerId is required'), `stderr: ${result.stderr}`);
+  });
+
+  test('rejects missing --permissions with exit code 1', async () => {
+    const result = await c8(
+      'create', 'authorization',
+      '--ownerId', 'alice',
+      '--ownerType', 'USER',
+      '--resourceType', 'PROCESS_DEFINITION',
+      '--resourceId', 'r',
+    );
+
+    assert.strictEqual(result.status, 1);
+    assert.ok(result.stderr.includes('--permissions is required'), `stderr: ${result.stderr}`);
+  });
+});
+
+// ─── delete authorization ────────────────────────────────────────────────────
+
+describe('CLI behavioral: delete authorization', () => {
+
+  test('--dry-run emits DELETE to /authorizations/:key', async () => {
+    const result = await c8(
+      'delete', 'authorization',
+      '--dry-run',
+      'auth-key-42',
+    );
+
+    assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+    const out = parseJson(result);
+    assert.strictEqual(out.dryRun, true);
+    assert.strictEqual(out.method, 'DELETE');
+    assert.ok((out.url as string).endsWith('/authorizations/auth-key-42'));
+  });
+});

--- a/tests/unit/identity.test.ts
+++ b/tests/unit/identity.test.ts
@@ -11,7 +11,7 @@ import { createIdentityRole, deleteIdentityRole } from '../../src/commands/ident
 import { createIdentityGroup, deleteIdentityGroup } from '../../src/commands/identity-groups.ts';
 import { createIdentityTenant, deleteIdentityTenant } from '../../src/commands/identity-tenants.ts';
 import { createIdentityMappingRule, deleteIdentityMappingRule } from '../../src/commands/identity-mapping-rules.ts';
-import { createIdentityAuthorization, deleteIdentityAuthorization } from '../../src/commands/identity-authorizations.ts';
+import { createIdentityAuthorization, deleteIdentityAuthorization, validateCreateAuthorizationOptions } from '../../src/commands/identity-authorizations.ts';
 import { handleAssign, handleUnassign } from '../../src/commands/identity.ts';
 
 const TEST_BASE_URL = 'http://test-cluster/v2';
@@ -145,37 +145,78 @@ describe('Identity Commands — required-flag validation', () => {
     assert.ok(errorSpy.some(l => l.includes('--claimValue is required')));
   });
 
-  // createIdentityAuthorization
+  // createIdentityAuthorization — validation now lives in validateCreateAuthorizationOptions
   test('createIdentityAuthorization: errors when --ownerId is missing', async () => {
-    await assert.rejects(
-      () => createIdentityAuthorization({ ownerType: 'USER', resourceType: 'PROCESS_DEFINITION', resourceId: 'r', permissions: 'READ' }),
+    assert.throws(
+      () => validateCreateAuthorizationOptions({ ownerType: 'USER', resourceType: 'PROCESS_DEFINITION', resourceId: 'r', permissions: 'READ' }),
       /process\.exit\(1\)/,
     );
     assert.ok(errorSpy.some(l => l.includes('--ownerId is required')));
   });
 
   test('createIdentityAuthorization: errors when --ownerType is missing', async () => {
-    await assert.rejects(
-      () => createIdentityAuthorization({ ownerId: 'alice', resourceType: 'PROCESS_DEFINITION', resourceId: 'r', permissions: 'READ' }),
+    assert.throws(
+      () => validateCreateAuthorizationOptions({ ownerId: 'alice', resourceType: 'PROCESS_DEFINITION', resourceId: 'r', permissions: 'READ' }),
       /process\.exit\(1\)/,
     );
     assert.ok(errorSpy.some(l => l.includes('--ownerType is required')));
   });
 
   test('createIdentityAuthorization: errors when --resourceId is missing', async () => {
-    await assert.rejects(
-      () => createIdentityAuthorization({ ownerId: 'alice', ownerType: 'USER', resourceType: 'PROCESS_DEFINITION', permissions: 'READ' }),
+    assert.throws(
+      () => validateCreateAuthorizationOptions({ ownerId: 'alice', ownerType: 'USER', resourceType: 'PROCESS_DEFINITION', permissions: 'READ' }),
       /process\.exit\(1\)/,
     );
     assert.ok(errorSpy.some(l => l.includes('--resourceId is required')));
   });
 
   test('createIdentityAuthorization: errors when --permissions is missing', async () => {
-    await assert.rejects(
-      () => createIdentityAuthorization({ ownerId: 'alice', ownerType: 'USER', resourceType: 'PROCESS_DEFINITION', resourceId: 'r' }),
+    assert.throws(
+      () => validateCreateAuthorizationOptions({ ownerId: 'alice', ownerType: 'USER', resourceType: 'PROCESS_DEFINITION', resourceId: 'r' }),
       /process\.exit\(1\)/,
     );
     assert.ok(errorSpy.some(l => l.includes('--permissions is required')));
+  });
+
+  // Enum validation — invalid values rejected with valid-values listing
+  test('createIdentityAuthorization: errors on invalid --ownerType', async () => {
+    assert.throws(
+      () => validateCreateAuthorizationOptions({ ownerId: 'alice', ownerType: 'BOGUS', resourceType: 'PROCESS_DEFINITION', resourceId: 'r', permissions: 'READ' }),
+      /process\.exit\(1\)/,
+    );
+    assert.ok(errorSpy.some(l => l.includes('Invalid --ownerType "BOGUS"')));
+    assert.ok(errorSpy.some(l => l.includes('Valid values:')));
+  });
+
+  test('createIdentityAuthorization: errors on invalid --resourceType', async () => {
+    assert.throws(
+      () => validateCreateAuthorizationOptions({ ownerId: 'alice', ownerType: 'USER', resourceType: 'NOPE', resourceId: 'r', permissions: 'READ' }),
+      /process\.exit\(1\)/,
+    );
+    assert.ok(errorSpy.some(l => l.includes('Invalid --resourceType "NOPE"')));
+  });
+
+  test('createIdentityAuthorization: errors on invalid --permissions', async () => {
+    assert.throws(
+      () => validateCreateAuthorizationOptions({ ownerId: 'alice', ownerType: 'USER', resourceType: 'PROCESS_DEFINITION', resourceId: 'r', permissions: 'READ,BOGUS' }),
+      /process\.exit\(1\)/,
+    );
+    assert.ok(errorSpy.some(l => l.includes('Invalid --permissions: BOGUS')));
+  });
+
+  test('createIdentityAuthorization: accepts valid enum values', () => {
+    const result = validateCreateAuthorizationOptions({
+      ownerId: 'alice',
+      ownerType: 'USER',
+      resourceType: 'PROCESS_DEFINITION',
+      resourceId: 'my-process',
+      permissions: 'READ,UPDATE',
+    });
+    assert.strictEqual(result.ownerId, 'alice');
+    assert.strictEqual(result.ownerType, 'USER');
+    assert.strictEqual(result.resourceType, 'PROCESS_DEFINITION');
+    assert.strictEqual(result.resourceId, 'my-process');
+    assert.deepStrictEqual(result.permissionTypes, ['READ', 'UPDATE']);
   });
 });
 
@@ -260,13 +301,14 @@ describe('Identity Commands — dry-run output', () => {
   });
 
   test('createIdentityAuthorization: emits POST to /authorizations with permissionTypes array', async () => {
-    await createIdentityAuthorization({
+    const validated = validateCreateAuthorizationOptions({
       ownerId: 'alice',
       ownerType: 'USER',
       resourceType: 'PROCESS_DEFINITION',
       resourceId: 'my-process',
       permissions: 'READ,UPDATE',
     });
+    await createIdentityAuthorization(validated);
 
     const out = capturedJson();
     assert.strictEqual(out.dryRun, true);

--- a/tests/unit/identity.test.ts
+++ b/tests/unit/identity.test.ts
@@ -170,6 +170,14 @@ describe('Identity Commands — required-flag validation', () => {
     assert.ok(errorSpy.some(l => l.includes('--resourceId is required')));
   });
 
+  test('createIdentityAuthorization: errors when --resourceType is missing', async () => {
+    assert.throws(
+      () => validateCreateAuthorizationOptions({ ownerId: 'alice', ownerType: 'USER', resourceId: 'r', permissions: 'READ' }),
+      /process\.exit\(1\)/,
+    );
+    assert.ok(errorSpy.some(l => l.includes('--resourceType is required')));
+  });
+
   test('createIdentityAuthorization: errors when --permissions is missing', async () => {
     assert.throws(
       () => validateCreateAuthorizationOptions({ ownerId: 'alice', ownerType: 'USER', resourceType: 'PROCESS_DEFINITION', resourceId: 'r' }),

--- a/tests/unit/open.test.ts
+++ b/tests/unit/open.test.ts
@@ -7,7 +7,7 @@ import assert from 'node:assert';
 import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { deriveAppUrl, getBrowserCommand, openApp, OPEN_APPS } from '../../src/commands/open.ts';
+import { deriveAppUrl, getBrowserCommand, openApp, validateOpenAppOptions, OPEN_APPS } from '../../src/commands/open.ts';
 
 const CLI_ENTRY = join(process.cwd(), 'src', 'index.ts');
 
@@ -131,20 +131,20 @@ describe('open command', () => {
 
     test('exits with error when app is undefined', async () => {
       try {
-        await openApp(undefined, {});
+        validateOpenAppOptions(undefined, {});
         assert.fail('Should have thrown');
       } catch (e: any) {
         assert.ok(e.message.includes('process.exit(1)'));
         assert.strictEqual(exitCode, 1);
       }
       const errorOutput = consoleErrorSpy.join('\n');
-      assert.ok(errorOutput.includes('Application required'));
-      assert.ok(errorOutput.includes('operate'));
+      assert.ok(errorOutput.includes('Application'));
+      assert.ok(errorOutput.includes('required'));
     });
 
     test('exits with error for invalid app name', async () => {
       try {
-        await openApp('console', {});
+        validateOpenAppOptions('console', {});
         assert.fail('Should have thrown');
       } catch (e: any) {
         assert.ok(e.message.includes('process.exit(1)'));
@@ -156,11 +156,19 @@ describe('open command', () => {
 
     test('shows usage hint on invalid app', async () => {
       try {
-        await openApp('invalid', {});
+        validateOpenAppOptions('invalid', {});
       } catch { /* expected */ }
       const allOutput = consoleLogSpy.join('\n') + consoleErrorSpy.join('\n');
       assert.ok(allOutput.includes('Usage: c8 open <app>') || allOutput.includes('c8 open <app>'),
         `Expected usage hint, got:\nstdout: ${consoleLogSpy.join('\n')}\nstderr: ${consoleErrorSpy.join('\n')}`);
+    });
+
+    test('accepts valid app names', () => {
+      for (const app of OPEN_APPS) {
+        const result = validateOpenAppOptions(app, { profile: 'test' });
+        assert.strictEqual(result.app, app);
+        assert.strictEqual(result.profile, 'test');
+      }
     });
   });
 
@@ -177,7 +185,7 @@ describe('open command', () => {
       });
 
       const output = (result.stdout ?? '') + (result.stderr ?? '');
-      assert.ok(output.includes('Application required'), `Expected error message, got: ${output}`);
+      assert.ok(output.includes('Application is required'), `Expected error message, got: ${output}`);
       assert.notStrictEqual(result.status, 0, 'Should exit with non-zero status');
     });
 

--- a/tests/unit/open.test.ts
+++ b/tests/unit/open.test.ts
@@ -7,7 +7,7 @@ import assert from 'node:assert';
 import { spawnSync } from 'node:child_process';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { deriveAppUrl, getBrowserCommand, openApp, validateOpenAppOptions, OPEN_APPS } from '../../src/commands/open.ts';
+import { deriveAppUrl, getBrowserCommand, validateOpenAppOptions, OPEN_APPS } from '../../src/commands/open.ts';
 
 const CLI_ENTRY = join(process.cwd(), 'src', 'index.ts');
 


### PR DESCRIPTION
## Summary

Introduces a **command-validation architectural layer** (`src/command-validation.ts`) that validates and type-narrows CLI string inputs before they reach command handlers. Handlers receive already-validated, properly-typed inputs — no internal validation needed.

Refactors both `identity-authorizations` and `open` commands to use boundary validation.

Closes #218

## Architecture

```
parseArgs()
  ↓
#213 (future): requireResource(verb, resource)      ← dispatch guard
  ↓
#212 (future): validateAcceptedFlags(values, ...)    ← dispatch guard
  ↓
#218 (this PR): validateXxxOptions(raw)              ← per-command validation
  ↓
handler(validated)                                   ← implementation
```

Each layer uses utilities from `command-validation.ts`. The module is designed as the extension point for #212 and #213.

## `src/command-validation.ts` — Boundary validation utilities

| Function | Purpose | Extension point |
|---|---|---|
| `requireOption(value, flag)` | Validate required `--flag` presence | Used by all commands |
| `requireEnum<T>(value, enumObj, flag)` | Validate + narrow to SDK enum type | #218 |
| `requireCsvEnum<T>(value, enumObj, flag)` | Validate + narrow CSV to enum array | #218 |
| `requirePositional(value, label, hint?)` | Validate required positional arg | #218 |
| `requireOneOf<T>(value, allowed, label, hint?)` | Validate + narrow to tuple member | #218 |
| *(future)* `validateAcceptedFlags()` | Detect unknown flags per verb×resource | #212 |
| *(future)* `requireResource()` | Validate resource arg before dispatch | #213 |

### Zero `as T` casts

Uses `Object.values(enumObj).find(v => v === value)` for enum validation and `allowed.find(v => v === value)` for tuple validation. Both return `T | undefined`. After `process.exit(1)` on `undefined`, TypeScript narrows to `T`. No casts, no `biome-ignore` suppressions anywhere.

## Changes

### `src/command-validation.ts` (new)
- `requireOption()` — exits with `--flag is required`
- `requireEnum()` — exits with `Invalid --flag "X". Valid values: ...`
- `requireCsvEnum()` — exits with `Invalid --flag: X, Y. Valid values: ...`
- `requirePositional()` — exits with `Label is required` + optional usage hint
- `requireOneOf()` — exits with `Unknown label 'X'. Available: ...` + optional usage hint

### `src/commands/identity-authorizations.ts`
- **Removed**: 3 inline type guard functions (`isOwnerType`, `isResourceType`, `isPermissionType`)
- **Removed**: all validation logic from `createIdentityAuthorization` handler
- **Removed**: 3 `biome-ignore lint/plugin:` suppressions for `as T` casts
- **Added**: `CreateAuthorizationInput` interface with validated types
- **Added**: `validateCreateAuthorizationOptions()` — raw options → validated input
- **Changed**: `createIdentityAuthorization()` now accepts `CreateAuthorizationInput` (non-optional, typed fields)

### `src/commands/open.ts`
- **Removed**: inline `if (!app)` / `if (!isAppName(app))` validation from handler
- **Added**: `OpenAppInput` interface with validated types
- **Added**: `validateOpenAppOptions()` — raw positional + options → validated input
- **Changed**: `openApp()` now accepts `OpenAppInput` (single validated object)

### `src/index.ts`
- Dispatch points now use two-step validate-then-handle pattern:
  - `validateCreateAuthorizationOptions()` → `createIdentityAuthorization(validated)`
  - `validateOpenAppOptions()` → `openApp(validated)`

### Tests

#### `tests/unit/command-validation.test.ts` (new) — 23 tests
- Direct unit tests for all 5 validation utilities
- Covers: valid input passthrough, missing/empty rejection, invalid enum/value rejection, case sensitivity, CSV edge cases (whitespace, trailing commas), hint output

#### `tests/unit/identity.test.ts` — updated
- Validation tests now call `validateCreateAuthorizationOptions()` directly (sync `assert.throws`)
- Added enum validation tests: invalid `--ownerType`, `--resourceType`, `--permissions` rejected with valid-values listing
- Added `--resourceType` required-field test (was missing)
- Added positive test: valid enum values pass through correctly

#### `tests/unit/identity-authorization-cli.test.ts` (new) — 8 tests
- CLI behavioral tests spawning subprocess with `--dry-run`
- Covers: body shape, CSV trimming, enum rejection (ownerType, resourceType, permissions), missing-field rejection, DELETE URL shape

#### `tests/unit/open.test.ts` — updated
- Updated `openApp` tests to call `validateOpenAppOptions()` (where validation now lives)
- Added positive test: all valid app names accepted
- Existing CLI integration tests with `--dry-run` all pass (7 tests: all 4 apps, invalid app, missing app, Cloud URL)

## Verification

- `npx tsc --noEmit` — clean
- `npx biome check src/ tests/` — clean (zero suppressions, zero diagnostics)
- `node --test` — 825 tests, 824 pass, 0 fail, 1 skipped