### PR TITLE
fix: clear stale active profile on deletion and suppress --none warning

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -814,7 +814,10 @@ function _resolveClusterConfig(profileFlag?: string): ClusterConfig {
 			// only uses env vars when CAMUNDA_BASE_URL is present.
 			// Skip the warning when suppressProfileWarning is set (e.g. during
 			// `use profile --none` which is about to clear the profile).
-			if (process.env.CAMUNDA_BASE_URL?.trim() && !c8ctl.suppressProfileWarning) {
+			if (
+				process.env.CAMUNDA_BASE_URL?.trim() &&
+				!c8ctl.suppressProfileWarning
+			) {
 				const logger = getLogger();
 				logger.warn(
 					`Active profile '${c8ctl.activeProfile}' is overriding CAMUNDA_* environment variables.`,

--- a/src/config.ts
+++ b/src/config.ts
@@ -362,6 +362,13 @@ export function removeProfile(name: string): boolean {
 	}
 
 	saveProfiles(filtered);
+
+	// If the removed profile was the active session profile, clear it
+	// so `which profile` doesn't report a ghost profile.
+	if (c8ctl.activeProfile === name) {
+		clearActiveProfile();
+	}
+
 	return true;
 }
 
@@ -804,8 +811,10 @@ function _resolveClusterConfig(profileFlag?: string): ClusterConfig {
 		if (profile) {
 			// Warn when env vars are also present — avoids silent surprise
 			// Only warn when CAMUNDA_BASE_URL is set, since resolveClusterConfig
-			// only uses env vars when CAMUNDA_BASE_URL is present
-			if (process.env.CAMUNDA_BASE_URL?.trim()) {
+			// only uses env vars when CAMUNDA_BASE_URL is present.
+			// Skip the warning when suppressProfileWarning is set (e.g. during
+			// `use profile --none` which is about to clear the profile).
+			if (process.env.CAMUNDA_BASE_URL?.trim() && !c8ctl.suppressProfileWarning) {
 				const logger = getLogger();
 				logger.warn(
 					`Active profile '${c8ctl.activeProfile}' is overriding CAMUNDA_* environment variables.`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -293,7 +293,9 @@ async function main() {
 		// clear the active profile — the warning tells them to run the very
 		// command they are already running.
 		const suppressWarning =
-			verb === "use" && normalizedResource === "profile" && values.none;
+			verb === "use" &&
+			normalizedResource === "profile" &&
+			bool(values.none) === true;
 		if (suppressWarning) {
 			c8ctl.suppressProfileWarning = true;
 		}

--- a/src/index.ts
+++ b/src/index.ts
@@ -292,27 +292,35 @@ async function main() {
 		// Suppress the env-var-override warning when the user is about to
 		// clear the active profile — the warning tells them to run the very
 		// command they are already running.
-		if (verb === "use" && normalizedResource === "profile" && values.none) {
+		const suppressWarning =
+			verb === "use" && normalizedResource === "profile" && values.none;
+		if (suppressWarning) {
 			c8ctl.suppressProfileWarning = true;
 		}
 
-		const ctx: CommandContext = {
-			client: createClient(profile),
-			logger,
-			tenantId: resolveTenantId(profile),
-			resource: useResourceKey ? normalizedResource : resource || "",
-			positionals: args,
-			sortOrder,
-			sortBy: str(values.sortBy),
-			limit,
-			all: bool(values.all),
-			between: str(values.between),
-			dateField: str(values.dateField),
-			version: parseVersionFlag(values),
-			dryRun: c8ctl.dryRun,
-			profile,
-		};
-		await handler.execute(ctx, values, args);
+		try {
+			const ctx: CommandContext = {
+				client: createClient(profile),
+				logger,
+				tenantId: resolveTenantId(profile),
+				resource: useResourceKey ? normalizedResource : resource || "",
+				positionals: args,
+				sortOrder,
+				sortBy: str(values.sortBy),
+				limit,
+				all: bool(values.all),
+				between: str(values.between),
+				dateField: str(values.dateField),
+				version: parseVersionFlag(values),
+				dryRun: c8ctl.dryRun,
+				profile,
+			};
+			await handler.execute(ctx, values, args);
+		} finally {
+			if (suppressWarning) {
+				c8ctl.suppressProfileWarning = false;
+			}
+		}
 		return;
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -288,6 +288,14 @@ async function main() {
 		(useResourceKey ? COMMAND_DISPATCH.get(`${verb}:`) : undefined);
 	if (handler) {
 		const profile = str(values.profile);
+
+		// Suppress the env-var-override warning when the user is about to
+		// clear the active profile — the warning tells them to run the very
+		// command they are already running.
+		if (verb === "use" && normalizedResource === "profile" && values.none) {
+			c8ctl.suppressProfileWarning = true;
+		}
+
 		const ctx: CommandContext = {
 			client: createClient(profile),
 			logger,

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -95,6 +95,9 @@ class C8ctl implements C8ctlPluginRuntime {
 	private _resolvedBaseUrl?: string;
 	private _deps?: C8ctlDeps;
 
+	/** When true, resolveClusterConfig skips the env-var-override warning. */
+	suppressProfileWarning = false;
+
 	readonly env: C8ctlEnv = {
 		version: getVersion(),
 		nodeVersion: process.version,

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -80,6 +80,7 @@ describe('Config Module', () => {
         rmSync(testModelerDir, { recursive: true, force: true });
       }
       process.env = originalEnv;
+      c8ctl.activeProfile = undefined;
     });
 
     test('loadProfiles returns empty array when no profiles exist', () => {

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -192,6 +192,26 @@ describe('Config Module', () => {
       const removed = removeProfile('nonexistent');
       assert.strictEqual(removed, false);
     });
+
+    test('removeProfile clears active session profile when it matches the removed profile', () => {
+      addProfile({ name: 'doomed', baseUrl: 'http://doomed.com/v2' });
+      setActiveProfile('doomed');
+      assert.strictEqual(c8ctl.activeProfile, 'doomed');
+
+      const removed = removeProfile('doomed');
+      assert.strictEqual(removed, true);
+      assert.strictEqual(c8ctl.activeProfile, undefined, 'Active profile should be cleared after deletion');
+    });
+
+    test('removeProfile does not clear active session profile when a different profile is removed', () => {
+      addProfile({ name: 'keep-active', baseUrl: 'http://keep.com/v2' });
+      addProfile({ name: 'remove-other', baseUrl: 'http://other.com/v2' });
+      setActiveProfile('keep-active');
+
+      const removed = removeProfile('remove-other');
+      assert.strictEqual(removed, true);
+      assert.strictEqual(c8ctl.activeProfile, 'keep-active', 'Active profile should be unchanged');
+    });
   });
   
   // Simplified tests for now - we'll expand later if needed

--- a/tests/unit/profile-management.test.ts
+++ b/tests/unit/profile-management.test.ts
@@ -227,6 +227,26 @@ describe('Profile management', () => {
       const allOutput = consoleErrorSpy.join('\n') + consoleLogSpy.join('\n');
       assert.ok(!allOutput.includes('overriding'), 'Should not warn when no env vars conflict');
     });
+
+    test('no warning when suppressProfileWarning is set (use profile --none)', () => {
+      addProfile({
+        name: 'about-to-clear',
+        baseUrl: 'https://profile-cluster.example.com',
+      });
+      c8ctl.activeProfile = 'about-to-clear';
+      process.env.CAMUNDA_BASE_URL = 'https://env-cluster.example.com';
+      c8ctl.suppressProfileWarning = true;
+
+      try {
+        resolveClusterConfig();
+
+        const allOutput = consoleErrorSpy.join('\n') + consoleLogSpy.join('\n');
+        assert.ok(!allOutput.includes('overriding'),
+          'Should not warn when suppressProfileWarning is set');
+      } finally {
+        c8ctl.suppressProfileWarning = false;
+      }
+    });
   });
 
   describe('clearActiveProfile', () => {


### PR DESCRIPTION
## Summary

Fixes two profile management bugs discovered during manual testing of #196.

### Bug 1: `c8 which profile` returns a deleted profile

After removing the currently active profile with `c8 remove profile X`, `c8 which profile` still reported `X` as active instead of falling back to `local (default)`.

**Root cause:** `removeProfile()` removed the profile from `profiles.json` but didn't check whether the deleted profile was the active session profile in `session.json`.

**Fix:** `removeProfile()` now calls `clearActiveProfile()` when the removed profile name matches `c8ctl.activeProfile`.

### Bug 2: `c8 use profile --none` shows env var override warning

Running `c8 use profile --none` — the command whose purpose is to stop overriding env vars — triggered the env var override warning before clearing the profile.

**Root cause:** The dispatch system calls `createClient()` (which calls `resolveClusterConfig()` → emits warning) eagerly before the command handler runs.

**Fix:** Added a `suppressProfileWarning` flag to the runtime. Set it before dispatch when the command is `use profile --none`. `_resolveClusterConfig()` checks this flag and skips the warning.

### Before

```
$ c8 remove profile testing3
✓ Profile 'testing3' removed
$ c8 which profile
testing3              ← ghost profile

$ c8 use profile --none
⚠ Active profile 'local' is overriding CAMUNDA_* environment variables.
  To use env vars instead, run: c8 use profile --none    ← telling user to do what they're already doing
✓ Session profile cleared
```

### After

```
$ c8 remove profile testing3
✓ Profile 'testing3' removed
$ c8 which profile
local (default)

$ c8 use profile --none
✓ Session profile cleared
```

## Tests

- `removeProfile clears active session profile when it matches the removed profile`
- `removeProfile does not clear active session profile when a different profile is removed`
- `no warning when suppressProfileWarning is set (use profile --none)`

All existing tests continue to pass.

Closes #267