### PR TITLE
feat: defer client creation until first access

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -308,10 +308,25 @@ async function main() {
 		(useResourceKey ? COMMAND_DISPATCH.get(`${verb}:`) : undefined);
 	if (handler) {
 		const profile = str(values.profile);
+		// Lazy client: createClient() and resolveTenantId() are deferred
+		// until first access, so commands that never touch ctx.client
+		// (e.g. session/profile management) skip config resolution entirely.
+		let _client: ReturnType<typeof createClient> | undefined;
+		let _tenantId: string | undefined;
+		let _tenantResolved = false;
 		const ctx: CommandContext = {
-			client: createClient(profile),
+			get client() {
+				if (!_client) _client = createClient(profile);
+				return _client;
+			},
 			logger,
-			tenantId: resolveTenantId(profile),
+			get tenantId() {
+				if (!_tenantResolved) {
+					_tenantId = resolveTenantId(profile);
+					_tenantResolved = true;
+				}
+				return _tenantId;
+			},
 			resource: useResourceKey ? normalizedResource : resource || "",
 			positionals: args,
 			sortOrder,

--- a/src/index.ts
+++ b/src/index.ts
@@ -308,9 +308,9 @@ async function main() {
 		(useResourceKey ? COMMAND_DISPATCH.get(`${verb}:`) : undefined);
 	if (handler) {
 		const profile = str(values.profile);
-		// Lazy client: createClient() and resolveTenantId() are deferred
-		// until first access, so commands that never touch ctx.client
-		// (e.g. session/profile management) skip config resolution entirely.
+		// Lazy config access: createClient() and resolveTenantId() are deferred
+		// until first access, so commands that never touch ctx.client or
+		// ctx.tenantId (e.g. session/profile management) skip config resolution.
 		let _client: ReturnType<typeof createClient> | undefined;
 		let _tenantId: string | undefined;
 		let _tenantResolved = false;

--- a/tests/unit/lazy-client.test.ts
+++ b/tests/unit/lazy-client.test.ts
@@ -30,6 +30,13 @@ describe("Lazy client getter", () => {
 				if (!_client) _client = factories.createClient();
 				return _client;
 			},
+			get tenantId() {
+				if (!_tenantResolved) {
+					_tenantId = factories.resolveTenantId();
+					_tenantResolved = true;
+				}
+				return _tenantId;
+			},
 			// biome-ignore lint/suspicious/noExplicitAny: test stub
 		} as any as CommandContext;
 	}
@@ -67,19 +74,13 @@ describe("Lazy client getter", () => {
 
 	test("tenantId resolver is not called until ctx.tenantId is accessed", () => {
 		let called = false;
-
-		let _tenantId: string | undefined;
-		let _tenantResolved = false;
-		const ctx = {
-			get tenantId() {
-				if (!_tenantResolved) {
-					called = true;
-					_tenantId = "test-tenant";
-					_tenantResolved = true;
-				}
-				return _tenantId;
+		const ctx = buildContext({
+			createClient: () => ({ fake: "client" }),
+			resolveTenantId: () => {
+				called = true;
+				return "test-tenant";
 			},
-		} as unknown as CommandContext;
+		});
 
 		assert.strictEqual(called, false, "Resolver must not be called eagerly");
 		const tid = ctx.tenantId;
@@ -89,19 +90,13 @@ describe("Lazy client getter", () => {
 
 	test("tenantId resolver is called only once (cached)", () => {
 		let callCount = 0;
-
-		let _tenantId: string | undefined;
-		let _tenantResolved = false;
-		const ctx = {
-			get tenantId() {
-				if (!_tenantResolved) {
-					callCount++;
-					_tenantId = "t1";
-					_tenantResolved = true;
-				}
-				return _tenantId;
+		const ctx = buildContext({
+			createClient: () => ({ fake: "client" }),
+			resolveTenantId: () => {
+				callCount++;
+				return "t1";
 			},
-		} as unknown as CommandContext;
+		});
 
 		const first = ctx.tenantId;
 		const second = ctx.tenantId;

--- a/tests/unit/lazy-client.test.ts
+++ b/tests/unit/lazy-client.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for lazy client/tenantId getters in the dispatch loop.
+ *
+ * The dispatcher in src/index.ts constructs CommandContext with lazy
+ * getters for `client` and `tenantId` so that commands which never
+ * access them (e.g. session/profile management) skip config resolution
+ * and client creation entirely.
+ *
+ * These tests verify the lazy getter pattern used in the dispatcher.
+ */
+
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import type { CommandContext } from "../../src/command-framework.ts";
+
+describe("Lazy client getter", () => {
+	/**
+	 * Helper: build a CommandContext with lazy getters, mirroring the
+	 * pattern used in src/index.ts dispatch.
+	 */
+	function buildContext(factories: {
+		createClient: () => unknown;
+		resolveTenantId: () => string | undefined;
+	}): CommandContext {
+		let _client: unknown | undefined;
+		let _tenantId: string | undefined;
+		let _tenantResolved = false;
+		return {
+			get client() {
+				if (!_client) _client = factories.createClient();
+				return _client;
+			},
+			// biome-ignore lint/suspicious/noExplicitAny: test stub
+		} as any as CommandContext;
+	}
+
+	test("client factory is not called until ctx.client is accessed", () => {
+		let called = false;
+		const ctx = buildContext({
+			createClient: () => {
+				called = true;
+				return { fake: "client" };
+			},
+			resolveTenantId: () => undefined,
+		});
+
+		assert.strictEqual(called, false, "Factory must not be called eagerly");
+		const _client = ctx.client;
+		assert.strictEqual(called, true, "Factory must be called on first access");
+	});
+
+	test("client factory is called only once (cached)", () => {
+		let callCount = 0;
+		const ctx = buildContext({
+			createClient: () => {
+				callCount++;
+				return { fake: "client" };
+			},
+			resolveTenantId: () => undefined,
+		});
+
+		const first = ctx.client;
+		const second = ctx.client;
+		assert.strictEqual(callCount, 1, "Factory must be called exactly once");
+		assert.strictEqual(first, second, "Same instance must be returned");
+	});
+
+	test("tenantId resolver is not called until ctx.tenantId is accessed", () => {
+		let called = false;
+
+		let _tenantId: string | undefined;
+		let _tenantResolved = false;
+		const ctx = {
+			get tenantId() {
+				if (!_tenantResolved) {
+					called = true;
+					_tenantId = "test-tenant";
+					_tenantResolved = true;
+				}
+				return _tenantId;
+			},
+		} as unknown as CommandContext;
+
+		assert.strictEqual(called, false, "Resolver must not be called eagerly");
+		const tid = ctx.tenantId;
+		assert.strictEqual(called, true, "Resolver must be called on first access");
+		assert.strictEqual(tid, "test-tenant");
+	});
+
+	test("tenantId resolver is called only once (cached)", () => {
+		let callCount = 0;
+
+		let _tenantId: string | undefined;
+		let _tenantResolved = false;
+		const ctx = {
+			get tenantId() {
+				if (!_tenantResolved) {
+					callCount++;
+					_tenantId = "t1";
+					_tenantResolved = true;
+				}
+				return _tenantId;
+			},
+		} as unknown as CommandContext;
+
+		const first = ctx.tenantId;
+		const second = ctx.tenantId;
+		assert.strictEqual(callCount, 1, "Resolver must be called exactly once");
+		assert.strictEqual(first, second);
+	});
+});

--- a/tests/unit/lazy-client.test.ts
+++ b/tests/unit/lazy-client.test.ts
@@ -20,7 +20,7 @@ describe("Lazy client getter", () => {
 	 */
 	function buildContext(factories: {
 		createClient: () => unknown;
-		resolveTenantId: () => string | undefined;
+		resolveTenantId: () => string;
 	}): CommandContext {
 		let _client: unknown | undefined;
 		let _tenantId: string | undefined;
@@ -102,5 +102,73 @@ describe("Lazy client getter", () => {
 		const second = ctx.tenantId;
 		assert.strictEqual(callCount, 1, "Resolver must be called exactly once");
 		assert.strictEqual(first, second);
+	});
+});
+
+// ─── Dispatch-level behavioural test ─────────────────────────────────────────
+
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { asyncSpawn } from "../utils/spawn.ts";
+
+const CLI = "src/index.ts";
+
+/**
+ * Node 22.6+ supports --experimental-strip-types; older versions don't.
+ * Behavioural tests that spawn the CLI require it, so skip on older Node.
+ */
+const [major] = process.versions.node.split(".").map(Number);
+const canStripTypes = major >= 22;
+
+describe("Lazy client dispatch integration", () => {
+	test("clientless command does not emit env-var override warning", {
+		skip: canStripTypes ? false : "requires Node 22+ for --experimental-strip-types",
+	}, async () => {
+		// Set up a test data dir with an active profile AND CAMUNDA_BASE_URL.
+		// Before the lazy getter fix, this combination would trigger:
+		//   "Active profile 'test-profile' is overriding CAMUNDA_* environment variables."
+		const dataDir = mkdtempSync(join(tmpdir(), "c8ctl-lazy-test-"));
+		writeFileSync(
+			join(dataDir, "profiles.json"),
+			JSON.stringify([
+				{ name: "test-profile", baseUrl: "http://localhost:8080/v2" },
+			]),
+		);
+		writeFileSync(
+			join(dataDir, "session.json"),
+			JSON.stringify({
+				activeProfile: "test-profile",
+				outputMode: "text",
+			}),
+		);
+
+		const result = await asyncSpawn(
+			"node",
+			[
+				"--experimental-strip-types",
+				CLI,
+				"which",
+				"profile",
+			],
+			{
+				env: {
+					...process.env,
+					CAMUNDA_BASE_URL: "http://other-cluster/v2",
+					C8CTL_DATA_DIR: dataDir,
+					HOME: "/tmp/c8ctl-lazy-test-home",
+				},
+			},
+		);
+
+		assert.strictEqual(result.status, 0, `exit=${result.status} stdout: ${result.stdout} stderr: ${result.stderr}`);
+		assert.ok(
+			!result.stderr.includes("overriding"),
+			`Expected no override warning, got stderr: ${result.stderr}`,
+		);
+		assert.ok(
+			!result.stdout.includes("overriding"),
+			`Expected no override warning, got stdout: ${result.stdout}`,
+		);
 	});
 });

--- a/tests/unit/lazy-client.test.ts
+++ b/tests/unit/lazy-client.test.ts
@@ -107,7 +107,7 @@ describe("Lazy client getter", () => {
 
 // ─── Dispatch-level behavioural test ─────────────────────────────────────────
 
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { asyncSpawn } from "../utils/spawn.ts";
@@ -116,59 +116,63 @@ const CLI = "src/index.ts";
 
 /**
  * Node 22.6+ supports --experimental-strip-types; older versions don't.
- * Behavioural tests that spawn the CLI require it, so skip on older Node.
+ * package.json requires >=22.18.0, but local dev may use older versions.
  */
-const [major] = process.versions.node.split(".").map(Number);
-const canStripTypes = major >= 22;
+const [major, minor] = process.versions.node.split(".").map(Number);
+const canStripTypes = major > 22 || (major === 22 && minor >= 6);
 
 describe("Lazy client dispatch integration", () => {
 	test("clientless command does not emit env-var override warning", {
-		skip: canStripTypes ? false : "requires Node 22+ for --experimental-strip-types",
+		skip: canStripTypes ? false : "requires Node 22.6+ for --experimental-strip-types",
 	}, async () => {
 		// Set up a test data dir with an active profile AND CAMUNDA_BASE_URL.
 		// Before the lazy getter fix, this combination would trigger:
 		//   "Active profile 'test-profile' is overriding CAMUNDA_* environment variables."
 		const dataDir = mkdtempSync(join(tmpdir(), "c8ctl-lazy-test-"));
-		writeFileSync(
-			join(dataDir, "profiles.json"),
-			JSON.stringify([
-				{ name: "test-profile", baseUrl: "http://localhost:8080/v2" },
-			]),
-		);
-		writeFileSync(
-			join(dataDir, "session.json"),
-			JSON.stringify({
-				activeProfile: "test-profile",
-				outputMode: "text",
-			}),
-		);
+		try {
+			writeFileSync(
+				join(dataDir, "profiles.json"),
+				JSON.stringify([
+					{ name: "test-profile", baseUrl: "http://localhost:8080/v2" },
+				]),
+			);
+			writeFileSync(
+				join(dataDir, "session.json"),
+				JSON.stringify({
+					activeProfile: "test-profile",
+					outputMode: "text",
+				}),
+			);
 
-		const result = await asyncSpawn(
-			"node",
-			[
-				"--experimental-strip-types",
-				CLI,
-				"which",
-				"profile",
-			],
-			{
-				env: {
-					...process.env,
-					CAMUNDA_BASE_URL: "http://other-cluster/v2",
-					C8CTL_DATA_DIR: dataDir,
-					HOME: "/tmp/c8ctl-lazy-test-home",
+			const result = await asyncSpawn(
+				"node",
+				[
+					"--experimental-strip-types",
+					CLI,
+					"which",
+					"profile",
+				],
+				{
+					env: {
+						...process.env,
+						CAMUNDA_BASE_URL: "http://other-cluster/v2",
+						C8CTL_DATA_DIR: dataDir,
+						HOME: "/tmp/c8ctl-lazy-test-home",
+					},
 				},
-			},
-		);
+			);
 
-		assert.strictEqual(result.status, 0, `exit=${result.status} stdout: ${result.stdout} stderr: ${result.stderr}`);
-		assert.ok(
-			!result.stderr.includes("overriding"),
-			`Expected no override warning, got stderr: ${result.stderr}`,
-		);
-		assert.ok(
-			!result.stdout.includes("overriding"),
-			`Expected no override warning, got stdout: ${result.stdout}`,
-		);
+			assert.strictEqual(result.status, 0, `exit=${result.status} stdout: ${result.stdout} stderr: ${result.stderr}`);
+			assert.ok(
+				!result.stderr.includes("overriding"),
+				`Expected no override warning, got stderr: ${result.stderr}`,
+			);
+			assert.ok(
+				!result.stdout.includes("overriding"),
+				`Expected no override warning, got stdout: ${result.stdout}`,
+			);
+		} finally {
+			rmSync(dataDir, { recursive: true, force: true });
+		}
 	});
 });


### PR DESCRIPTION
## Summary

Replace eager `createClient(profile)` in the dispatch loop with a lazy getter. Commands that never access `ctx.client` (session, profile, plugin, open) no longer trigger config resolution, auth setup, or the "overriding env vars" warning.

`tenantId` is also lazily resolved since it shares the same config path.

## What changed

**`src/index.ts`** (~15 lines): The `CommandContext` object literal now uses `get client()` and `get tenantId()` getters instead of eagerly calling `createClient()` and `resolveTenantId()`. The client is created on first access and cached.

**`tests/unit/lazy-client.test.ts`** (new): Four tests verifying the lazy getter pattern — factory deferral, single-call caching, and the same for `tenantId`.

## What didn't change

- `CommandContext` interface — stays exactly as-is, `client: CamundaClient` remains non-optional
- `CommandHandler` interface — no new fields  
- `defineCommand` signature — no new parameters
- Every existing command file — zero modifications

## Why

See #273 for the full discussion. The dispatcher was unconditionally creating an authenticated SDK client for every command, including local-only commands that never use it. This caused spurious warnings and unnecessary config/auth overhead.

Closes #273