### PR TITLE
chore(cluster): set stable alias to 8.9

### DIFF
--- a/default-plugins/cluster/package.json
+++ b/default-plugins/cluster/package.json
@@ -7,7 +7,7 @@
   "main": "c8ctl-plugin.js",
   "c8ctl": {
     "versionAliases": {
-      "stable": "8.8",
+      "stable": "8.9",
       "alpha": "8.9"
     }
   }


### PR DESCRIPTION
* 8.9 was released as stable today
* keeping 8.9 also as alpha as there is no 8.10 alpha yet. Will update this in a month