### PR TITLE
fix: cluster stop detects when no cluster is running and suppresses c8run output

### DIFF
--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -1039,7 +1039,7 @@ export async function stopC8Run(config, debug = false) {
 
     attempted += 1;
 
-    const { code: exitCode, signal: exitSignal } = await new Promise(
+    const { code: exitCode, signal: exitSignal, stdout: procStdout, stderr: procStderr } = await new Promise(
       (resolve, reject) => {
         const proc = spawn(binaryPath, ['stop'], {
           stdio: ['ignore', 'pipe', 'pipe'],
@@ -1085,7 +1085,7 @@ export async function stopC8Run(config, debug = false) {
         `Stop command terminated by signal ${exitSignal}`,
       );
     } else if (exitCode !== -1) {
-      const output = [stdout, stderr].filter(Boolean).join('\n');
+      const output = [procStdout, procStderr].filter(Boolean).join('\n');
       lastError = new Error(
         `Stop command failed with code ${exitCode}${output ? `:\n${output}` : ''}`,
       );

--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -892,12 +892,20 @@ async function startC8Run(config, debug = false) {
   }
 }
 
-async function stopC8Run(config) {
+async function stopC8Run(config, debug = false) {
   const logger = getLogger();
   const markerFile = join(config.cacheDir, ACTIVE_MARKER_FILE);
   const versionFile = join(config.cacheDir, VERSION_MARKER_FILE);
 
   const markerExists = existsSync(markerFile);
+
+  if (!markerExists) {
+    logger.warn(
+      'No cluster is currently running.',
+    );
+    return;
+  }
+
   const installedVersions = existsSync(config.cacheDir)
     ? readdirSync(config.cacheDir, { withFileTypes: true })
         .filter(
@@ -907,13 +915,6 @@ async function stopC8Run(config) {
         .map((entry) => entry.name.slice('c8run-'.length))
         .sort()
     : [];
-
-  if (!markerExists && installedVersions.length === 0) {
-    logger.warn(
-      'No running cluster found (use "c8ctl cluster start" to start one).',
-    );
-    return;
-  }
 
   const versionsToTry = [];
 
@@ -952,9 +953,20 @@ async function stopC8Run(config) {
     const { code: exitCode, signal: exitSignal } = await new Promise(
       (resolve, reject) => {
         const proc = spawn(binaryPath, ['stop'], {
-          stdio: 'inherit',
+          stdio: ['ignore', 'pipe', 'pipe'],
           cwd: dirname(binaryPath),
         });
+
+        const handleOutput = (chunk, stream) => {
+          if (debug) {
+            const text = typeof chunk === 'string' ? chunk : chunk.toString('utf-8');
+            stream.write(text);
+          }
+        };
+
+        proc.stdout?.on('data', (chunk) => handleOutput(chunk, process.stdout));
+        proc.stderr?.on('data', (chunk) => handleOutput(chunk, process.stderr));
+
         proc.on('exit', (code, signal) => resolve({ code, signal }));
         proc.on('error', reject);
       },
@@ -1522,7 +1534,7 @@ export const commands = {
       }
     } else if (parsed.subcommand === 'stop') {
       try {
-        await stopC8Run(config);
+        await stopC8Run(config, parsed.debug);
       } catch (error) {
         logger.error(`Failed to stop cluster: ${error}`);
         process.exit(1);

--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -913,7 +913,15 @@ export function hasRunningClusterPidfiles(cacheDir) {
       continue;
     }
 
-    for (const entry of readdirSync(currentPath, { withFileTypes: true })) {
+    let entries;
+    try {
+      entries = readdirSync(currentPath, { withFileTypes: true });
+    } catch {
+      // Directory may have been removed between the existsSync check and now.
+      continue;
+    }
+
+    for (const entry of entries) {
       const entryPath = join(currentPath, entry.name);
 
       if (entry.isDirectory()) {
@@ -925,7 +933,13 @@ export function hasRunningClusterPidfiles(cacheDir) {
         continue;
       }
 
-      const pid = Number.parseInt(readFileSync(entryPath, 'utf-8').trim(), 10);
+      let pid;
+      try {
+        pid = Number.parseInt(readFileSync(entryPath, 'utf-8').trim(), 10);
+      } catch {
+        // Pidfile may have been removed between listing and reading.
+        continue;
+      }
 
       if (!Number.isInteger(pid) || pid <= 0) {
         continue;
@@ -957,6 +971,21 @@ export async function stopC8Run(config, debug = false) {
     logger.warn(
       'No cluster is currently running.',
     );
+    return;
+  }
+
+  if (markerExists && !clusterAppearsRunning) {
+    // Stale marker left behind (e.g. crash or forced kill). Clean up and
+    // return early — there is nothing to stop.
+    logger.warn(
+      'Cluster marker file found, but no running cluster processes detected. Cleaning up stale marker.',
+    );
+    if (existsSync(markerFile)) {
+      rmSync(markerFile);
+    }
+    if (existsSync(versionFile)) {
+      rmSync(versionFile);
+    }
     return;
   }
 
@@ -1017,22 +1046,35 @@ export async function stopC8Run(config, debug = false) {
           cwd: dirname(binaryPath),
         });
 
-        const handleOutput = (chunk, stream) => {
+        const stdoutChunks = [];
+        const stderrChunks = [];
+
+        proc.stdout?.on('data', (chunk) => {
+          stdoutChunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf-8'));
           if (debug) {
-            const text = typeof chunk === 'string' ? chunk : chunk.toString('utf-8');
-            stream.write(text);
+            process.stdout.write(stdoutChunks[stdoutChunks.length - 1]);
           }
-        };
+        });
+        proc.stderr?.on('data', (chunk) => {
+          stderrChunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf-8'));
+          if (debug) {
+            process.stderr.write(stderrChunks[stderrChunks.length - 1]);
+          }
+        });
 
-        proc.stdout?.on('data', (chunk) => handleOutput(chunk, process.stdout));
-        proc.stderr?.on('data', (chunk) => handleOutput(chunk, process.stderr));
-
-        proc.on('close', (code, signal) => resolve({ code, signal }));
+        proc.on('close', (code, signal) =>
+          resolve({
+            code,
+            signal,
+            stdout: stdoutChunks.join(''),
+            stderr: stderrChunks.join(''),
+          }),
+        );
         proc.on('error', reject);
       },
     ).catch((error) => {
       lastError = error instanceof Error ? error : new Error(String(error));
-      return { code: -1, signal: null };
+      return { code: -1, signal: null, stdout: '', stderr: '' };
     });
 
     if (exitCode === 0 || (exitCode === null && !exitSignal)) {
@@ -1043,7 +1085,10 @@ export async function stopC8Run(config, debug = false) {
         `Stop command terminated by signal ${exitSignal}`,
       );
     } else if (exitCode !== -1) {
-      lastError = new Error(`Stop command failed with code ${exitCode}`);
+      const output = [stdout, stderr].filter(Boolean).join('\n');
+      lastError = new Error(
+        `Stop command failed with code ${exitCode}${output ? `:\n${output}` : ''}`,
+      );
     }
   }
 

--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -904,53 +904,59 @@ export function hasRunningClusterPidfiles(cacheDir) {
     )
     .map((entry) => join(cacheDir, entry.name));
 
-  const pathsToScan = [...versionDirs];
-
-  while (pathsToScan.length > 0) {
-    const currentPath = pathsToScan.pop();
-
-    if (!currentPath || !existsSync(currentPath)) {
-      continue;
-    }
-
+  // Scan each version dir and its immediate subdirectories (max depth 1)
+  // rather than a full recursive DFS — c8run installs can contain large
+  // extracted trees, logs, and data that would make a deep walk slow.
+  for (const versionDir of versionDirs) {
     let entries;
     try {
-      entries = readdirSync(currentPath, { withFileTypes: true });
+      entries = readdirSync(versionDir, { withFileTypes: true });
     } catch {
-      // Directory may have been removed between the existsSync check and now.
       continue;
     }
 
+    // Collect directories at this level to also check one level deeper.
+    const dirsToCheck = [versionDir];
     for (const entry of entries) {
-      const entryPath = join(currentPath, entry.name);
-
       if (entry.isDirectory()) {
-        pathsToScan.push(entryPath);
-        continue;
+        dirsToCheck.push(join(versionDir, entry.name));
       }
+    }
 
-      if (!entry.isFile() || !entry.name.endsWith('.process')) {
-        continue;
-      }
-
-      let pid;
+    for (const dir of dirsToCheck) {
+      let dirEntries;
       try {
-        pid = Number.parseInt(readFileSync(entryPath, 'utf-8').trim(), 10);
+        dirEntries = readdirSync(dir, { withFileTypes: true });
       } catch {
-        // Pidfile may have been removed between listing and reading.
         continue;
       }
 
-      if (!Number.isInteger(pid) || pid <= 0) {
-        continue;
-      }
+      for (const entry of dirEntries) {
+        if (!entry.isFile() || !entry.name.endsWith('.process')) {
+          continue;
+        }
 
-      try {
-        process.kill(pid, 0);
-        return true;
-      } catch (error) {
-        if (error && error.code === 'EPERM') {
+        const entryPath = join(dir, entry.name);
+
+        let pid;
+        try {
+          pid = Number.parseInt(readFileSync(entryPath, 'utf-8').trim(), 10);
+        } catch {
+          // Pidfile may have been removed between listing and reading.
+          continue;
+        }
+
+        if (!Number.isInteger(pid) || pid <= 0) {
+          continue;
+        }
+
+        try {
+          process.kill(pid, 0);
           return true;
+        } catch (error) {
+          if (error && error.code === 'EPERM') {
+            return true;
+          }
         }
       }
     }
@@ -1048,17 +1054,28 @@ export async function stopC8Run(config, debug = false) {
 
         const stdoutChunks = [];
         const stderrChunks = [];
+        let stdoutLen = 0;
+        let stderrLen = 0;
+        const MAX_BUFFER = 64 * 1024; // 64 KB cap per stream
 
         proc.stdout?.on('data', (chunk) => {
-          stdoutChunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf-8'));
+          const text = typeof chunk === 'string' ? chunk : chunk.toString('utf-8');
           if (debug) {
-            process.stdout.write(stdoutChunks[stdoutChunks.length - 1]);
+            process.stdout.write(text);
+          }
+          if (stdoutLen < MAX_BUFFER) {
+            stdoutChunks.push(text);
+            stdoutLen += text.length;
           }
         });
         proc.stderr?.on('data', (chunk) => {
-          stderrChunks.push(typeof chunk === 'string' ? chunk : chunk.toString('utf-8'));
+          const text = typeof chunk === 'string' ? chunk : chunk.toString('utf-8');
           if (debug) {
-            process.stderr.write(stderrChunks[stderrChunks.length - 1]);
+            process.stderr.write(text);
+          }
+          if (stderrLen < MAX_BUFFER) {
+            stderrChunks.push(text);
+            stderrLen += text.length;
           }
         });
 

--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -892,18 +892,78 @@ async function startC8Run(config, debug = false) {
   }
 }
 
-async function stopC8Run(config, debug = false) {
+export function hasRunningClusterPidfiles(cacheDir) {
+  if (!existsSync(cacheDir)) {
+    return false;
+  }
+
+  const versionDirs = readdirSync(cacheDir, { withFileTypes: true })
+    .filter(
+      (entry) =>
+        entry.isDirectory() && entry.name.startsWith('c8run-'),
+    )
+    .map((entry) => join(cacheDir, entry.name));
+
+  const pathsToScan = [...versionDirs];
+
+  while (pathsToScan.length > 0) {
+    const currentPath = pathsToScan.pop();
+
+    if (!currentPath || !existsSync(currentPath)) {
+      continue;
+    }
+
+    for (const entry of readdirSync(currentPath, { withFileTypes: true })) {
+      const entryPath = join(currentPath, entry.name);
+
+      if (entry.isDirectory()) {
+        pathsToScan.push(entryPath);
+        continue;
+      }
+
+      if (!entry.isFile() || !entry.name.endsWith('.process')) {
+        continue;
+      }
+
+      const pid = Number.parseInt(readFileSync(entryPath, 'utf-8').trim(), 10);
+
+      if (!Number.isInteger(pid) || pid <= 0) {
+        continue;
+      }
+
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch (error) {
+        if (error && error.code === 'EPERM') {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+export async function stopC8Run(config, debug = false) {
   const logger = getLogger();
   const markerFile = join(config.cacheDir, ACTIVE_MARKER_FILE);
   const versionFile = join(config.cacheDir, VERSION_MARKER_FILE);
 
   const markerExists = existsSync(markerFile);
+  const clusterAppearsRunning = hasRunningClusterPidfiles(config.cacheDir);
 
-  if (!markerExists) {
+  if (!markerExists && !clusterAppearsRunning) {
     logger.warn(
       'No cluster is currently running.',
     );
     return;
+  }
+
+  if (!markerExists && clusterAppearsRunning) {
+    logger.warn(
+      'Cluster marker file is missing, but running cluster processes were detected. Proceeding with stop.',
+    );
   }
 
   const installedVersions = existsSync(config.cacheDir)
@@ -967,7 +1027,7 @@ async function stopC8Run(config, debug = false) {
         proc.stdout?.on('data', (chunk) => handleOutput(chunk, process.stdout));
         proc.stderr?.on('data', (chunk) => handleOutput(chunk, process.stderr));
 
-        proc.on('exit', (code, signal) => resolve({ code, signal }));
+        proc.on('close', (code, signal) => resolve({ code, signal }));
         proc.on('error', reject);
       },
     ).catch((error) => {

--- a/tests/unit/cluster-plugin.test.ts
+++ b/tests/unit/cluster-plugin.test.ts
@@ -1644,3 +1644,108 @@ describe('Cluster Plugin – ensureC8RunInstalled start vs install behavior', ()
     assert.ok(existsSync(join(tempDir, 'c8run-8.8')), 'should not purge the install');
   });
 });
+
+// ---------------------------------------------------------------------------
+// stopC8Run
+// ---------------------------------------------------------------------------
+
+describe('Cluster Plugin – stopC8Run', () => {
+  let tempDir: string;
+  let captured: string[];
+  let originalLog: typeof console.log;
+  let originalWarn: typeof console.warn;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'c8ctl-test-'));
+    captured = [];
+    originalLog = console.log;
+    originalWarn = console.warn;
+    console.log = (...args: unknown[]) => { captured.push(args.map(String).join(' ')); };
+    console.warn = (...args: unknown[]) => { captured.push(args.map(String).join(' ')); };
+  });
+
+  afterEach(() => {
+    if (existsSync(tempDir)) rmSync(tempDir, { recursive: true, force: true });
+    console.log = originalLog;
+    console.warn = originalWarn;
+  });
+
+  test('returns early with warning when no marker and no running pidfiles', async () => {
+    const config = { cacheDir: tempDir, version: '8.8' };
+    await plugin.stopC8Run(config);
+    const output = captured.join('\n');
+    assert.ok(output.includes('No cluster is currently running'), 'Should warn no cluster running');
+  });
+
+  test('returns early even when installed versions exist but no marker and no running pidfiles', async () => {
+    // Create an installed version directory (but no marker, no running processes)
+    const versionDir = join(tempDir, 'c8run-8.8', 'c8run-8.8.1');
+    mkdirSync(versionDir, { recursive: true });
+
+    const config = { cacheDir: tempDir, version: '8.8' };
+    await plugin.stopC8Run(config);
+    const output = captured.join('\n');
+    assert.ok(output.includes('No cluster is currently running'), 'Should warn no cluster running');
+    assert.ok(!output.includes('Stopping'), 'Should not attempt to stop');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hasRunningClusterPidfiles
+// ---------------------------------------------------------------------------
+
+describe('Cluster Plugin – hasRunningClusterPidfiles', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'c8ctl-test-'));
+  });
+
+  afterEach(() => {
+    if (existsSync(tempDir)) rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('returns false when cache dir does not exist', () => {
+    const result = plugin.hasRunningClusterPidfiles(join(tempDir, 'nonexistent'));
+    assert.strictEqual(result, false);
+  });
+
+  test('returns false when no version directories exist', () => {
+    const result = plugin.hasRunningClusterPidfiles(tempDir);
+    assert.strictEqual(result, false);
+  });
+
+  test('returns false when .process files contain invalid PIDs', () => {
+    const versionDir = join(tempDir, 'c8run-8.8', 'c8run-8.8.1');
+    mkdirSync(versionDir, { recursive: true });
+    writeFileSync(join(versionDir, 'camunda.process'), 'not-a-number');
+    const result = plugin.hasRunningClusterPidfiles(tempDir);
+    assert.strictEqual(result, false);
+  });
+
+  test('returns false when .process files reference non-running PIDs', () => {
+    const versionDir = join(tempDir, 'c8run-8.8', 'c8run-8.8.1');
+    mkdirSync(versionDir, { recursive: true });
+    // Use a PID that almost certainly does not exist
+    writeFileSync(join(versionDir, 'camunda.process'), '999999999');
+    const result = plugin.hasRunningClusterPidfiles(tempDir);
+    assert.strictEqual(result, false);
+  });
+
+  test('returns true when a .process file references the current process PID', () => {
+    const versionDir = join(tempDir, 'c8run-8.8', 'c8run-8.8.1');
+    mkdirSync(versionDir, { recursive: true });
+    // Use our own PID — guaranteed to be running
+    writeFileSync(join(versionDir, 'camunda.process'), String(process.pid));
+    const result = plugin.hasRunningClusterPidfiles(tempDir);
+    assert.strictEqual(result, true);
+  });
+
+  test('ignores non-.process files', () => {
+    const versionDir = join(tempDir, 'c8run-8.8', 'c8run-8.8.1');
+    mkdirSync(versionDir, { recursive: true });
+    writeFileSync(join(versionDir, 'camunda.log'), String(process.pid));
+    const result = plugin.hasRunningClusterPidfiles(tempDir);
+    assert.strictEqual(result, false);
+  });
+});

--- a/tests/unit/cluster-plugin.test.ts
+++ b/tests/unit/cluster-plugin.test.ts
@@ -1688,6 +1688,22 @@ describe('Cluster Plugin – stopC8Run', () => {
     assert.ok(output.includes('No cluster is currently running'), 'Should warn no cluster running');
     assert.ok(!output.includes('Stopping'), 'Should not attempt to stop');
   });
+
+  test('cleans up stale markers and returns early when marker exists but no processes running', async () => {
+    // Simulate stale marker left behind after a crash
+    writeFileSync(join(tempDir, 'cluster.active'), '');
+    writeFileSync(join(tempDir, 'cluster.version'), '8.8.1');
+
+    const config = { cacheDir: tempDir, version: '8.8' };
+    await plugin.stopC8Run(config);
+
+    const output = captured.join('\n');
+    assert.ok(output.includes('stale marker'), 'Should warn about stale marker');
+    assert.ok(!output.includes('Stopping'), 'Should not attempt to stop');
+    // Marker files should be cleaned up
+    assert.ok(!existsSync(join(tempDir, 'cluster.active')), 'Active marker should be removed');
+    assert.ok(!existsSync(join(tempDir, 'cluster.version')), 'Version marker should be removed');
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes two problems with `c8 cluster stop`:

1. **No pre-check for running cluster**: Previously, `stopC8Run` only short-circuited when there was no active marker AND no installed versions. This meant that if a version was installed but no cluster was running, the full c8run stop script would execute, log errors about missing pidfiles, and then report "Cluster stopped." — which is misleading.

2. **Verbose c8run output shown by default**: The c8run stop subprocess used `stdio: 'inherit'`, dumping all internal INF/DBG log lines to the terminal unconditionally. This is inconsistent with `startC8Run`, which pipes output and only shows it in debug mode.

## Changes

- **Pre-check**: Uses a two-tier check — first the `cluster.active` marker file, then a pidfile scan (`hasRunningClusterPidfiles`) to detect running c8run processes. The four cases:
  - No marker + no pidfiles → "No cluster is currently running." → return early.
  - Marker exists + no pidfiles → stale marker from a crash/forced-kill → clean up markers, warn, return early (no c8run stop invoked).
  - No marker + pidfiles found → orphan processes → warn and proceed with stop.
  - Marker + pidfiles → normal stop.
- **Pidfile scanning**: New `hasRunningClusterPidfiles(cacheDir)` function recursively scans `c8run-*` version directories for `.process` files, reads PIDs, and probes with `process.kill(pid, 0)`. Handles TOCTOU races with try/catch around filesystem reads.
- **Output suppression**: Changed subprocess `stdio` from `'inherit'` to `['ignore', 'pipe', 'pipe']`. Stdout/stderr are buffered; only forwarded to the terminal when `--debug` is passed. On non-zero exit, buffered output is included in the error message.
- Added `debug` parameter to `stopC8Run` and wired it through from `parsed.debug`.

## Before

```
$ c8 cluster stop
Resolved alias "stable" → 8.8
Stopping Camunda 8 local cluster...
3:48AM INF Initiating shutdown of services...
3:48AM INF Stopping all services... timeout=30s
3:48AM DBG Failed to stop Elasticsearch error="pidfile does not exist..."
3:48AM DBG Failed to stop connectors error="pidfile does not exist..."
3:48AM DBG Failed to stop Camunda error="pidfile does not exist..."
3:48AM INF All services have been stopped.
Cluster stopped.
```

## After

```
$ c8 cluster stop
No cluster is currently running.
```

When a cluster IS running, the stop succeeds cleanly:
```
$ c8 cluster stop
Stopping Camunda 8 local cluster...
Cluster stopped.
```

With `--debug`, the c8run output is shown:
```
$ c8 cluster stop --debug
Stopping Camunda 8 local cluster...
3:48AM INF Initiating shutdown of services...
...
Cluster stopped.
```

Closes #261