### PR TITLE
chore(tests): remove all 'as T' casts from test suite

### DIFF
--- a/tests/fixtures/plugins/README.md
+++ b/tests/fixtures/plugins/README.md
@@ -14,8 +14,9 @@ TypeScript implementation demonstrating:
 
 **Usage in plugins:**
 ```typescript
-// c8ctl runtime is available as a global variable
-const c8ctl = (globalThis as any).c8ctl;
+// c8ctl runtime is available as a global variable (typed in src/runtime.ts)
+const c8ctl = globalThis.c8ctl;
+if (!c8ctl) throw new Error("c8ctl runtime is not available");
 
 export const metadata = {
   name: 'my-plugin',

--- a/tests/fixtures/plugins/ts-plugin/c8ctl-plugin.ts
+++ b/tests/fixtures/plugins/ts-plugin/c8ctl-plugin.ts
@@ -3,10 +3,11 @@
  * This demonstrates the expected structure for a c8ctl plugin
  */
 
-// c8ctl runtime is available as a global variable
-// biome-ignore lint/plugin: plugin boundary — c8ctl runtime is injected at runtime
-// biome-ignore lint/suspicious/noExplicitAny: plugin fixture intentionally uses any to mirror real-world plugin authoring
-const c8ctl = (globalThis as any).c8ctl;
+// c8ctl runtime is available as a global variable (typed in src/runtime.ts)
+const c8ctl = globalThis.c8ctl;
+if (!c8ctl) {
+	throw new Error("c8ctl runtime is not available on globalThis");
+}
 
 export const metadata = {
 	name: "sample-ts-plugin",

--- a/tests/fixtures/plugins/ts-plugin/c8ctl-plugin.ts
+++ b/tests/fixtures/plugins/ts-plugin/c8ctl-plugin.ts
@@ -4,6 +4,8 @@
  */
 
 // c8ctl runtime is available as a global variable
+// biome-ignore lint/plugin: plugin boundary — c8ctl runtime is injected at runtime
+// biome-ignore lint/suspicious/noExplicitAny: plugin fixture intentionally uses any to mirror real-world plugin authoring
 const c8ctl = (globalThis as any).c8ctl;
 
 export const metadata = {

--- a/tests/integration/deploy.test.ts
+++ b/tests/integration/deploy.test.ts
@@ -7,7 +7,6 @@ import assert from "node:assert";
 import { existsSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, test } from "node:test";
-import { createClient } from "../../src/client.ts";
 import { deploy } from "../../src/commands/deployments.ts";
 import { getUserDataDir } from "../../src/config.ts";
 

--- a/tests/integration/forms.test.ts
+++ b/tests/integration/forms.test.ts
@@ -78,7 +78,7 @@ describe("Form Integration Tests", () => {
 		const definitionFound = await pollUntil(
 			async () => {
 				const result = await cli("search", "pd", "--id=Process_0t60ay7");
-				const items = parseJson<any[]>(result.stdout);
+				const items = parseJson<unknown[]>(result.stdout);
 				return items.length > 0;
 			},
 			POLL_TIMEOUT_MS,
@@ -181,7 +181,7 @@ describe("Form Integration Tests", () => {
 		const definitionFound = await pollUntil(
 			async () => {
 				const result = await cli("search", "pd", "--id=Process_0t60ay7");
-				const items = parseJson<any[]>(result.stdout);
+				const items = parseJson<unknown[]>(result.stdout);
 				return items.length > 0;
 			},
 			POLL_TIMEOUT_MS,
@@ -246,7 +246,7 @@ describe("Form Integration Tests", () => {
 		const definitionFound = await pollUntil(
 			async () => {
 				const result = await cli("search", "pd", "--id=Process_0t60ay7");
-				const items = parseJson<any[]>(result.stdout);
+				const items = parseJson<unknown[]>(result.stdout);
 				return items.length > 0;
 			},
 			POLL_TIMEOUT_MS,

--- a/tests/integration/forms.test.ts
+++ b/tests/integration/forms.test.ts
@@ -11,6 +11,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { after, before, beforeEach, describe, test } from "node:test";
+import { makeTestEnv } from "../utils/mocks.ts";
 import { pollUntil } from "../utils/polling.ts";
 import { asyncSpawn, type SpawnResult } from "../utils/spawn.ts";
 
@@ -24,12 +25,13 @@ let dataDir = "";
 function cli(...args: string[]) {
 	return asyncSpawn("node", ["--experimental-strip-types", CLI, ...args], {
 		cwd: PROJECT_ROOT,
-		env: { ...process.env, C8CTL_DATA_DIR: dataDir } as NodeJS.ProcessEnv,
+		env: makeTestEnv({ C8CTL_DATA_DIR: dataDir }),
 	});
 }
 
 function parseJson<T>(stdout: string): T {
 	try {
+		// biome-ignore lint/plugin: generic JSON parse helper; T supplied by caller
 		return JSON.parse(stdout) as T;
 	} catch (error) {
 		const msg = error instanceof Error ? error.message : String(error);

--- a/tests/integration/mcp-proxy-mock.test.ts
+++ b/tests/integration/mcp-proxy-mock.test.ts
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, test } from "node:test";
 import type { createClient } from "../../src/client.ts";
 import { createCamundaFetch } from "../../src/commands/mcp-proxy.ts";
 import type { Logger } from "../../src/logger.ts";
+import { makeMockClient, makeMockLogger } from "../utils/mocks.ts";
 
 type CamundaClient = ReturnType<typeof createClient>;
 
@@ -27,13 +28,7 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 		mockServerPort = 9876 + Math.floor(Math.random() * 1000);
 		mockServerUrl = `http://localhost:${mockServerPort}`;
 
-		mockLogger = {
-			info: () => {},
-			debug: () => {},
-			error: () => {},
-			warn: () => {},
-			json: () => {},
-		} as unknown as Logger;
+		mockLogger = makeMockLogger();
 	});
 
 	afterEach(async () => {
@@ -57,10 +52,10 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 			mockServer.listen(mockServerPort, () => resolve());
 		});
 
-		const mockCamundaClient = {
+		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({ Authorization: "Bearer test-token-123" }),
 			getConfig: () => ({ restAddress: mockServerUrl }),
-		} as unknown as CamundaClient;
+		});
 
 		const customFetch = createCamundaFetch(mockCamundaClient, mockLogger);
 		const response = await customFetch(`${mockServerUrl}/mcp/cluster`, {});
@@ -79,10 +74,10 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 			mockServer.listen(mockServerPort, () => resolve());
 		});
 
-		const mockCamundaClient = {
+		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),
 			getConfig: () => ({ restAddress: mockServerUrl }),
-		} as unknown as CamundaClient;
+		});
 
 		const customFetch = createCamundaFetch(mockCamundaClient, mockLogger);
 		const response = await customFetch(`${mockServerUrl}/mcp/cluster`, {});
@@ -100,10 +95,10 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 			mockServer.listen(mockServerPort, () => resolve());
 		});
 
-		const mockCamundaClient = {
+		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),
 			getConfig: () => ({ restAddress: mockServerUrl }),
-		} as unknown as CamundaClient;
+		});
 
 		const customFetch = createCamundaFetch(mockCamundaClient, mockLogger);
 		const response = await customFetch(`${mockServerUrl}/mcp/cluster`, {});
@@ -133,14 +128,14 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 			mockServer.listen(mockServerPort, () => resolve());
 		});
 
-		const mockCamundaClient = {
+		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({
 				Authorization:
 					requestCount === 0 ? "Bearer expired-token" : "Bearer fresh-token",
 			}),
 			forceAuthRefresh: async () => {},
 			getConfig: () => ({ restAddress: mockServerUrl }),
-		} as unknown as CamundaClient;
+		});
 
 		const customFetch = createCamundaFetch(mockCamundaClient, mockLogger);
 		const response = await customFetch(`${mockServerUrl}/mcp/cluster`, {});
@@ -154,12 +149,12 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 		// Don't start server - connection will be refused
 		const unreachablePort = 9999;
 
-		const mockCamundaClient = {
+		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),
 			getConfig: () => ({
 				restAddress: `http://localhost:${unreachablePort}`,
 			}),
-		} as unknown as CamundaClient;
+		});
 
 		const customFetch = createCamundaFetch(mockCamundaClient, mockLogger);
 
@@ -194,10 +189,10 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 			mockServer.listen(mockServerPort, () => resolve());
 		});
 
-		const mockCamundaClient = {
+		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),
 			getConfig: () => ({ restAddress: mockServerUrl }),
-		} as unknown as CamundaClient;
+		});
 
 		// Set timeout to 100ms (shorter than server response time)
 		const customFetch = createCamundaFetch(mockCamundaClient, mockLogger, 100);
@@ -222,10 +217,10 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 			mockServer.listen(mockServerPort, () => resolve());
 		});
 
-		const mockCamundaClient = {
+		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),
 			getConfig: () => ({ restAddress: mockServerUrl }),
-		} as unknown as CamundaClient;
+		});
 
 		// Set generous timeout
 		const customFetch = createCamundaFetch(mockCamundaClient, mockLogger, 5000);
@@ -251,10 +246,10 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 			mockServer.listen(mockServerPort, () => resolve());
 		});
 
-		const mockCamundaClient = {
+		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),
 			getConfig: () => ({ restAddress: mockServerUrl }),
-		} as unknown as CamundaClient;
+		});
 
 		const customFetch = createCamundaFetch(mockCamundaClient, mockLogger);
 		await customFetch(`${mockServerUrl}/api`, {
@@ -287,10 +282,10 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 			mockServer.listen(mockServerPort, () => resolve());
 		});
 
-		const mockCamundaClient = {
+		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),
 			getConfig: () => ({ restAddress: mockServerUrl }),
-		} as unknown as CamundaClient;
+		});
 
 		const customFetch = createCamundaFetch(mockCamundaClient, mockLogger);
 		const requestBody = JSON.stringify({ test: "data" });

--- a/tests/integration/mcp-proxy-mock.test.ts
+++ b/tests/integration/mcp-proxy-mock.test.ts
@@ -65,7 +65,7 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 	});
 
 	test("handles 404 response from server", async () => {
-		mockServer = createServer((req: IncomingMessage, res: ServerResponse) => {
+		mockServer = createServer((_req: IncomingMessage, res: ServerResponse) => {
 			res.writeHead(404, { "Content-Type": "text/plain" });
 			res.end("Not Found");
 		});
@@ -86,7 +86,7 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 	});
 
 	test("handles 500 error from server", async () => {
-		mockServer = createServer((req: IncomingMessage, res: ServerResponse) => {
+		mockServer = createServer((_req: IncomingMessage, res: ServerResponse) => {
 			res.writeHead(500, { "Content-Type": "text/plain" });
 			res.end("Internal Server Error");
 		});
@@ -177,7 +177,7 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 
 	test("handles slow server response with timeout", async () => {
 		mockServer = createServer(
-			async (req: IncomingMessage, res: ServerResponse) => {
+			async (_req: IncomingMessage, res: ServerResponse) => {
 				// Simulate slow response (200ms)
 				await new Promise((resolve) => setTimeout(resolve, 200));
 				res.writeHead(200, { "Content-Type": "application/json" });
@@ -207,7 +207,7 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 	});
 
 	test("successfully completes request within timeout", async () => {
-		mockServer = createServer((req: IncomingMessage, res: ServerResponse) => {
+		mockServer = createServer((_req: IncomingMessage, res: ServerResponse) => {
 			// Fast response
 			res.writeHead(200, { "Content-Type": "application/json" });
 			res.end(JSON.stringify({ success: true }));

--- a/tests/integration/output-mode.test.ts
+++ b/tests/integration/output-mode.test.ts
@@ -9,6 +9,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, test } from "node:test";
 import { createClient } from "../../src/client.ts";
+import { makeTestEnv } from "../utils/mocks.ts";
 import { pollUntil } from "../utils/polling.ts";
 import { asyncSpawn } from "../utils/spawn.ts";
 
@@ -18,7 +19,7 @@ const CLI = join(PROJECT_ROOT, "src", "index.ts");
 function cli(dataDir: string, ...args: string[]) {
 	return asyncSpawn("node", ["--experimental-strip-types", CLI, ...args], {
 		cwd: PROJECT_ROOT,
-		env: { ...process.env, C8CTL_DATA_DIR: dataDir } as NodeJS.ProcessEnv,
+		env: makeTestEnv({ C8CTL_DATA_DIR: dataDir }),
 	});
 }
 

--- a/tests/integration/pagination.test.ts
+++ b/tests/integration/pagination.test.ts
@@ -21,6 +21,7 @@ import {
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { after, before, describe, test } from "node:test";
+import { makeTestEnv } from "../utils/mocks.ts";
 import { pollUntil } from "../utils/polling.ts";
 import { asyncSpawn } from "../utils/spawn.ts";
 
@@ -55,7 +56,7 @@ let dataDir: string;
 function cli(...args: string[]) {
 	return asyncSpawn("node", ["--experimental-strip-types", CLI, ...args], {
 		cwd: PROJECT_ROOT,
-		env: { ...process.env, C8CTL_DATA_DIR: dataDir } as NodeJS.ProcessEnv,
+		env: makeTestEnv({ C8CTL_DATA_DIR: dataDir }),
 	});
 }
 

--- a/tests/integration/pagination.test.ts
+++ b/tests/integration/pagination.test.ts
@@ -42,8 +42,8 @@ const DEPLOY_BATCH_SIZE = 25;
 const POLL_TIMEOUT_MS = 120_000;
 const POLL_INTERVAL_MS = 3_000;
 
-/** Spawn timeout for CLI commands */
-const _SPAWN_TIMEOUT_MS = 300_000;
+/** Spawn timeout for CLI commands (bounds CLI hangs during this long-running integration test) */
+const SPAWN_TIMEOUT_MS = 300_000;
 
 /** Shared temp directory + data dir for this test suite */
 let bpmnDir: string;
@@ -57,6 +57,7 @@ function cli(...args: string[]) {
 	return asyncSpawn("node", ["--experimental-strip-types", CLI, ...args], {
 		cwd: PROJECT_ROOT,
 		env: makeTestEnv({ C8CTL_DATA_DIR: dataDir }),
+		timeout: SPAWN_TIMEOUT_MS,
 	});
 }
 

--- a/tests/integration/pagination.test.ts
+++ b/tests/integration/pagination.test.ts
@@ -43,7 +43,7 @@ const POLL_TIMEOUT_MS = 120_000;
 const POLL_INTERVAL_MS = 3_000;
 
 /** Spawn timeout for CLI commands */
-const SPAWN_TIMEOUT_MS = 300_000;
+const _SPAWN_TIMEOUT_MS = 300_000;
 
 /** Shared temp directory + data dir for this test suite */
 let bpmnDir: string;

--- a/tests/integration/plugin-lifecycle.test.ts
+++ b/tests/integration/plugin-lifecycle.test.ts
@@ -15,6 +15,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, before, describe, test } from "node:test";
 import { getUserDataDir } from "../../src/config.ts";
+import { getExecErrorOutput, getExecField } from "../utils/guards.ts";
 
 describe("Plugin Lifecycle Integration Tests", () => {
 	const testPluginDir = join(process.cwd(), "test-plugin-temp");
@@ -139,12 +140,11 @@ describe("Plugin Lifecycle Integration Tests", () => {
 					encoding: "utf-8",
 					timeout: 5000,
 				});
-			} catch (error: any) {
+			} catch (error) {
 				// Command may exit with 0 or throw, check both outputs
-				commandOutput = error.stdout || "";
-				commandStderr = error.stderr || "";
+				commandOutput = getExecField(error, "stdout");
+				commandStderr = getExecField(error, "stderr");
 			}
-
 			assert.ok(
 				commandOutput.includes("TEST_COMMAND_EXECUTED"),
 				`Plugin command should execute. Output: ${commandOutput}, Stderr: ${commandStderr}`,
@@ -192,9 +192,9 @@ describe("Plugin Lifecycle Integration Tests", () => {
 				});
 				// If we get here, command didn't fail as expected
 				shouldFail = !failOutput.includes("TEST_COMMAND_EXECUTED");
-			} catch (error: any) {
+			} catch (error) {
 				// Expected to fail - check error message
-				const errorOutput = error.stderr || error.stdout || error.message;
+				const errorOutput = getExecErrorOutput(error);
 				shouldFail =
 					errorOutput.includes("Unknown command") ||
 					errorOutput.includes("test-command");
@@ -237,8 +237,8 @@ describe("Plugin Lifecycle Integration Tests", () => {
 				env: { ...process.env, C8CTL_DATA_DIR: tempDir },
 			});
 			assert.fail("Unloading a non-existent plugin should fail");
-		} catch (error: any) {
-			const errorOutput = error.stderr || error.message;
+		} catch (error) {
+			const errorOutput = getExecErrorOutput(error);
 			assert.ok(
 				errorOutput.includes("neither registered nor installed"),
 				`Error should mention plugin is neither registered nor installed. Got: ${errorOutput}`,
@@ -667,8 +667,8 @@ export const commands = {
 					encoding: "utf-8",
 					timeout: 5000,
 				});
-			} catch (error: any) {
-				commandOutput = error.stdout || "";
+			} catch (error) {
+				commandOutput = getExecField(error, "stdout");
 			}
 
 			assert.ok(
@@ -803,8 +803,9 @@ export const commands = {
 					encoding: "utf-8",
 					timeout: 5000,
 				});
-			} catch (error: any) {
-				listOutput = error.stdout || error.stderr || "";
+			} catch (error) {
+				listOutput =
+					getExecField(error, "stdout") || getExecField(error, "stderr");
 			}
 
 			// Built-in command should execute (showing profiles or "No profiles found")
@@ -923,11 +924,10 @@ export const commands = {
 						timeout: 5000,
 					},
 				);
-			} catch (error: any) {
+			} catch (error) {
 				downgradeFailed = true;
-				downgradeOutput = `${error.stdout || ""}${error.stderr || ""}`;
+				downgradeOutput = `${getExecField(error, "stdout")}${getExecField(error, "stderr")}`;
 			}
-
 			assert.ok(
 				downgradeFailed,
 				"Downgrade should fail for file-based plugin source",
@@ -1043,11 +1043,10 @@ export const commands = {
 						timeout: 5000,
 					},
 				);
-			} catch (error: any) {
+			} catch (error) {
 				upgradeFailed = true;
-				upgradeOutput = `${error.stdout || ""}${error.stderr || ""}`;
+				upgradeOutput = `${getExecField(error, "stdout")}${getExecField(error, "stderr")}`;
 			}
-
 			assert.ok(
 				upgradeFailed,
 				"Versioned upgrade should fail for file-based plugin source",
@@ -1115,10 +1114,11 @@ export const commands = {
 
 		try {
 			// Create two distinct plugin directories
-			for (const [dir, name, cmd] of [
+			const pluginConfigs: Array<[string, string, string]> = [
 				[pluginOneDir, pluginOneName, "multi-test-one"],
 				[pluginTwoDir, pluginTwoName, "multi-test-two"],
-			] as [string, string, string][]) {
+			];
+			for (const [dir, name, cmd] of pluginConfigs) {
 				mkdirSync(dir, { recursive: true });
 				writeFileSync(
 					join(dir, "package.json"),
@@ -1277,9 +1277,9 @@ export const commands = {
 					env: cliEnv,
 				},
 			);
-		} catch (err: any) {
+		} catch (err) {
 			throw new Error(
-				`Failed to load plugin: ${err.stdout || ""}${err.stderr || ""}`,
+				`Failed to load plugin: ${getExecField(err, "stdout")}${getExecField(err, "stderr")}`,
 			);
 		}
 	});

--- a/tests/integration/process-definitions.test.ts
+++ b/tests/integration/process-definitions.test.ts
@@ -8,6 +8,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { after, before, beforeEach, describe, test } from "node:test";
+import { makeTestEnv } from "../utils/mocks.ts";
 import { pollUntil } from "../utils/polling.ts";
 import { asyncSpawn } from "../utils/spawn.ts";
 
@@ -35,12 +36,13 @@ type RawProcessDefinition = {
 function cli(...args: string[]) {
 	return asyncSpawn("node", ["--experimental-strip-types", CLI, ...args], {
 		cwd: PROJECT_ROOT,
-		env: { ...process.env, C8CTL_DATA_DIR: dataDir } as NodeJS.ProcessEnv,
+		env: makeTestEnv({ C8CTL_DATA_DIR: dataDir }),
 	});
 }
 
 function parseJsonOutput<T>(output: string): T {
 	try {
+		// biome-ignore lint/plugin: generic JSON parse helper; T supplied by caller
 		return JSON.parse(output) as T;
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);

--- a/tests/integration/process-instances.test.ts
+++ b/tests/integration/process-instances.test.ts
@@ -19,6 +19,7 @@ import { afterEach, beforeEach, describe, test } from "node:test";
 import { createClient } from "../../src/client.ts";
 import { deploy } from "../../src/commands/deployments.ts";
 import { todayRange } from "../utils/date-helpers.ts";
+import { makeTestEnv } from "../utils/mocks.ts";
 import { pollUntil } from "../utils/polling.ts";
 import { asyncSpawn } from "../utils/spawn.ts";
 
@@ -41,12 +42,13 @@ type ProcessInstanceRow = {
 function cli(dataDir: string, ...args: string[]) {
 	return asyncSpawn("node", ["--experimental-strip-types", CLI, ...args], {
 		cwd: PROJECT_ROOT,
-		env: { ...process.env, C8CTL_DATA_DIR: dataDir } as NodeJS.ProcessEnv,
+		env: makeTestEnv({ C8CTL_DATA_DIR: dataDir }),
 	});
 }
 
 function parseItems<T>(stdout: string): T[] {
 	if (!stdout.trim()) return [];
+	// biome-ignore lint/plugin: generic JSON parse helper; T supplied by caller
 	return JSON.parse(stdout) as T[];
 }
 

--- a/tests/integration/profile-switching.test.ts
+++ b/tests/integration/profile-switching.test.ts
@@ -8,6 +8,7 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, test } from "node:test";
+import { makeTestEnv } from "../utils/mocks.ts";
 import { pollUntil } from "../utils/polling.ts";
 import { asyncSpawn } from "../utils/spawn.ts";
 
@@ -17,7 +18,7 @@ const CLI = join(PROJECT_ROOT, "src", "index.ts");
 function cli(dataDir: string, ...args: string[]) {
 	return asyncSpawn("node", ["--experimental-strip-types", CLI, ...args], {
 		cwd: PROJECT_ROOT,
-		env: { ...process.env, C8CTL_DATA_DIR: dataDir } as NodeJS.ProcessEnv,
+		env: makeTestEnv({ C8CTL_DATA_DIR: dataDir }),
 	});
 }
 

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -13,6 +13,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { after, before, beforeEach, describe, test } from "node:test";
 import { MS_PER_DAY, todayRange } from "../utils/date-helpers.ts";
+import { makeTestEnv } from "../utils/mocks.ts";
 import { pollUntil } from "../utils/polling.ts";
 import { asyncSpawn, type SpawnResult } from "../utils/spawn.ts";
 
@@ -77,12 +78,13 @@ type VariableRow = {
 function cli(...args: string[]) {
 	return asyncSpawn("node", ["--experimental-strip-types", CLI, ...args], {
 		cwd: PROJECT_ROOT,
-		env: { ...process.env, C8CTL_DATA_DIR: dataDir } as NodeJS.ProcessEnv,
+		env: makeTestEnv({ C8CTL_DATA_DIR: dataDir }),
 	});
 }
 
 function parseJsonOutput<T>(stdout: string): T {
 	try {
+		// biome-ignore lint/plugin: generic JSON parse helper; T supplied by caller
 		return JSON.parse(stdout) as T;
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);

--- a/tests/integration/topology.test.ts
+++ b/tests/integration/topology.test.ts
@@ -44,11 +44,9 @@ describe("Topology Integration Tests (requires Camunda 8 at localhost:8080)", ()
 			const badClient = createClient();
 
 			// Should throw an error when trying to connect to non-existent server
-			let _errorThrown = false;
 			try {
 				await badClient.getTopology();
 			} catch (error) {
-				_errorThrown = true;
 				// Verify it's a connection-related error
 				assert.ok(error instanceof Error, "Should be an Error instance");
 			}

--- a/tests/integration/topology.test.ts
+++ b/tests/integration/topology.test.ts
@@ -44,11 +44,11 @@ describe("Topology Integration Tests (requires Camunda 8 at localhost:8080)", ()
 			const badClient = createClient();
 
 			// Should throw an error when trying to connect to non-existent server
-			let errorThrown = false;
+			let _errorThrown = false;
 			try {
 				await badClient.getTopology();
-			} catch (error: any) {
-				errorThrown = true;
+			} catch (error) {
+				_errorThrown = true;
 				// Verify it's a connection-related error
 				assert.ok(error instanceof Error, "Should be an Error instance");
 			}

--- a/tests/integration/watch.test.ts
+++ b/tests/integration/watch.test.ts
@@ -16,6 +16,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { after, before, describe, test } from "node:test";
 import { DEPLOY_COOLDOWN } from "../../src/commands/watch.ts";
+import { makeTestEnv } from "../utils/mocks.ts";
 import { pollUntil } from "../utils/polling.ts";
 
 const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
@@ -74,7 +75,7 @@ function startWatch(
 		["--experimental-strip-types", CLI, "watch", ...extraArgs, watchDir],
 		{
 			cwd: PROJECT_ROOT,
-			env: { ...process.env, C8CTL_DATA_DIR: dataDir } as NodeJS.ProcessEnv,
+			env: makeTestEnv({ C8CTL_DATA_DIR: dataDir }),
 			stdio: ["ignore", "pipe", "pipe"],
 		},
 	);

--- a/tests/integration/watch.test.ts
+++ b/tests/integration/watch.test.ts
@@ -161,7 +161,7 @@ describe("Watch Command Integration Tests (requires Camunda 8 at localhost:8080)
 			// Step 1: write an invalid BPMN to trigger a deployment error.
 			// On some file systems, creating a new file via rename can occasionally
 			// miss the first watch event, so we retry with an in-place rewrite.
-			const tmpInvalid = bpmnFile + ".tmp";
+			const tmpInvalid = `${bpmnFile}.tmp`;
 			writeFileSync(tmpInvalid, invalidBpmn());
 			renameSync(tmpInvalid, bpmnFile);
 
@@ -212,7 +212,7 @@ describe("Watch Command Integration Tests (requires Camunda 8 at localhost:8080)
 				cooldownElapsed,
 				`Expected cooldown to elapse before correcting BPMN file.\nActual output:\n${watch.getOutput()}`,
 			);
-			const tmpValid = bpmnFile + ".tmp";
+			const tmpValid = `${bpmnFile}.tmp`;
 			writeFileSync(tmpValid, validBpmn());
 			renameSync(tmpValid, bpmnFile);
 
@@ -248,7 +248,7 @@ describe("Watch Command Integration Tests (requires Camunda 8 at localhost:8080)
 			);
 
 			// Step 1: write an invalid BPMN to trigger an INVALID_ARGUMENT deployment error
-			const tmpInvalid = bpmnFile + ".tmp";
+			const tmpInvalid = `${bpmnFile}.tmp`;
 			writeFileSync(tmpInvalid, invalidBpmn());
 			renameSync(tmpInvalid, bpmnFile);
 
@@ -299,7 +299,7 @@ describe("Watch Command Integration Tests (requires Camunda 8 at localhost:8080)
 				cooldownElapsed,
 				`Timed out waiting for deployment cooldown before correcting the file.\nActual output:\n${watch.getOutput()}`,
 			);
-			const tmpValid = bpmnFile + ".tmp";
+			const tmpValid = `${bpmnFile}.tmp`;
 			writeFileSync(tmpValid, validBpmn());
 			renameSync(tmpValid, bpmnFile);
 

--- a/tests/unit/000-setup.test.ts
+++ b/tests/unit/000-setup.test.ts
@@ -24,7 +24,7 @@ function cleanUserDataDir() {
 	if (existsSync(profilesPath)) {
 		try {
 			rmSync(profilesPath, { force: true });
-		} catch (error) {
+		} catch (_error) {
 			// Ignore errors - file might be locked or already removed
 		}
 	}
@@ -32,7 +32,7 @@ function cleanUserDataDir() {
 	if (existsSync(sessionPath)) {
 		try {
 			rmSync(sessionPath, { force: true });
-		} catch (error) {
+		} catch (_error) {
 			// Ignore errors - file might be locked or already removed
 		}
 	}

--- a/tests/unit/agent-flags.test.ts
+++ b/tests/unit/agent-flags.test.ts
@@ -18,7 +18,7 @@ describe("--fields flag (output field filtering)", () => {
 		originalLog = console.log;
 		originalOutputMode = c8ctl.outputMode;
 		originalFields = c8ctl.fields;
-		console.log = (...args: any[]) => {
+		console.log = (...args: unknown[]) => {
 			consoleLogSpy.push(args.join(" "));
 		};
 	});

--- a/tests/unit/cluster-plugin.test.ts
+++ b/tests/unit/cluster-plugin.test.ts
@@ -14,6 +14,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, test } from "node:test";
+import { mockProcessExit } from "../utils/mocks.ts";
 
 // @ts-expect-error — JS plugin has no declaration file; typed via runtime shape assertions below
 const plugin = await import("../../default-plugins/cluster/c8ctl-plugin.js");
@@ -37,13 +38,13 @@ describe("Cluster Plugin – metadata", () => {
 
 	test('declares the "cluster" command', () => {
 		assert.ok(
-			plugin.metadata.commands["cluster"],
+			plugin.metadata.commands.cluster,
 			'Should declare a "cluster" command',
 		);
 	});
 
 	test("cluster command has a description", () => {
-		const cmd = plugin.metadata.commands["cluster"];
+		const cmd = plugin.metadata.commands.cluster;
 		assert.ok(
 			typeof cmd.description === "string" && cmd.description.length > 0,
 			"cluster command should have a non-empty description",
@@ -51,7 +52,7 @@ describe("Cluster Plugin – metadata", () => {
 	});
 
 	test("cluster command provides examples", () => {
-		const examples = plugin.metadata.commands["cluster"].examples;
+		const examples = plugin.metadata.commands.cluster.examples;
 		assert.ok(Array.isArray(examples), "examples should be an array");
 		assert.ok(examples.length >= 2, "Should have at least two examples");
 
@@ -68,7 +69,7 @@ describe("Cluster Plugin – metadata", () => {
 	});
 
 	test("examples include start, stop, status, list, logs, list-remote, install, and delete commands", () => {
-		const examples = plugin.metadata.commands["cluster"].examples;
+		const examples = plugin.metadata.commands.cluster.examples;
 		const cmds = examples.map((e: { command: string }) => e.command);
 		assert.ok(
 			cmds.some((c: string) => c.includes("start")),
@@ -115,7 +116,7 @@ describe("Cluster Plugin – commands export", () => {
 	test('exports a commands object with a "cluster" key', () => {
 		assert.ok(plugin.commands, "Should export commands");
 		assert.ok(
-			typeof plugin.commands["cluster"] === "function",
+			typeof plugin.commands.cluster === "function",
 			'"cluster" should be a function',
 		);
 	});
@@ -152,7 +153,7 @@ describe("Cluster Plugin – command usage output", () => {
 	});
 
 	test("prints usage when called with no arguments", async () => {
-		await plugin.commands["cluster"]([]);
+		await plugin.commands.cluster([]);
 
 		const output = captured.join("\n");
 		assert.ok(output.includes("Usage"), "Should print usage header");
@@ -161,7 +162,7 @@ describe("Cluster Plugin – command usage output", () => {
 	});
 
 	test("prints usage when called with an invalid subcommand", async () => {
-		await plugin.commands["cluster"](["invalid"]);
+		await plugin.commands.cluster(["invalid"]);
 
 		const output = captured.join("\n");
 		assert.ok(
@@ -171,7 +172,7 @@ describe("Cluster Plugin – command usage output", () => {
 	});
 
 	test("usage mentions version option", async () => {
-		await plugin.commands["cluster"]([]);
+		await plugin.commands.cluster([]);
 
 		const output = captured.join("\n");
 		assert.ok(
@@ -181,14 +182,14 @@ describe("Cluster Plugin – command usage output", () => {
 	});
 
 	test("usage mentions --debug flag", async () => {
-		await plugin.commands["cluster"]([]);
+		await plugin.commands.cluster([]);
 
 		const output = captured.join("\n");
 		assert.ok(output.includes("--debug"), "Should document --debug flag");
 	});
 
 	test("usage contains examples", async () => {
-		await plugin.commands["cluster"]([]);
+		await plugin.commands.cluster([]);
 
 		const output = captured.join("\n");
 		assert.ok(
@@ -198,7 +199,7 @@ describe("Cluster Plugin – command usage output", () => {
 	});
 
 	test("usage lists version aliases", async () => {
-		await plugin.commands["cluster"]([]);
+		await plugin.commands.cluster([]);
 
 		const output = captured.join("\n");
 		assert.ok(
@@ -360,7 +361,7 @@ describe("Cluster Plugin – findC8RunBinaryPath", () => {
 		writeFileSync(join(binaryDir, "c8run"), "");
 		const result = plugin.findC8RunBinaryPath(config);
 		assert.ok(result !== null, "should find binary");
-		assert.ok(result!.includes("c8run"), "path should reference binary name");
+		assert.ok(result?.includes("c8run"), "path should reference binary name");
 	});
 });
 
@@ -1068,7 +1069,7 @@ describe("Cluster Plugin – resolveVersion", () => {
 describe("Cluster Plugin – checkBackgroundAliasFreshness", () => {
 	let originalFetch: typeof globalThis.fetch;
 	let loggedMessages: string[];
-	let originalC8ctl: any;
+	let originalC8ctl: typeof globalThis.c8ctl;
 
 	beforeEach(() => {
 		originalFetch = globalThis.fetch;
@@ -1424,7 +1425,7 @@ describe("Cluster Plugin – status and list subcommands", () => {
 	});
 
 	test("status subcommand does not print usage", async () => {
-		await plugin.commands["cluster"](["status"]);
+		await plugin.commands.cluster(["status"]);
 		const output = captured.join("\n");
 		assert.ok(
 			!output.includes("Usage:"),
@@ -1433,7 +1434,7 @@ describe("Cluster Plugin – status and list subcommands", () => {
 	});
 
 	test("list subcommand does not print usage", async () => {
-		await plugin.commands["cluster"](["list"]);
+		await plugin.commands.cluster(["list"]);
 		const output = captured.join("\n");
 		assert.ok(
 			!output.includes("Usage:"),
@@ -1442,7 +1443,7 @@ describe("Cluster Plugin – status and list subcommands", () => {
 	});
 
 	test("usage mentions status subcommand", async () => {
-		await plugin.commands["cluster"]([]);
+		await plugin.commands.cluster([]);
 		const output = captured.join("\n");
 		assert.ok(
 			output.includes("status"),
@@ -1451,7 +1452,7 @@ describe("Cluster Plugin – status and list subcommands", () => {
 	});
 
 	test("usage mentions list subcommand", async () => {
-		await plugin.commands["cluster"]([]);
+		await plugin.commands.cluster([]);
 		const output = captured.join("\n");
 		assert.ok(
 			output.includes("list"),
@@ -1460,7 +1461,7 @@ describe("Cluster Plugin – status and list subcommands", () => {
 	});
 
 	test("usage mentions logs subcommand", async () => {
-		await plugin.commands["cluster"]([]);
+		await plugin.commands.cluster([]);
 		const output = captured.join("\n");
 		assert.ok(
 			output.includes("logs"),
@@ -1469,7 +1470,7 @@ describe("Cluster Plugin – status and list subcommands", () => {
 	});
 
 	test("usage mentions list-remote subcommand", async () => {
-		await plugin.commands["cluster"]([]);
+		await plugin.commands.cluster([]);
 		const output = captured.join("\n");
 		assert.ok(
 			output.includes("list-remote"),
@@ -1478,7 +1479,7 @@ describe("Cluster Plugin – status and list subcommands", () => {
 	});
 
 	test("usage mentions install subcommand", async () => {
-		await plugin.commands["cluster"]([]);
+		await plugin.commands.cluster([]);
 		const output = captured.join("\n");
 		assert.ok(
 			output.includes("install"),
@@ -1487,7 +1488,7 @@ describe("Cluster Plugin – status and list subcommands", () => {
 	});
 
 	test("usage mentions delete subcommand", async () => {
-		await plugin.commands["cluster"]([]);
+		await plugin.commands.cluster([]);
 		const output = captured.join("\n");
 		assert.ok(
 			output.includes("delete"),
@@ -1496,7 +1497,7 @@ describe("Cluster Plugin – status and list subcommands", () => {
 	});
 
 	test("usage shows stable as default alias", async () => {
-		await plugin.commands["cluster"]([]);
+		await plugin.commands.cluster([]);
 		const output = captured.join("\n");
 		assert.ok(
 			output.includes("default: stable"),
@@ -1505,13 +1506,13 @@ describe("Cluster Plugin – status and list subcommands", () => {
 	});
 
 	test("stop usage does not show a [<version>] argument", async () => {
-		await plugin.commands["cluster"]([]);
+		await plugin.commands.cluster([]);
 		const output = captured.join("\n");
 		// The stop line should just be 'c8ctl cluster stop' with no version arg
 		const stopLine = output.split("\n").find((l) => l.includes("cluster stop"));
 		assert.ok(stopLine, "Should have a stop usage line");
 		assert.ok(
-			!stopLine!.includes("[<version>]"),
+			!stopLine?.includes("[<version>]"),
 			"stop usage should not show [<version>]",
 		);
 	});
@@ -1581,16 +1582,19 @@ describe("Cluster Plugin – deleteVersion", () => {
 		writeFileSync(join(tempDir, "cluster.version"), "8.8");
 
 		let exitCalled = false;
-		process.exit = (() => {
+		const restoreExit = mockProcessExit(() => {
 			exitCalled = true;
-			throw new Error("exit");
-		}) as never;
+		});
 
-		await assert.rejects(() => plugin.deleteVersion(tempDir, "8.8"), /exit/);
-		assert.ok(
-			exitCalled,
-			"Should call process.exit when trying to delete running version",
-		);
+		try {
+			await assert.rejects(() => plugin.deleteVersion(tempDir, "8.8"), /exit/);
+			assert.ok(
+				exitCalled,
+				"Should call process.exit when trying to delete running version",
+			);
+		} finally {
+			restoreExit();
+		}
 	});
 });
 
@@ -1682,18 +1686,16 @@ describe("Cluster Plugin – listRemoteVersions", () => {
 			configurable: true,
 		});
 
-		const originalExit = process.exit;
 		let exitCalled = false;
-		process.exit = (() => {
+		const restoreExit = mockProcessExit(() => {
 			exitCalled = true;
-			throw new Error("exit");
-		}) as never;
+		});
 
 		try {
 			await assert.rejects(() => plugin.listRemoteVersions(), /exit/);
 			assert.ok(exitCalled, "Should exit on network error");
 		} finally {
-			process.exit = originalExit;
+			restoreExit();
 		}
 	});
 });
@@ -1818,7 +1820,7 @@ describe("Cluster Plugin – logs, list-remote, install, delete subcommands", ()
 	});
 
 	test("log subcommand does not print usage", async () => {
-		await plugin.commands["cluster"](["log"]);
+		await plugin.commands.cluster(["log"]);
 		const output = captured.join("\n");
 		assert.ok(
 			!output.includes("Usage:"),
@@ -1827,7 +1829,7 @@ describe("Cluster Plugin – logs, list-remote, install, delete subcommands", ()
 	});
 
 	test("logs subcommand does not print usage", async () => {
-		await plugin.commands["cluster"](["logs"]);
+		await plugin.commands.cluster(["logs"]);
 		const output = captured.join("\n");
 		assert.ok(
 			!output.includes("Usage:"),
@@ -1836,15 +1838,12 @@ describe("Cluster Plugin – logs, list-remote, install, delete subcommands", ()
 	});
 
 	test("list-remote subcommand does not print usage", async () => {
-		const originalExit = process.exit;
-		process.exit = (() => {
-			throw new Error("exit");
-		}) as never;
+		const restoreExit = mockProcessExit();
 
 		try {
-			await plugin.commands["cluster"](["list-remote"]).catch(() => {});
+			await plugin.commands.cluster(["list-remote"]).catch(() => {});
 		} finally {
-			process.exit = originalExit;
+			restoreExit();
 		}
 		// If we got here without "Usage:" in output, the subcommand was recognized
 		const output = captured.join("\n");
@@ -1855,15 +1854,12 @@ describe("Cluster Plugin – logs, list-remote, install, delete subcommands", ()
 	});
 
 	test("delete subcommand does not print usage", async () => {
-		const originalExit = process.exit;
-		process.exit = (() => {
-			throw new Error("exit");
-		}) as never;
+		const restoreExit = mockProcessExit();
 
 		try {
-			await plugin.commands["cluster"](["delete", "8.8"]).catch(() => {});
+			await plugin.commands.cluster(["delete", "8.8"]).catch(() => {});
 		} finally {
-			process.exit = originalExit;
+			restoreExit();
 		}
 		const output = captured.join("\n");
 		assert.ok(
@@ -1873,15 +1869,12 @@ describe("Cluster Plugin – logs, list-remote, install, delete subcommands", ()
 	});
 
 	test("install subcommand does not print usage", async () => {
-		const originalExit = process.exit;
-		process.exit = (() => {
-			throw new Error("exit");
-		}) as never;
+		const restoreExit = mockProcessExit();
 
 		try {
-			await plugin.commands["cluster"](["install", "8.8"]).catch(() => {});
+			await plugin.commands.cluster(["install", "8.8"]).catch(() => {});
 		} finally {
-			process.exit = originalExit;
+			restoreExit();
 		}
 		const output = captured.join("\n");
 		assert.ok(
@@ -1891,15 +1884,12 @@ describe("Cluster Plugin – logs, list-remote, install, delete subcommands", ()
 	});
 
 	test("install without version exits with error", async () => {
-		const originalExit = process.exit;
-		process.exit = (() => {
-			throw new Error("exit");
-		}) as never;
+		const restoreExit = mockProcessExit();
 
 		try {
-			await plugin.commands["cluster"](["install"]).catch(() => {});
+			await plugin.commands.cluster(["install"]).catch(() => {});
 		} finally {
-			process.exit = originalExit;
+			restoreExit();
 		}
 		const output = captured.join("\n");
 		assert.ok(
@@ -1909,15 +1899,12 @@ describe("Cluster Plugin – logs, list-remote, install, delete subcommands", ()
 	});
 
 	test("delete without version exits with error", async () => {
-		const originalExit = process.exit;
-		process.exit = (() => {
-			throw new Error("exit");
-		}) as never;
+		const restoreExit = mockProcessExit();
 
 		try {
-			await plugin.commands["cluster"](["delete"]).catch(() => {});
+			await plugin.commands.cluster(["delete"]).catch(() => {});
 		} finally {
-			process.exit = originalExit;
+			restoreExit();
 		}
 		const output = captured.join("\n");
 		assert.ok(
@@ -1991,7 +1978,7 @@ describe("Cluster Plugin – ensureC8RunInstalled start vs install behavior", ()
 
 	test("start (checkForUpdateHint=true) does not block or re-download, but checks remote for hint", async () => {
 		// Simulate: 8.8 is installed locally with an old ETag, remote has a new ETag
-		const config: any = {
+		const config = {
 			cacheDir: tempDir,
 			version: "8.8",
 			isRolling: true,
@@ -2065,7 +2052,7 @@ describe("Cluster Plugin – ensureC8RunInstalled start vs install behavior", ()
 	});
 
 	test("start with minor version succeeds offline (hint check swallows error)", async () => {
-		const config: any = {
+		const config = {
 			cacheDir: tempDir,
 			version: "8.8",
 			isRolling: true,

--- a/tests/unit/command-framework.test.ts
+++ b/tests/unit/command-framework.test.ts
@@ -20,10 +20,8 @@ import {
 	type CommandResult,
 	defineCommand,
 	deserializeFlags,
-	deserializePositionals,
 	type InferFlags,
 	type InferPositionals,
-	type PositionalDef,
 	type ResolvedFlags,
 	type ResolvedPositionals,
 } from "../../src/command-framework.ts";

--- a/tests/unit/command-framework.test.ts
+++ b/tests/unit/command-framework.test.ts
@@ -28,6 +28,7 @@ import {
 	type ResolvedPositionals,
 } from "../../src/command-framework.ts";
 import type { FlagDef } from "../../src/command-registry.ts";
+import { makeMockClient, makeMockLogger } from "../utils/mocks.ts";
 
 // ─── Test flag schemas ───────────────────────────────────────────────────────
 
@@ -288,21 +289,12 @@ describe("defineCommand", () => {
 			},
 		);
 
-		// Simulate dispatch. The handler under test does not touch ctx.client, and
-		// it does not log directly, but cmd.execute() may still use ctx.logger
-		// when rendering a non-undefined CommandResult. The two casts below are
-		// the unavoidable boundary where we stub external SDK and internal class
-		// types that cannot be satisfied structurally.
-		const mockLogger: CommandContext["logger"] =
-			// biome-ignore lint/plugin: test-only stub for Logger class; structural satisfaction impractical
-			{
-				json: () => {},
-				table: () => {},
-				output: () => {},
-				info: () => {},
-			} as unknown as CommandContext["logger"];
-		// biome-ignore lint/plugin: test-only stub for CamundaClient class; structural satisfaction impractical
-		const mockClient = {} as CommandContext["client"];
+		// Simulate dispatch. The handler under test does not touch ctx.client,
+		// and it does not log directly, but cmd.execute() may still use
+		// ctx.logger when rendering a non-undefined CommandResult. The stubs
+		// below cross the unavoidable test/SDK boundary via tests/utils/mocks.ts.
+		const mockLogger = makeMockLogger();
+		const mockClient = makeMockClient();
 		const mockCtx: CommandContext = {
 			client: mockClient,
 			logger: mockLogger,

--- a/tests/unit/command-registry.test.ts
+++ b/tests/unit/command-registry.test.ts
@@ -16,7 +16,6 @@ import {
 	getAcceptedFlags,
 	getCommandDef,
 	isValidCommand,
-	RESOURCE_ALIASES,
 	resolveAlias,
 	SEARCH_FLAGS,
 	VERB_ALIASES,

--- a/tests/unit/command-validation.test.ts
+++ b/tests/unit/command-validation.test.ts
@@ -29,9 +29,10 @@ function setup() {
 	originalError = console.error;
 	originalExit = process.exit;
 	console.error = (...args: any[]) => errorSpy.push(args.join(" "));
-	(process.exit as any) = (code: number) => {
+	process.exit = ((code: number) => {
 		throw new Error(`process.exit(${code})`);
-	};
+		// biome-ignore lint/plugin: test-only override of process.exit signature
+	}) as typeof process.exit;
 }
 
 function teardown() {
@@ -400,7 +401,8 @@ describe("validateFlags behaviour", () => {
 		const searchDef = COMMAND_REGISTRY.search;
 		// processDefinitionKey as boolean should be skipped (not validated)
 		const result = validateFlags(
-			{ processDefinitionKey: true as any },
+			// biome-ignore lint/plugin: intentionally passing wrong type to test skip path
+			{ processDefinitionKey: true as unknown as string },
 			searchDef.flags,
 		);
 		assert.strictEqual(result.size, 0);

--- a/tests/unit/command-validation.test.ts
+++ b/tests/unit/command-validation.test.ts
@@ -15,29 +15,27 @@ import {
 	requireOption,
 	requirePositional,
 } from "../../src/command-validation.ts";
+import { mockProcessExit } from "../utils/mocks.ts";
 
 // A minimal enum-like object matching the SDK pattern
 const ColorEnum = { RED: "RED", GREEN: "GREEN", BLUE: "BLUE" } as const;
-type ColorEnum = (typeof ColorEnum)[keyof typeof ColorEnum];
 
 let errorSpy: string[];
 let originalError: typeof console.error;
-let originalExit: typeof process.exit;
+let restoreExit: () => void;
 
 function setup() {
 	errorSpy = [];
 	originalError = console.error;
-	originalExit = process.exit;
-	console.error = (...args: any[]) => errorSpy.push(args.join(" "));
-	process.exit = ((code: number) => {
+	console.error = (...args: unknown[]) => errorSpy.push(args.join(" "));
+	restoreExit = mockProcessExit((code) => {
 		throw new Error(`process.exit(${code})`);
-		// biome-ignore lint/plugin: test-only override of process.exit signature
-	}) as typeof process.exit;
+	});
 }
 
 function teardown() {
 	console.error = originalError;
-	process.exit = originalExit;
+	restoreExit();
 }
 
 // ─── requireOption ───────────────────────────────────────────────────────────
@@ -190,7 +188,7 @@ describe("requirePositional", () => {
 	test("prints hint when provided", () => {
 		const logSpy: string[] = [];
 		const origLog = console.log;
-		console.log = (...args: any[]) => {
+		console.log = (...args: unknown[]) => {
 			logSpy.push(args.join(" "));
 		};
 		try {
@@ -238,7 +236,7 @@ describe("requireOneOf", () => {
 	test("prints hint when provided", () => {
 		const logSpy: string[] = [];
 		const origLog = console.log;
-		console.log = (...args: any[]) => {
+		console.log = (...args: unknown[]) => {
 			logSpy.push(args.join(" "));
 		};
 		try {
@@ -317,7 +315,7 @@ describe("validateFlags structural invariants", () => {
 				// Key-type fields (numeric pattern) reject non-numeric strings
 				if (flagName.endsWith("Key")) {
 					assert.throws(
-						() => flagDef.validate!("not-a-number"),
+						() => flagDef.validate?.("not-a-number"),
 						`${verb}.flags.${flagName}.validate should throw on invalid input`,
 					);
 				}
@@ -401,8 +399,7 @@ describe("validateFlags behaviour", () => {
 		const searchDef = COMMAND_REGISTRY.search;
 		// processDefinitionKey as boolean should be skipped (not validated)
 		const result = validateFlags(
-			// biome-ignore lint/plugin: intentionally passing wrong type to test skip path
-			{ processDefinitionKey: true as unknown as string },
+			{ processDefinitionKey: true },
 			searchDef.flags,
 		);
 		assert.strictEqual(result.size, 0);

--- a/tests/unit/completion.test.ts
+++ b/tests/unit/completion.test.ts
@@ -5,13 +5,14 @@
 import assert from "node:assert";
 import { afterEach, beforeEach, describe, test } from "node:test";
 import { showCompletion } from "../../src/commands/completion.ts";
+import { mockProcessExit } from "../utils/mocks.ts";
 
 describe("Completion Module", () => {
-	let consoleLogSpy: any[];
-	let consoleErrorSpy: any[];
+	let consoleLogSpy: unknown[];
+	let consoleErrorSpy: unknown[];
 	let originalLog: typeof console.log;
 	let originalError: typeof console.error;
-	let processExitStub: ((code: number) => never) | undefined;
+	let restoreExit: (() => void) | undefined;
 	let exitCode: number | undefined;
 
 	beforeEach(() => {
@@ -21,29 +22,25 @@ describe("Completion Module", () => {
 		originalError = console.error;
 		exitCode = undefined;
 
-		console.log = (...args: any[]) => {
+		console.log = (...args: unknown[]) => {
 			consoleLogSpy.push(args.join(" "));
 		};
 
-		console.error = (...args: any[]) => {
+		console.error = (...args: unknown[]) => {
 			consoleErrorSpy.push(args.join(" "));
 		};
 
 		// Stub process.exit to capture exit codes
-		processExitStub = process.exit;
-		process.exit = ((code: number) => {
-			exitCode = code;
+		restoreExit = mockProcessExit((code) => {
+			exitCode = typeof code === "number" ? code : undefined;
 			throw new Error(`process.exit(${code})`);
-			// biome-ignore lint/plugin: test-only override of process.exit signature
-		}) as typeof process.exit;
+		});
 	});
 
 	afterEach(() => {
 		console.log = originalLog;
 		console.error = originalError;
-		if (processExitStub) {
-			process.exit = processExitStub;
-		}
+		restoreExit?.();
 	});
 
 	test("generates bash completion script", () => {
@@ -174,8 +171,10 @@ describe("Completion Module", () => {
 		try {
 			showCompletion(undefined);
 			assert.fail("Should have thrown an error");
-		} catch (error: any) {
-			assert.ok(error.message.includes("process.exit(1)"));
+		} catch (error) {
+			assert.ok(
+				error instanceof Error && error.message.includes("process.exit(1)"),
+			);
 			assert.strictEqual(exitCode, 1);
 		}
 
@@ -188,8 +187,10 @@ describe("Completion Module", () => {
 		try {
 			showCompletion("powershell");
 			assert.fail("Should have thrown an error");
-		} catch (error: any) {
-			assert.ok(error.message.includes("process.exit(1)"));
+		} catch (error) {
+			assert.ok(
+				error instanceof Error && error.message.includes("process.exit(1)"),
+			);
 			assert.strictEqual(exitCode, 1);
 		}
 

--- a/tests/unit/completion.test.ts
+++ b/tests/unit/completion.test.ts
@@ -31,10 +31,11 @@ describe("Completion Module", () => {
 
 		// Stub process.exit to capture exit codes
 		processExitStub = process.exit;
-		(process.exit as any) = (code: number) => {
+		process.exit = ((code: number) => {
 			exitCode = code;
 			throw new Error(`process.exit(${code})`);
-		};
+			// biome-ignore lint/plugin: test-only override of process.exit signature
+		}) as typeof process.exit;
 	});
 
 	afterEach(() => {

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -9,34 +9,23 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, test } from "node:test";
 import {
-	AUTH_TYPES,
 	addProfile,
-	type Connection,
 	connectionToClusterConfig,
-	connectionToProfile,
 	DEFAULT_PROFILE,
 	DEFAULT_PROFILE_CONFIG,
 	ensureDefaultProfile,
-	getAllProfiles,
 	getModelerDataDir,
 	getProfile,
-	getProfileOrModeler,
 	getUserDataDir,
 	loadModelerConnections,
 	loadProfiles,
 	loadSessionState,
 	type Profile,
-	profileToClusterConfig,
 	removeProfile,
 	resolveClusterConfig,
-	resolveTenantId,
 	saveProfiles,
-	saveSessionState,
 	setActiveProfile,
-	setActiveTenant,
-	setOutputMode,
 	TARGET_TYPES,
-	validateConnection,
 } from "../../src/config.ts";
 import { c8ctl } from "../../src/runtime.ts";
 

--- a/tests/unit/deploy-behaviour.test.ts
+++ b/tests/unit/deploy-behaviour.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, test } from "node:test";
 import { c8, parseJson } from "../utils/cli.ts";
+import { asRecord, asRecordArray } from "../utils/guards.ts";
 
 const MINIMAL_BPMN = `<?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
@@ -52,11 +53,10 @@ describe("CLI behavioural: deploy", () => {
 
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
-		assert.ok((out.url as string).endsWith("/deployments"));
+		assert.ok(typeof out.url === "string" && out.url.endsWith("/deployments"));
 
-		const body = out.body as Record<string, unknown>;
-		const resources = body.resources as Array<Record<string, unknown>>;
-		assert.ok(Array.isArray(resources), "body.resources should be an array");
+		const body = asRecord(out.body, "dry-run body");
+		const resources = asRecordArray(body.resources, "body.resources");
 		assert.ok(resources.length > 0, "should include at least one resource");
 		assert.ok(resources[0].name, "resource should have a name");
 	});

--- a/tests/unit/deploy-traversal.test.ts
+++ b/tests/unit/deploy-traversal.test.ts
@@ -3,7 +3,7 @@
  */
 
 import assert from "node:assert";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, test } from "node:test";

--- a/tests/unit/deployment-logging.test.ts
+++ b/tests/unit/deployment-logging.test.ts
@@ -8,6 +8,7 @@ import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, test } from "node:test";
+import { getExecField } from "../utils/guards.ts";
 
 // Timeout for deployment commands (longer for CI environments)
 const DEPLOYMENT_TIMEOUT = 10000;
@@ -53,8 +54,8 @@ describe("Deployment Logging", () => {
 				env: process.env,
 			});
 			return output;
-		} catch (error: any) {
-			return error.stdout + error.stderr;
+		} catch (error) {
+			return getExecField(error, "stdout") + getExecField(error, "stderr");
 		}
 	}
 

--- a/tests/unit/deployment-validation.test.ts
+++ b/tests/unit/deployment-validation.test.ts
@@ -47,7 +47,7 @@ describe("Deployment Validation", () => {
 				env: process.env,
 			});
 			assert.fail("Should have thrown an error for duplicate process IDs");
-		} catch (error: any) {
+		} catch (error) {
 			const output = error.stdout + error.stderr;
 			assert.match(
 				output,
@@ -85,7 +85,7 @@ describe("Deployment Validation", () => {
 			});
 			// If Camunda is running, this should succeed
 			assert.ok(true);
-		} catch (error: any) {
+		} catch (error) {
 			// If it fails, it should be a connection error, not a validation error
 			const output = error.stdout + error.stderr;
 			assert.doesNotMatch(
@@ -108,7 +108,7 @@ describe("Deployment Validation", () => {
 			});
 			// If Camunda is running, this should succeed
 			assert.ok(true);
-		} catch (error: any) {
+		} catch (error) {
 			// If it fails, it should be a connection error, not a validation error
 			const output = error.stdout + error.stderr;
 			assert.doesNotMatch(

--- a/tests/unit/deployment-validation.test.ts
+++ b/tests/unit/deployment-validation.test.ts
@@ -8,6 +8,7 @@ import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, test } from "node:test";
+import { getExecErrorOutput } from "../utils/guards.ts";
 
 describe("Deployment Validation", () => {
 	let testDir: string;
@@ -48,7 +49,7 @@ describe("Deployment Validation", () => {
 			});
 			assert.fail("Should have thrown an error for duplicate process IDs");
 		} catch (error) {
-			const output = error.stdout + error.stderr;
+			const output = getExecErrorOutput(error);
 			assert.match(
 				output,
 				/Cannot deploy.*Multiple files with the same process\/decision ID/,
@@ -87,7 +88,7 @@ describe("Deployment Validation", () => {
 			assert.ok(true);
 		} catch (error) {
 			// If it fails, it should be a connection error, not a validation error
-			const output = error.stdout + error.stderr;
+			const output = getExecErrorOutput(error);
 			assert.doesNotMatch(
 				output,
 				/Cannot deploy.*Multiple files/,
@@ -110,7 +111,7 @@ describe("Deployment Validation", () => {
 			assert.ok(true);
 		} catch (error) {
 			// If it fails, it should be a connection error, not a validation error
-			const output = error.stdout + error.stderr;
+			const output = getExecErrorOutput(error);
 			assert.doesNotMatch(
 				output,
 				/Cannot deploy.*Multiple files/,

--- a/tests/unit/fetch-all-pages.test.ts
+++ b/tests/unit/fetch-all-pages.test.ts
@@ -13,9 +13,13 @@ function createMockSearch(totalItems: number, pageSize: number) {
 	}));
 	let callCount = 0;
 
-	const searchFn = async (filter: any, _opts?: any) => {
+	const searchFn = async (
+		filter: Record<string, unknown> & { page?: Record<string, unknown> },
+		_opts?: unknown,
+	) => {
 		callCount++;
-		const after = filter.page?.after as number | undefined;
+		const afterRaw = filter.page?.after;
+		const after = typeof afterRaw === "number" ? afterRaw : undefined;
 		const start = after ?? 0;
 		const end = Math.min(start + pageSize, totalItems);
 		const items = allItems.slice(start, end);
@@ -32,7 +36,10 @@ function createMockSearch(totalItems: number, pageSize: number) {
 	};
 
 	// Expose a way to parse the `after` cursor back into a number
-	const wrappedSearch = async (filter: any, opts?: any) => {
+	const wrappedSearch = async (
+		filter: Record<string, unknown> & { page?: Record<string, unknown> },
+		opts?: unknown,
+	) => {
 		const parsedFilter = {
 			...filter,
 			page: {
@@ -131,7 +138,10 @@ describe("fetchAllPages", () => {
 
 	test("stops when search returns duplicate cursor", async () => {
 		let callCount = 0;
-		const stuckSearch = async (_filter: any, _opts?: any) => {
+		const stuckSearch = async (
+			_filter: Record<string, unknown>,
+			_opts?: unknown,
+		) => {
 			callCount++;
 			return {
 				items: [{ id: callCount }],
@@ -151,7 +161,10 @@ describe("fetchAllPages", () => {
 
 	test("stops when search returns no endCursor", async () => {
 		let callCount = 0;
-		const noCursorSearch = async (_filter: any, _opts?: any) => {
+		const noCursorSearch = async (
+			_filter: Record<string, unknown>,
+			_opts?: unknown,
+		) => {
 			callCount++;
 			return {
 				items: [{ id: callCount }],
@@ -170,7 +183,10 @@ describe("fetchAllPages", () => {
 
 	test("stops when search returns empty items", async () => {
 		let callCount = 0;
-		const emptySearch = async (_filter: any, _opts?: any) => {
+		const emptySearch = async (
+			_filter: Record<string, unknown>,
+			_opts?: unknown,
+		) => {
 			callCount++;
 			if (callCount === 1) {
 				return {
@@ -190,8 +206,11 @@ describe("fetchAllPages", () => {
 	});
 
 	test("passes filter through to search function", async () => {
-		let receivedFilter: any;
-		const capturingSearch = async (filter: any, _opts?: any) => {
+		let receivedFilter: unknown;
+		const capturingSearch = async (
+			filter: Record<string, unknown> & { page?: Record<string, unknown> },
+			_opts?: unknown,
+		) => {
 			receivedFilter = filter;
 			return { items: [], page: {} };
 		};
@@ -204,9 +223,12 @@ describe("fetchAllPages", () => {
 	});
 
 	test("passes cursor in page.after on subsequent calls", async () => {
-		const receivedFilters: any[] = [];
+		const receivedFilters: unknown[] = [];
 		let callCount = 0;
-		const trackingSearch = async (filter: any, _opts?: any) => {
+		const trackingSearch = async (
+			filter: Record<string, unknown> & { page?: Record<string, unknown> },
+			_opts?: unknown,
+		) => {
 			receivedFilters.push(JSON.parse(JSON.stringify(filter)));
 			callCount++;
 			if (callCount === 1) {
@@ -244,7 +266,10 @@ describe("fetchAllPages", () => {
 		// The Camunda 8 SDK uses z.coerce.bigint() for totalItems, so it returns BigInt at runtime.
 		// fetchAllPages must convert it to number before comparing with allItems.length (a number).
 		let callCount = 0;
-		const bigintTotalItemsSearch = async (_filter: any, _opts?: any) => {
+		const bigintTotalItemsSearch = async (
+			_filter: Record<string, unknown>,
+			_opts?: unknown,
+		) => {
 			callCount++;
 			return {
 				items: [{ id: 1 }, { id: 2 }],

--- a/tests/unit/form-topology-run-behaviour.test.ts
+++ b/tests/unit/form-topology-run-behaviour.test.ts
@@ -9,7 +9,7 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { c8, parseJson } from "../utils/cli.ts";
-import { asRecord } from "../utils/guards.ts";
+import { asRecord, getUrl } from "../utils/guards.ts";
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
@@ -20,7 +20,7 @@ function assertDryRun(
 	assert.strictEqual(out.dryRun, true);
 	assert.strictEqual(out.method, expected.method);
 	assert.ok(
-		(out.url as string).endsWith(expected.urlSuffix),
+		getUrl(out).endsWith(expected.urlSuffix),
 		`Expected URL to end with "${expected.urlSuffix}", got "${out.url}"`,
 	);
 }
@@ -92,7 +92,7 @@ describe("CLI behavioural: get form", () => {
 		assert.strictEqual(out.method, "GET");
 		// The generic form lookup tries user-tasks first, then process-definitions
 		assert.ok(
-			(out.url as string).includes("/user-tasks/abc/form"),
+			getUrl(out).includes("/user-tasks/abc/form"),
 			`Expected URL to contain /user-tasks/abc/form, got "${out.url}"`,
 		);
 	});
@@ -115,7 +115,7 @@ describe("CLI behavioural: run", () => {
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
 		assert.ok(
-			(out.url as string).includes("/deployments"),
+			getUrl(out).includes("/deployments"),
 			`Expected URL to contain /deployments, got "${out.url}"`,
 		);
 		const body = asRecord(out.body, "dry-run body");

--- a/tests/unit/form-topology-run-behaviour.test.ts
+++ b/tests/unit/form-topology-run-behaviour.test.ts
@@ -9,6 +9,7 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { c8, parseJson } from "../utils/cli.ts";
+import { asRecord } from "../utils/guards.ts";
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
@@ -117,7 +118,7 @@ describe("CLI behavioural: run", () => {
 			(out.url as string).includes("/deployments"),
 			`Expected URL to contain /deployments, got "${out.url}"`,
 		);
-		const body = out.body as Record<string, unknown>;
+		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.path, "test.bpmn");
 	});
 
@@ -132,7 +133,7 @@ describe("CLI behavioural: run", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assert.strictEqual(out.dryRun, true);
-		const body = out.body as Record<string, unknown>;
+		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.path, "test.bpmn");
 		assert.strictEqual(body.variables, '{"x":1}');
 	});

--- a/tests/unit/help.test.ts
+++ b/tests/unit/help.test.ts
@@ -14,7 +14,7 @@ import {
 import { c8ctl } from "../../src/runtime.ts";
 
 describe("Help Module", () => {
-	let consoleLogSpy: any[];
+	let consoleLogSpy: unknown[];
 	let originalLog: typeof console.log;
 	let originalOutputMode: typeof c8ctl.outputMode;
 
@@ -24,7 +24,7 @@ describe("Help Module", () => {
 		originalOutputMode = c8ctl.outputMode;
 		c8ctl.outputMode = "text";
 
-		console.log = (...args: any[]) => {
+		console.log = (...args: unknown[]) => {
 			consoleLogSpy.push(args.join(" "));
 		};
 	});
@@ -634,7 +634,7 @@ describe("Help Module", () => {
 		c8ctl.outputMode = "json";
 		const jsonSpy: string[] = [];
 		const originalConsoleLog = console.log;
-		console.log = (...args: any[]) => {
+		console.log = (...args: unknown[]) => {
 			jsonSpy.push(args.join(" "));
 		};
 
@@ -666,7 +666,7 @@ describe("Help Module", () => {
 		c8ctl.outputMode = "json";
 		const jsonSpy: string[] = [];
 		const originalConsoleLog = console.log;
-		console.log = (...args: any[]) => {
+		console.log = (...args: unknown[]) => {
 			jsonSpy.push(args.join(" "));
 		};
 
@@ -674,7 +674,7 @@ describe("Help Module", () => {
 
 		console.log = originalConsoleLog;
 		const parsed = JSON.parse(jsonSpy[0]);
-		const flagNames = parsed.agentFlags.map((f: any) => f.flag);
+		const flagNames = parsed.agentFlags.map((f: { flag: string }) => f.flag);
 		assert.ok(
 			flagNames.includes("--fields"),
 			"agentFlags should include --fields",
@@ -689,7 +689,7 @@ describe("Help Module", () => {
 		c8ctl.outputMode = "json";
 		const jsonSpy: string[] = [];
 		const originalConsoleLog = console.log;
-		console.log = (...args: any[]) => {
+		console.log = (...args: unknown[]) => {
 			jsonSpy.push(args.join(" "));
 		};
 
@@ -697,10 +697,14 @@ describe("Help Module", () => {
 
 		console.log = originalConsoleLog;
 		const parsed = JSON.parse(jsonSpy[0]);
-		const createCmd = parsed.commands.find((c: any) => c.verb === "create");
+		const createCmd = parsed.commands.find(
+			(c: { verb: string }) => c.verb === "create",
+		);
 		assert.ok(createCmd, "commands should include create");
 		assert.strictEqual(createCmd.mutating, true, "create should be mutating");
-		const listCmd = parsed.commands.find((c: any) => c.verb === "list");
+		const listCmd = parsed.commands.find(
+			(c: { verb: string }) => c.verb === "list",
+		);
 		assert.ok(listCmd, "commands should include list");
 		assert.strictEqual(listCmd.mutating, false, "list should not be mutating");
 	});
@@ -709,7 +713,7 @@ describe("Help Module", () => {
 		c8ctl.outputMode = "json";
 		const jsonSpy: string[] = [];
 		const originalConsoleLog = console.log;
-		console.log = (...args: any[]) => {
+		console.log = (...args: unknown[]) => {
 			jsonSpy.push(args.join(" "));
 		};
 
@@ -1109,7 +1113,7 @@ describe("Help Module", () => {
 		c8ctl.outputMode = "json";
 		const jsonSpy: string[] = [];
 		const originalConsoleLog = console.log;
-		console.log = (...args: any[]) => {
+		console.log = (...args: unknown[]) => {
 			jsonSpy.push(args.join(" "));
 		};
 
@@ -1119,7 +1123,7 @@ describe("Help Module", () => {
 		const parsed = JSON.parse(jsonSpy[0]);
 
 		// Check for new verbs
-		const verbs = parsed.commands.map((c: any) => c.verb);
+		const verbs = parsed.commands.map((c: { verb: string }) => c.verb);
 		assert.ok(verbs.includes("delete"), "JSON help should include delete verb");
 		assert.ok(verbs.includes("assign"), "JSON help should include assign verb");
 		assert.ok(
@@ -1135,7 +1139,9 @@ describe("Help Module", () => {
 		assert.ok(parsed.resourceAliases.mr, "JSON help should include mr alias");
 
 		// Check identity resources in list verb
-		const listCmd = parsed.commands.find((c: any) => c.verb === "list");
+		const listCmd = parsed.commands.find(
+			(c: { verb: string }) => c.verb === "list",
+		);
 		assert.ok(
 			listCmd.resources.includes("users"),
 			"list resources should include users",
@@ -1150,7 +1156,9 @@ describe("Help Module", () => {
 		);
 
 		// Check delete is mutating
-		const deleteCmd = parsed.commands.find((c: any) => c.verb === "delete");
+		const deleteCmd = parsed.commands.find(
+			(c: { verb: string }) => c.verb === "delete",
+		);
 		assert.ok(deleteCmd, "commands should include delete");
 		assert.strictEqual(deleteCmd.mutating, true, "delete should be mutating");
 	});

--- a/tests/unit/identity-authorization-cli.test.ts
+++ b/tests/unit/identity-authorization-cli.test.ts
@@ -12,6 +12,7 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { c8, parseJson } from "../utils/cli.ts";
+import { asRecord } from "../utils/guards.ts";
 
 // ─── create authorization ────────────────────────────────────────────────────
 
@@ -44,7 +45,7 @@ describe("CLI behavioral: create authorization", () => {
 		assert.strictEqual(out.method, "POST");
 		assert.ok((out.url as string).endsWith("/authorizations"));
 
-		const body = out.body as Record<string, unknown>;
+		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.ownerId, "alice");
 		assert.strictEqual(body.ownerType, "USER");
 		assert.strictEqual(body.resourceType, "PROCESS_DEFINITION");
@@ -70,7 +71,7 @@ describe("CLI behavioral: create authorization", () => {
 		);
 
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const body = parseJson(result).body as Record<string, unknown>;
+		const body = asRecord(parseJson(result).body, "dry-run body");
 		assert.deepStrictEqual(body.permissionTypes, ["READ", "UPDATE", "DELETE"]);
 	});
 

--- a/tests/unit/identity-authorization-cli.test.ts
+++ b/tests/unit/identity-authorization-cli.test.ts
@@ -12,7 +12,7 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { c8, parseJson } from "../utils/cli.ts";
-import { asRecord } from "../utils/guards.ts";
+import { asRecord, getUrl } from "../utils/guards.ts";
 
 // ─── create authorization ────────────────────────────────────────────────────
 
@@ -43,7 +43,7 @@ describe("CLI behavioral: create authorization", () => {
 
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
-		assert.ok((out.url as string).endsWith("/authorizations"));
+		assert.ok(getUrl(out).endsWith("/authorizations"));
 
 		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.ownerId, "alice");
@@ -203,6 +203,6 @@ describe("CLI behavioral: delete authorization", () => {
 		const out = parseJson(result);
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "DELETE");
-		assert.ok((out.url as string).endsWith("/authorizations/42"));
+		assert.ok(getUrl(out).endsWith("/authorizations/42"));
 	});
 });

--- a/tests/unit/identity-behaviour.test.ts
+++ b/tests/unit/identity-behaviour.test.ts
@@ -12,7 +12,7 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { c8, parseJson } from "../utils/cli.ts";
-import { asRecord } from "../utils/guards.ts";
+import { asRecord, getUrl } from "../utils/guards.ts";
 
 // ─── create user ─────────────────────────────────────────────────────────────
 
@@ -33,7 +33,7 @@ describe("CLI behavioural: create user", () => {
 
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
-		assert.ok((out.url as string).endsWith("/users"));
+		assert.ok(getUrl(out).endsWith("/users"));
 
 		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.username, "alice");
@@ -96,7 +96,7 @@ describe("CLI behavioural: delete user", () => {
 		const out = parseJson(result);
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "DELETE");
-		assert.ok((out.url as string).endsWith("/users/alice"));
+		assert.ok(getUrl(out).endsWith("/users/alice"));
 	});
 
 	test("rejects missing username with exit code 1", async () => {
@@ -127,7 +127,7 @@ describe("CLI behavioural: create role", () => {
 		const out = parseJson(result);
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
-		assert.ok((out.url as string).endsWith("/roles"));
+		assert.ok(getUrl(out).endsWith("/roles"));
 
 		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.roleId, "admin");
@@ -161,7 +161,7 @@ describe("CLI behavioural: delete role", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assert.strictEqual(out.method, "DELETE");
-		assert.ok((out.url as string).endsWith("/roles/admin"));
+		assert.ok(getUrl(out).endsWith("/roles/admin"));
 	});
 
 	test("rejects missing role ID with exit code 1", async () => {
@@ -191,7 +191,7 @@ describe("CLI behavioural: create group", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assert.strictEqual(out.method, "POST");
-		assert.ok((out.url as string).endsWith("/groups"));
+		assert.ok(getUrl(out).endsWith("/groups"));
 
 		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.groupId, "devs");
@@ -225,7 +225,7 @@ describe("CLI behavioural: delete group", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assert.strictEqual(out.method, "DELETE");
-		assert.ok((out.url as string).endsWith("/groups/devs"));
+		assert.ok(getUrl(out).endsWith("/groups/devs"));
 	});
 
 	test("rejects missing group ID with exit code 1", async () => {
@@ -255,7 +255,7 @@ describe("CLI behavioural: create tenant", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assert.strictEqual(out.method, "POST");
-		assert.ok((out.url as string).endsWith("/tenants"));
+		assert.ok(getUrl(out).endsWith("/tenants"));
 
 		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.tenantId, "acme");
@@ -289,7 +289,7 @@ describe("CLI behavioural: delete tenant", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assert.strictEqual(out.method, "DELETE");
-		assert.ok((out.url as string).endsWith("/tenants/acme"));
+		assert.ok(getUrl(out).endsWith("/tenants/acme"));
 	});
 
 	test("rejects missing tenant ID with exit code 1", async () => {
@@ -323,7 +323,7 @@ describe("CLI behavioural: create mapping-rule", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assert.strictEqual(out.method, "POST");
-		assert.ok((out.url as string).endsWith("/mapping-rules"));
+		assert.ok(getUrl(out).endsWith("/mapping-rules"));
 
 		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.mappingRuleId, "rule-1");
@@ -377,7 +377,7 @@ describe("CLI behavioural: delete mapping-rule", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assert.strictEqual(out.method, "DELETE");
-		assert.ok((out.url as string).endsWith("/mapping-rules/rule-1"));
+		assert.ok(getUrl(out).endsWith("/mapping-rules/rule-1"));
 	});
 
 	test("rejects missing mapping-rule ID with exit code 1", async () => {
@@ -407,8 +407,8 @@ describe("CLI behavioural: assign", () => {
 		const out = parseJson(result);
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
-		assert.ok((out.url as string).includes("/roles/admin/"));
-		assert.ok((out.url as string).includes("alice"));
+		assert.ok(getUrl(out).includes("/roles/admin/"));
+		assert.ok(getUrl(out).includes("alice"));
 	});
 
 	test("--dry-run assign role --to-group emits POST", async () => {
@@ -424,8 +424,8 @@ describe("CLI behavioural: assign", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assert.strictEqual(out.method, "POST");
-		assert.ok((out.url as string).includes("/roles/admin/"));
-		assert.ok((out.url as string).includes("devs"));
+		assert.ok(getUrl(out).includes("/roles/admin/"));
+		assert.ok(getUrl(out).includes("devs"));
 	});
 
 	test("--dry-run assign user --to-tenant emits POST", async () => {
@@ -441,10 +441,7 @@ describe("CLI behavioural: assign", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assert.strictEqual(out.method, "POST");
-		assert.ok(
-			(out.url as string).includes("alice") ||
-				(out.url as string).includes("acme"),
-		);
+		assert.ok(getUrl(out).includes("alice") || getUrl(out).includes("acme"));
 	});
 
 	test("rejects missing target flag with exit code 1", async () => {
@@ -484,10 +481,7 @@ describe("CLI behavioural: unassign", () => {
 		const out = parseJson(result);
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "DELETE");
-		assert.ok(
-			(out.url as string).includes("alice") ||
-				(out.url as string).includes("ops"),
-		);
+		assert.ok(getUrl(out).includes("alice") || getUrl(out).includes("ops"));
 	});
 
 	test("--dry-run unassign role --from-user emits DELETE", async () => {
@@ -503,7 +497,7 @@ describe("CLI behavioural: unassign", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assert.strictEqual(out.method, "DELETE");
-		assert.ok((out.url as string).includes("/roles/admin/"));
+		assert.ok(getUrl(out).includes("/roles/admin/"));
 	});
 
 	test("rejects missing source flag with exit code 1", async () => {

--- a/tests/unit/identity-behaviour.test.ts
+++ b/tests/unit/identity-behaviour.test.ts
@@ -12,6 +12,7 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { c8, parseJson } from "../utils/cli.ts";
+import { asRecord } from "../utils/guards.ts";
 
 // ─── create user ─────────────────────────────────────────────────────────────
 
@@ -34,7 +35,7 @@ describe("CLI behavioural: create user", () => {
 		assert.strictEqual(out.method, "POST");
 		assert.ok((out.url as string).endsWith("/users"));
 
-		const body = out.body as Record<string, unknown>;
+		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.username, "alice");
 		// password is redacted by sanitizeForLogging
 		assert.ok(
@@ -59,7 +60,7 @@ describe("CLI behavioural: create user", () => {
 		);
 
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const body = parseJson(result).body as Record<string, unknown>;
+		const body = asRecord(parseJson(result).body, "dry-run body");
 		assert.strictEqual(body.name, "Bob Smith");
 		assert.strictEqual(body.email, "bob@example.com");
 	});
@@ -128,7 +129,7 @@ describe("CLI behavioural: create role", () => {
 		assert.strictEqual(out.method, "POST");
 		assert.ok((out.url as string).endsWith("/roles"));
 
-		const body = out.body as Record<string, unknown>;
+		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.roleId, "admin");
 		assert.strictEqual(body.name, "Administrator");
 	});
@@ -192,7 +193,7 @@ describe("CLI behavioural: create group", () => {
 		assert.strictEqual(out.method, "POST");
 		assert.ok((out.url as string).endsWith("/groups"));
 
-		const body = out.body as Record<string, unknown>;
+		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.groupId, "devs");
 		assert.strictEqual(body.name, "Developers");
 	});
@@ -256,7 +257,7 @@ describe("CLI behavioural: create tenant", () => {
 		assert.strictEqual(out.method, "POST");
 		assert.ok((out.url as string).endsWith("/tenants"));
 
-		const body = out.body as Record<string, unknown>;
+		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.tenantId, "acme");
 		assert.strictEqual(body.name, "ACME Corp");
 	});
@@ -324,7 +325,7 @@ describe("CLI behavioural: create mapping-rule", () => {
 		assert.strictEqual(out.method, "POST");
 		assert.ok((out.url as string).endsWith("/mapping-rules"));
 
-		const body = out.body as Record<string, unknown>;
+		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.mappingRuleId, "rule-1");
 		assert.strictEqual(body.name, "My Rule");
 		assert.strictEqual(body.claimName, "groups");

--- a/tests/unit/identity.test.ts
+++ b/tests/unit/identity.test.ts
@@ -35,6 +35,7 @@ import {
 import { resolveTenantId } from "../../src/config.ts";
 import { getLogger } from "../../src/logger.ts";
 import { c8ctl } from "../../src/runtime.ts";
+import { asRecord } from "../utils/guards.ts";
 
 const TEST_BASE_URL = "http://test-cluster/v2";
 
@@ -64,9 +65,10 @@ function setup() {
 	console.log = (...args: any[]) => logSpy.push(args.join(" "));
 	console.error = (...args: any[]) => errorSpy.push(args.join(" "));
 	// Make process.exit throw so tests can catch it with assert.rejects / assert.throws
-	(process.exit as any) = (code: number) => {
+	process.exit = ((code: number) => {
 		throw new Error(`process.exit(${code})`);
-	};
+		// biome-ignore lint/plugin: test-only override of process.exit signature
+	}) as typeof process.exit;
 
 	// Provide a base URL so resolveClusterConfig uses the env-var path,
 	// no profile file or local cluster needed.
@@ -385,10 +387,10 @@ describe("Identity Commands — dry-run output", () => {
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
 		assert.ok(
-			(out.url as string).endsWith("/users"),
+			(typeof out.url === "string" ? out.url : "").endsWith("/users"),
 			`expected URL to end with /users, got: ${out.url}`,
 		);
-		const body = out.body as Record<string, unknown>;
+		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.username, "alice");
 		assert.strictEqual(
 			body.password,
@@ -406,7 +408,7 @@ describe("Identity Commands — dry-run output", () => {
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "DELETE");
 		assert.ok(
-			(out.url as string).endsWith("/users/alice"),
+			(typeof out.url === "string" ? out.url : "").endsWith("/users/alice"),
 			`expected URL to end with /users/alice, got: ${out.url}`,
 		);
 	});
@@ -422,7 +424,7 @@ describe("Identity Commands — dry-run output", () => {
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
 		assert.ok(
-			(out.url as string).endsWith("/roles"),
+			(typeof out.url === "string" ? out.url : "").endsWith("/roles"),
 			`expected URL to end with /roles, got: ${out.url}`,
 		);
 		assert.deepStrictEqual(out.body, { roleId: "admin-role", name: "admin" });
@@ -434,7 +436,11 @@ describe("Identity Commands — dry-run output", () => {
 		const out = capturedJson();
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "DELETE");
-		assert.ok((out.url as string).endsWith("/roles/admin-role"));
+		assert.ok(
+			(typeof out.url === "string" ? out.url : "").endsWith(
+				"/roles/admin-role",
+			),
+		);
 	});
 
 	test("createIdentityMappingRule: emits POST to /mapping-rules with all fields", async () => {
@@ -452,7 +458,9 @@ describe("Identity Commands — dry-run output", () => {
 		const out = capturedJson();
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
-		assert.ok((out.url as string).endsWith("/mapping-rules"));
+		assert.ok(
+			(typeof out.url === "string" ? out.url : "").endsWith("/mapping-rules"),
+		);
 		assert.deepStrictEqual(out.body, {
 			mappingRuleId: "rule-1",
 			name: "My Rule",
@@ -467,7 +475,11 @@ describe("Identity Commands — dry-run output", () => {
 		const out = capturedJson();
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "DELETE");
-		assert.ok((out.url as string).endsWith("/mapping-rules/rule-1"));
+		assert.ok(
+			(typeof out.url === "string" ? out.url : "").endsWith(
+				"/mapping-rules/rule-1",
+			),
+		);
 	});
 
 	test("createIdentityAuthorization: emits POST to /authorizations with permissionTypes array", async () => {
@@ -486,8 +498,10 @@ describe("Identity Commands — dry-run output", () => {
 		const out = capturedJson();
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
-		assert.ok((out.url as string).endsWith("/authorizations"));
-		const body = out.body as Record<string, unknown>;
+		assert.ok(
+			(typeof out.url === "string" ? out.url : "").endsWith("/authorizations"),
+		);
+		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.ownerId, "alice");
 		assert.strictEqual(body.ownerType, "USER");
 		assert.strictEqual(body.resourceType, "PROCESS_DEFINITION");
@@ -501,7 +515,11 @@ describe("Identity Commands — dry-run output", () => {
 		const out = capturedJson();
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "DELETE");
-		assert.ok((out.url as string).endsWith("/authorizations/42"));
+		assert.ok(
+			(typeof out.url === "string" ? out.url : "").endsWith(
+				"/authorizations/42",
+			),
+		);
 	});
 });
 
@@ -639,45 +657,49 @@ describe("sanitizeForLogging — credential redaction", () => {
 	// Import directly to unit-test the sanitizer in isolation
 	test("redacts password from a flat object", async () => {
 		const { sanitizeForLogging } = await import("../../src/logger.ts");
-		const result = sanitizeForLogging({
-			username: "alice",
-			password: "secret",
-		}) as any;
+		const result = asRecord(
+			sanitizeForLogging({
+				username: "alice",
+				password: "secret",
+			}),
+		);
 		assert.strictEqual(result.username, "alice");
 		assert.strictEqual(result.password, "[REDACTED]");
 	});
 
 	test("redacts clientSecret from a nested body object", async () => {
 		const { sanitizeForLogging } = await import("../../src/logger.ts");
-		const result = sanitizeForLogging({
-			config: { clientId: "id", clientSecret: "shhh" },
-		}) as any;
-		assert.strictEqual(result.config.clientId, "id");
-		assert.strictEqual(result.config.clientSecret, "[REDACTED]");
+		const result = asRecord(
+			sanitizeForLogging({
+				config: { clientId: "id", clientSecret: "shhh" },
+			}),
+		);
+		const config = asRecord(result.config);
+		assert.strictEqual(config.clientId, "id");
+		assert.strictEqual(config.clientSecret, "[REDACTED]");
 	});
 
 	test("does NOT redact oAuthUrl (it is a URL, not a credential)", async () => {
 		const { sanitizeForLogging } = await import("../../src/logger.ts");
 		const url = "https://auth.example.com/oauth/token";
-		const result = sanitizeForLogging({ oAuthUrl: url }) as Record<
-			string,
-			unknown
-		>;
+		const result = asRecord(sanitizeForLogging({ oAuthUrl: url }));
 		assert.strictEqual(result.oAuthUrl, url);
 	});
 
 	test("does NOT redact authorizationKey (false positive — it is a resource identifier)", async () => {
 		const { sanitizeForLogging } = await import("../../src/logger.ts");
-		const result = sanitizeForLogging({ authorizationKey: "42" }) as any;
+		const result = asRecord(sanitizeForLogging({ authorizationKey: "42" }));
 		assert.strictEqual(result.authorizationKey, "42");
 	});
 
 	test("redacts password inside an array of objects", async () => {
 		const { sanitizeForLogging } = await import("../../src/logger.ts");
-		const result = sanitizeForLogging([
+		const raw = sanitizeForLogging([
 			{ user: "alice", password: "p1" },
 			{ user: "bob", password: "p2" },
-		]) as any[];
+		]);
+		assert.ok(Array.isArray(raw), "expected array result");
+		const result = raw.map((x) => asRecord(x));
 		assert.strictEqual(result[0].password, "[REDACTED]");
 		assert.strictEqual(result[1].password, "[REDACTED]");
 		assert.strictEqual(result[0].user, "alice");
@@ -815,7 +837,10 @@ describe("handleAssign — every allowed resource/target pair works in dry-run",
 			assert.strictEqual(out.dryRun, true);
 			assert.strictEqual(out.command, "assign");
 			assert.strictEqual(out.method, "POST");
-			assert.ok(typeof out.url === "string" && (out.url as string).length > 0);
+			assert.ok(
+				typeof out.url === "string" &&
+					(typeof out.url === "string" ? out.url : "").length > 0,
+			);
 		});
 	}
 
@@ -845,7 +870,7 @@ describe("sanitizeForLogging — built-in type preservation", () => {
 	test("preserves Error name, message, and stack", async () => {
 		const { sanitizeForLogging } = await import("../../src/logger.ts");
 		const err = new Error("something broke");
-		const result = sanitizeForLogging(err) as Record<string, unknown>;
+		const result = asRecord(sanitizeForLogging(err));
 		assert.strictEqual(result.name, "Error");
 		assert.strictEqual(result.message, "something broke");
 		assert.ok(
@@ -858,17 +883,17 @@ describe("sanitizeForLogging — built-in type preservation", () => {
 		const { sanitizeForLogging } = await import("../../src/logger.ts");
 		const inner = new Error("root cause");
 		const outer = new Error("wrapper", { cause: inner });
-		const result = sanitizeForLogging(outer) as Record<string, unknown>;
+		const result = asRecord(sanitizeForLogging(outer));
 		assert.strictEqual(result.message, "wrapper");
-		const causeResult = result.cause as Record<string, unknown>;
+		const causeResult = asRecord(result.cause);
 		assert.strictEqual(causeResult.message, "root cause");
 	});
 
 	test("redacts sensitive fields on Error with enumerable credentials", async () => {
 		const { sanitizeForLogging } = await import("../../src/logger.ts");
 		const err = new Error("auth failed");
-		(err as any).password = "secret123";
-		const result = sanitizeForLogging(err) as Record<string, unknown>;
+		Object.assign(err, { password: "secret123" });
+		const result = asRecord(sanitizeForLogging(err));
 		assert.strictEqual(result.message, "auth failed");
 		assert.strictEqual(result.password, "[REDACTED]");
 	});

--- a/tests/unit/identity.test.ts
+++ b/tests/unit/identity.test.ts
@@ -12,10 +12,7 @@ import {
 	deleteIdentityAuthorizationCommand,
 	validateCreateAuthorizationOptions,
 } from "../../src/commands/identity-authorizations.ts";
-import {
-	createIdentityGroupCommand,
-	deleteIdentityGroupCommand,
-} from "../../src/commands/identity-groups.ts";
+import { deleteIdentityGroupCommand } from "../../src/commands/identity-groups.ts";
 import {
 	createIdentityMappingRuleCommand,
 	deleteIdentityMappingRuleCommand,
@@ -24,10 +21,7 @@ import {
 	createIdentityRoleCommand,
 	deleteIdentityRoleCommand,
 } from "../../src/commands/identity-roles.ts";
-import {
-	createIdentityTenantCommand,
-	deleteIdentityTenantCommand,
-} from "../../src/commands/identity-tenants.ts";
+import { deleteIdentityTenantCommand } from "../../src/commands/identity-tenants.ts";
 import {
 	createIdentityUserCommand,
 	deleteIdentityUserCommand,
@@ -35,7 +29,8 @@ import {
 import { resolveTenantId } from "../../src/config.ts";
 import { getLogger } from "../../src/logger.ts";
 import { c8ctl } from "../../src/runtime.ts";
-import { asRecord } from "../utils/guards.ts";
+import { asRecord, getUrl } from "../utils/guards.ts";
+import { mockProcessExit } from "../utils/mocks.ts";
 
 const TEST_BASE_URL = "http://test-cluster/v2";
 
@@ -45,7 +40,7 @@ let logSpy: string[];
 let errorSpy: string[];
 let originalLog: typeof console.log;
 let originalError: typeof console.error;
-let originalExit: typeof process.exit;
+let restoreExit: () => void;
 let originalBaseUrl: string | undefined;
 let originalActiveProfile: typeof c8ctl.activeProfile;
 let originalDryRun: typeof c8ctl.dryRun;
@@ -56,19 +51,17 @@ function setup() {
 	errorSpy = [];
 	originalLog = console.log;
 	originalError = console.error;
-	originalExit = process.exit;
 	originalBaseUrl = process.env.CAMUNDA_BASE_URL;
 	originalActiveProfile = c8ctl.activeProfile;
 	originalDryRun = c8ctl.dryRun;
 	originalOutputMode = c8ctl.outputMode;
 
-	console.log = (...args: any[]) => logSpy.push(args.join(" "));
-	console.error = (...args: any[]) => errorSpy.push(args.join(" "));
+	console.log = (...args: unknown[]) => logSpy.push(args.join(" "));
+	console.error = (...args: unknown[]) => errorSpy.push(args.join(" "));
 	// Make process.exit throw so tests can catch it with assert.rejects / assert.throws
-	process.exit = ((code: number) => {
+	restoreExit = mockProcessExit((code) => {
 		throw new Error(`process.exit(${code})`);
-		// biome-ignore lint/plugin: test-only override of process.exit signature
-	}) as typeof process.exit;
+	});
 
 	// Provide a base URL so resolveClusterConfig uses the env-var path,
 	// no profile file or local cluster needed.
@@ -81,7 +74,7 @@ function setup() {
 function teardown() {
 	console.log = originalLog;
 	console.error = originalError;
-	process.exit = originalExit;
+	restoreExit();
 	if (originalBaseUrl === undefined) {
 		delete process.env.CAMUNDA_BASE_URL;
 	} else {
@@ -100,12 +93,13 @@ function capturedJson(): Record<string, unknown> {
 
 /** Build a minimal CommandContext for test execution */
 function buildCtx(profile?: string) {
+	const positionals: string[] = [];
 	return {
 		client: createClient(profile),
 		logger: getLogger(),
 		tenantId: resolveTenantId(profile),
 		resource: "",
-		positionals: [] as string[],
+		positionals,
 		sortOrder: "asc" as const,
 		sortBy: undefined,
 		limit: undefined,
@@ -387,7 +381,7 @@ describe("Identity Commands — dry-run output", () => {
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
 		assert.ok(
-			(typeof out.url === "string" ? out.url : "").endsWith("/users"),
+			getUrl(out).endsWith("/users"),
 			`expected URL to end with /users, got: ${out.url}`,
 		);
 		const body = asRecord(out.body, "dry-run body");
@@ -408,7 +402,7 @@ describe("Identity Commands — dry-run output", () => {
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "DELETE");
 		assert.ok(
-			(typeof out.url === "string" ? out.url : "").endsWith("/users/alice"),
+			getUrl(out).endsWith("/users/alice"),
 			`expected URL to end with /users/alice, got: ${out.url}`,
 		);
 	});
@@ -424,7 +418,7 @@ describe("Identity Commands — dry-run output", () => {
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
 		assert.ok(
-			(typeof out.url === "string" ? out.url : "").endsWith("/roles"),
+			getUrl(out).endsWith("/roles"),
 			`expected URL to end with /roles, got: ${out.url}`,
 		);
 		assert.deepStrictEqual(out.body, { roleId: "admin-role", name: "admin" });
@@ -436,11 +430,7 @@ describe("Identity Commands — dry-run output", () => {
 		const out = capturedJson();
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "DELETE");
-		assert.ok(
-			(typeof out.url === "string" ? out.url : "").endsWith(
-				"/roles/admin-role",
-			),
-		);
+		assert.ok(getUrl(out).endsWith("/roles/admin-role"));
 	});
 
 	test("createIdentityMappingRule: emits POST to /mapping-rules with all fields", async () => {
@@ -458,9 +448,7 @@ describe("Identity Commands — dry-run output", () => {
 		const out = capturedJson();
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
-		assert.ok(
-			(typeof out.url === "string" ? out.url : "").endsWith("/mapping-rules"),
-		);
+		assert.ok(getUrl(out).endsWith("/mapping-rules"));
 		assert.deepStrictEqual(out.body, {
 			mappingRuleId: "rule-1",
 			name: "My Rule",
@@ -475,11 +463,7 @@ describe("Identity Commands — dry-run output", () => {
 		const out = capturedJson();
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "DELETE");
-		assert.ok(
-			(typeof out.url === "string" ? out.url : "").endsWith(
-				"/mapping-rules/rule-1",
-			),
-		);
+		assert.ok(getUrl(out).endsWith("/mapping-rules/rule-1"));
 	});
 
 	test("createIdentityAuthorization: emits POST to /authorizations with permissionTypes array", async () => {
@@ -498,9 +482,7 @@ describe("Identity Commands — dry-run output", () => {
 		const out = capturedJson();
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
-		assert.ok(
-			(typeof out.url === "string" ? out.url : "").endsWith("/authorizations"),
-		);
+		assert.ok(getUrl(out).endsWith("/authorizations"));
 		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.ownerId, "alice");
 		assert.strictEqual(body.ownerType, "USER");
@@ -515,11 +497,7 @@ describe("Identity Commands — dry-run output", () => {
 		const out = capturedJson();
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "DELETE");
-		assert.ok(
-			(typeof out.url === "string" ? out.url : "").endsWith(
-				"/authorizations/42",
-			),
-		);
+		assert.ok(getUrl(out).endsWith("/authorizations/42"));
 	});
 });
 
@@ -537,7 +515,7 @@ describe("handleAssign — dry-run and flag validation", () => {
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.command, "assign");
 		assert.strictEqual(out.method, "POST");
-		assert.ok((out.url as string).includes("/roles/admin-role/users/alice"));
+		assert.ok(getUrl(out).includes("/roles/admin-role/users/alice"));
 		assert.strictEqual(out.body, null);
 	});
 
@@ -597,10 +575,8 @@ describe("handleAssign — dry-run and flag validation", () => {
 		);
 
 		const out = capturedJson();
-		assert.ok(
-			(out.url as string).includes(encodeURIComponent("alice@example.com")),
-		);
-		assert.ok((out.url as string).includes(encodeURIComponent("my group")));
+		assert.ok(getUrl(out).includes(encodeURIComponent("alice@example.com")));
+		assert.ok(getUrl(out).includes(encodeURIComponent("my group")));
 	});
 });
 
@@ -616,7 +592,7 @@ describe("handleUnassign — dry-run and flag validation", () => {
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.command, "unassign");
 		assert.strictEqual(out.method, "DELETE");
-		assert.ok((out.url as string).includes("/users/alice/groups/ops"));
+		assert.ok(getUrl(out).includes("/users/alice/groups/ops"));
 		assert.strictEqual(out.body, null);
 	});
 
@@ -837,10 +813,7 @@ describe("handleAssign — every allowed resource/target pair works in dry-run",
 			assert.strictEqual(out.dryRun, true);
 			assert.strictEqual(out.command, "assign");
 			assert.strictEqual(out.method, "POST");
-			assert.ok(
-				typeof out.url === "string" &&
-					(typeof out.url === "string" ? out.url : "").length > 0,
-			);
+			assert.ok(typeof out.url === "string" && out.url.length > 0);
 		});
 	}
 

--- a/tests/unit/incidents-behaviour.test.ts
+++ b/tests/unit/incidents-behaviour.test.ts
@@ -9,6 +9,7 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { c8, parseJson } from "../utils/cli.ts";
+import { getUrl } from "../utils/guards.ts";
 
 // ─── resolve incident ────────────────────────────────────────────────────────
 
@@ -21,7 +22,7 @@ describe("CLI behavioural: resolve incident", () => {
 
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
-		assert.ok((out.url as string).includes("/incidents/77777/resolution"));
+		assert.ok(getUrl(out).includes("/incidents/77777/resolution"));
 	});
 
 	test("--dry-run works with inc alias", async () => {
@@ -30,7 +31,7 @@ describe("CLI behavioural: resolve incident", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assert.strictEqual(out.dryRun, true);
-		assert.ok((out.url as string).includes("/incidents/77777/resolution"));
+		assert.ok(getUrl(out).includes("/incidents/77777/resolution"));
 	});
 
 	test("rejects missing incident key with exit code 1", async () => {

--- a/tests/unit/jobs-behaviour.test.ts
+++ b/tests/unit/jobs-behaviour.test.ts
@@ -9,6 +9,7 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { c8, parseJson } from "../utils/cli.ts";
+import { asRecord } from "../utils/guards.ts";
 
 // ─── activate jobs ───────────────────────────────────────────────────────────
 
@@ -23,7 +24,7 @@ describe("CLI behavioural: activate jobs", () => {
 		assert.strictEqual(out.method, "POST");
 		assert.ok((out.url as string).endsWith("/jobs/activation"));
 
-		const body = out.body as Record<string, unknown>;
+		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.type, "my-job-type");
 		assert.strictEqual(body.maxJobsToActivate, 10);
 		assert.strictEqual(body.timeout, 60000);
@@ -41,7 +42,7 @@ describe("CLI behavioural: activate jobs", () => {
 		);
 
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const body = parseJson(result).body as Record<string, unknown>;
+		const body = asRecord(parseJson(result).body, "dry-run body");
 		assert.strictEqual(body.maxJobsToActivate, 5);
 	});
 
@@ -58,7 +59,7 @@ describe("CLI behavioural: activate jobs", () => {
 		);
 
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const body = parseJson(result).body as Record<string, unknown>;
+		const body = asRecord(parseJson(result).body, "dry-run body");
 		assert.strictEqual(body.timeout, 30000);
 		assert.strictEqual(body.worker, "custom-worker");
 	});
@@ -99,7 +100,7 @@ describe("CLI behavioural: complete job", () => {
 		);
 
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const body = parseJson(result).body as Record<string, unknown>;
+		const body = asRecord(parseJson(result).body, "dry-run body");
 		assert.deepStrictEqual(body.variables, { result: "ok" });
 	});
 
@@ -127,7 +128,7 @@ describe("CLI behavioural: fail job", () => {
 		assert.strictEqual(out.method, "POST");
 		assert.ok((out.url as string).includes("/jobs/88888/failure"));
 
-		const body = out.body as Record<string, unknown>;
+		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.retries, 0);
 		assert.strictEqual(body.errorMessage, "Job failed via c8ctl");
 	});
@@ -145,7 +146,7 @@ describe("CLI behavioural: fail job", () => {
 		);
 
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const body = parseJson(result).body as Record<string, unknown>;
+		const body = asRecord(parseJson(result).body, "dry-run body");
 		assert.strictEqual(body.retries, 3);
 		assert.strictEqual(body.errorMessage, "custom error");
 	});

--- a/tests/unit/jobs-behaviour.test.ts
+++ b/tests/unit/jobs-behaviour.test.ts
@@ -9,7 +9,7 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { c8, parseJson } from "../utils/cli.ts";
-import { asRecord } from "../utils/guards.ts";
+import { asRecord, getUrl } from "../utils/guards.ts";
 
 // ─── activate jobs ───────────────────────────────────────────────────────────
 
@@ -22,7 +22,7 @@ describe("CLI behavioural: activate jobs", () => {
 
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
-		assert.ok((out.url as string).endsWith("/jobs/activation"));
+		assert.ok(getUrl(out).endsWith("/jobs/activation"));
 
 		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.type, "my-job-type");
@@ -86,7 +86,7 @@ describe("CLI behavioural: complete job", () => {
 
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
-		assert.ok((out.url as string).includes("/jobs/99999/completion"));
+		assert.ok(getUrl(out).includes("/jobs/99999/completion"));
 	});
 
 	test("--dry-run includes variables when provided", async () => {
@@ -126,7 +126,7 @@ describe("CLI behavioural: fail job", () => {
 
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
-		assert.ok((out.url as string).includes("/jobs/88888/failure"));
+		assert.ok(getUrl(out).includes("/jobs/88888/failure"));
 
 		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.retries, 0);

--- a/tests/unit/lazy-client.test.ts
+++ b/tests/unit/lazy-client.test.ts
@@ -37,8 +37,8 @@ describe("Lazy client getter", () => {
 				}
 				return _tenantId;
 			},
-			// biome-ignore lint/suspicious/noExplicitAny: test stub
-		} as any as CommandContext;
+			// biome-ignore lint/plugin: test stub for CommandContext with only lazy getters populated
+		} as unknown as CommandContext;
 	}
 
 	test("client factory is not called until ctx.client is accessed", () => {

--- a/tests/unit/lazy-client.test.ts
+++ b/tests/unit/lazy-client.test.ts
@@ -25,7 +25,7 @@ describe("Lazy client getter", () => {
 		let _client: unknown | undefined;
 		let _tenantId: string | undefined;
 		let _tenantResolved = false;
-		return {
+		const stub = {
 			get client() {
 				if (!_client) _client = factories.createClient();
 				return _client;
@@ -37,8 +37,9 @@ describe("Lazy client getter", () => {
 				}
 				return _tenantId;
 			},
-			// biome-ignore lint/plugin: test stub for CommandContext with only lazy getters populated
-		} as unknown as CommandContext;
+		};
+		// biome-ignore lint/plugin: test stub for CommandContext with only lazy getters populated
+		return stub as unknown as CommandContext;
 	}
 
 	test("client factory is not called until ctx.client is accessed", () => {

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -671,7 +671,7 @@ describe("sortTableData", () => {
 
 	test("places null/undefined values last", () => {
 		const data = [{ State: null }, { State: "ACTIVE" }, { State: undefined }];
-		const result = sortTableData(data as any, "State", logger);
+		const result = sortTableData(data, "State", logger);
 		assert.strictEqual(result[0].State, "ACTIVE");
 	});
 
@@ -709,7 +709,7 @@ describe("sortTableData", () => {
 			{ State: "ACTIVE" },
 			{ State: undefined },
 		];
-		const result = sortTableData(data as any, "State", logger, "desc");
+		const result = sortTableData(data, "State", logger, "desc");
 		assert.strictEqual(result[0].State, "COMPLETED");
 		assert.strictEqual(result[1].State, "ACTIVE");
 	});

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -4,17 +4,12 @@
 
 import assert from "node:assert";
 import { afterEach, beforeEach, describe, test } from "node:test";
-import {
-	getLogger,
-	Logger,
-	type SortOrder,
-	sortTableData,
-} from "../../src/logger.ts";
+import { getLogger, Logger, sortTableData } from "../../src/logger.ts";
 import { c8ctl } from "../../src/runtime.ts";
 
 describe("Logger Module", () => {
-	let consoleLogSpy: any[];
-	let consoleErrorSpy: any[];
+	let consoleLogSpy: unknown[];
+	let consoleErrorSpy: unknown[];
 	let originalLog: typeof console.log;
 	let originalError: typeof console.error;
 
@@ -24,11 +19,11 @@ describe("Logger Module", () => {
 		originalLog = console.log;
 		originalError = console.error;
 
-		console.log = (...args: any[]) => {
+		console.log = (...args: unknown[]) => {
 			consoleLogSpy.push(args.join(" "));
 		};
 
-		console.error = (...args: any[]) => {
+		console.error = (...args: unknown[]) => {
 			consoleErrorSpy.push(args.join(" "));
 		};
 
@@ -441,14 +436,14 @@ describe("Logger Module", () => {
 
 		test("Logger accepts custom writer", () => {
 			c8ctl.outputMode = "text";
-			const customLogOutput: any[] = [];
-			const customErrorOutput: any[] = [];
+			const customLogOutput: unknown[] = [];
+			const customErrorOutput: unknown[] = [];
 
 			const customWriter = {
-				log(...data: any[]): void {
+				log(...data: unknown[]): void {
 					customLogOutput.push(data.join(" "));
 				},
-				error(...data: any[]): void {
+				error(...data: unknown[]): void {
 					customErrorOutput.push(data.join(" "));
 				},
 			};
@@ -474,14 +469,14 @@ describe("Logger Module", () => {
 
 		test("Custom writer receives all method calls", () => {
 			c8ctl.outputMode = "text";
-			const logCalls: any[][] = [];
-			const errorCalls: any[][] = [];
+			const logCalls: unknown[][] = [];
+			const errorCalls: unknown[][] = [];
 
 			const trackingWriter = {
-				log(...data: any[]): void {
+				log(...data: unknown[]): void {
 					logCalls.push(data);
 				},
-				error(...data: any[]): void {
+				error(...data: unknown[]): void {
 					errorCalls.push(data);
 				},
 			};
@@ -508,10 +503,10 @@ describe("Logger Module", () => {
 
 			// Simulate stderrWriter behavior
 			const stderrWriter = {
-				log(...data: any[]): void {
+				log(...data: unknown[]): void {
 					console.error(...data);
 				},
-				error(...data: any[]): void {
+				error(...data: unknown[]): void {
 					console.error(...data);
 				},
 			};
@@ -538,14 +533,14 @@ describe("Logger Module", () => {
 
 		test("Custom writer works with JSON mode", () => {
 			c8ctl.outputMode = "json";
-			const logOutput: any[] = [];
-			const errorOutput: any[] = [];
+			const logOutput: unknown[] = [];
+			const errorOutput: unknown[] = [];
 
 			const customWriter = {
-				log(...data: any[]): void {
+				log(...data: unknown[]): void {
 					logOutput.push(data[0]);
 				},
-				error(...data: any[]): void {
+				error(...data: unknown[]): void {
 					errorOutput.push(data[0]);
 				},
 			};
@@ -574,11 +569,11 @@ describe("Logger Module", () => {
 
 		test("Custom writer handles debug with multiple arguments", () => {
 			c8ctl.outputMode = "text";
-			const errorCalls: any[][] = [];
+			const errorCalls: unknown[][] = [];
 
 			const trackingWriter = {
-				log(...data: any[]): void {},
-				error(...data: any[]): void {
+				log(..._data: unknown[]): void {},
+				error(...data: unknown[]): void {
 					errorCalls.push(data);
 				},
 			};
@@ -602,8 +597,8 @@ describe("sortTableData", () => {
 	beforeEach(() => {
 		warnMessages = [];
 		const trackingWriter = {
-			log(...data: any[]): void {},
-			error(...data: any[]): void {
+			log(..._data: unknown[]): void {},
+			error(...data: unknown[]): void {
 				warnMessages.push(data.join(" "));
 			},
 		};
@@ -717,10 +712,10 @@ describe("sortTableData", () => {
 	test("sorted output is serialized in order when table() is called in json mode", () => {
 		const logMessages: string[] = [];
 		const trackingWriter = {
-			log(...data: any[]): void {
+			log(...data: unknown[]): void {
 				logMessages.push(data.join(" "));
 			},
-			error(...data: any[]): void {},
+			error(..._data: unknown[]): void {},
 		};
 		const jsonLogger = new Logger(trackingWriter);
 		c8ctl.outputMode = "json";
@@ -736,7 +731,7 @@ describe("sortTableData", () => {
 		assert.strictEqual(logMessages.length, 1);
 		const parsed = JSON.parse(logMessages[0]);
 		assert.deepStrictEqual(
-			parsed.map((r: any) => r.State),
+			parsed.map((r: { State: string }) => r.State),
 			["ACTIVE", "CANCELED", "COMPLETED"],
 		);
 	});
@@ -744,8 +739,8 @@ describe("sortTableData", () => {
 	test("warns with JSON-formatted message in json mode when column not found", () => {
 		const warnJson: string[] = [];
 		const trackingWriter = {
-			log(...data: any[]): void {},
-			error(...data: any[]): void {
+			log(..._data: unknown[]): void {},
+			error(...data: unknown[]): void {
 				warnJson.push(data.join(" "));
 			},
 		};

--- a/tests/unit/mcp-proxy-auth.test.ts
+++ b/tests/unit/mcp-proxy-auth.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, test } from "node:test";
 import type { createClient } from "../../src/client.ts";
 import { createCamundaFetch } from "../../src/commands/mcp-proxy.ts";
 import type { Logger } from "../../src/logger.ts";
+import { makeMockClient, makeMockLogger } from "../utils/mocks.ts";
 
 type CamundaClient = ReturnType<typeof createClient>;
 
@@ -16,13 +17,7 @@ describe("createCamundaFetch", () => {
 
 	beforeEach(() => {
 		originalFetch = global.fetch;
-		mockLogger = {
-			info: () => {},
-			debug: () => {},
-			error: () => {},
-			warn: () => {},
-			json: () => {},
-		} as unknown as Logger;
+		mockLogger = makeMockLogger();
 	});
 
 	afterEach(() => {
@@ -32,19 +27,19 @@ describe("createCamundaFetch", () => {
 	test("injects auth headers from CamundaClient", async () => {
 		let capturedHeaders: Headers | undefined;
 
-		const mockCamundaClient = {
+		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({
 				Authorization: "Bearer test-token",
 				"X-Custom-Header": "custom-value",
 			}),
 			getConfig: () => ({ restAddress: "http://localhost:8080" }),
-		} as unknown as CamundaClient;
+		});
 
 		global.fetch = async (
 			input: string | URL | Request,
 			init?: RequestInit,
 		) => {
-			capturedHeaders = init?.headers as Headers;
+			capturedHeaders = new Headers(init?.headers);
 			return new Response("success", { status: 200 });
 		};
 
@@ -62,16 +57,16 @@ describe("createCamundaFetch", () => {
 	test("merges auth headers with existing request headers", async () => {
 		let capturedHeaders: Headers | undefined;
 
-		const mockCamundaClient = {
+		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({ Authorization: "Bearer test-token" }),
 			getConfig: () => ({ restAddress: "http://localhost:8080" }),
-		} as unknown as CamundaClient;
+		});
 
 		global.fetch = async (
 			input: string | URL | Request,
 			init?: RequestInit,
 		) => {
-			capturedHeaders = init?.headers as Headers;
+			capturedHeaders = new Headers(init?.headers);
 			return new Response("success", { status: 200 });
 		};
 
@@ -95,7 +90,7 @@ describe("createCamundaFetch", () => {
 		let callCount = 0;
 		let authRefreshCalled = false;
 
-		const mockCamundaClient = {
+		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({
 				Authorization:
 					callCount === 0 ? "Bearer expired-token" : "Bearer fresh-token",
@@ -104,13 +99,13 @@ describe("createCamundaFetch", () => {
 				authRefreshCalled = true;
 			},
 			getConfig: () => ({ restAddress: "http://localhost:8080" }),
-		} as unknown as CamundaClient;
+		});
 
 		global.fetch = async (
 			input: string | URL | Request,
 			init?: RequestInit,
 		) => {
-			const headers = init?.headers as Headers;
+			const headers = new Headers(init?.headers);
 			const authHeader = headers?.get("Authorization");
 
 			if (callCount === 0) {
@@ -132,10 +127,10 @@ describe("createCamundaFetch", () => {
 	});
 
 	test("converts AbortError to descriptive timeout error", async () => {
-		const mockCamundaClient = {
+		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),
 			getConfig: () => ({ restAddress: "http://localhost:8080" }),
-		} as unknown as CamundaClient;
+		});
 
 		global.fetch = async (
 			input: string | URL | Request,
@@ -158,10 +153,10 @@ describe("createCamundaFetch", () => {
 	});
 
 	test("converts ECONNREFUSED to descriptive connection error", async () => {
-		const mockCamundaClient = {
+		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),
 			getConfig: () => ({ restAddress: "http://localhost:8080" }),
-		} as unknown as CamundaClient;
+		});
 
 		global.fetch = async (
 			input: string | URL | Request,
@@ -189,10 +184,10 @@ describe("createCamundaFetch", () => {
 	});
 
 	test("preserves other errors unchanged", async () => {
-		const mockCamundaClient = {
+		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),
 			getConfig: () => ({ restAddress: "http://localhost:8080" }),
-		} as unknown as CamundaClient;
+		});
 
 		const customError = new Error("Custom network error");
 
@@ -217,10 +212,10 @@ describe("createCamundaFetch", () => {
 	test("merges abort signals from init and timeout", async () => {
 		let capturedSignal: AbortSignal | null | undefined;
 
-		const mockCamundaClient = {
+		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),
 			getConfig: () => ({ restAddress: "http://localhost:8080" }),
-		} as unknown as CamundaClient;
+		});
 
 		global.fetch = async (
 			input: string | URL | Request,
@@ -244,10 +239,10 @@ describe("createCamundaFetch", () => {
 	test("uses timeout signal when no external signal provided", async () => {
 		let capturedSignal: AbortSignal | null | undefined;
 
-		const mockCamundaClient = {
+		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),
 			getConfig: () => ({ restAddress: "http://localhost:8080" }),
-		} as unknown as CamundaClient;
+		});
 
 		global.fetch = async (
 			input: string | URL | Request,
@@ -268,20 +263,20 @@ describe("createCamundaFetch", () => {
 		let firstCallHeaders: Headers | undefined;
 		let secondCallHeaders: Headers | undefined;
 
-		const mockCamundaClient = {
+		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({
 				Authorization:
 					callCount === 0 ? "Bearer expired-token" : "Bearer fresh-token",
 			}),
 			forceAuthRefresh: async () => {},
 			getConfig: () => ({ restAddress: "http://localhost:8080" }),
-		} as unknown as CamundaClient;
+		});
 
 		global.fetch = async (
 			input: string | URL | Request,
 			init?: RequestInit,
 		) => {
-			const headers = init?.headers as Headers;
+			const headers = new Headers(init?.headers);
 
 			if (callCount === 0) {
 				firstCallHeaders = headers;
@@ -315,10 +310,10 @@ describe("createCamundaFetch", () => {
 	});
 
 	test("respects custom timeout value", async () => {
-		const mockCamundaClient = {
+		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),
 			getConfig: () => ({ restAddress: "http://localhost:8080" }),
-		} as unknown as CamundaClient;
+		});
 
 		global.fetch = async (
 			input: string | URL | Request,
@@ -351,10 +346,10 @@ describe("createCamundaFetch", () => {
 	});
 
 	test("clears timeout on successful response", async () => {
-		const mockCamundaClient = {
+		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),
 			getConfig: () => ({ restAddress: "http://localhost:8080" }),
-		} as unknown as CamundaClient;
+		});
 
 		global.fetch = async (
 			input: string | URL | Request,

--- a/tests/unit/mcp-proxy-auth.test.ts
+++ b/tests/unit/mcp-proxy-auth.test.ts
@@ -4,12 +4,9 @@
 
 import assert from "node:assert";
 import { afterEach, beforeEach, describe, test } from "node:test";
-import type { createClient } from "../../src/client.ts";
 import { createCamundaFetch } from "../../src/commands/mcp-proxy.ts";
 import type { Logger } from "../../src/logger.ts";
 import { makeMockClient, makeMockLogger } from "../utils/mocks.ts";
-
-type CamundaClient = ReturnType<typeof createClient>;
 
 describe("createCamundaFetch", () => {
 	let originalFetch: typeof fetch;
@@ -36,7 +33,7 @@ describe("createCamundaFetch", () => {
 		});
 
 		global.fetch = async (
-			input: string | URL | Request,
+			_input: string | URL | Request,
 			init?: RequestInit,
 		) => {
 			capturedHeaders = new Headers(init?.headers);
@@ -63,7 +60,7 @@ describe("createCamundaFetch", () => {
 		});
 
 		global.fetch = async (
-			input: string | URL | Request,
+			_input: string | URL | Request,
 			init?: RequestInit,
 		) => {
 			capturedHeaders = new Headers(init?.headers);
@@ -102,7 +99,7 @@ describe("createCamundaFetch", () => {
 		});
 
 		global.fetch = async (
-			input: string | URL | Request,
+			_input: string | URL | Request,
 			init?: RequestInit,
 		) => {
 			const headers = new Headers(init?.headers);
@@ -133,8 +130,8 @@ describe("createCamundaFetch", () => {
 		});
 
 		global.fetch = async (
-			input: string | URL | Request,
-			init?: RequestInit,
+			_input: string | URL | Request,
+			_init?: RequestInit,
 		) => {
 			const error = new Error("The operation was aborted");
 			error.name = "AbortError";
@@ -159,11 +156,12 @@ describe("createCamundaFetch", () => {
 		});
 
 		global.fetch = async (
-			input: string | URL | Request,
-			init?: RequestInit,
+			_input: string | URL | Request,
+			_init?: RequestInit,
 		) => {
-			const error: any = new Error("fetch failed");
-			error.cause = { code: "ECONNREFUSED" };
+			const error = new Error("fetch failed", {
+				cause: { code: "ECONNREFUSED" },
+			});
 			throw error;
 		};
 
@@ -192,8 +190,8 @@ describe("createCamundaFetch", () => {
 		const customError = new Error("Custom network error");
 
 		global.fetch = async (
-			input: string | URL | Request,
-			init?: RequestInit,
+			_input: string | URL | Request,
+			_init?: RequestInit,
 		) => {
 			throw customError;
 		};
@@ -218,7 +216,7 @@ describe("createCamundaFetch", () => {
 		});
 
 		global.fetch = async (
-			input: string | URL | Request,
+			_input: string | URL | Request,
 			init?: RequestInit,
 		) => {
 			capturedSignal = init?.signal;
@@ -245,7 +243,7 @@ describe("createCamundaFetch", () => {
 		});
 
 		global.fetch = async (
-			input: string | URL | Request,
+			_input: string | URL | Request,
 			init?: RequestInit,
 		) => {
 			capturedSignal = init?.signal;
@@ -273,7 +271,7 @@ describe("createCamundaFetch", () => {
 		});
 
 		global.fetch = async (
-			input: string | URL | Request,
+			_input: string | URL | Request,
 			init?: RequestInit,
 		) => {
 			const headers = new Headers(init?.headers);
@@ -316,7 +314,7 @@ describe("createCamundaFetch", () => {
 		});
 
 		global.fetch = async (
-			input: string | URL | Request,
+			_input: string | URL | Request,
 			init?: RequestInit,
 		) => {
 			// Simulate slow response - wait for abort signal
@@ -327,7 +325,7 @@ describe("createCamundaFetch", () => {
 
 				init?.signal?.addEventListener("abort", () => {
 					clearTimeout(timeout);
-					const error: any = new Error("The operation was aborted");
+					const error = new Error("The operation was aborted");
 					error.name = "AbortError";
 					reject(error);
 				});
@@ -352,8 +350,8 @@ describe("createCamundaFetch", () => {
 		});
 
 		global.fetch = async (
-			input: string | URL | Request,
-			init?: RequestInit,
+			_input: string | URL | Request,
+			_init?: RequestInit,
 		) => {
 			return new Response("success", { status: 200 });
 		};

--- a/tests/unit/messages-behaviour.test.ts
+++ b/tests/unit/messages-behaviour.test.ts
@@ -9,7 +9,7 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { c8, parseJson } from "../utils/cli.ts";
-import { asRecord } from "../utils/guards.ts";
+import { asRecord, getUrl } from "../utils/guards.ts";
 
 // ─── publish message ─────────────────────────────────────────────────────────
 
@@ -22,7 +22,7 @@ describe("CLI behavioural: publish message", () => {
 
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
-		assert.ok((out.url as string).includes("/messages/publication"));
+		assert.ok(getUrl(out).includes("/messages/publication"));
 
 		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.name, "my-message");
@@ -95,7 +95,7 @@ describe("CLI behavioural: correlate message", () => {
 
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
-		assert.ok((out.url as string).includes("/messages/correlation"));
+		assert.ok(getUrl(out).includes("/messages/correlation"));
 
 		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.name, "my-message");

--- a/tests/unit/messages-behaviour.test.ts
+++ b/tests/unit/messages-behaviour.test.ts
@@ -9,6 +9,7 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { c8, parseJson } from "../utils/cli.ts";
+import { asRecord } from "../utils/guards.ts";
 
 // ─── publish message ─────────────────────────────────────────────────────────
 
@@ -23,7 +24,7 @@ describe("CLI behavioural: publish message", () => {
 		assert.strictEqual(out.method, "POST");
 		assert.ok((out.url as string).includes("/messages/publication"));
 
-		const body = out.body as Record<string, unknown>;
+		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.name, "my-message");
 	});
 
@@ -38,7 +39,7 @@ describe("CLI behavioural: publish message", () => {
 		);
 
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const body = parseJson(result).body as Record<string, unknown>;
+		const body = asRecord(parseJson(result).body, "dry-run body");
 		assert.strictEqual(body.correlationKey, "order-123");
 	});
 
@@ -53,7 +54,7 @@ describe("CLI behavioural: publish message", () => {
 		);
 
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const body = parseJson(result).body as Record<string, unknown>;
+		const body = asRecord(parseJson(result).body, "dry-run body");
 		assert.deepStrictEqual(body.variables, { orderId: "123" });
 	});
 
@@ -68,7 +69,7 @@ describe("CLI behavioural: publish message", () => {
 		);
 
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const body = parseJson(result).body as Record<string, unknown>;
+		const body = asRecord(parseJson(result).body, "dry-run body");
 		assert.strictEqual(body.timeToLive, 60000);
 	});
 
@@ -96,7 +97,7 @@ describe("CLI behavioural: correlate message", () => {
 		assert.strictEqual(out.method, "POST");
 		assert.ok((out.url as string).includes("/messages/correlation"));
 
-		const body = out.body as Record<string, unknown>;
+		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.name, "my-message");
 	});
 
@@ -113,7 +114,7 @@ describe("CLI behavioural: correlate message", () => {
 		);
 
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const body = parseJson(result).body as Record<string, unknown>;
+		const body = asRecord(parseJson(result).body, "dry-run body");
 		assert.strictEqual(body.correlationKey, "order-456");
 		assert.deepStrictEqual(body.variables, { status: "done" });
 	});

--- a/tests/unit/open.test.ts
+++ b/tests/unit/open.test.ts
@@ -13,6 +13,7 @@ import {
 	OPEN_APPS,
 	validateOpenAppOptions,
 } from "../../src/commands/open.ts";
+import { mockProcessExit } from "../utils/mocks.ts";
 
 const CLI_ENTRY = join(process.cwd(), "src", "index.ts");
 
@@ -140,7 +141,7 @@ describe("open command", () => {
 		let consoleErrorSpy: string[];
 		let originalLog: typeof console.log;
 		let originalError: typeof console.error;
-		let originalExit: typeof process.exit;
+		let restoreExit: () => void;
 		let exitCode: number | undefined;
 
 		beforeEach(() => {
@@ -148,34 +149,32 @@ describe("open command", () => {
 			consoleErrorSpy = [];
 			originalLog = console.log;
 			originalError = console.error;
-			originalExit = process.exit;
 			exitCode = undefined;
 
-			console.log = (...args: any[]) => {
+			console.log = (...args: unknown[]) => {
 				consoleLogSpy.push(args.join(" "));
 			};
-			console.error = (...args: any[]) => {
+			console.error = (...args: unknown[]) => {
 				consoleErrorSpy.push(args.join(" "));
 			};
-			process.exit = ((code: number) => {
-				exitCode = code;
+			restoreExit = mockProcessExit((code) => {
+				exitCode = typeof code === "number" ? code : undefined;
 				throw new Error(`process.exit(${code})`);
-				// biome-ignore lint/plugin: test-only override of process.exit signature
-			}) as typeof process.exit;
+			});
 		});
 
 		afterEach(() => {
 			console.log = originalLog;
 			console.error = originalError;
-			process.exit = originalExit;
+			restoreExit();
 		});
 
 		test("exits with error when app is undefined", async () => {
 			try {
 				validateOpenAppOptions(undefined, {});
 				assert.fail("Should have thrown");
-			} catch (e: any) {
-				assert.ok(e.message.includes("process.exit(1)"));
+			} catch (e) {
+				assert.ok(e instanceof Error && e.message.includes("process.exit(1)"));
 				assert.strictEqual(exitCode, 1);
 			}
 			const errorOutput = consoleErrorSpy.join("\n");
@@ -187,8 +186,8 @@ describe("open command", () => {
 			try {
 				validateOpenAppOptions("console", {});
 				assert.fail("Should have thrown");
-			} catch (e: any) {
-				assert.ok(e.message.includes("process.exit(1)"));
+			} catch (e) {
+				assert.ok(e instanceof Error && e.message.includes("process.exit(1)"));
 				assert.strictEqual(exitCode, 1);
 			}
 			const errorOutput = consoleErrorSpy.join("\n");

--- a/tests/unit/open.test.ts
+++ b/tests/unit/open.test.ts
@@ -118,11 +118,9 @@ describe("open command", () => {
 		});
 
 		test("defaults to xdg-open for unknown platforms", () => {
-			const { command, args } = getBrowserCommand(
-				url,
-				"freebsd" as NodeJS.Platform,
-				{},
-			);
+			// biome-ignore lint/plugin: narrowing unknown platform string to NodeJS.Platform for test
+			const platform = "freebsd" as NodeJS.Platform;
+			const { command, args } = getBrowserCommand(url, platform, {});
 			assert.strictEqual(command, "xdg-open");
 			assert.deepStrictEqual(args, [url]);
 		});
@@ -159,10 +157,11 @@ describe("open command", () => {
 			console.error = (...args: any[]) => {
 				consoleErrorSpy.push(args.join(" "));
 			};
-			(process.exit as any) = (code: number) => {
+			process.exit = ((code: number) => {
 				exitCode = code;
 				throw new Error(`process.exit(${code})`);
-			};
+				// biome-ignore lint/plugin: test-only override of process.exit signature
+			}) as typeof process.exit;
 		});
 
 		afterEach(() => {

--- a/tests/unit/output-mode.test.ts
+++ b/tests/unit/output-mode.test.ts
@@ -9,6 +9,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, test } from "node:test";
+import { makeTestEnv } from "../utils/mocks.ts";
 import { asyncSpawn } from "../utils/spawn.ts";
 
 const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
@@ -19,7 +20,7 @@ let dataDir = "";
 function cli(...args: string[]) {
 	return asyncSpawn("node", ["--experimental-strip-types", CLI, ...args], {
 		cwd: PROJECT_ROOT,
-		env: { ...process.env, C8CTL_DATA_DIR: dataDir } as NodeJS.ProcessEnv,
+		env: makeTestEnv({ C8CTL_DATA_DIR: dataDir }),
 	});
 }
 

--- a/tests/unit/plugin-registry.test.ts
+++ b/tests/unit/plugin-registry.test.ts
@@ -154,7 +154,7 @@ describe("Plugin Registry", () => {
 			// Verify it's a valid ISO 8601 timestamp
 			const timestamp = new Date(entry.installedAt);
 			assert.ok(
-				!isNaN(timestamp.getTime()),
+				!Number.isNaN(timestamp.getTime()),
 				"installedAt should be a valid date",
 			);
 

--- a/tests/unit/plugins.test.ts
+++ b/tests/unit/plugins.test.ts
@@ -167,7 +167,7 @@ describe("Plugin Structure", () => {
 			try {
 				// Need to inject global for the plugin to work
 				const { c8ctl } = await import("../../src/runtime.js");
-				(globalThis as any).c8ctl = c8ctl;
+				Object.assign(globalThis, { c8ctl });
 
 				const pluginPath = join(
 					process.cwd(),

--- a/tests/unit/plugins.test.ts
+++ b/tests/unit/plugins.test.ts
@@ -177,7 +177,7 @@ describe("Plugin Structure", () => {
 
 				assert.ok(plugin.commands, "Plugin has commands export");
 				assert.ok(
-					typeof plugin.commands["analyze"] === "function",
+					typeof plugin.commands.analyze === "function",
 					"analyze is a function",
 				);
 				assert.ok(
@@ -188,7 +188,7 @@ describe("Plugin Structure", () => {
 					typeof plugin.commands.config === "function",
 					"config is a function",
 				);
-			} catch (error) {
+			} catch (_error) {
 				// If import fails, just verify the file exists
 				const pluginPath = join(
 					process.cwd(),

--- a/tests/unit/process-instances-behaviour.test.ts
+++ b/tests/unit/process-instances-behaviour.test.ts
@@ -9,7 +9,7 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { c8, parseJson } from "../utils/cli.ts";
-import { asRecord } from "../utils/guards.ts";
+import { asRecord, getUrl } from "../utils/guards.ts";
 
 // ─── create process-instance ─────────────────────────────────────────────────
 
@@ -26,7 +26,7 @@ describe("CLI behavioural: create process-instance", () => {
 
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
-		assert.ok((out.url as string).endsWith("/process-instances"));
+		assert.ok(getUrl(out).endsWith("/process-instances"));
 
 		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.processDefinitionId, "my-process");
@@ -136,9 +136,7 @@ describe("CLI behavioural: cancel process-instance", () => {
 
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
-		assert.ok(
-			(out.url as string).includes("/process-instances/12345/cancellation"),
-		);
+		assert.ok(getUrl(out).includes("/process-instances/12345/cancellation"));
 	});
 
 	test("rejects missing key with exit code 1", async () => {

--- a/tests/unit/process-instances-behaviour.test.ts
+++ b/tests/unit/process-instances-behaviour.test.ts
@@ -9,6 +9,7 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { c8, parseJson } from "../utils/cli.ts";
+import { asRecord } from "../utils/guards.ts";
 
 // ─── create process-instance ─────────────────────────────────────────────────
 
@@ -27,7 +28,7 @@ describe("CLI behavioural: create process-instance", () => {
 		assert.strictEqual(out.method, "POST");
 		assert.ok((out.url as string).endsWith("/process-instances"));
 
-		const body = out.body as Record<string, unknown>;
+		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.processDefinitionId, "my-process");
 	});
 
@@ -43,7 +44,7 @@ describe("CLI behavioural: create process-instance", () => {
 		);
 
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const body = parseJson(result).body as Record<string, unknown>;
+		const body = asRecord(parseJson(result).body, "dry-run body");
 		assert.deepStrictEqual(body.variables, { foo: "bar" });
 	});
 
@@ -59,7 +60,7 @@ describe("CLI behavioural: create process-instance", () => {
 		);
 
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const body = parseJson(result).body as Record<string, unknown>;
+		const body = asRecord(parseJson(result).body, "dry-run body");
 		assert.strictEqual(body.processDefinitionVersion, 3);
 	});
 
@@ -74,7 +75,7 @@ describe("CLI behavioural: create process-instance", () => {
 		);
 
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const body = parseJson(result).body as Record<string, unknown>;
+		const body = asRecord(parseJson(result).body, "dry-run body");
 		assert.strictEqual(body.awaitCompletion, true);
 	});
 
@@ -91,7 +92,7 @@ describe("CLI behavioural: create process-instance", () => {
 		);
 
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const body = parseJson(result).body as Record<string, unknown>;
+		const body = asRecord(parseJson(result).body, "dry-run body");
 		assert.strictEqual(body.requestTimeout, 5000);
 	});
 
@@ -118,7 +119,7 @@ describe("CLI behavioural: await process-instance", () => {
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
 
-		const body = out.body as Record<string, unknown>;
+		const body = asRecord(out.body, "dry-run body");
 		assert.strictEqual(body.processDefinitionId, "my-process");
 		assert.strictEqual(body.awaitCompletion, true);
 	});

--- a/tests/unit/process-instances.test.ts
+++ b/tests/unit/process-instances.test.ts
@@ -10,7 +10,17 @@ describe("Process Instances Table Formatting", () => {
 	 * The table row mapping used in listProcessInstances.
 	 * Mirrors the logic in src/commands/process-instances.ts.
 	 */
-	const formatRow = (pi: any) => ({
+	const formatRow = (pi: {
+		hasIncident?: boolean;
+		processInstanceKey?: string;
+		key?: string;
+		processDefinitionId?: string;
+		state?: string;
+		processDefinitionVersion?: number | string;
+		version?: number | string;
+		startDate?: string;
+		tenantId?: string;
+	}) => ({
 		Key: `${pi.hasIncident ? "⚠ " : ""}${pi.processInstanceKey || pi.key}`,
 		"Process ID": pi.processDefinitionId,
 		State: pi.state,

--- a/tests/unit/profile-management.test.ts
+++ b/tests/unit/profile-management.test.ts
@@ -16,7 +16,6 @@ import {
 	addProfile,
 	clearActiveProfile,
 	envVarsToProfile,
-	getProfile,
 	hasCamundaEnvVars,
 	loadSessionState,
 	parseEnvFile,
@@ -161,10 +160,10 @@ describe("Profile management", () => {
 			consoleLogSpy = [];
 			originalError = console.error;
 			originalLog = console.log;
-			console.error = (...args: any[]) => {
+			console.error = (...args: unknown[]) => {
 				consoleErrorSpy.push(args.join(" "));
 			};
-			console.log = (...args: any[]) => {
+			console.log = (...args: unknown[]) => {
 				consoleLogSpy.push(args.join(" "));
 			};
 			c8ctl.activeProfile = undefined;
@@ -196,8 +195,7 @@ describe("Profile management", () => {
 			// Profile should win
 			assert.strictEqual(config.baseUrl, "https://profile-cluster.example.com");
 			// Warning on stderr, hints on stdout
-			const allOutput =
-				consoleErrorSpy.join("\n") + "\n" + consoleLogSpy.join("\n");
+			const allOutput = `${consoleErrorSpy.join("\n")}\n${consoleLogSpy.join("\n")}`;
 			assert.ok(
 				allOutput.includes(
 					"Active profile 'my-profile' is overriding CAMUNDA_*",

--- a/tests/unit/read-commands-behaviour.test.ts
+++ b/tests/unit/read-commands-behaviour.test.ts
@@ -20,9 +20,27 @@ function assertDryRun(
 	assert.strictEqual(out.dryRun, true);
 	assert.strictEqual(out.method, expected.method);
 	assert.ok(
-		(out.url as string).endsWith(expected.urlSuffix),
-		`Expected URL to end with "${expected.urlSuffix}", got "${out.url}"`,
+		typeof out.url === "string" && out.url.endsWith(expected.urlSuffix),
+		`Expected URL to end with "${expected.urlSuffix}", got "${String(out.url)}"`,
 	);
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+	return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Narrow the `body.filter` of a dry-run payload to a record. Throws with a
+ * descriptive message if the shape is wrong — no type assertions needed at
+ * call sites.
+ */
+function getFilter(out: Record<string, unknown>): Record<string, unknown> {
+	assert.ok(isRecord(out.body), "expected dry-run body to be an object");
+	assert.ok(
+		isRecord(out.body.filter),
+		"expected dry-run body.filter to be an object",
+	);
+	return out.body.filter;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -58,18 +76,14 @@ describe("CLI behavioural: search process-instances", () => {
 			method: "POST",
 			urlSuffix: "/process-instances/search",
 		});
-		const body = out.body as Record<string, Record<string, unknown>>;
-		assert.strictEqual(body.filter?.state, "ACTIVE");
+		assert.strictEqual(getFilter(out).state, "ACTIVE");
 	});
 
 	test("--dry-run includes processDefinitionId filter", async () => {
 		const result = await c8("search", "pi", "--dry-run", "--id", "my-process");
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const body = parseJson(result).body as Record<
-			string,
-			Record<string, unknown>
-		>;
-		assert.strictEqual(body.filter?.processDefinitionId, "my-process");
+		const out = parseJson(result);
+		assert.strictEqual(getFilter(out).processDefinitionId, "my-process");
 	});
 
 	test("--dry-run includes date range filter", async () => {
@@ -81,11 +95,8 @@ describe("CLI behavioural: search process-instances", () => {
 			"2024-01-01..2024-12-31",
 		);
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const body = parseJson(result).body as Record<
-			string,
-			Record<string, unknown>
-		>;
-		assert.ok(body.filter?.startDate, "Expected startDate filter");
+		const out = parseJson(result);
+		assert.ok(getFilter(out).startDate, "Expected startDate filter");
 	});
 });
 
@@ -139,8 +150,7 @@ describe("CLI behavioural: search process-definitions", () => {
 			method: "POST",
 			urlSuffix: "/process-definitions/search",
 		});
-		const body = out.body as Record<string, Record<string, unknown>>;
-		assert.strictEqual(body.filter?.name, "My Process");
+		assert.strictEqual(getFilter(out).name, "My Process");
 	});
 
 	test("--dry-run includes processDefinitionId filter", async () => {
@@ -152,11 +162,8 @@ describe("CLI behavioural: search process-definitions", () => {
 			"order-process",
 		);
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const body = parseJson(result).body as Record<
-			string,
-			Record<string, unknown>
-		>;
-		assert.strictEqual(body.filter?.processDefinitionId, "order-process");
+		const out = parseJson(result);
+		assert.strictEqual(getFilter(out).processDefinitionId, "order-process");
 	});
 });
 
@@ -201,8 +208,7 @@ describe("CLI behavioural: search user-tasks", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assertDryRun(out, { method: "POST", urlSuffix: "/user-tasks/search" });
-		const body = out.body as Record<string, Record<string, unknown>>;
-		assert.strictEqual(body.filter?.state, "CREATED");
+		assert.strictEqual(getFilter(out).state, "CREATED");
 	});
 
 	test("--dry-run includes assignee filter", async () => {
@@ -214,11 +220,8 @@ describe("CLI behavioural: search user-tasks", () => {
 			"alice",
 		);
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const body = parseJson(result).body as Record<
-			string,
-			Record<string, unknown>
-		>;
-		assert.strictEqual(body.filter?.assignee, "alice");
+		const out = parseJson(result);
+		assert.strictEqual(getFilter(out).assignee, "alice");
 	});
 });
 
@@ -243,8 +246,7 @@ describe("CLI behavioural: search incidents", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assertDryRun(out, { method: "POST", urlSuffix: "/incidents/search" });
-		const body = out.body as Record<string, Record<string, unknown>>;
-		assert.strictEqual(body.filter?.state, "ACTIVE");
+		assert.strictEqual(getFilter(out).state, "ACTIVE");
 	});
 });
 
@@ -275,8 +277,7 @@ describe("CLI behavioural: search jobs", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assertDryRun(out, { method: "POST", urlSuffix: "/jobs/search" });
-		const body = out.body as Record<string, Record<string, unknown>>;
-		assert.strictEqual(body.filter?.state, "ACTIVATABLE");
+		assert.strictEqual(getFilter(out).state, "ACTIVATABLE");
 	});
 
 	test("--dry-run includes type filter", async () => {
@@ -288,11 +289,8 @@ describe("CLI behavioural: search jobs", () => {
 			"send-email",
 		);
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const body = parseJson(result).body as Record<
-			string,
-			Record<string, unknown>
-		>;
-		assert.strictEqual(body.filter?.type, "send-email");
+		const out = parseJson(result);
+		assert.strictEqual(getFilter(out).type, "send-email");
 	});
 });
 
@@ -306,8 +304,7 @@ describe("CLI behavioural: search variables", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assertDryRun(out, { method: "POST", urlSuffix: "/variables/search" });
-		const body = out.body as Record<string, Record<string, unknown>>;
-		assert.strictEqual(body.filter?.name, "orderId");
+		assert.strictEqual(getFilter(out).name, "orderId");
 	});
 });
 
@@ -338,8 +335,7 @@ describe("CLI behavioural: search users", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assertDryRun(out, { method: "POST", urlSuffix: "/users/search" });
-		const body = out.body as Record<string, Record<string, unknown>>;
-		assert.strictEqual(body.filter?.username, "alice");
+		assert.strictEqual(getFilter(out).username, "alice");
 	});
 });
 
@@ -375,8 +371,7 @@ describe("CLI behavioural: search roles", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assertDryRun(out, { method: "POST", urlSuffix: "/roles/search" });
-		const body = out.body as Record<string, Record<string, unknown>>;
-		assert.strictEqual(body.filter?.name, "admin");
+		assert.strictEqual(getFilter(out).name, "admin");
 	});
 });
 
@@ -418,8 +413,7 @@ describe("CLI behavioural: search groups", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assertDryRun(out, { method: "POST", urlSuffix: "/groups/search" });
-		const body = out.body as Record<string, Record<string, unknown>>;
-		assert.strictEqual(body.filter?.name, "engineering");
+		assert.strictEqual(getFilter(out).name, "engineering");
 	});
 });
 
@@ -455,8 +449,7 @@ describe("CLI behavioural: search tenants", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assertDryRun(out, { method: "POST", urlSuffix: "/tenants/search" });
-		const body = out.body as Record<string, Record<string, unknown>>;
-		assert.strictEqual(body.filter?.name, "acme");
+		assert.strictEqual(getFilter(out).name, "acme");
 	});
 });
 
@@ -498,8 +491,7 @@ describe("CLI behavioural: search authorizations", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assertDryRun(out, { method: "POST", urlSuffix: "/authorizations/search" });
-		const body = out.body as Record<string, Record<string, unknown>>;
-		assert.strictEqual(body.filter?.ownerId, "alice");
+		assert.strictEqual(getFilter(out).ownerId, "alice");
 	});
 });
 
@@ -535,8 +527,7 @@ describe("CLI behavioural: search mapping-rules", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assertDryRun(out, { method: "POST", urlSuffix: "/mapping-rules/search" });
-		const body = out.body as Record<string, Record<string, unknown>>;
-		assert.strictEqual(body.filter?.name, "my-rule");
+		assert.strictEqual(getFilter(out).name, "my-rule");
 	});
 });
 

--- a/tests/unit/read-commands-behaviour.test.ts
+++ b/tests/unit/read-commands-behaviour.test.ts
@@ -10,6 +10,7 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { c8, parseJson } from "../utils/cli.ts";
+import { getFilter } from "../utils/guards.ts";
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
@@ -23,24 +24,6 @@ function assertDryRun(
 		typeof out.url === "string" && out.url.endsWith(expected.urlSuffix),
 		`Expected URL to end with "${expected.urlSuffix}", got "${String(out.url)}"`,
 	);
-}
-
-function isRecord(v: unknown): v is Record<string, unknown> {
-	return typeof v === "object" && v !== null && !Array.isArray(v);
-}
-
-/**
- * Narrow the `body.filter` of a dry-run payload to a record. Throws with a
- * descriptive message if the shape is wrong — no type assertions needed at
- * call sites.
- */
-function getFilter(out: Record<string, unknown>): Record<string, unknown> {
-	assert.ok(isRecord(out.body), "expected dry-run body to be an object");
-	assert.ok(
-		isRecord(out.body.filter),
-		"expected dry-run body.filter to be an object",
-	);
-	return out.body.filter;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/unit/search-feedback.test.ts
+++ b/tests/unit/search-feedback.test.ts
@@ -27,10 +27,10 @@ function createTestLogger(): {
 	const logs: string[] = [];
 	const errors: string[] = [];
 	const logWriter: LogWriter = {
-		log(...data: any[]) {
+		log(...data: unknown[]) {
 			logs.push(data.map(String).join(" "));
 		},
-		error(...data: any[]) {
+		error(...data: unknown[]) {
 			errors.push(data.map(String).join(" "));
 		},
 	};
@@ -276,7 +276,7 @@ describe("search resourceFlags (from registry)", () => {
 	});
 
 	test("incident includes all expected flags", () => {
-		const flags = resourceFlags["incident"];
+		const flags = resourceFlags.incident;
 		assert.ok("state" in flags);
 		assert.ok("processInstanceKey" in flags);
 		assert.ok("processDefinitionKey" in flags);
@@ -290,7 +290,7 @@ describe("search resourceFlags (from registry)", () => {
 	});
 
 	test("jobs includes all expected flags", () => {
-		const flags = resourceFlags["jobs"];
+		const flags = resourceFlags.jobs;
 		assert.ok("state" in flags);
 		assert.ok("type" in flags);
 		assert.ok("processInstanceKey" in flags);
@@ -299,7 +299,7 @@ describe("search resourceFlags (from registry)", () => {
 	});
 
 	test("variable includes all expected flags", () => {
-		const flags = resourceFlags["variable"];
+		const flags = resourceFlags.variable;
 		assert.ok("name" in flags);
 		assert.ok("value" in flags);
 		assert.ok("processInstanceKey" in flags);

--- a/tests/unit/unknown-flags-behaviour.test.ts
+++ b/tests/unit/unknown-flags-behaviour.test.ts
@@ -36,7 +36,7 @@ function parseWarning(
 /** Assert stderr contains NO unknown-flag warning. */
 function assertNoWarning(stderr: string): void {
 	const warning = parseWarning(stderr);
-	if (warning && warning.message.includes("not recognized")) {
+	if (warning?.message.includes("not recognized")) {
 		assert.fail(`Unexpected unknown-flag warning: ${warning.message}`);
 	}
 }

--- a/tests/unit/update-check.test.ts
+++ b/tests/unit/update-check.test.ts
@@ -557,7 +557,7 @@ describe("patient vs impatient check timing", () => {
 			_input: string | URL | Request,
 			init?: RequestInit,
 		) => {
-			return new Promise((resolve, reject) => {
+			return new Promise((_resolve, reject) => {
 				// If aborted before resolving, record it
 				init?.signal?.addEventListener("abort", () => {
 					fetchAborted = true;

--- a/tests/unit/user-tasks-behaviour.test.ts
+++ b/tests/unit/user-tasks-behaviour.test.ts
@@ -9,6 +9,7 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { c8, parseJson } from "../utils/cli.ts";
+import { asRecord } from "../utils/guards.ts";
 
 // ─── complete user-task ──────────────────────────────────────────────────────
 
@@ -44,7 +45,7 @@ describe("CLI behavioural: complete user-task", () => {
 		);
 
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const body = parseJson(result).body as Record<string, unknown>;
+		const body = asRecord(parseJson(result).body, "dry-run body");
 		assert.deepStrictEqual(body.variables, { approved: true });
 	});
 

--- a/tests/unit/user-tasks-behaviour.test.ts
+++ b/tests/unit/user-tasks-behaviour.test.ts
@@ -9,7 +9,7 @@
 import assert from "node:assert";
 import { describe, test } from "node:test";
 import { c8, parseJson } from "../utils/cli.ts";
-import { asRecord } from "../utils/guards.ts";
+import { asRecord, getUrl } from "../utils/guards.ts";
 
 // ─── complete user-task ──────────────────────────────────────────────────────
 
@@ -22,7 +22,7 @@ describe("CLI behavioural: complete user-task", () => {
 
 		assert.strictEqual(out.dryRun, true);
 		assert.strictEqual(out.method, "POST");
-		assert.ok((out.url as string).includes("/user-tasks/66666/completion"));
+		assert.ok(getUrl(out).includes("/user-tasks/66666/completion"));
 	});
 
 	test("--dry-run works with ut alias", async () => {
@@ -31,7 +31,7 @@ describe("CLI behavioural: complete user-task", () => {
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
 		assert.strictEqual(out.dryRun, true);
-		assert.ok((out.url as string).includes("/user-tasks/66666/completion"));
+		assert.ok(getUrl(out).includes("/user-tasks/66666/completion"));
 	});
 
 	test("--dry-run includes variables when provided", async () => {

--- a/tests/unit/verbose.test.ts
+++ b/tests/unit/verbose.test.ts
@@ -33,9 +33,10 @@ describe("handleCommandError", () => {
 		console.log = (...args: any[]) => {
 			infoSpy.push(args.join(" "));
 		};
-		(process.exit as any) = (code: number) => {
+		process.exit = ((code: number) => {
 			throw new Error(`process.exit(${code})`);
-		};
+			// biome-ignore lint/plugin: test-only override of process.exit signature
+		}) as typeof process.exit;
 
 		c8ctl.verbose = false;
 		c8ctl.outputMode = "text";

--- a/tests/unit/verbose.test.ts
+++ b/tests/unit/verbose.test.ts
@@ -7,13 +7,14 @@ import { afterEach, beforeEach, describe, test } from "node:test";
 import { handleCommandError } from "../../src/errors.ts";
 import { Logger } from "../../src/logger.ts";
 import { c8ctl } from "../../src/runtime.ts";
+import { mockProcessExit } from "../utils/mocks.ts";
 
 describe("handleCommandError", () => {
 	let errorSpy: string[];
 	let infoSpy: string[];
 	let originalErr: typeof console.error;
 	let originalLog: typeof console.log;
-	let originalExit: typeof process.exit;
+	let restoreExit: () => void;
 	let originalVerbose: typeof c8ctl.verbose;
 	let originalOutputMode: typeof c8ctl.outputMode;
 	let logger: Logger;
@@ -23,20 +24,18 @@ describe("handleCommandError", () => {
 		infoSpy = [];
 		originalErr = console.error;
 		originalLog = console.log;
-		originalExit = process.exit;
 		originalVerbose = c8ctl.verbose;
 		originalOutputMode = c8ctl.outputMode;
 
-		console.error = (...args: any[]) => {
+		console.error = (...args: unknown[]) => {
 			errorSpy.push(args.join(" "));
 		};
-		console.log = (...args: any[]) => {
+		console.log = (...args: unknown[]) => {
 			infoSpy.push(args.join(" "));
 		};
-		process.exit = ((code: number) => {
+		restoreExit = mockProcessExit((code) => {
 			throw new Error(`process.exit(${code})`);
-			// biome-ignore lint/plugin: test-only override of process.exit signature
-		}) as typeof process.exit;
+		});
 
 		c8ctl.verbose = false;
 		c8ctl.outputMode = "text";
@@ -46,7 +45,7 @@ describe("handleCommandError", () => {
 	afterEach(() => {
 		console.error = originalErr;
 		console.log = originalLog;
-		process.exit = originalExit;
+		restoreExit();
 		c8ctl.verbose = originalVerbose;
 		c8ctl.outputMode = originalOutputMode;
 	});

--- a/tests/utils/guards.ts
+++ b/tests/utils/guards.ts
@@ -80,7 +80,12 @@ export function asError(v: unknown, label = "error"): Error {
  */
 export function getExecErrorOutput(v: unknown): string {
 	if (isRecord(v)) {
-		for (const key of ["stderr", "stdout", "message"] as const) {
+		const keys: Array<"stderr" | "stdout" | "message"> = [
+			"stderr",
+			"stdout",
+			"message",
+		];
+		for (const key of keys) {
 			const val = v[key];
 			if (typeof val === "string" && val.length > 0) return val;
 			if (val != null) {

--- a/tests/utils/guards.ts
+++ b/tests/utils/guards.ts
@@ -1,0 +1,49 @@
+/**
+ * Runtime type guards for narrowing values in tests without `as T` casts.
+ *
+ * These helpers replace `x as Record<string, unknown>` patterns with
+ * assertions that throw a descriptive error on failure — giving better
+ * diagnostics than a silent cast when a future change breaks the assumption.
+ */
+
+import assert from "node:assert";
+
+export function isRecord(v: unknown): v is Record<string, unknown> {
+	return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Assert `v` is a non-array object and return it typed as a record.
+ * Throws with a descriptive message on failure.
+ */
+export function asRecord(v: unknown, label = "value"): Record<string, unknown> {
+	assert.ok(isRecord(v), `expected ${label} to be an object`);
+	return v;
+}
+
+/**
+ * Extract `out.body` as a record. Used by dry-run tests.
+ */
+export function getBody(out: Record<string, unknown>): Record<string, unknown> {
+	return asRecord(out.body, "dry-run body");
+}
+
+/**
+ * Extract `out.body.filter` as a record. Used by read-command dry-run tests.
+ */
+export function getFilter(
+	out: Record<string, unknown>,
+): Record<string, unknown> {
+	return asRecord(getBody(out).filter, "dry-run body.filter");
+}
+
+/**
+ * Narrow a JSON array of objects to `Record<string, unknown>[]`.
+ */
+export function asRecordArray(
+	v: unknown,
+	label = "value",
+): Record<string, unknown>[] {
+	assert.ok(Array.isArray(v), `expected ${label} to be an array`);
+	return v.map((item, i) => asRecord(item, `${label}[${i}]`));
+}

--- a/tests/utils/guards.ts
+++ b/tests/utils/guards.ts
@@ -47,3 +47,63 @@ export function asRecordArray(
 	assert.ok(Array.isArray(v), `expected ${label} to be an array`);
 	return v.map((item, i) => asRecord(item, `${label}[${i}]`));
 }
+
+/**
+ * Assert `v` is a string and return it. Throws with a descriptive message
+ * on failure.
+ */
+export function asString(v: unknown, label = "value"): string {
+	assert.ok(typeof v === "string", `expected ${label} to be a string`);
+	return v;
+}
+
+/**
+ * Extract `out.url` as a string. Used by dry-run tests.
+ */
+export function getUrl(out: Record<string, unknown>): string {
+	return asString(out.url, "dry-run url");
+}
+
+/**
+ * Assert `v` is an Error instance and return it. Throws with a descriptive
+ * message on failure. Useful for narrowing in catch blocks.
+ */
+export function asError(v: unknown, label = "error"): Error {
+	assert.ok(v instanceof Error, `expected ${label} to be an Error`);
+	return v;
+}
+
+/**
+ * Extract stderr/stdout/message from a Node `child_process` error (e.g. the
+ * object thrown by `execSync` on a non-zero exit). Falls back through
+ * `stderr`, `stdout`, then `message`.
+ */
+export function getExecErrorOutput(v: unknown): string {
+	if (isRecord(v)) {
+		for (const key of ["stderr", "stdout", "message"] as const) {
+			const val = v[key];
+			if (typeof val === "string" && val.length > 0) return val;
+			if (val != null) {
+				const s = String(val);
+				if (s.length > 0 && s !== "[object Object]") return s;
+			}
+		}
+	}
+	return String(v);
+}
+
+/**
+ * Extract a single field from a Node `child_process` error object. Returns
+ * an empty string when the field is missing or the value is not a string.
+ */
+export function getExecField(
+	v: unknown,
+	field: "stdout" | "stderr" | "message",
+): string {
+	if (isRecord(v)) {
+		const val = v[field];
+		if (typeof val === "string") return val;
+		if (val != null) return String(val);
+	}
+	return "";
+}

--- a/tests/utils/mocks.ts
+++ b/tests/utils/mocks.ts
@@ -1,0 +1,58 @@
+/**
+ * Shared test stubs for SDK / internal class types that cannot be satisfied
+ * structurally from a test.
+ *
+ * These helpers centralize the unavoidable `as unknown as T` boundary so that
+ * individual tests do not each carry their own `biome-ignore lint/plugin`
+ * directives for the `no-unsafe-type-assertion` plugin.
+ *
+ * Overloads accept a partial shape so tests can supply whatever fields the
+ * code under test actually touches; everything else is stubbed to a no-op.
+ */
+
+import type { createClient } from "../../src/client.ts";
+import type { Logger } from "../../src/logger.ts";
+
+type CamundaClient = ReturnType<typeof createClient>;
+
+/**
+ * Build a CamundaClient stub from a partial shape.
+ *
+ * The cast crosses the test/SDK boundary: CamundaClient is a class with
+ * private state that cannot be reproduced structurally.
+ */
+export function makeMockClient(
+	partial: Record<string, unknown> = {},
+): CamundaClient {
+	// biome-ignore lint/plugin: test-only stub for CamundaClient class; structural satisfaction impractical
+	return partial as unknown as CamundaClient;
+}
+
+/**
+ * Build a Logger stub. Defaults all methods to no-ops; override individual
+ * methods by passing them in `partial`.
+ */
+export function makeMockLogger(partial: Partial<Logger> = {}): Logger {
+	const base = {
+		info: () => {},
+		debug: () => {},
+		error: () => {},
+		warn: () => {},
+		json: () => {},
+		table: () => {},
+		output: () => {},
+		...partial,
+	};
+	// biome-ignore lint/plugin: test-only stub for Logger class; structural satisfaction impractical
+	return base as unknown as Logger;
+}
+
+/**
+ * Build a NodeJS.ProcessEnv from `process.env` plus overrides, without
+ * needing an `as NodeJS.ProcessEnv` cast at call sites.
+ */
+export function makeTestEnv(
+	overrides: Record<string, string> = {},
+): NodeJS.ProcessEnv {
+	return { ...process.env, ...overrides };
+}

--- a/tests/utils/mocks.ts
+++ b/tests/utils/mocks.ts
@@ -56,3 +56,28 @@ export function makeTestEnv(
 ): NodeJS.ProcessEnv {
 	return { ...process.env, ...overrides };
 }
+
+/**
+ * Replace `process.exit` with a throwing stub and return a restore function.
+ * The returned stub throws `new Error("exit")` (or the supplied error) so
+ * callers can assert on it via `await ....catch(() => {})` or `assert.throws`.
+ *
+ * Centralizes the unavoidable cast: the replacement function always throws,
+ * so its return type is `never`, but TypeScript cannot widen
+ * `(code?: number | string | null) => never` from a plain `() => never`
+ * without help.
+ */
+export function mockProcessExit(
+	onExit?: (code?: number | string | null) => void,
+): () => void {
+	const original = process.exit;
+	const stub = ((code?: number | string | null): never => {
+		onExit?.(code);
+		throw new Error("exit");
+	}) satisfies (code?: number | string | null) => never;
+	// biome-ignore lint/plugin: test-only override of process.exit global; signature matches via satisfies
+	process.exit = stub as typeof process.exit;
+	return () => {
+		process.exit = original;
+	};
+}

--- a/tests/utils/mocks.ts
+++ b/tests/utils/mocks.ts
@@ -59,8 +59,10 @@ export function makeTestEnv(
 
 /**
  * Replace `process.exit` with a throwing stub and return a restore function.
- * The returned stub throws `new Error("exit")` (or the supplied error) so
- * callers can assert on it via `await ....catch(() => {})` or `assert.throws`.
+ * The returned stub always throws `new Error("exit")` so callers can assert
+ * on it via `await ....catch(() => {})` or `assert.throws`. The optional
+ * `onExit` callback runs before the throw and receives the exit code; if it
+ * throws, its error propagates instead of the default `Error("exit")`.
  *
  * Centralizes the unavoidable cast: the replacement function always throws,
  * so its return type is `never`, but TypeScript cannot widen

--- a/tests/utils/spawn.ts
+++ b/tests/utils/spawn.ts
@@ -100,6 +100,7 @@ export async function asyncSpawn(
 		});
 		return { stdout: stdout ?? "", stderr: stderr ?? "", status: 0 };
 	} catch (err) {
+		// biome-ignore lint/plugin: unavoidable narrowing of catch-clause unknown to ExecFileException
 		const e = err as ExecFileException & { stdout?: string; stderr?: string };
 		return {
 			stdout: e.stdout ?? "",

--- a/tests/utils/spawn.ts
+++ b/tests/utils/spawn.ts
@@ -56,7 +56,7 @@ function assertNoControlChars(value: string, fieldName: string): void {
 function validateSpawnInputs(
 	command: string,
 	args: string[],
-	options?: { cwd?: string; env?: NodeJS.ProcessEnv },
+	options?: { cwd?: string; env?: NodeJS.ProcessEnv; timeout?: number },
 ): void {
 	assertAllowedCommand(command);
 	assertNoControlChars(command, "command");
@@ -77,6 +77,19 @@ function validateSpawnInputs(
 			if (typeof value === "string") {
 				assertNoNul(value, `env value (${key})`);
 			}
+		}
+	}
+
+	if (options?.timeout !== undefined) {
+		if (
+			typeof options.timeout !== "number" ||
+			!Number.isFinite(options.timeout) ||
+			options.timeout < 0 ||
+			!Number.isSafeInteger(options.timeout)
+		) {
+			throw new Error(
+				`Unsafe timeout: must be a non-negative safe integer (got ${String(options.timeout)})`,
+			);
 		}
 	}
 }

--- a/tests/utils/spawn.ts
+++ b/tests/utils/spawn.ts
@@ -90,13 +90,14 @@ export interface SpawnResult {
 export async function asyncSpawn(
 	command: string,
 	args: string[],
-	options?: { cwd?: string; env?: NodeJS.ProcessEnv },
+	options?: { cwd?: string; env?: NodeJS.ProcessEnv; timeout?: number },
 ): Promise<SpawnResult> {
 	validateSpawnInputs(command, args, options);
 	try {
 		const { stdout, stderr } = await execFile(command, args, {
 			...options,
 			maxBuffer: 10 * 1024 * 1024,
+			...(options?.timeout !== undefined ? { timeout: options.timeout } : {}),
 		});
 		return { stdout: stdout ?? "", stderr: stderr ?? "", status: 0 };
 	} catch (err) {


### PR DESCRIPTION
Closes work item 1 of #257. Consolidates PR #280 (command-framework tests) and all remaining test-file cast removal into a single review unit.

**Scope**: all `as T` casts AND all `any` usages removed across `tests/` (`src/` was already clean). 43 test files modified.

## Approach

Shared helpers centralize the unavoidable test-boundary casts into a single `biome-ignore` each:

### `tests/utils/mocks.ts`

- `makeMockClient(partial)` — builds a `CamundaClient` stub. Replaces ~20 inline casts.
- `makeMockLogger(partial)` — builds a `Logger` stub with no-op defaults. Replaces ~5 inline casts.
- `makeTestEnv(overrides)` — builds a `NodeJS.ProcessEnv` without needing the spread cast. Replaces ~9 inline casts across integration tests.
- `mockProcessExit(onExit?)` — replaces `process.exit` with a throwing stub and returns a restore function. Centralizes the unavoidable `as typeof process.exit` cast (with `biome-ignore` correctly placed immediately above the assertion) behind one helper. Replaces 6+ per-file `process.exit = (() => {...}) as typeof process.exit` blocks across `command-validation`, `open`, `completion`, `identity`, `verbose`, `cluster-plugin`.

### `tests/utils/guards.ts`

- `isRecord(v)` / `asRecord(v, label?)` / `asRecordArray(v, label?)` — `Record<string, unknown>` narrowing.
- `getBody(out)` / `getFilter(out)` / `getUrl(out)` — convenience narrowers for dry-run output.
- `asString(v, label)` / `asError(v, label)` — descriptive-message assertions.
- `getExecField(v, field)` / `getExecErrorOutput(v)` — narrow `execSync`/`execFileSync` error objects without `catch (e: any)`.

These replace all `x.body as Record<string, unknown>`, `x.url as string`, `catch (e: any)` and `const error: any = new Error(...)` patterns. Strictly stronger than the casts: failures throw with a descriptive message instead of silently yielding `undefined`.

## Per-file highlights

- **mcp-proxy-auth.test.ts / mcp-proxy-mock.test.ts**: 26 CamundaClient/Logger stubs converted. `init?.headers as Headers` → `new Headers(init?.headers)`. `const error: any = new Error(...)` → `new Error(msg, { cause })`.
- **8 `*-behaviour.test.ts` files**: all `out.body as Record<...>` → `asRecord(...)`, `out.url as string` → `getUrl(out)`.
- **identity.test.ts**: 8 `(typeof out.url === "string" ? out.url : "").endsWith(...)` → `getUrl(out).endsWith(...)`. `sanitizeForLogging(x) as Record<...>` → `asRecord(sanitizeForLogging(x))`. `(err as any).password = …` → `Object.assign(err, { password: … })`.
- **fetch-all-pages.test.ts** (19 → 0): typed filter params with `Record<string, unknown>`; `filter.page?.after as number | undefined` → `typeof afterRaw === "number" ? afterRaw : undefined`.
- **help.test.ts** (13 → 0), **logger.test.ts** (28 → 0), **cluster-plugin.test.ts** (10 → 0): `any[]` → `unknown[]` for varargs; structural types for map callbacks.
- **deployment-logging.test.ts / plugin-lifecycle.test.ts**: 8 `catch (error: any) { error.stdout || error.stderr }` → `catch (error) { getExecField(error, "stdout") + getExecField(error, "stderr") }`.
- **9 integration test files**: `env: {…} as NodeJS.ProcessEnv` → `makeTestEnv({…})`.
- **JSON.parse generic casts** (4 integration runners): a single `biome-ignore lint/plugin: generic JSON parse helper` with the reason recorded in-line.
- **lazy-client / plugins / command-validation**: per-case tightening where safe; `biome-ignore` with concrete reasons where the boundary is unavoidable (with the directive placed immediately above the assertion).

## Addressed review comments

- `"bogus" in result` → `Object.hasOwn(result, "bogus")` (own-property check rather than prototype chain).
- `biome-ignore` directives moved from inside `process.exit` stub bodies (after `throw`, read as dead code) to immediately above the `as typeof process.exit` assertion, via the `mockProcessExit` helper.
- Redundant `typeof out.url === "string" && (typeof out.url === "string" ? out.url : "").length > 0` → `typeof out.url === "string" && out.url.length > 0`.
- `{ processDefinitionKey: true as unknown as string }` → `{ processDefinitionKey: true }` (since `validateFlags` accepts boolean natively).
- All `out.url as string` in behavioural tests → `getUrl(out)` helper.

## Verification

- `npx biome check tests/` — 0 errors (11 pre-existing warnings for `noNonNullAssertion` / `noTemplateCurlyInString`, out of scope).
- `npx tsc --noEmit -p tsconfig.check.json` — does not regress the 61-error baseline.
- **1064/1064 unit tests pass** in ~21s.

## Follow-up (work item 4b of #257)

- Fix the remaining 61 baseline tsc errors.
- Add `tsc --noEmit -p tsconfig.check.json` to `.githooks/pre-commit`.
- Add `tests/**/*.ts` to `biome.json` `linter.includes` to activate the `no-unsafe-type-assertion` plugin and `noExplicitAny` rule as a regression guard on this change (branch `chore/lint-tests-no-unsafe-cast` ready).
