### PR TITLE
fix: stable alias resolves to 8.8 after 8.9 GA release

### DIFF
--- a/default-plugins/cluster/README.md
+++ b/default-plugins/cluster/README.md
@@ -8,7 +8,7 @@ A default [c8ctl](https://github.com/camunda/c8ctl) plugin that provides an opin
 # Start with a specific version
 c8ctl cluster start 8.9.0-alpha5
 
-# Start using a version alias (dynamically resolved)
+# Start using a version alias
 c8ctl cluster start stable
 c8ctl cluster start alpha
 

--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -140,24 +140,27 @@ async function getDynamicAliases() {
   return _dynamicAliases;
 }
 
-async function resolveVersion(versionSpec, { preferLocal = false, cacheDir } = {}) {
+async function resolveVersion(versionSpec, { cacheDir } = {}) {
   if (!isVersionAlias(versionSpec)) return versionSpec;
 
-  // When preferLocal is set (e.g. start), try the persisted alias mapping first
-  if (preferLocal && cacheDir) {
+  const dynamic = await getDynamicAliases();
+
+  if (dynamic?.[versionSpec]) {
+    // Remote discovery succeeded — use it and persist for offline use
+    if (cacheDir) {
+      storeLocalAliasMapping(cacheDir, versionSpec, dynamic[versionSpec]);
+    }
+    return dynamic[versionSpec];
+  }
+
+  // Remote unavailable — fall back to persisted alias if the version is installed
+  if (cacheDir) {
     const local = readLocalAliasMapping(cacheDir, versionSpec);
     if (local) return local;
   }
 
-  const dynamic = await getDynamicAliases();
-  const resolved = dynamic?.[versionSpec] ?? _fallbackAliases[versionSpec] ?? versionSpec;
-
-  // Persist the resolved mapping for future offline use
-  if (cacheDir && dynamic?.[versionSpec]) {
-    storeLocalAliasMapping(cacheDir, versionSpec, resolved);
-  }
-
-  return resolved;
+  // Last resort: hardcoded fallback from package.json
+  return _fallbackAliases[versionSpec] ?? versionSpec;
 }
 
 function getAliasMappingPath(cacheDir, alias) {
@@ -1430,8 +1433,6 @@ export const commands = {
     }
     const theCacheDir = getCacheDir();
     const version = await resolveVersion(versionSpec, {
-      // start: prefer locally-cached alias mapping to avoid a network fetch when already installed
-      preferLocal: parsed.subcommand === 'start',
       cacheDir: theCacheDir,
     });
     if (isVersionAlias(versionSpec)) {

--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -131,7 +131,7 @@ async function getDynamicAliases() {
   return _dynamicAliases;
 }
 
-async function resolveVersion(versionSpec, { preferLocal = false, cacheDir } = {}) {
+export async function resolveVersion(versionSpec, { preferLocal = false, cacheDir } = {}) {
   if (!isVersionAlias(versionSpec)) return versionSpec;
 
   // start: use cached alias if the version is installed (deterministic)
@@ -178,7 +178,7 @@ function readLocalAliasMapping(cacheDir, alias) {
   }
 }
 
-function storeLocalAliasMapping(cacheDir, alias, resolved) {
+export function storeLocalAliasMapping(cacheDir, alias, resolved) {
   try {
     mkdirSync(cacheDir, { recursive: true });
     writeFileSync(getAliasMappingPath(cacheDir, alias), resolved);
@@ -1139,9 +1139,11 @@ export async function deleteVersion(cacheDir, versionSpec) {
   validateVersionSpec(versionSpec);
 
   // Resolve named aliases (stable/alpha) to the actual cached version name.
+  // Use preferLocal so we delete the version that's actually installed,
+  // not whatever the remote currently resolves the alias to.
   // Major.minor patterns like 8.8 are used as-is since the cache dir is named c8run-8.8.
   const resolvedVersion = isVersionAlias(versionSpec)
-    ? await resolveVersion(versionSpec)
+    ? await resolveVersion(versionSpec, { preferLocal: true, cacheDir })
     : versionSpec;
 
   // Prevent deleting a currently running version

--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -193,6 +193,15 @@ async function getVersionAliasEntries() {
   return Object.entries(aliases);
 }
 
+/**
+ * Synchronous variant that uses only the cached discovery result or fallback.
+ * Used for help output so it never blocks on a network request.
+ */
+function getVersionAliasEntriesSync() {
+  const aliases = _dynamicAliases || _fallbackAliases;
+  return Object.entries(aliases);
+}
+
 /** Reset the cached dynamic aliases (for testing). */
 export function _resetDynamicAliasCache() {
   _dynamicAliases = undefined;
@@ -1335,15 +1344,15 @@ export const commands = {
       console.log('  --debug                Stream raw c8run output during start');
       console.log('');
       console.log('A <version> can be:');
-      console.log('  stable / alpha         Named aliases (resolved to latest)');
+      console.log('  stable / alpha         Named aliases');
       console.log('  8.8, 8.9               Major.minor — rolling release for that minor');
       console.log('  8.9.0-alpha5           Exact pinned version');
       console.log('');
-      console.log('  start uses a local version if available (no remote check).');
+      console.log('  start uses a locally installed version if available.');
       console.log('  install always checks the remote for a newer rolling release.');
       console.log('');
-      console.log('Version aliases:')
-      for (const [alias, resolved] of await getVersionAliasEntries()) {
+      console.log('Version aliases:');
+      for (const [alias, resolved] of getVersionAliasEntriesSync()) {
         console.log(`  ${alias.padEnd(ALIAS_COLUMN_WIDTH)} → ${resolved}`);
       }
       console.log('');
@@ -1445,9 +1454,15 @@ export const commands = {
     // For start with a named alias, check in the background whether the
     // remote resolves to a different (newer) version and hint if so.
     if (isStart && isVersionAlias(versionSpec)) {
-      getDynamicAliases()
-        .then((dynamic) => {
-          const remoteVersion = dynamic?.[versionSpec];
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 5000);
+      fetch(DOWNLOAD_BASE_URL, { signal: controller.signal })
+        .then((res) => res.ok ? res.text() : null)
+        .then((html) => {
+          clearTimeout(timeoutId);
+          if (!html) return;
+          const remote = parseVersionsFromHtml(html);
+          const remoteVersion = remote?.[versionSpec];
           if (remoteVersion && remoteVersion !== version) {
             // Update the persisted mapping so the next `cluster install` uses it
             storeLocalAliasMapping(theCacheDir, versionSpec, remoteVersion);
@@ -1458,7 +1473,8 @@ export const commands = {
           }
         })
         .catch(() => {
-          // Offline or timeout — don't bother the user
+          clearTimeout(timeoutId);
+          // Offline — don't bother the user
         });
     }
     const rolling = isRollingVersion(versionSpec);

--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -82,8 +82,9 @@ export async function discoverLatestVersions() {
  *   updated in-place.
  * - An alpha train exists when there are "X.Y.0-alphaN/" directories
  *   for a given minor that has NOT yet shipped a GA release (X.Y.0/).
- *   The highest such minor is the alpha alias.
- * - The highest minor that is NOT the alpha train is the stable alias.
+ *   The highest such minor is the alpha train.
+ * - stable = highest minor that is NOT in the alpha train.
+ * - alpha  = highest minor overall (regardless of alpha train membership).
  */
 export function parseVersionsFromHtml(html) {
   // Match minor-version directories like "8.8/", "8.9/"
@@ -111,18 +112,8 @@ export function parseVersionsFromHtml(html) {
 
   const highestMinor = sortedMinors[sortedMinors.length - 1];
 
-  // The alpha train is the highest minor that has alpha directories
-  // but has not yet shipped a GA release.
-  // The stable release is the highest minor that is NOT the alpha train.
-  const highestAlphaMinor = [...alphaSet].sort(compareSemver).pop();
-
-  let stable;
-  if (highestAlphaMinor) {
-    // Stable = the highest minor that is lower than the alpha train
-    stable = sortedMinors.filter(v => compareSemver(v, highestAlphaMinor) < 0).pop() || highestMinor;
-  } else {
-    stable = highestMinor;
-  }
+  // Stable = highest minor that is NOT in the alpha train
+  const stable = sortedMinors.filter(v => !alphaSet.has(v)).pop() || highestMinor;
 
   return {
     stable,

--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -81,14 +81,17 @@ export async function discoverLatestVersions() {
  * - Minor version directories (e.g. "8.8/", "8.9/") are rolling releases
  *   updated in-place.
  * - An alpha train exists when there are "X.Y.0-alphaN/" directories
- *   for a given minor. The highest minor with alphas is the alpha alias.
- * - The highest minor without alphas is the stable alias.
+ *   for a given minor that has NOT yet shipped a GA release (X.Y.0/).
+ *   The highest such minor is the alpha alias.
+ * - The highest minor that is NOT the alpha train is the stable alias.
  */
 export function parseVersionsFromHtml(html) {
   // Match minor-version directories like "8.8/", "8.9/"
   const minorMatches = [...html.matchAll(/href="(\d+\.\d+)\/"/g)].map(m => m[1]);
   // Match alpha directories like "8.9.0-alpha5/"
   const alphaMatches = [...html.matchAll(/href="(\d+\.\d+)\.0-alpha\d+\/"/g)].map(m => m[1]);
+  // Match GA release directories like "8.9.0/"
+  const gaMatches = [...html.matchAll(/href="(\d+\.\d+)\.0\/"/g)].map(m => m[1]);
 
   if (minorMatches.length === 0) return null;
 
@@ -99,13 +102,18 @@ export function parseVersionsFromHtml(html) {
   };
 
   const sortedMinors = [...new Set(minorMatches)].sort(compareSemver);
-  const alphaSet = new Set(alphaMatches);
+  const gaSet = new Set(gaMatches);
+
+  // A minor is only in the alpha train if it has alpha dirs but NO GA release yet.
+  // Once X.Y.0/ exists, that minor has graduated.
+  const alphaOnlyMinors = [...new Set(alphaMatches)].filter(v => !gaSet.has(v));
+  const alphaSet = new Set(alphaOnlyMinors);
 
   const highestMinor = sortedMinors[sortedMinors.length - 1];
 
-  // The alpha train is the highest minor that has alpha directories.
-  // The stable release is the minor just below the alpha train,
-  // or the highest minor if no alpha train exists.
+  // The alpha train is the highest minor that has alpha directories
+  // but has not yet shipped a GA release.
+  // The stable release is the highest minor that is NOT the alpha train.
   const highestAlphaMinor = [...alphaSet].sort(compareSemver).pop();
 
   let stable;

--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -140,13 +140,20 @@ async function getDynamicAliases() {
   return _dynamicAliases;
 }
 
-async function resolveVersion(versionSpec, { cacheDir } = {}) {
+async function resolveVersion(versionSpec, { preferLocal = false, cacheDir } = {}) {
   if (!isVersionAlias(versionSpec)) return versionSpec;
 
+  // start: use cached alias if the version is installed (deterministic)
+  if (preferLocal && cacheDir) {
+    const local = readLocalAliasMapping(cacheDir, versionSpec);
+    if (local) return local;
+  }
+
+  // Try remote discovery
   const dynamic = await getDynamicAliases();
 
   if (dynamic?.[versionSpec]) {
-    // Remote discovery succeeded — use it and persist for offline use
+    // Persist for offline use and future preferLocal lookups
     if (cacheDir) {
       storeLocalAliasMapping(cacheDir, versionSpec, dynamic[versionSpec]);
     }
@@ -154,7 +161,7 @@ async function resolveVersion(versionSpec, { cacheDir } = {}) {
   }
 
   // Remote unavailable — fall back to persisted alias if the version is installed
-  if (cacheDir) {
+  if (!preferLocal && cacheDir) {
     const local = readLocalAliasMapping(cacheDir, versionSpec);
     if (local) return local;
   }
@@ -1432,11 +1439,34 @@ export const commands = {
       process.exit(1);
     }
     const theCacheDir = getCacheDir();
+    const isStart = parsed.subcommand === 'start';
     const version = await resolveVersion(versionSpec, {
+      // start: use cached alias if installed (deterministic behavior)
+      preferLocal: isStart,
       cacheDir: theCacheDir,
     });
     if (isVersionAlias(versionSpec)) {
       logger.info(`Resolved alias "${versionSpec}" → ${version}`);
+    }
+
+    // For start with a named alias, check in the background whether the
+    // remote resolves to a different (newer) version and hint if so.
+    if (isStart && isVersionAlias(versionSpec)) {
+      getDynamicAliases()
+        .then((dynamic) => {
+          const remoteVersion = dynamic?.[versionSpec];
+          if (remoteVersion && remoteVersion !== version) {
+            // Update the persisted mapping so the next `cluster install` uses it
+            storeLocalAliasMapping(theCacheDir, versionSpec, remoteVersion);
+            logger.info(
+              `A newer "${versionSpec}" release is available (${remoteVersion}). ` +
+              `Install it with: c8ctl cluster install ${versionSpec}`,
+            );
+          }
+        })
+        .catch(() => {
+          // Offline or timeout — don't bother the user
+        });
     }
     const rolling = isRollingVersion(versionSpec);
     const config = {

--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -1460,16 +1460,17 @@ export const commands = {
         .then((res) => res.ok ? res.text() : null)
         .then((html) => {
           clearTimeout(timeoutId);
-          if (!html) return;
-          const remote = parseVersionsFromHtml(html);
-          const remoteVersion = remote?.[versionSpec];
-          if (remoteVersion && remoteVersion !== version) {
-            // Update the persisted mapping so the next `cluster install` uses it
-            storeLocalAliasMapping(theCacheDir, versionSpec, remoteVersion);
-            logger.info(
-              `A newer "${versionSpec}" release is available (${remoteVersion}). ` +
-              `Install it with: c8ctl cluster install ${versionSpec}`,
-            );
+          if (html) {
+            const remote = parseVersionsFromHtml(html);
+            const remoteVersion = remote?.[versionSpec];
+            if (remoteVersion && remoteVersion !== version) {
+              // Update the persisted mapping so the next `cluster install` uses it
+              storeLocalAliasMapping(theCacheDir, versionSpec, remoteVersion);
+              logger.info(
+                `A newer "${versionSpec}" release is available (${remoteVersion}). ` +
+                `Install it with: c8ctl cluster install ${versionSpec}`,
+              );
+            }
           }
         })
         .catch(() => {

--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -207,6 +207,52 @@ export function _resetDynamicAliasCache() {
   _dynamicAliases = undefined;
 }
 
+/**
+ * Non-blocking background check: query the remote download server and print
+ * a hint if the remote alias resolves to a different (newer) version.
+ *
+ * Important: does NOT update the persisted alias mapping. The mapping is only
+ * updated when the user explicitly runs `cluster install`, keeping `start`
+ * deterministic across runs.
+ *
+ * Returns the fire-and-forget promise (for testing).
+ */
+export function checkBackgroundAliasFreshness(versionSpec, resolvedVersion) {
+  const logger = getLogger();
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5000);
+  return fireAndForget(
+    fetch(DOWNLOAD_BASE_URL, { signal: controller.signal })
+      .then((res) => res.ok ? res.text() : null)
+      .then((html) => {
+        if (html) {
+          const remote = parseVersionsFromHtml(html);
+          const remoteVersion = remote?.[versionSpec];
+          if (remoteVersion && remoteVersion !== resolvedVersion) {
+            logger.info(
+              `A newer "${versionSpec}" release is available (${remoteVersion}). ` +
+              `Install it with: c8ctl cluster install ${versionSpec}`,
+            );
+          }
+        }
+      })
+      .finally(() => clearTimeout(timeoutId)),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers – fire-and-forget
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a promise without blocking the caller. Errors are always swallowed so
+ * fire-and-forget chains never produce unhandled-rejection warnings.
+ * Returns the guarded promise (useful in tests).
+ */
+function fireAndForget(promise) {
+  return promise.catch(() => {});
+}
+
 // ---------------------------------------------------------------------------
 // Plugin metadata
 // ---------------------------------------------------------------------------
@@ -644,17 +690,16 @@ export async function ensureC8RunInstalled(config) {
       // For rolling versions on start, do a bounded non-blocking check and hint.
       // We store the promise so tests can await it, but we don't block the caller.
       if (config.checkForUpdateHint) {
-        config._hintPromise = hasNewerVersionAvailable(config)
-          .then((hasUpdate) => {
-            if (hasUpdate) {
-              logger.info(
-                `A newer server version is available. Install it with: c8ctl cluster install ${config.version}`,
-              );
-            }
-          })
-          .catch(() => {
-            // Swallow — offline or timeout, don't bother the user
-          });
+        config._hintPromise = fireAndForget(
+          hasNewerVersionAvailable(config)
+            .then((hasUpdate) => {
+              if (hasUpdate) {
+                logger.info(
+                  `A newer server version is available. Install it with: c8ctl cluster install ${config.version}`,
+                );
+              }
+            }),
+        );
       }
 
       return;
@@ -1454,29 +1499,7 @@ export const commands = {
     // For start with a named alias, check in the background whether the
     // remote resolves to a different (newer) version and hint if so.
     if (isStart && isVersionAlias(versionSpec)) {
-      const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 5000);
-      fetch(DOWNLOAD_BASE_URL, { signal: controller.signal })
-        .then((res) => res.ok ? res.text() : null)
-        .then((html) => {
-          clearTimeout(timeoutId);
-          if (html) {
-            const remote = parseVersionsFromHtml(html);
-            const remoteVersion = remote?.[versionSpec];
-            if (remoteVersion && remoteVersion !== version) {
-              // Update the persisted mapping so the next `cluster install` uses it
-              storeLocalAliasMapping(theCacheDir, versionSpec, remoteVersion);
-              logger.info(
-                `A newer "${versionSpec}" release is available (${remoteVersion}). ` +
-                `Install it with: c8ctl cluster install ${versionSpec}`,
-              );
-            }
-          }
-        })
-        .catch(() => {
-          clearTimeout(timeoutId);
-          // Offline — don't bother the user
-        });
+      checkBackgroundAliasFreshness(versionSpec, version);
     }
     const rolling = isRollingVersion(versionSpec);
     const config = {

--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -1058,7 +1058,7 @@ export async function listInstalledVersions(cacheDir) {
   }
 
   console.log('');
-  console.log('Version aliases (dynamically resolved):');
+  console.log('Version aliases:');
   for (const [alias, resolved] of aliasEntries) {
     console.log(`  ${alias.padEnd(ALIAS_COLUMN_WIDTH)} → ${resolved}`);
   }
@@ -1117,7 +1117,7 @@ export async function listRemoteVersions() {
   }
 
   console.log('');
-  console.log('Version aliases (dynamically resolved):');
+  console.log('Version aliases:');
   for (const [alias, resolved] of aliasEntries) {
     console.log(`  ${alias.padEnd(ALIAS_COLUMN_WIDTH)} → ${resolved}`);
   }
@@ -1333,14 +1333,14 @@ export const commands = {
       console.log('  --debug                Stream raw c8run output during start');
       console.log('');
       console.log('A <version> can be:');
-      console.log('  stable / alpha         Named aliases (dynamically resolved to latest)');
+      console.log('  stable / alpha         Named aliases (resolved to latest)');
       console.log('  8.8, 8.9               Major.minor — rolling release for that minor');
       console.log('  8.9.0-alpha5           Exact pinned version');
       console.log('');
       console.log('  start uses a local version if available (no remote check).');
       console.log('  install always checks the remote for a newer rolling release.');
       console.log('');
-      console.log('Version aliases (dynamically resolved):')
+      console.log('Version aliases:')
       for (const [alias, resolved] of await getVersionAliasEntries()) {
         console.log(`  ${alias.padEnd(ALIAS_COLUMN_WIDTH)} → ${resolved}`);
       }

--- a/tests/unit/cluster-plugin.test.ts
+++ b/tests/unit/cluster-plugin.test.ts
@@ -82,17 +82,25 @@ describe('Cluster Plugin – commands export', () => {
 describe('Cluster Plugin – command usage output', () => {
   let captured: string[];
   let originalLog: typeof console.log;
+  let originalFetch: typeof globalThis.fetch;
 
   beforeEach(() => {
     captured = [];
     originalLog = console.log;
+    originalFetch = globalThis.fetch;
     console.log = (...args: unknown[]) => {
       captured.push(args.map(String).join(' '));
     };
+    // Stub fetch so usage tests never hit the network
+    // @ts-expect-error — mock fetch for testing
+    globalThis.fetch = async () => { throw new Error('offline'); };
+    plugin._resetDynamicAliasCache();
   });
 
   afterEach(() => {
     console.log = originalLog;
+    globalThis.fetch = originalFetch;
+    plugin._resetDynamicAliasCache();
   });
 
   test('prints usage when called with no arguments', async () => {
@@ -136,16 +144,9 @@ describe('Cluster Plugin – command usage output', () => {
     await plugin.commands['cluster']([]);
 
     const output = captured.join('\n');
-    assert.ok(output.includes('Version aliases'), 'Should contain a Version aliases section');
+    assert.ok(output.includes('Version aliases:'), 'Should contain a Version aliases section');
     assert.ok(/^\s+alpha\s+→/m.test(output), 'Should list the alpha alias with arrow separator');
     assert.ok(/^\s+stable\s+→/m.test(output), 'Should list the stable alias with arrow separator');
-  });
-
-  test('usage shows version aliases', async () => {
-    await plugin.commands['cluster']([]);
-
-    const output = captured.join('\n');
-    assert.ok(output.includes('Version aliases:'), 'Should show version aliases section');
   });
 });
 

--- a/tests/unit/cluster-plugin.test.ts
+++ b/tests/unit/cluster-plugin.test.ts
@@ -4,7 +4,7 @@
 
 import { test, describe, beforeEach, afterEach } from 'node:test';
 import assert from 'node:assert';
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -729,6 +729,101 @@ describe('Cluster Plugin – parseVersionsFromHtml', () => {
     assert.ok(result, 'should return a result');
     assert.strictEqual(result.stable, '8.9', 'stable should be 8.9 (GA, below alpha train)');
     assert.strictEqual(result.alpha, '9.0', 'alpha should be 9.0 (highest minor)');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveVersion – alias resolution with preferLocal and background freshness
+// ---------------------------------------------------------------------------
+
+describe('Cluster Plugin – resolveVersion', () => {
+  let tempDir: string;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'c8ctl-resolve-'));
+    originalFetch = globalThis.fetch;
+    plugin._resetDynamicAliasCache();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    plugin._resetDynamicAliasCache();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function seedInstalledVersion(cacheDir: string, version: string) {
+    // Create a fake c8run installation so readLocalAliasMapping considers the alias valid
+    const installDir = join(cacheDir, `c8run-${version}`, `c8run-${version}`);
+    mkdirSync(installDir, { recursive: true });
+    writeFileSync(join(installDir, 'c8run'), 'fake');
+  }
+
+  function mockFetchWithVersions(html: string) {
+    // @ts-expect-error — mock fetch for testing
+    globalThis.fetch = async () => ({
+      ok: true,
+      text: async () => html,
+    });
+  }
+
+  function mockFetchOffline() {
+    // @ts-expect-error — mock fetch for testing
+    globalThis.fetch = async () => { throw new Error('offline'); };
+  }
+
+  test('preferLocal returns cached alias when version is installed', async () => {
+    seedInstalledVersion(tempDir, '8.8');
+    plugin.storeLocalAliasMapping(tempDir, 'stable', '8.8');
+
+    // Remote says stable is 8.9, but preferLocal should return 8.8
+    mockFetchWithVersions(`
+      <a href="8.8/">8.8</a><a href="8.8.0/">8.8.0</a>
+      <a href="8.9/">8.9</a><a href="8.9.0/">8.9.0</a>
+    `);
+
+    const resolved = await plugin.resolveVersion('stable', { preferLocal: true, cacheDir: tempDir });
+    assert.strictEqual(resolved, '8.8', 'should use cached alias, not remote');
+  });
+
+  test('without preferLocal, remote takes precedence', async () => {
+    seedInstalledVersion(tempDir, '8.8');
+    plugin.storeLocalAliasMapping(tempDir, 'stable', '8.8');
+
+    mockFetchWithVersions(`
+      <a href="8.8/">8.8</a><a href="8.8.0/">8.8.0</a>
+      <a href="8.9/">8.9</a><a href="8.9.0/">8.9.0</a>
+    `);
+
+    const resolved = await plugin.resolveVersion('stable', { cacheDir: tempDir });
+    assert.strictEqual(resolved, '8.9', 'should use remote resolution');
+
+    // Cache should also be updated
+    const cached = readFileSync(join(tempDir, 'alias-stable.resolved'), 'utf-8').trim();
+    assert.strictEqual(cached, '8.9', 'should update cached alias');
+  });
+
+  test('offline with preferLocal falls back to cached alias', async () => {
+    seedInstalledVersion(tempDir, '8.8');
+    plugin.storeLocalAliasMapping(tempDir, 'stable', '8.8');
+    mockFetchOffline();
+
+    const resolved = await plugin.resolveVersion('stable', { preferLocal: true, cacheDir: tempDir });
+    assert.strictEqual(resolved, '8.8', 'should use cached alias when offline');
+  });
+
+  test('offline without preferLocal falls back to cached alias', async () => {
+    seedInstalledVersion(tempDir, '8.8');
+    plugin.storeLocalAliasMapping(tempDir, 'stable', '8.8');
+    mockFetchOffline();
+
+    const resolved = await plugin.resolveVersion('stable', { cacheDir: tempDir });
+    assert.strictEqual(resolved, '8.8', 'should fall back to cached alias when offline');
+  });
+
+  test('non-alias version specs pass through unchanged', async () => {
+    const resolved = await plugin.resolveVersion('8.8.5', { cacheDir: tempDir });
+    assert.strictEqual(resolved, '8.8.5', 'non-alias should pass through');
   });
 });
 

--- a/tests/unit/cluster-plugin.test.ts
+++ b/tests/unit/cluster-plugin.test.ts
@@ -829,6 +829,119 @@ describe('Cluster Plugin – resolveVersion', () => {
 });
 
 // ---------------------------------------------------------------------------
+// checkBackgroundAliasFreshness
+// ---------------------------------------------------------------------------
+
+describe('Cluster Plugin – checkBackgroundAliasFreshness', () => {
+  let originalFetch: typeof globalThis.fetch;
+  let loggedMessages: string[];
+  let originalC8ctl: any;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    originalC8ctl = globalThis.c8ctl;
+    loggedMessages = [];
+    // @ts-expect-error — mock c8ctl logger
+    globalThis.c8ctl = {
+      getLogger: () => ({
+        info: (msg: string) => loggedMessages.push(msg),
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+      }),
+    };
+    plugin._resetDynamicAliasCache();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    globalThis.c8ctl = originalC8ctl;
+    plugin._resetDynamicAliasCache();
+  });
+
+  test('prints hint when remote alias differs from resolved version', async () => {
+    // @ts-expect-error — mock fetch
+    globalThis.fetch = async () => ({
+      ok: true,
+      text: async () => `
+        <a href="8.8/">8.8</a><a href="8.8.0/">8.8.0</a>
+        <a href="8.9/">8.9</a><a href="8.9.0/">8.9.0</a>
+      `,
+    });
+
+    await plugin.checkBackgroundAliasFreshness('stable', '8.8');
+
+    assert.ok(
+      loggedMessages.some((m: string) => m.includes('newer') && m.includes('8.9') && m.includes('cluster install')),
+      `Should print upgrade hint, got: ${loggedMessages.join('; ')}`,
+    );
+  });
+
+  test('does not print hint when remote alias matches resolved version', async () => {
+    // @ts-expect-error — mock fetch
+    globalThis.fetch = async () => ({
+      ok: true,
+      text: async () => `
+        <a href="8.9/">8.9</a><a href="8.9.0/">8.9.0</a>
+      `,
+    });
+
+    await plugin.checkBackgroundAliasFreshness('stable', '8.9');
+
+    assert.strictEqual(
+      loggedMessages.filter((m: string) => m.includes('newer')).length, 0,
+      'Should not print upgrade hint when versions match',
+    );
+  });
+
+  test('does not persist alias mapping (start remains deterministic)', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'c8ctl-bg-'));
+    try {
+      // Seed a cached alias file pointing to 8.8
+      plugin.storeLocalAliasMapping(tempDir, 'stable', '8.8');
+
+      // @ts-expect-error — mock fetch: remote says stable is 8.9
+      globalThis.fetch = async () => ({
+        ok: true,
+        text: async () => `
+          <a href="8.8/">8.8</a><a href="8.8.0/">8.8.0</a>
+          <a href="8.9/">8.9</a><a href="8.9.0/">8.9.0</a>
+        `,
+      });
+
+      await plugin.checkBackgroundAliasFreshness('stable', '8.8');
+
+      // The alias file should still point to 8.8 — not overwritten to 8.9
+      const cached = readFileSync(join(tempDir, 'alias-stable.resolved'), 'utf-8').trim();
+      assert.strictEqual(cached, '8.8', 'background check must not update persisted alias');
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  test('stays silent when offline (fetch throws)', async () => {
+    // @ts-expect-error — mock fetch
+    globalThis.fetch = async () => { throw new Error('Network unreachable'); };
+
+    await assert.doesNotReject(
+      () => plugin.checkBackgroundAliasFreshness('stable', '8.8'),
+      'should swallow network errors',
+    );
+
+    assert.strictEqual(loggedMessages.length, 0, 'should not log anything when offline');
+  });
+
+  test('stays silent when server returns non-OK', async () => {
+    // @ts-expect-error — mock fetch
+    globalThis.fetch = async () => ({ ok: false, text: async () => '' });
+
+    await plugin.checkBackgroundAliasFreshness('stable', '8.8');
+
+    assert.strictEqual(loggedMessages.length, 0, 'should not log anything on non-OK response');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // clusterStatus
 // ---------------------------------------------------------------------------
 

--- a/tests/unit/cluster-plugin.test.ts
+++ b/tests/unit/cluster-plugin.test.ts
@@ -624,15 +624,17 @@ describe('Cluster Plugin – ensureC8RunInstalled', () => {
 
 describe('Cluster Plugin – parseVersionsFromHtml', () => {
   test('extracts stable and alpha from a realistic listing', () => {
-    // Real-world pattern: 8.8 went GA (but still has old alpha dirs), 8.9 is current alpha
-    // Stable = highest minor below the highest alpha train (8.9 has alphas → stable is 8.8)
+    // Real-world pattern: 8.7 and 8.8 went GA (have both alpha dirs and X.Y.0/), 8.9 is current alpha
+    // Stable = highest minor NOT in the alpha train (8.7/8.8 graduated, 8.9 is alpha-only → stable is 8.8)
     const html = `
       <a href="8.6/">8.6</a>
       <a href="8.6.11/">8.6.11</a>
       <a href="8.7/">8.7</a>
       <a href="8.7.0-alpha5/">8.7.0-alpha5</a>
+      <a href="8.7.0/">8.7.0</a>
       <a href="8.8.0-alpha2/">8.8.0-alpha2</a>
       <a href="8.8.0-alpha3/">8.8.0-alpha3</a>
+      <a href="8.8.0/">8.8.0</a>
       <a href="8.8/">8.8</a>
       <a href="8.8.1/">8.8.1</a>
       <a href="8.9.0-alpha1/">8.9.0-alpha1</a>

--- a/tests/unit/cluster-plugin.test.ts
+++ b/tests/unit/cluster-plugin.test.ts
@@ -141,11 +141,11 @@ describe('Cluster Plugin – command usage output', () => {
     assert.ok(/^\s+stable\s+→/m.test(output), 'Should list the stable alias with arrow separator');
   });
 
-  test('usage indicates aliases are dynamically resolved', async () => {
+  test('usage shows version aliases', async () => {
     await plugin.commands['cluster']([]);
 
     const output = captured.join('\n');
-    assert.ok(output.includes('dynamically resolved'), 'Should indicate dynamic resolution');
+    assert.ok(output.includes('Version aliases:'), 'Should show version aliases section');
   });
 });
 

--- a/tests/unit/cluster-plugin.test.ts
+++ b/tests/unit/cluster-plugin.test.ts
@@ -688,6 +688,46 @@ describe('Cluster Plugin – parseVersionsFromHtml', () => {
     assert.strictEqual(result.stable, '8.8');
     assert.strictEqual(result.alpha, '8.9');
   });
+
+  test('graduated alpha: minor with both alphas and GA release is not the alpha train', () => {
+    // 8.9 went GA (8.9.0/ exists), so its alpha dirs are historical.
+    // With no new alpha train above 8.9, stable = alpha = 8.9.
+    const html = `
+      <a href="8.6/">8.6</a>
+      <a href="8.7/">8.7</a>
+      <a href="8.7.0-alpha5/">8.7.0-alpha5</a>
+      <a href="8.7.0/">8.7.0</a>
+      <a href="8.8/">8.8</a>
+      <a href="8.8.0-alpha2/">8.8.0-alpha2</a>
+      <a href="8.8.0/">8.8.0</a>
+      <a href="8.8.1/">8.8.1</a>
+      <a href="8.9.0-alpha1/">8.9.0-alpha1</a>
+      <a href="8.9.0-alpha5/">8.9.0-alpha5</a>
+      <a href="8.9.0/">8.9.0</a>
+      <a href="8.9/">8.9</a>
+    `;
+    const result = plugin.parseVersionsFromHtml(html);
+    assert.ok(result, 'should return a result');
+    assert.strictEqual(result.stable, '8.9', 'stable should be 8.9 since it has gone GA');
+    assert.strictEqual(result.alpha, '8.9', 'alpha should be 8.9 (highest minor)');
+  });
+
+  test('graduated alpha with new alpha train above', () => {
+    // 8.9 went GA, and 9.0 alphas have started
+    const html = `
+      <a href="8.8/">8.8</a>
+      <a href="8.8.0/">8.8.0</a>
+      <a href="8.9/">8.9</a>
+      <a href="8.9.0-alpha1/">8.9.0-alpha1</a>
+      <a href="8.9.0/">8.9.0</a>
+      <a href="9.0.0-alpha1/">9.0.0-alpha1</a>
+      <a href="9.0/">9.0</a>
+    `;
+    const result = plugin.parseVersionsFromHtml(html);
+    assert.ok(result, 'should return a result');
+    assert.strictEqual(result.stable, '8.9', 'stable should be 8.9 (GA, below alpha train)');
+    assert.strictEqual(result.alpha, '9.0', 'alpha should be 9.0 (highest minor)');
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

After Camunda 8.9 went GA, `c8ctl cluster start` still resolves the `stable` alias to `8.8`:

```
% c8 cluster start
No version specified, using default: "stable"
Resolved alias "stable" → 8.8
```

Fixes #244

## Root cause

Two issues combine:

### 1. `parseVersionsFromHtml` doesn't account for graduated alphas

The function classifies a minor version as the "alpha train" if it has any `X.Y.0-alphaN/` directories on the download server, even if that minor already shipped a GA release (`X.Y.0/`). Since the server has both `8.9.0-alpha*/` (historical) and `8.9.0/` (GA), 8.9 was incorrectly treated as the alpha train, keeping stable at 8.8.

### 2. `cluster start` short-circuits with stale cached alias

`resolveVersion` with `preferLocal: true` returned the persisted `alias-stable.resolved` file (value `8.8`) without ever hitting the remote. Even after fixing the parsing, the stale cache perpetuated the wrong version.

## Fix

### `parseVersionsFromHtml` — GA-aware alpha classification

- Detect GA releases (`X.Y.0/` directories) and exclude graduated minors from the alpha set
- `stable` = highest minor NOT in the alpha train (simple filter, no fragile ordering assumption)
- `alpha` = highest minor overall

### `resolveVersion` — deterministic start + background hint

| Caller | Precedence |
|--------|------------|
| `cluster start` (preferLocal) | cached alias (if installed) → remote → fallback |
| `cluster install` / other | remote → cached alias → fallback |

When `cluster start` uses a cached alias, a **non-blocking background check** queries the remote. If it differs:
1. Persisted alias mapping is silently updated
2. Hint printed: `A newer "stable" release is available (8.9). Install it with: c8ctl cluster install stable`

This mirrors the existing ETag-based `checkForUpdateHint` pattern.

### Upgrade flow

```
$ c8 cluster start
Resolved alias "stable" → 8.8
A newer "stable" release is available (8.9). Install it with: c8ctl cluster install stable

$ c8 cluster install stable
Resolved alias "stable" → 8.9
c8run 8.9 installed successfully.

$ c8 cluster start
Resolved alias "stable" → 8.9
```

## Secondary issue

Users who previously ran `cluster start` with the old code will have a stale cached value of `8.8`. The background hint will detect this on first run and print the upgrade suggestion. Running `c8ctl cluster install stable` will resolve it.