### PR TITLE
fix: `c8ctl help <plugin-verb>` delegates to plugin handler

### DIFF
--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -15,7 +15,9 @@ import {
 } from "../command-registry.ts";
 import { getLogger } from "../logger.ts";
 import {
+	executePluginCommand,
 	getPluginCommandsInfo,
+	isPluginCommand,
 	type PluginCommandInfo,
 } from "../plugin-loader.ts";
 
@@ -815,7 +817,7 @@ function showVirtualTopicHelp(topic: string, resource: string): void {
  * Show detailed help for a specific command.
  * Dispatches to the generic renderer for all verbs.
  */
-export function showCommandHelp(command: string): void {
+export async function showCommandHelp(command: string): Promise<void> {
 	const logger = getLogger();
 
 	// JSON mode: emit structured help for machine/agent consumption
@@ -856,6 +858,14 @@ export function showCommandHelp(command: string): void {
 				break;
 			}
 		}
+	}
+
+	// If the verb is still not in the registry, check if it's a plugin command.
+	// Delegate to the plugin's own handler which renders its own help output.
+	if (!lookupVerb(resolvedVerb) && isPluginCommand(resolvedVerb)) {
+		// Plugin handlers show help when called with no valid subcommand
+		await executePluginCommand(resolvedVerb, []);
+		return;
 	}
 
 	showGenericVerbHelp(resolvedVerb);

--- a/src/index.ts
+++ b/src/index.ts
@@ -194,7 +194,7 @@ async function main() {
 	) {
 		// Check if user wants help for a specific command
 		if (resource) {
-			showCommandHelp(resource);
+			await showCommandHelp(resource);
 		} else {
 			showHelp();
 		}

--- a/tests/unit/help-behaviour.test.ts
+++ b/tests/unit/help-behaviour.test.ts
@@ -138,4 +138,22 @@ describe('CLI behavioural: help (text mode)', () => {
 
     rmSync(dataDir, { recursive: true, force: true });
   });
+
+  test('help for plugin command delegates to plugin (c8ctl help cluster)', async () => {
+    dataDir = mkdtempSync(join(tmpdir(), 'c8ctl-help-test-'));
+    writeFileSync(join(dataDir, 'session.json'), JSON.stringify({ outputMode: 'text' }));
+
+    const result = await c8text(dataDir, 'help', 'cluster');
+    assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+    const output = result.stdout + result.stderr;
+    // The cluster plugin shows its own help — verify key sections appear
+    assert.ok(output.includes('c8ctl cluster start'), 'Expected cluster start usage');
+    assert.ok(output.includes('c8ctl cluster stop'), 'Expected cluster stop usage');
+    assert.ok(output.includes('Subcommands:'), 'Expected Subcommands section');
+    assert.ok(output.includes('Examples:'), 'Expected Examples section');
+    // Must NOT show the "No detailed help available" fallback
+    assert.ok(!output.includes('No detailed help available'), 'Should not show fallback message');
+
+    rmSync(dataDir, { recursive: true, force: true });
+  });
 });


### PR DESCRIPTION
## Problem

`c8ctl help cluster` shows:

```
No detailed help available for: cluster
Run "c8ctl help" for general usage information.
```

But `c8ctl cluster` (with no subcommand) shows rich help with usage, subcommands, options, version aliases, and examples.

## Root cause

`showCommandHelp()` only searches the built-in `COMMAND_REGISTRY`. Plugin commands like `cluster` are not in the registry, so it falls through to `showGenericVerbHelp()` which prints the unhelpful fallback message.

## Fix

After the registry and alias lookup fails, `showCommandHelp` now checks whether the verb is a plugin command via `isPluginCommand()`. If so, it delegates to `executePluginCommand(verb, [])` — the plugin's handler already shows its own help when called with no valid subcommand.

Changes:
- Make `showCommandHelp` async to support the async plugin delegation
- Add plugin command check after registry/alias resolution
- Update the call site in `src/index.ts` to `await`
- Add behavioural test verifying `c8ctl help cluster` produces the plugin's help output

## Result

```
$ c8ctl help cluster
Usage:
  c8ctl cluster start [<version>] [--debug]
  c8ctl cluster stop
  c8ctl cluster status
  ...
```

Fixes #246