### PR TITLE
docs: add chore: scope convention for review-comment commits

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,15 +1,3 @@
 # Copilot Instructions
 
 Read and follow the conventions in [DEVELOPMENT.md](../DEVELOPMENT.md) at the project root.
-
-## Commit scope for review-comment fixes
-
-When committing changes that address PR review comments, always use `chore:` — never `fix:`. The `fix:` scope triggers a patch release and CHANGELOG entry, which is incorrect for review iterations within a PR.
-
-```
-# Correct
-chore: address review comments — use logger.json for dry-run
-
-# Wrong
-fix: address review comments — use logger.json for dry-run
-```

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,15 @@
 # Copilot Instructions
 
 Read and follow the conventions in [DEVELOPMENT.md](../DEVELOPMENT.md) at the project root.
+
+## Commit scope for review-comment fixes
+
+When committing changes that address PR review comments, always use `chore:` — never `fix:`. The `fix:` scope triggers a patch release and CHANGELOG entry, which is incorrect for review iterations within a PR.
+
+```
+# Correct
+chore: address review comments — use logger.json for dry-run
+
+# Wrong
+fix: address review comments — use logger.json for dry-run
+```

--- a/COMMIT-MESSAGE-GUIDELINE.md
+++ b/COMMIT-MESSAGE-GUIDELINE.md
@@ -31,8 +31,8 @@ Prefix breaking changes with BREAKING CHANGE: either in body or footer.
 
 ### Review-comment fix-ups
 
-Commits that address PR review comments must use `chore:`, **not** `fix:`.
-`fix:` triggers a patch release and a CHANGELOG entry — review iterations are not user-facing bug fixes.
+Commits that address PR review comments must use the `chore` type (e.g. `chore:` or `chore(<scope>):`), **not** the `fix` type.
+`fix` commits (e.g. `fix:` or `fix(<scope>):`) trigger a patch release and a CHANGELOG entry — review iterations are not user-facing bug fixes.
 
 ```
 # Correct

--- a/COMMIT-MESSAGE-GUIDELINE.md
+++ b/COMMIT-MESSAGE-GUIDELINE.md
@@ -29,10 +29,24 @@ Lowercase subject (except proper nouns). No PascalCase subjects (rule enforced).
 Keep subject concise; body can include details, rationale, links.
 Prefix breaking changes with BREAKING CHANGE: either in body or footer.
 
+### Review-comment fix-ups
+
+Commits that address PR review comments must use `chore:`, **not** `fix:`.
+`fix:` triggers a patch release and a CHANGELOG entry — review iterations are not user-facing bug fixes.
+
+```
+# Correct
+chore: address review comments — use logger.json for dry-run
+
+# Wrong — will pollute the CHANGELOG
+fix: address review comments — use logger.json for dry-run
+```
+
 Examples:
 
 feat(worker): add job worker concurrency gating
 fix(retry): prevent double backoff application
 chore(ci): stabilize deterministic publish (skip spec fetch)
+chore: address review comments — NUL-safe pre-commit hook
 docs: document deterministic build flag
 refactor(auth): simplify token refresh jitter logic

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -7,6 +7,19 @@ Cluster API npm module https://www.npmjs.com/package/@camunda8/orchestration-clu
 
 Follow conventions in [COMMIT-MESSAGE-GUIDELINE.md](COMMIT-MESSAGE-GUIDELINE.md).
 
+### Review-comment fix-ups
+
+Commits that address PR review comments must use `chore:`, **not** `fix:`.
+`fix:` triggers a patch release and a CHANGELOG entry — review iterations are not user-facing bug fixes.
+
+```
+# Correct
+chore: address review comments — use logger.json for dry-run
+
+# Wrong — will pollute the CHANGELOG
+fix: address review comments — use logger.json for dry-run
+```
+
 ## Implementation Details
 
 - always make sure that CLI commands, resources and options are reflected in

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,8 +9,8 @@ Follow conventions in [COMMIT-MESSAGE-GUIDELINE.md](COMMIT-MESSAGE-GUIDELINE.md)
 
 ### Review-comment fix-ups
 
-Commits that address PR review comments must use `chore:`, **not** `fix:`.
-`fix:` triggers a patch release and a CHANGELOG entry — review iterations are not user-facing bug fixes.
+Commits that address PR review comments must use the `chore` type (e.g. `chore:` or `chore(<scope>):`), **not** the `fix` type.
+`fix` commits (e.g. `fix:` or `fix(<scope>):`) trigger a patch release and a CHANGELOG entry — review iterations are not user-facing bug fixes.
 
 ```
 # Correct


### PR DESCRIPTION
## Summary

Documents the convention that commits addressing PR review comments should use `chore:` instead of `fix:`.

Closes #263

## Problem

Using `fix:` for review-comment iterations triggers a patch release via semantic-release and pollutes the CHANGELOG with entries that aren't meaningful bug fixes.

## Changes

- **COMMIT-MESSAGE-GUIDELINE.md**: Added "Review-comment fix-ups" section explaining when to use `chore:` vs `fix:`
- **DEVELOPMENT.md**: Added the same convention so AI agents (Copilot, Claude, etc.) follow it automatically