### PR TITLE
perf(tests): re-enable process isolation for unit tests (~28x speedup)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "copy-plugins": "node -e \"const fs=require('fs');const path=require('path');const src='default-plugins';const dest='dist/default-plugins';if(fs.existsSync(src)){fs.cpSync(src,dest,{recursive:true})}\"",
     "copy-templates": "node -e \"const fs=require('fs');const src='src/templates';const dest='dist/templates';if(fs.existsSync(src)){fs.cpSync(src,dest,{recursive:true})}\"",
     "prepublishOnly": "npm run build",
-    "test": "node --experimental-strip-types --test --experimental-test-isolation=none tests/unit/*.test.ts tests/integration/*.test.ts",
-    "test:unit": "node --experimental-strip-types --test --experimental-test-isolation=none tests/unit/*.test.ts",
-    "test:integration": "node --experimental-strip-types --test --experimental-test-isolation=none tests/integration/*.test.ts",
+    "test": "node --experimental-strip-types --test tests/unit/*.test.ts tests/integration/*.test.ts",
+    "test:unit": "node --experimental-strip-types --test tests/unit/*.test.ts",
+    "test:integration": "node --experimental-strip-types --test tests/integration/*.test.ts",
     "dev": "node src/index.ts",
     "cli": "node src/index.ts"
   },

--- a/tests/unit/cluster-plugin.test.ts
+++ b/tests/unit/cluster-plugin.test.ts
@@ -1764,6 +1764,8 @@ describe("Cluster Plugin – logs, list-remote, install, delete subcommands", ()
 	let originalWarn: typeof console.warn;
 	let originalError: typeof console.error;
 	let originalFetch: typeof globalThis.fetch;
+	let originalCacheDir: string | undefined;
+	let tempCacheDir: string;
 
 	beforeEach(() => {
 		captured = [];
@@ -1779,6 +1781,13 @@ describe("Cluster Plugin – logs, list-remote, install, delete subcommands", ()
 		console.error = (...args: unknown[]) => {
 			captured.push(args.map(String).join(" "));
 		};
+		// Redirect the plugin to an empty temp cache dir so the `logs`
+		// subcommand does not spawn `tail -f` against a real running
+		// cluster on the developer's machine (which would leak and hang
+		// the test runner).
+		originalCacheDir = process.env.C8RUN_CACHE_DIR;
+		tempCacheDir = mkdtempSync(join(tmpdir(), "c8ctl-test-cache-"));
+		process.env.C8RUN_CACHE_DIR = tempCacheDir;
 		originalFetch = globalThis.fetch;
 		Object.defineProperty(globalThis, "fetch", {
 			value: async () => {
@@ -1793,6 +1802,14 @@ describe("Cluster Plugin – logs, list-remote, install, delete subcommands", ()
 		console.log = originalLog;
 		console.warn = originalWarn;
 		console.error = originalError;
+		if (originalCacheDir === undefined) {
+			delete process.env.C8RUN_CACHE_DIR;
+		} else {
+			process.env.C8RUN_CACHE_DIR = originalCacheDir;
+		}
+		if (existsSync(tempCacheDir)) {
+			rmSync(tempCacheDir, { recursive: true, force: true });
+		}
 		Object.defineProperty(globalThis, "fetch", {
 			value: originalFetch,
 			writable: true,


### PR DESCRIPTION
## Summary

Removes `--experimental-test-isolation=none` from the npm test scripts and fixes a pre-existing `tail -f` leak in the cluster-plugin tests that the `isolation=none` mode was masking.

## Why

`--experimental-test-isolation=none` was set previously because process isolation triggered worker serialization failures (`'Promise resolution is still pending but the event loop has already resolved'`) on earlier Node versions. On Node v24.12.0 the failures no longer reproduce.

## Measurements (Node v24.12.0, local)

| Mode | Wall time | Result |
|---|---|---|
| `--experimental-test-isolation=none` (previous) | 10m35s + hang | Failures in `tests/unit/watch-force.test.ts` |
| Default per-file process isolation (this PR) | **~22s** (3 consecutive runs: 21.4s, 22.2s, 22.8s) | 1064 / 1064 pass |

That is roughly a **28× speedup** locally, and should similarly accelerate CI.

## The `tail -f` leak fix

The `'logs'` subcommand test in `tests/unit/cluster-plugin.test.ts` invoked `plugin.commands["cluster"](["logs"])`, which calls `streamLogs(getCacheDir())` against the real `~/Library/Caches/c8run/...` directory. On any developer machine with a running cluster, this spawned `tail -f` with `stdio: 'inherit'` — and the subprocess outlived the test, hanging the runner. The leak was hidden by the in-process `isolation=none` mode (it just blocked the same process forever), and only became obvious when switching modes.

The test now sets `C8RUN_CACHE_DIR` to a fresh temp dir in `beforeEach` and restores it in `afterEach`, so `streamLogs` takes the "no cluster running" early-return path and never reaches the `spawn('tail', ...)` line.

## Verification

- ✅ `npm run test:unit` — 1064/1064 pass, 3 runs in a row
- ✅ `npm run lint` — clean