### PR TITLE
chore: add biome pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Pre-commit hook: run biome check --fix on staged src/ files
+# and re-stage any auto-fixed changes.
+
+staged_files=()
+while IFS= read -r -d '' f; do
+  staged_files+=("$f")
+done < <(git diff --cached --name-only --diff-filter=d -z -- 'src/')
+
+# Only check if there are staged files under src/
+if [ ${#staged_files[@]} -eq 0 ]; then
+  exit 0
+fi
+
+npx biome check --fix -- "${staged_files[@]}"
+BIOME_EXIT=$?
+
+# Re-stage any files that biome auto-fixed
+for f in "${staged_files[@]}"; do
+  if [ -f "$f" ]; then
+    git add -- "$f"
+  fi
+done
+
+# Fail the commit if biome reported unfixable errors
+exit $BIOME_EXIT
+#!/bin/sh
+# Pre-commit hook: run biome check --fix on staged src/ files
+# and re-stage any auto-fixed changes.
+
+# Only check if there are staged files under src/
+if ! git diff --cached --name-only --diff-filter=d -z -- 'src/' | grep -qz .; then
+  exit 0
+fi
+
+git diff --cached --name-only --diff-filter=d -z -- 'src/' \
+  | xargs -0 npx biome check --fix
+BIOME_EXIT=$?
+
+# Re-stage any files that biome auto-fixed
+git diff --cached --name-only --diff-filter=d -z -- 'src/' \
+  | while IFS= read -r -d '' f; do
+  if [ -f "$f" ]; then
+    git add -- "$f"
+  fi
+done
+
+# Fail the commit if biome reported unfixable errors
+exit $BIOME_EXIT

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,7 +5,7 @@
 staged_files=()
 while IFS= read -r -d '' f; do
   staged_files+=("$f")
-done < <(git diff --cached --name-only --diff-filter=d -z -- 'src/')
+done < <(git diff --cached --name-only --diff-filter=d -z -- 'src/*.ts' 'src/**/*.ts' ':!src/templates')
 
 # Only check if there are staged files under src/
 if [ ${#staged_files[@]} -eq 0 ]; then
@@ -22,7 +22,7 @@ while IFS= read -r -d '' f; do
       break
     fi
   done
-done < <(git diff --name-only -z -- 'src/')
+done < <(git diff --name-only -z -- 'src/*.ts' 'src/**/*.ts' ':!src/templates')
 
 if [ ${#dirty_files[@]} -gt 0 ]; then
   echo "pre-commit: These files have both staged and unstaged changes:"
@@ -31,7 +31,13 @@ if [ ${#dirty_files[@]} -gt 0 ]; then
   exit 1
 fi
 
-npx biome check --fix -- "${staged_files[@]}"
+# Skip if biome is not installed locally (avoid npx downloading it)
+if ! npx --no-install biome --version >/dev/null 2>&1; then
+  echo "pre-commit: Skipping — biome not installed locally. Run npm install first."
+  exit 0
+fi
+
+npx --no-install biome check --fix -- "${staged_files[@]}"
 BIOME_EXIT=$?
 
 # Re-stage any files that biome auto-fixed

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -12,34 +12,30 @@ if [ ${#staged_files[@]} -eq 0 ]; then
   exit 0
 fi
 
+# Abort if any staged file also has unstaged changes — running biome on the
+# working-tree version and then `git add`-ing would sweep in those unstaged edits.
+dirty_files=()
+while IFS= read -r -d '' f; do
+  for sf in "${staged_files[@]}"; do
+    if [ "$f" = "$sf" ]; then
+      dirty_files+=("$f")
+      break
+    fi
+  done
+done < <(git diff --name-only -z -- 'src/')
+
+if [ ${#dirty_files[@]} -gt 0 ]; then
+  echo "pre-commit: These files have both staged and unstaged changes:"
+  printf '  %s\n' "${dirty_files[@]}"
+  echo "Stage or stash the unstaged changes before committing."
+  exit 1
+fi
+
 npx biome check --fix -- "${staged_files[@]}"
 BIOME_EXIT=$?
 
 # Re-stage any files that biome auto-fixed
 for f in "${staged_files[@]}"; do
-  if [ -f "$f" ]; then
-    git add -- "$f"
-  fi
-done
-
-# Fail the commit if biome reported unfixable errors
-exit $BIOME_EXIT
-#!/bin/sh
-# Pre-commit hook: run biome check --fix on staged src/ files
-# and re-stage any auto-fixed changes.
-
-# Only check if there are staged files under src/
-if ! git diff --cached --name-only --diff-filter=d -z -- 'src/' | grep -qz .; then
-  exit 0
-fi
-
-git diff --cached --name-only --diff-filter=d -z -- 'src/' \
-  | xargs -0 npx biome check --fix
-BIOME_EXIT=$?
-
-# Re-stage any files that biome auto-fixed
-git diff --cached --name-only --diff-filter=d -z -- 'src/' \
-  | while IFS= read -r -d '' f; do
   if [ -f "$f" ]; then
     git add -- "$f"
   fi

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "prepare": "git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git config core.hooksPath .githooks || true",
+    "prepare": "git rev-parse --is-inside-work-tree >/dev/null 2>&1 && sh -c 'hp=$(git config --local --get core.hooksPath 2>/dev/null || true); if [ -z \"$hp\" ] || [ \"$hp\" = \".githooks\" ]; then git config --local core.hooksPath .githooks; else echo \"prepare: leaving existing core.hooksPath=$hp\"; fi' || true",
     "build": "npm run lint && npm run clean && tsc && npm run copy-plugins && npm run copy-templates",
     "lint": "biome check src/",
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "LICENSE"
   ],
   "scripts": {
+    "prepare": "git rev-parse --is-inside-work-tree >/dev/null 2>&1 && git config core.hooksPath .githooks || true",
     "build": "npm run lint && npm run clean && tsc && npm run copy-plugins && npm run copy-templates",
     "lint": "biome check src/",
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",


### PR DESCRIPTION
## Summary

Adds a git pre-commit hook that runs `biome check --fix` on staged `src/` files and re-stages any auto-fixed changes.

Closes #265

## What changed

### `.githooks/pre-commit`

Bash script that:
1. Collects staged `src/` files into an array (NUL-delimited for space-safe paths)
2. Runs `npx biome check --fix` on them
3. Re-stages any auto-fixed files
4. Fails the commit if biome reported unfixable errors

Uses `#!/usr/bin/env bash` (not `#!/bin/sh`) — the hook uses bash arrays and process substitution which aren't POSIX.

### `package.json` — `prepare` script

Runs `git config core.hooksPath .githooks` on `npm install` so contributors get the hook automatically. Guarded with `|| true` for non-git environments (e.g. `npm pack`).

## Context

Split out from #255 to keep the completion install PR focused. The pre-commit hook is an independent improvement that applies regardless of #255.

Related: #257 (extend pre-commit to cover tests)