### PR TITLE
fix: clear active session profile when matching profile is deleted

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -362,6 +362,13 @@ export function removeProfile(name: string): boolean {
 	}
 
 	saveProfiles(filtered);
+
+	// If the removed profile was the active session profile, clear it
+	// so `which profile` doesn't report a ghost profile.
+	if (c8ctl.activeProfile === name) {
+		clearActiveProfile();
+	}
+
 	return true;
 }
 

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -80,6 +80,7 @@ describe('Config Module', () => {
         rmSync(testModelerDir, { recursive: true, force: true });
       }
       process.env = originalEnv;
+      c8ctl.activeProfile = undefined;
     });
 
     test('loadProfiles returns empty array when no profiles exist', () => {
@@ -191,6 +192,26 @@ describe('Config Module', () => {
     test('removeProfile returns false for non-existent profile', () => {
       const removed = removeProfile('nonexistent');
       assert.strictEqual(removed, false);
+    });
+
+    test('removeProfile clears active session profile when it matches the removed profile', () => {
+      addProfile({ name: 'doomed', baseUrl: 'http://doomed.com/v2' });
+      setActiveProfile('doomed');
+      assert.strictEqual(c8ctl.activeProfile, 'doomed');
+
+      const removed = removeProfile('doomed');
+      assert.strictEqual(removed, true);
+      assert.strictEqual(c8ctl.activeProfile, undefined, 'Active profile should be cleared after deletion');
+    });
+
+    test('removeProfile does not clear active session profile when a different profile is removed', () => {
+      addProfile({ name: 'keep-active', baseUrl: 'http://keep.com/v2' });
+      addProfile({ name: 'remove-other', baseUrl: 'http://other.com/v2' });
+      setActiveProfile('keep-active');
+
+      const removed = removeProfile('remove-other');
+      assert.strictEqual(removed, true);
+      assert.strictEqual(c8ctl.activeProfile, 'keep-active', 'Active profile should be unchanged');
     });
   });
   


### PR DESCRIPTION
## Problem

When a user deletes the currently active session profile via `remove profile <name>`, the in-memory `activeProfile` reference is not cleared. This causes `which profile` to report a "ghost" profile that no longer exists in `profiles.json`.

## Fix

After `removeProfile()` persists the filtered profile list, it now checks whether the deleted profile matches `c8ctl.activeProfile` and calls `clearActiveProfile()` if so.

## Tests

- **removeProfile clears active session profile when it matches the removed profile** — verifies the fix
- **removeProfile does not clear active session profile when a different profile is removed** — verifies no unintended side effects
- Added `c8ctl.activeProfile = undefined` cleanup in `afterEach` to prevent test pollution

Ref: #267 (addresses bug 1 of 2; bug 2 — `use profile --none` env var warning — will be addressed separately with an architectural change)