### PR TITLE
chore(tests): fix 110 tsc errors in test suite

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -5,7 +5,7 @@
   },
   "linter": {
     "enabled": true,
-    "includes": ["src/**/*.ts", "!/src/templates/**"],
+    "includes": ["src/**/*.ts", "!/src/templates/**", "tests/**/*.ts"],
     "rules": {
       "recommended": true,
       "suspicious": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -82,6 +82,8 @@ type PagedResponse<T> = {
 	};
 };
 
+export type { PagedResponse };
+
 /**
  * Fetch all pages from a Camunda 8 search endpoint using cursor-based
  * pagination. The caller supplies a search function that accepts a filter
@@ -94,7 +96,7 @@ type PagedResponse<T> = {
  * @returns all collected items across every page (up to maxItems)
  */
 /** Consistency options passed to every search call in fetchAllPages */
-type SearchConsistencyOpts = { consistency: { waitUpToMs: number } };
+export type SearchConsistencyOpts = { consistency: { waitUpToMs: number } };
 
 export async function fetchAllPages<
 	T,

--- a/tests/integration/bash-completion.test.ts
+++ b/tests/integration/bash-completion.test.ts
@@ -299,11 +299,11 @@ echo "\${COMPREPLY[@]}"
 
 		// Verify it initializes variables manually
 		assert.ok(
-			completionResult.stdout.includes('cur="${COMP_WORDS[COMP_CWORD]}"'),
+			completionResult.stdout.includes(`cur="\${COMP_WORDS[COMP_CWORD]}"`),
 			"Should initialize cur variable",
 		);
 		assert.ok(
-			completionResult.stdout.includes('prev="${COMP_WORDS[COMP_CWORD-1]}"'),
+			completionResult.stdout.includes(`prev="\${COMP_WORDS[COMP_CWORD-1]}"`),
 			"Should initialize prev variable",
 		);
 	});

--- a/tests/integration/forms.test.ts
+++ b/tests/integration/forms.test.ts
@@ -12,7 +12,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { after, before, beforeEach, describe, test } from "node:test";
 import { makeTestEnv } from "../utils/mocks.ts";
-import { pollUntil } from "../utils/polling.ts";
+import { pollUntil, pollUntilValue } from "../utils/polling.ts";
 import { asyncSpawn, type SpawnResult } from "../utils/spawn.ts";
 
 const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
@@ -97,8 +97,7 @@ describe("Form Integration Tests", () => {
 		assert.ok(piKey, "Process instance key should exist");
 
 		// Poll until user task is available
-		let userTaskKey: string | undefined;
-		const userTaskFound = await pollUntil(
+		const userTaskKey = await pollUntilValue(
 			async () => {
 				const result = await cli(
 					"search",
@@ -106,20 +105,15 @@ describe("Form Integration Tests", () => {
 					`--processInstanceKey=${piKey}`,
 				);
 				const items = parseJson<UserTaskRow[]>(result.stdout);
-				if (items.length > 0) {
-					userTaskKey = String(items[0].Key);
-					return true;
-				}
-				return false;
+				return items.length > 0 ? String(items[0].Key) : undefined;
 			},
 			POLL_TIMEOUT_MS,
 			POLL_INTERVAL_MS,
+			"user task key",
 		);
-		assert.ok(userTaskFound, "User task should be created and indexed");
-		assert.ok(userTaskKey, "User task key should exist");
 
 		// Retrieve the form via CLI
-		const formResult = await cli("get", "form", userTaskKey!, "--ut");
+		const formResult = await cli("get", "form", userTaskKey, "--ut");
 		assert.strictEqual(
 			formResult.status,
 			0,
@@ -141,25 +135,19 @@ describe("Form Integration Tests", () => {
 		await cli("deploy", "tests/fixtures/list-pis");
 
 		// Poll until process definition is indexed and get its key
-		let processDefinitionKey: string | undefined;
-		const definitionFound = await pollUntil(
+		const processDefinitionKey = await pollUntilValue(
 			async () => {
 				const result = await cli("search", "pd", "--id=Process_0t60ay7");
 				const items = parseJson<{ Key: string | number }[]>(result.stdout);
-				if (items.length > 0) {
-					processDefinitionKey = String(items[0].Key);
-					return true;
-				}
-				return false;
+				return items.length > 0 ? String(items[0].Key) : undefined;
 			},
 			POLL_TIMEOUT_MS,
 			POLL_INTERVAL_MS,
+			"process definition key",
 		);
-		assert.ok(definitionFound, "Process definition should exist");
-		assert.ok(processDefinitionKey, "Process definition key should exist");
 
 		// This BPMN doesn't have a start form, so the CLI should indicate no form
-		const formResult = await cli("get", "form", processDefinitionKey!, "--pd");
+		const formResult = await cli("get", "form", processDefinitionKey, "--pd");
 		// The CLI logs "no associated start form" to stderr and exits 0
 		assert.strictEqual(
 			formResult.status,
@@ -200,8 +188,7 @@ describe("Form Integration Tests", () => {
 		assert.ok(piKey, "Process instance key should exist");
 
 		// Poll until user task is available
-		let userTaskKey: string | undefined;
-		const userTaskFound = await pollUntil(
+		const userTaskKey = await pollUntilValue(
 			async () => {
 				const result = await cli(
 					"search",
@@ -209,20 +196,15 @@ describe("Form Integration Tests", () => {
 					`--processInstanceKey=${piKey}`,
 				);
 				const items = parseJson<UserTaskRow[]>(result.stdout);
-				if (items.length > 0) {
-					userTaskKey = String(items[0].Key);
-					return true;
-				}
-				return false;
+				return items.length > 0 ? String(items[0].Key) : undefined;
 			},
 			POLL_TIMEOUT_MS,
 			POLL_INTERVAL_MS,
+			"user task key",
 		);
-		assert.ok(userTaskFound, "User task should be created");
-		assert.ok(userTaskKey, "User task key should exist");
 
 		// Retrieve form via CLI with --ut flag
-		const formResult = await cli("get", "form", userTaskKey!, "--ut");
+		const formResult = await cli("get", "form", userTaskKey, "--ut");
 		assert.strictEqual(
 			formResult.status,
 			0,
@@ -264,8 +246,7 @@ describe("Form Integration Tests", () => {
 		assert.ok(piKey, "Process instance key should exist");
 
 		// Poll until user task is available
-		let userTaskKey: string | undefined;
-		const userTaskFound = await pollUntil(
+		const userTaskKey = await pollUntilValue(
 			async () => {
 				const result = await cli(
 					"search",
@@ -273,20 +254,15 @@ describe("Form Integration Tests", () => {
 					`--processInstanceKey=${piKey}`,
 				);
 				const items = parseJson<UserTaskRow[]>(result.stdout);
-				if (items.length > 0) {
-					userTaskKey = String(items[0].Key);
-					return true;
-				}
-				return false;
+				return items.length > 0 ? String(items[0].Key) : undefined;
 			},
 			POLL_TIMEOUT_MS,
 			POLL_INTERVAL_MS,
+			"user task key",
 		);
-		assert.ok(userTaskFound, "User task should be created");
-		assert.ok(userTaskKey, "User task key should exist");
 
 		// Use generic getForm via CLI (no --ut or --pd flag — tries both APIs)
-		const formResult = await cli("get", "form", userTaskKey!);
+		const formResult = await cli("get", "form", userTaskKey);
 		assert.strictEqual(
 			formResult.status,
 			0,

--- a/tests/integration/mcp-proxy-mock.test.ts
+++ b/tests/integration/mcp-proxy-mock.test.ts
@@ -10,12 +10,9 @@ import {
 	type ServerResponse,
 } from "node:http";
 import { afterEach, beforeEach, describe, test } from "node:test";
-import type { createClient } from "../../src/client.ts";
 import { createCamundaFetch } from "../../src/commands/mcp-proxy.ts";
 import type { Logger } from "../../src/logger.ts";
 import { makeMockClient, makeMockLogger } from "../utils/mocks.ts";
-
-type CamundaClient = ReturnType<typeof createClient>;
 
 describe("MCP Proxy Mock Server Integration Tests", () => {
 	let mockServer: Server;

--- a/tests/integration/output-mode.test.ts
+++ b/tests/integration/output-mode.test.ts
@@ -8,6 +8,7 @@ import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, test } from "node:test";
+import { ProcessDefinitionId } from "@camunda8/orchestration-cluster-api";
 import { createClient } from "../../src/client.ts";
 import { makeTestEnv } from "../utils/mocks.ts";
 import { pollUntil } from "../utils/polling.ts";
@@ -46,7 +47,7 @@ describe("Output Mode Integration Tests", () => {
 
 		const client = createClient();
 		await client.createProcessInstance({
-			processDefinitionId: "Process_0t60ay7",
+			processDefinitionId: ProcessDefinitionId.assumeExists("Process_0t60ay7"),
 		});
 
 		// Set JSON output mode for indexing poll

--- a/tests/integration/process-instances.test.ts
+++ b/tests/integration/process-instances.test.ts
@@ -16,6 +16,7 @@ import {
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, test } from "node:test";
+import { ProcessDefinitionId } from "@camunda8/orchestration-cluster-api";
 import { createClient } from "../../src/client.ts";
 import { deploy } from "../../src/commands/deployments.ts";
 import { todayRange } from "../utils/date-helpers.ts";
@@ -78,7 +79,7 @@ describe("Process Instance Integration Tests (requires Camunda 8 at localhost:80
 
 		// Create process instance using the SDK client directly
 		const result = await client.createProcessInstance({
-			processDefinitionId: "simple-process",
+			processDefinitionId: ProcessDefinitionId.assumeExists("simple-process"),
 		});
 
 		// Verify instance key is returned
@@ -97,7 +98,7 @@ describe("Process Instance Integration Tests (requires Camunda 8 at localhost:80
 	test("list process instances filters by process definition via CLI", async () => {
 		await deploy(["tests/fixtures/simple.bpmn"], {});
 		await client.createProcessInstance({
-			processDefinitionId: "simple-process",
+			processDefinitionId: ProcessDefinitionId.assumeExists("simple-process"),
 		});
 
 		// Use CLI to list and verify it runs without error
@@ -119,13 +120,13 @@ describe("Process Instance Integration Tests (requires Camunda 8 at localhost:80
 	test("list process instances respects --limit via CLI", async () => {
 		await deploy(["tests/fixtures/simple.bpmn"], {});
 		await client.createProcessInstance({
-			processDefinitionId: "simple-process",
+			processDefinitionId: ProcessDefinitionId.assumeExists("simple-process"),
 		});
 		await client.createProcessInstance({
-			processDefinitionId: "simple-process",
+			processDefinitionId: ProcessDefinitionId.assumeExists("simple-process"),
 		});
 		await client.createProcessInstance({
-			processDefinitionId: "simple-process",
+			processDefinitionId: ProcessDefinitionId.assumeExists("simple-process"),
 		});
 
 		const result = await cli(testDir, "list", "pi", "--all", "--limit", "2");
@@ -152,7 +153,9 @@ describe("Process Instance Integration Tests (requires Camunda 8 at localhost:80
 		const v1Path = join(testDir, "v1.bpmn");
 		writeFileSync(v1Path, baseBpmn);
 		await deploy([v1Path], {});
-		await client.createProcessInstance({ processDefinitionId: uniqueId });
+		await client.createProcessInstance({
+			processDefinitionId: ProcessDefinitionId.assumeExists(uniqueId),
+		});
 
 		// Deploy v2 with a minimal change (different task name)
 		const v2Bpmn = baseBpmn.replace(
@@ -162,7 +165,9 @@ describe("Process Instance Integration Tests (requires Camunda 8 at localhost:80
 		const v2Path = join(testDir, "v2.bpmn");
 		writeFileSync(v2Path, v2Bpmn);
 		await deploy([v2Path], {});
-		await client.createProcessInstance({ processDefinitionId: uniqueId });
+		await client.createProcessInstance({
+			processDefinitionId: ProcessDefinitionId.assumeExists(uniqueId),
+		});
 
 		// Wait for both versions to be indexed via CLI
 		const v1Indexed = await pollUntil(
@@ -244,7 +249,7 @@ describe("Process Instance Integration Tests (requires Camunda 8 at localhost:80
 	test("list process instances --limit via CLI produces correct output", async () => {
 		await deploy(["tests/fixtures/simple.bpmn"], {});
 		await client.createProcessInstance({
-			processDefinitionId: "simple-process",
+			processDefinitionId: ProcessDefinitionId.assumeExists("simple-process"),
 		});
 
 		const result = await cli(testDir, "list", "pi", "--all", "--limit", "1");
@@ -266,7 +271,7 @@ describe("Process Instance Integration Tests (requires Camunda 8 at localhost:80
 		// Deploy and create an instance
 		await deploy(["tests/fixtures/simple.bpmn"], {});
 		const result = await client.createProcessInstance({
-			processDefinitionId: "simple-process",
+			processDefinitionId: ProcessDefinitionId.assumeExists("simple-process"),
 		});
 
 		assert.ok(result, "Create result should exist");
@@ -302,7 +307,7 @@ describe("Process Instance Integration Tests (requires Camunda 8 at localhost:80
 
 		// Test with awaitCompletion flag using the SDK client directly
 		const result = await client.createProcessInstance({
-			processDefinitionId: "simple-process",
+			processDefinitionId: ProcessDefinitionId.assumeExists("simple-process"),
 			awaitCompletion: true,
 		});
 
@@ -368,7 +373,7 @@ describe("Process Instance Integration Tests (requires Camunda 8 at localhost:80
 	test("list pi --between spanning today finds recently created instance via CLI", async () => {
 		await deploy(["tests/fixtures/simple.bpmn"], {});
 		await client.createProcessInstance({
-			processDefinitionId: "simple-process",
+			processDefinitionId: ProcessDefinitionId.assumeExists("simple-process"),
 		});
 
 		const found = await pollUntil(

--- a/tests/integration/search.test.ts
+++ b/tests/integration/search.test.ts
@@ -14,7 +14,7 @@ import { join, resolve } from "node:path";
 import { after, before, beforeEach, describe, test } from "node:test";
 import { MS_PER_DAY, todayRange } from "../utils/date-helpers.ts";
 import { makeTestEnv } from "../utils/mocks.ts";
-import { pollUntil } from "../utils/polling.ts";
+import { pollUntil, pollUntilValue } from "../utils/polling.ts";
 import { asyncSpawn, type SpawnResult } from "../utils/spawn.ts";
 
 // Polling configuration for Elasticsearch consistency
@@ -430,8 +430,7 @@ describe("Search Command Integration Tests (requires Camunda 8 at localhost:8080
 		await cli("deploy", "tests/fixtures/simple-will-create-incident.bpmn");
 		await cli("create", "pi", "--id=Process_0yyrstd");
 
-		let jobKey: string | undefined;
-		const jobFound = await pollUntil(
+		const jobKey = await pollUntilValue(
 			async () => {
 				const result = await cli(
 					"search",
@@ -440,26 +439,20 @@ describe("Search Command Integration Tests (requires Camunda 8 at localhost:8080
 					"--state=CREATED",
 				);
 				const items = parseItems<JobRow>(result.stdout);
-				if (items.length > 0) {
-					const createdJob = items.find(
-						(j) => String(j.State).toUpperCase() === "CREATED",
-					);
-					if (createdJob) {
-						jobKey = String(createdJob.Key);
-						return true;
-					}
-				}
-				return false;
+				const createdJob = items.find(
+					(j) => String(j.State).toUpperCase() === "CREATED",
+				);
+				return createdJob ? String(createdJob.Key) : undefined;
 			},
 			POLL_TIMEOUT_MS,
 			POLL_INTERVAL_MS,
+			"job key (incident test)",
 		);
-		assert.ok(jobFound && jobKey, "Job should appear before failing it");
 
 		await cli(
 			"fail",
 			"job",
-			jobKey!,
+			jobKey,
 			"--retries=0",
 			"--errorMessage=Intentional failure for incident test",
 		);
@@ -1040,8 +1033,7 @@ describe("Search Command Integration Tests (requires Camunda 8 at localhost:8080
 
 		// Wait for the job and fail it to produce an incident; filter by processInstanceKey to avoid
 		// picking up jobs from previous tests that may still appear as CREATED in the search index
-		let jobKey: string | undefined;
-		const jobFound = await pollUntil(
+		const jobKey = await pollUntilValue(
 			async () => {
 				const result = await cli(
 					"search",
@@ -1051,26 +1043,20 @@ describe("Search Command Integration Tests (requires Camunda 8 at localhost:8080
 					`--processInstanceKey=${piKey}`,
 				);
 				const items = parseItems<JobRow>(result.stdout);
-				if (items.length > 0) {
-					const job = items.find(
-						(j) => String(j.State).toUpperCase() === "CREATED",
-					);
-					if (job) {
-						jobKey = String(job.Key);
-						return true;
-					}
-				}
-				return false;
+				const job = items.find(
+					(j) => String(j.State).toUpperCase() === "CREATED",
+				);
+				return job ? String(job.Key) : undefined;
 			},
 			POLL_TIMEOUT_MS,
 			POLL_INTERVAL_MS,
+			"job key (between test)",
 		);
-		assert.ok(jobFound && jobKey, "Job should exist before failing");
 
 		await cli(
 			"fail",
 			"job",
-			jobKey!,
+			jobKey,
 			"--retries=0",
 			"--errorMessage=Intentional failure for between test",
 		);
@@ -1151,8 +1137,7 @@ describe("Search Command Integration Tests (requires Camunda 8 at localhost:8080
 
 		// Wait for a job and fail it to produce an incident; filter by processInstanceKey to avoid
 		// picking up jobs from previous tests that may still appear as CREATED in the search index
-		let jobKey: string | undefined;
-		await pollUntil(
+		const jobKey = await pollUntilValue(
 			async () => {
 				const result = await cli(
 					"search",
@@ -1162,24 +1147,19 @@ describe("Search Command Integration Tests (requires Camunda 8 at localhost:8080
 					`--processInstanceKey=${piKey}`,
 				);
 				const items = parseItems<JobRow>(result.stdout);
-				if (items.length > 0) {
-					const job = items.find(
-						(j) => String(j.State).toUpperCase() === "CREATED",
-					);
-					if (job) {
-						jobKey = String(job.Key);
-						return true;
-					}
-				}
-				return false;
+				const job = items.find(
+					(j) => String(j.State).toUpperCase() === "CREATED",
+				);
+				return job ? String(job.Key) : undefined;
 			},
 			POLL_TIMEOUT_MS,
 			POLL_INTERVAL_MS,
+			"job key (list between test)",
 		);
 		await cli(
 			"fail",
 			"job",
-			jobKey!,
+			jobKey,
 			"--retries=0",
 			"--errorMessage=Intentional failure for list between test",
 		);

--- a/tests/unit/cluster-plugin.test.ts
+++ b/tests/unit/cluster-plugin.test.ts
@@ -139,7 +139,6 @@ describe("Cluster Plugin – command usage output", () => {
 			captured.push(args.map(String).join(" "));
 		};
 		// Stub fetch so usage tests never hit the network
-		// @ts-expect-error — mock fetch for testing
 		globalThis.fetch = async () => {
 			throw new Error("offline");
 		};
@@ -982,7 +981,6 @@ describe("Cluster Plugin – resolveVersion", () => {
 	}
 
 	function mockFetchOffline() {
-		// @ts-expect-error — mock fetch for testing
 		globalThis.fetch = async () => {
 			throw new Error("offline");
 		};
@@ -1075,8 +1073,8 @@ describe("Cluster Plugin – checkBackgroundAliasFreshness", () => {
 		originalFetch = globalThis.fetch;
 		originalC8ctl = globalThis.c8ctl;
 		loggedMessages = [];
-		// @ts-expect-error — mock c8ctl logger
 		globalThis.c8ctl = {
+			// @ts-expect-error — partial Logger mock for testing
 			getLogger: () => ({
 				info: (msg: string) => loggedMessages.push(msg),
 				warn: () => {},
@@ -1167,7 +1165,6 @@ describe("Cluster Plugin – checkBackgroundAliasFreshness", () => {
 	});
 
 	test("stays silent when offline (fetch throws)", async () => {
-		// @ts-expect-error — mock fetch
 		globalThis.fetch = async () => {
 			throw new Error("Network unreachable");
 		};
@@ -1978,7 +1975,14 @@ describe("Cluster Plugin – ensureC8RunInstalled start vs install behavior", ()
 
 	test("start (checkForUpdateHint=true) does not block or re-download, but checks remote for hint", async () => {
 		// Simulate: 8.8 is installed locally with an old ETag, remote has a new ETag
-		const config = {
+		const config: {
+			cacheDir: string;
+			version: string;
+			isRolling: boolean;
+			checkForUpdates: boolean;
+			checkForUpdateHint: boolean;
+			_hintPromise?: Promise<unknown>;
+		} = {
 			cacheDir: tempDir,
 			version: "8.8",
 			isRolling: true,
@@ -2052,7 +2056,14 @@ describe("Cluster Plugin – ensureC8RunInstalled start vs install behavior", ()
 	});
 
 	test("start with minor version succeeds offline (hint check swallows error)", async () => {
-		const config = {
+		const config: {
+			cacheDir: string;
+			version: string;
+			isRolling: boolean;
+			checkForUpdates: boolean;
+			checkForUpdateHint: boolean;
+			_hintPromise?: Promise<unknown>;
+		} = {
 			cacheDir: tempDir,
 			version: "8.8",
 			isRolling: true,
@@ -2078,7 +2089,7 @@ describe("Cluster Plugin – ensureC8RunInstalled start vs install behavior", ()
 
 		// Await the hint promise — it should resolve (swallowing the error) without throwing
 		await assert.doesNotReject(
-			() => config._hintPromise,
+			() => config._hintPromise ?? Promise.resolve(),
 			"hint check should swallow network errors",
 		);
 

--- a/tests/unit/command-registry.test.ts
+++ b/tests/unit/command-registry.test.ts
@@ -9,6 +9,7 @@
 
 import assert from "node:assert";
 import { describe, test } from "node:test";
+import type { CommandDef, FlagDef } from "../../src/command-registry.ts";
 import {
 	COMMAND_REGISTRY,
 	deriveParseArgsOptions,
@@ -20,6 +21,20 @@ import {
 	SEARCH_FLAGS,
 	VERB_ALIASES,
 } from "../../src/command-registry.ts";
+
+/** Widened views for iterating with index signatures. */
+const REGISTRY: Record<string, CommandDef> = COMMAND_REGISTRY as Record<
+	string,
+	CommandDef
+>;
+const GLOBAL_FLAGS_MAP: Record<string, FlagDef> = GLOBAL_FLAGS as Record<
+	string,
+	FlagDef
+>;
+const SEARCH_FLAGS_MAP: Record<string, FlagDef> = SEARCH_FLAGS as Record<
+	string,
+	FlagDef
+>;
 
 // ─── Registry completeness ──────────────────────────────────────────────────
 
@@ -63,15 +78,12 @@ describe("COMMAND_REGISTRY completeness", () => {
 
 	test("every expected verb has a registry entry", () => {
 		for (const verb of EXPECTED_VERBS) {
-			assert.ok(
-				COMMAND_REGISTRY[verb],
-				`Missing registry entry for verb "${verb}"`,
-			);
+			assert.ok(REGISTRY[verb], `Missing registry entry for verb "${verb}"`);
 		}
 	});
 
 	test("registry contains no unexpected verbs", () => {
-		const registryVerbs = Object.keys(COMMAND_REGISTRY);
+		const registryVerbs = Object.keys(REGISTRY);
 		for (const verb of registryVerbs) {
 			assert.ok(
 				EXPECTED_VERBS.includes(verb),
@@ -81,7 +93,7 @@ describe("COMMAND_REGISTRY completeness", () => {
 	});
 
 	test("every command has required metadata fields", () => {
-		for (const [verb, def] of Object.entries(COMMAND_REGISTRY)) {
+		for (const [verb, def] of Object.entries(REGISTRY)) {
 			assert.ok(
 				typeof def.description === "string" && def.description.length > 0,
 				`${verb}: missing description`,
@@ -106,7 +118,7 @@ describe("COMMAND_REGISTRY completeness", () => {
 		// Some verbs require a positional arg but accept free-form input (e.g. file path)
 		// rather than a fixed set of resource names.
 		const FREE_FORM_POSITIONAL = new Set(["run"]);
-		for (const [verb, def] of Object.entries(COMMAND_REGISTRY)) {
+		for (const [verb, def] of Object.entries(REGISTRY)) {
 			if (def.requiresResource && !FREE_FORM_POSITIONAL.has(verb)) {
 				assert.ok(
 					def.resources.length > 0,
@@ -117,14 +129,14 @@ describe("COMMAND_REGISTRY completeness", () => {
 	});
 
 	test("verb aliases point to existing registry entries", () => {
-		for (const [verb, def] of Object.entries(COMMAND_REGISTRY)) {
+		for (const [verb, def] of Object.entries(REGISTRY)) {
 			for (const alias of def.aliases ?? []) {
 				assert.ok(
 					typeof alias === "string" && alias.length > 0,
 					`${verb}: alias must be a non-empty string`,
 				);
 				assert.ok(
-					!COMMAND_REGISTRY[alias],
+					!REGISTRY[alias],
 					`${verb}: alias "${alias}" conflicts with an existing verb entry`,
 				);
 			}
@@ -136,11 +148,11 @@ describe("COMMAND_REGISTRY completeness", () => {
 		for (const [alias, targets] of Object.entries(VERB_ALIASES)) {
 			for (const target of targets) {
 				assert.ok(
-					COMMAND_REGISTRY[target],
+					REGISTRY[target],
 					`VERB_ALIASES["${alias}"] points to "${target}" which is not in COMMAND_REGISTRY`,
 				);
 				assert.ok(
-					COMMAND_REGISTRY[target].aliases?.includes(alias),
+					REGISTRY[target].aliases?.includes(alias),
 					`VERB_ALIASES["${alias}"] → "${target}" but ${target}.aliases does not include "${alias}"`,
 				);
 			}
@@ -193,7 +205,16 @@ describe("RESOURCE_ALIASES consistency", () => {
 // ─── Search resource flags ───────────────────────────────────────────────────
 
 describe("search resourceFlags consistency", () => {
-	const resourceFlags = COMMAND_REGISTRY.search.resourceFlags;
+	const resourceFlagsRaw = COMMAND_REGISTRY.search.resourceFlags as
+		| Record<string, Record<string, FlagDef>>
+		| undefined;
+	if (!resourceFlagsRaw) {
+		throw new Error("search.resourceFlags must be defined");
+	}
+	const resourceFlags: Record<
+		string,
+		Record<string, FlagDef>
+	> = resourceFlagsRaw;
 	const EXPECTED_SEARCH_RESOURCES = [
 		"process-definition",
 		"process-instance",
@@ -251,7 +272,7 @@ describe("GLOBAL_FLAGS", () => {
 	test("includes required infrastructure flags", () => {
 		const required = ["help", "version", "profile", "dry-run", "verbose"];
 		for (const flag of required) {
-			assert.ok(GLOBAL_FLAGS[flag], `Missing global flag "${flag}"`);
+			assert.ok(GLOBAL_FLAGS_MAP[flag], `Missing global flag "${flag}"`);
 		}
 	});
 
@@ -270,7 +291,7 @@ describe("SEARCH_FLAGS", () => {
 	test("includes shared search flags", () => {
 		const expected = ["sortBy", "asc", "desc", "limit", "between", "dateField"];
 		for (const flag of expected) {
-			assert.ok(SEARCH_FLAGS[flag], `Missing search flag "${flag}"`);
+			assert.ok(SEARCH_FLAGS_MAP[flag], `Missing search flag "${flag}"`);
 		}
 	});
 });
@@ -491,7 +512,7 @@ describe("mutating flag correctness", () => {
 
 	test("all mutating verbs are marked as mutating", () => {
 		for (const verb of MUTATING_VERBS) {
-			const def = COMMAND_REGISTRY[verb];
+			const def = REGISTRY[verb];
 			assert.ok(def, `Missing entry for "${verb}"`);
 			assert.strictEqual(def.mutating, true, `"${verb}" should be mutating`);
 		}
@@ -499,7 +520,7 @@ describe("mutating flag correctness", () => {
 
 	test("all non-mutating verbs are marked as non-mutating", () => {
 		for (const verb of NON_MUTATING_VERBS) {
-			const def = COMMAND_REGISTRY[verb];
+			const def = REGISTRY[verb];
 			assert.ok(def, `Missing entry for "${verb}"`);
 			assert.strictEqual(
 				def.mutating,

--- a/tests/unit/command-registry.test.ts
+++ b/tests/unit/command-registry.test.ts
@@ -22,19 +22,10 @@ import {
 	VERB_ALIASES,
 } from "../../src/command-registry.ts";
 
-/** Widened views for iterating with index signatures. */
-const REGISTRY: Record<string, CommandDef> = COMMAND_REGISTRY as Record<
-	string,
-	CommandDef
->;
-const GLOBAL_FLAGS_MAP: Record<string, FlagDef> = GLOBAL_FLAGS as Record<
-	string,
-	FlagDef
->;
-const SEARCH_FLAGS_MAP: Record<string, FlagDef> = SEARCH_FLAGS as Record<
-	string,
-	FlagDef
->;
+/** Widened read-only views for iterating with index signatures. */
+const REGISTRY: Readonly<Record<string, CommandDef>> = COMMAND_REGISTRY;
+const GLOBAL_FLAGS_MAP: Readonly<Record<string, FlagDef>> = GLOBAL_FLAGS;
+const SEARCH_FLAGS_MAP: Readonly<Record<string, FlagDef>> = SEARCH_FLAGS;
 
 // ─── Registry completeness ──────────────────────────────────────────────────
 
@@ -205,16 +196,11 @@ describe("RESOURCE_ALIASES consistency", () => {
 // ─── Search resource flags ───────────────────────────────────────────────────
 
 describe("search resourceFlags consistency", () => {
-	const resourceFlagsRaw = COMMAND_REGISTRY.search.resourceFlags as
-		| Record<string, Record<string, FlagDef>>
-		| undefined;
-	if (!resourceFlagsRaw) {
-		throw new Error("search.resourceFlags must be defined");
-	}
-	const resourceFlags: Record<
-		string,
-		Record<string, FlagDef>
-	> = resourceFlagsRaw;
+	const resourceFlagsRaw:
+		| Readonly<Record<string, Readonly<Record<string, FlagDef>>>>
+		| undefined = COMMAND_REGISTRY.search.resourceFlags;
+	assert.ok(resourceFlagsRaw, "search.resourceFlags must be defined");
+	const resourceFlags = resourceFlagsRaw;
 	const EXPECTED_SEARCH_RESOURCES = [
 		"process-definition",
 		"process-instance",

--- a/tests/unit/command-validation.test.ts
+++ b/tests/unit/command-validation.test.ts
@@ -251,8 +251,15 @@ describe("requireOneOf", () => {
 
 // ─── validateFlags ───────────────────────────────────────────────────────────
 
+import type { CommandDef, FlagDef } from "../../src/command-registry.ts";
 import { COMMAND_REGISTRY, GLOBAL_FLAGS } from "../../src/command-registry.ts";
 import { validateFlags } from "../../src/command-validation.ts";
+
+/** Widened view of COMMAND_REGISTRY for iterating with index signatures. */
+const REGISTRY: Record<string, CommandDef> = COMMAND_REGISTRY as Record<
+	string,
+	CommandDef
+>;
 
 /**
  * Flag names that are known to map to branded SDK types.
@@ -288,7 +295,7 @@ describe("validateFlags structural invariants", () => {
 	test("every branded-type flag in the registry has a validate function", () => {
 		const missing: string[] = [];
 
-		for (const [verb, def] of Object.entries(COMMAND_REGISTRY)) {
+		for (const [verb, def] of Object.entries(REGISTRY)) {
 			for (const [flagName, flagDef] of Object.entries(def.flags)) {
 				if (
 					BRANDED_FLAG_NAMES.has(flagName) &&
@@ -308,7 +315,7 @@ describe("validateFlags structural invariants", () => {
 	});
 
 	test("validate functions throw on invalid input for key-type flags", () => {
-		for (const [verb, def] of Object.entries(COMMAND_REGISTRY)) {
+		for (const [verb, def] of Object.entries(REGISTRY)) {
 			for (const [flagName, flagDef] of Object.entries(def.flags)) {
 				if (!flagDef.validate) continue;
 
@@ -324,7 +331,7 @@ describe("validateFlags structural invariants", () => {
 	});
 
 	test("validate functions return the input for valid values", () => {
-		for (const [verb, def] of Object.entries(COMMAND_REGISTRY)) {
+		for (const [verb, def] of Object.entries(REGISTRY)) {
 			for (const [flagName, flagDef] of Object.entries(def.flags)) {
 				if (!flagDef.validate) continue;
 
@@ -538,8 +545,8 @@ describe("detectUnknownFlags — non-search verbs", () => {
 
 describe("detectUnknownFlags — structural coverage", () => {
 	test("every verb in COMMAND_REGISTRY gets unknown-flag detection that rejects invented flags", () => {
-		for (const verb of Object.keys(COMMAND_REGISTRY)) {
-			const def = COMMAND_REGISTRY[verb];
+		for (const verb of Object.keys(REGISTRY)) {
+			const def = REGISTRY[verb];
 			const resource = def.resources?.[0] ?? "any";
 			const unknown = detectUnknownFlags(verb, resource, {
 				zzz_invented_flag: "value",
@@ -552,8 +559,8 @@ describe("detectUnknownFlags — structural coverage", () => {
 	});
 
 	test("every verb accepts all global flags without flagging them", () => {
-		for (const verb of Object.keys(COMMAND_REGISTRY)) {
-			const def = COMMAND_REGISTRY[verb];
+		for (const verb of Object.keys(REGISTRY)) {
+			const def = REGISTRY[verb];
 			const resource = def.resources?.[0] ?? "any";
 			const globalValues = Object.fromEntries(
 				Object.keys(GLOBAL_FLAGS).map((k) => [k, "test-value"]),
@@ -570,8 +577,8 @@ describe("detectUnknownFlags — structural coverage", () => {
 	test("every verb accepts its own registered flags without flagging them", () => {
 		// Verbs with resourceFlags scope flags per-resource — test each resource separately.
 		// Verbs without resourceFlags use the full verb-level flag set.
-		for (const verb of Object.keys(COMMAND_REGISTRY)) {
-			const def = COMMAND_REGISTRY[verb];
+		for (const verb of Object.keys(REGISTRY)) {
+			const def = REGISTRY[verb];
 			if (def.resourceFlags) {
 				// Test each resource entry in resourceFlags
 				for (const [resource, resFlags] of Object.entries(def.resourceFlags)) {

--- a/tests/unit/command-validation.test.ts
+++ b/tests/unit/command-validation.test.ts
@@ -251,15 +251,12 @@ describe("requireOneOf", () => {
 
 // ─── validateFlags ───────────────────────────────────────────────────────────
 
-import type { CommandDef, FlagDef } from "../../src/command-registry.ts";
+import type { CommandDef } from "../../src/command-registry.ts";
 import { COMMAND_REGISTRY, GLOBAL_FLAGS } from "../../src/command-registry.ts";
 import { validateFlags } from "../../src/command-validation.ts";
 
-/** Widened view of COMMAND_REGISTRY for iterating with index signatures. */
-const REGISTRY: Record<string, CommandDef> = COMMAND_REGISTRY as Record<
-	string,
-	CommandDef
->;
+/** Widened read-only view of COMMAND_REGISTRY for iterating with index signatures. */
+const REGISTRY: Readonly<Record<string, CommandDef>> = COMMAND_REGISTRY;
 
 /**
  * Flag names that are known to map to branded SDK types.

--- a/tests/unit/completion.test.ts
+++ b/tests/unit/completion.test.ts
@@ -52,7 +52,7 @@ describe("Completion Module", () => {
 		assert.ok(output.includes("# c8ctl bash completion"));
 		assert.ok(output.includes("_c8ctl_completions()"));
 		assert.ok(
-			output.includes('cur="${COMP_WORDS[COMP_CWORD]}"'),
+			output.includes(`cur="\${COMP_WORDS[COMP_CWORD]}"`),
 			"Should initialize cur variable",
 		);
 		assert.ok(output.includes("COMPREPLY=()"), "Should initialize COMPREPLY");

--- a/tests/unit/fetch-all-pages.test.ts
+++ b/tests/unit/fetch-all-pages.test.ts
@@ -4,7 +4,29 @@
 
 import assert from "node:assert";
 import { describe, test } from "node:test";
-import { DEFAULT_MAX_ITEMS, fetchAllPages } from "../../src/client.ts";
+import {
+	DEFAULT_MAX_ITEMS,
+	fetchAllPages,
+	type PagedResponse,
+	type SearchConsistencyOpts,
+} from "../../src/client.ts";
+
+/** Build a properly shaped PagedResponse, filling missing fields with defaults. */
+function makePage<T>(
+	items: T[],
+	overrides: Partial<PagedResponse<T>["page"]> = {},
+): PagedResponse<T> {
+	return {
+		items,
+		page: {
+			totalItems: 0,
+			startCursor: null,
+			endCursor: null,
+			hasMoreTotalItems: false,
+			...overrides,
+		},
+	};
+}
 
 /** Helper: create a mock search function that returns `totalItems` items across pages. */
 function createMockSearch(totalItems: number, pageSize: number) {
@@ -15,31 +37,28 @@ function createMockSearch(totalItems: number, pageSize: number) {
 
 	const searchFn = async (
 		filter: Record<string, unknown> & { page?: Record<string, unknown> },
-		_opts?: unknown,
-	) => {
+		_opts: SearchConsistencyOpts,
+	): Promise<PagedResponse<{ id: number }>> => {
 		callCount++;
 		const afterRaw = filter.page?.after;
 		const after = typeof afterRaw === "number" ? afterRaw : undefined;
 		const start = after ?? 0;
 		const end = Math.min(start + pageSize, totalItems);
 		const items = allItems.slice(start, end);
-		const endCursor = end < totalItems ? end : undefined;
+		const endCursor = end < totalItems ? String(end) : null;
 
-		return {
-			items,
-			page: {
-				totalItems,
-				startCursor: String(start),
-				endCursor: endCursor !== undefined ? String(endCursor) : undefined,
-			},
-		};
+		return makePage(items, {
+			totalItems,
+			startCursor: String(start),
+			endCursor,
+		});
 	};
 
 	// Expose a way to parse the `after` cursor back into a number
 	const wrappedSearch = async (
 		filter: Record<string, unknown> & { page?: Record<string, unknown> },
-		opts?: unknown,
-	) => {
+		opts: SearchConsistencyOpts,
+	): Promise<PagedResponse<{ id: number }>> => {
 		const parsedFilter = {
 			...filter,
 			page: {
@@ -140,16 +159,13 @@ describe("fetchAllPages", () => {
 		let callCount = 0;
 		const stuckSearch = async (
 			_filter: Record<string, unknown>,
-			_opts?: unknown,
-		) => {
+			_opts: SearchConsistencyOpts,
+		): Promise<PagedResponse<{ id: number }>> => {
 			callCount++;
-			return {
-				items: [{ id: callCount }],
-				page: {
-					totalItems: 999,
-					endCursor: "same-cursor-forever",
-				},
-			};
+			return makePage([{ id: callCount }], {
+				totalItems: 999,
+				endCursor: "same-cursor-forever",
+			});
 		};
 
 		const items = await fetchAllPages(stuckSearch, {});
@@ -163,16 +179,13 @@ describe("fetchAllPages", () => {
 		let callCount = 0;
 		const noCursorSearch = async (
 			_filter: Record<string, unknown>,
-			_opts?: unknown,
-		) => {
+			_opts: SearchConsistencyOpts,
+		): Promise<PagedResponse<{ id: number }>> => {
 			callCount++;
-			return {
-				items: [{ id: callCount }],
-				page: {
-					totalItems: 999,
-					endCursor: undefined,
-				},
-			};
+			return makePage([{ id: callCount }], {
+				totalItems: 999,
+				endCursor: null,
+			});
 		};
 
 		const items = await fetchAllPages(noCursorSearch, {});
@@ -185,19 +198,19 @@ describe("fetchAllPages", () => {
 		let callCount = 0;
 		const emptySearch = async (
 			_filter: Record<string, unknown>,
-			_opts?: unknown,
-		) => {
+			_opts: SearchConsistencyOpts,
+		): Promise<PagedResponse<{ id: number }>> => {
 			callCount++;
 			if (callCount === 1) {
-				return {
-					items: [{ id: 1 }],
-					page: { totalItems: 10, endCursor: "cursor-1" },
-				};
+				return makePage([{ id: 1 }], {
+					totalItems: 10,
+					endCursor: "cursor-1",
+				});
 			}
-			return {
-				items: [],
-				page: { totalItems: 10, endCursor: "cursor-2" },
-			};
+			return makePage<{ id: number }>([], {
+				totalItems: 10,
+				endCursor: "cursor-2",
+			});
 		};
 
 		const items = await fetchAllPages(emptySearch, {});
@@ -206,53 +219,59 @@ describe("fetchAllPages", () => {
 	});
 
 	test("passes filter through to search function", async () => {
-		let receivedFilter: unknown;
+		let receivedFilter:
+			| (Record<string, unknown> & { page?: Record<string, unknown> })
+			| undefined;
 		const capturingSearch = async (
-			filter: Record<string, unknown> & { page?: Record<string, unknown> },
-			_opts?: unknown,
-		) => {
+			filter: { filter: { state: string } } & {
+				page?: Record<string, unknown>;
+			},
+			_opts: SearchConsistencyOpts,
+		): Promise<PagedResponse<never>> => {
 			receivedFilter = filter;
-			return { items: [], page: {} };
+			return makePage<never>([]);
 		};
 
 		await fetchAllPages(capturingSearch, { filter: { state: "ACTIVE" } }, 50);
 
 		assert.ok(receivedFilter, "search function should have been called");
 		assert.deepStrictEqual(receivedFilter.filter, { state: "ACTIVE" });
-		assert.strictEqual(receivedFilter.page.limit, 50);
+		assert.strictEqual(receivedFilter.page?.limit, 50);
 	});
 
 	test("passes cursor in page.after on subsequent calls", async () => {
-		const receivedFilters: unknown[] = [];
+		const receivedFilters: Array<{
+			page?: { after?: unknown; limit?: unknown };
+		}> = [];
 		let callCount = 0;
 		const trackingSearch = async (
 			filter: Record<string, unknown> & { page?: Record<string, unknown> },
-			_opts?: unknown,
-		) => {
+			_opts: SearchConsistencyOpts,
+		): Promise<PagedResponse<{ id: number }>> => {
 			receivedFilters.push(JSON.parse(JSON.stringify(filter)));
 			callCount++;
 			if (callCount === 1) {
-				return {
-					items: [{ id: 1 }],
-					page: { totalItems: 2, endCursor: "abc123" },
-				};
+				return makePage([{ id: 1 }], {
+					totalItems: 2,
+					endCursor: "abc123",
+				});
 			}
-			return {
-				items: [{ id: 2 }],
-				page: { totalItems: 2, endCursor: undefined },
-			};
+			return makePage([{ id: 2 }], {
+				totalItems: 2,
+				endCursor: null,
+			});
 		};
 
 		await fetchAllPages(trackingSearch, {});
 
 		assert.strictEqual(receivedFilters.length, 2);
 		assert.strictEqual(
-			receivedFilters[0].page.after,
+			receivedFilters[0].page?.after,
 			undefined,
 			"first call should not have after",
 		);
 		assert.strictEqual(
-			receivedFilters[1].page.after,
+			receivedFilters[1].page?.after,
 			"abc123",
 			"second call should have cursor",
 		);
@@ -268,16 +287,13 @@ describe("fetchAllPages", () => {
 		let callCount = 0;
 		const bigintTotalItemsSearch = async (
 			_filter: Record<string, unknown>,
-			_opts?: unknown,
-		) => {
+			_opts: SearchConsistencyOpts,
+		): Promise<PagedResponse<{ id: number }>> => {
 			callCount++;
-			return {
-				items: [{ id: 1 }, { id: 2 }],
-				page: {
-					totalItems: 2n, // BigInt, as returned by the SDK
-					endCursor: undefined,
-				},
-			};
+			return makePage([{ id: 1 }, { id: 2 }], {
+				totalItems: 2n, // BigInt, as returned by the SDK
+				endCursor: null,
+			});
 		};
 
 		// Should NOT throw TypeError: Cannot mix BigInt and other types

--- a/tests/unit/help.test.ts
+++ b/tests/unit/help.test.ts
@@ -14,7 +14,7 @@ import {
 import { c8ctl } from "../../src/runtime.ts";
 
 describe("Help Module", () => {
-	let consoleLogSpy: unknown[];
+	let consoleLogSpy: string[];
 	let originalLog: typeof console.log;
 	let originalOutputMode: typeof c8ctl.outputMode;
 

--- a/tests/unit/lazy-client.test.ts
+++ b/tests/unit/lazy-client.test.ts
@@ -49,7 +49,7 @@ describe("Lazy client getter", () => {
 				called = true;
 				return { fake: "client" };
 			},
-			resolveTenantId: () => undefined,
+			resolveTenantId: () => "",
 		});
 
 		assert.strictEqual(called, false, "Factory must not be called eagerly");
@@ -64,7 +64,7 @@ describe("Lazy client getter", () => {
 				callCount++;
 				return { fake: "client" };
 			},
-			resolveTenantId: () => undefined,
+			resolveTenantId: () => "",
 		});
 
 		const first = ctx.client;

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -8,8 +8,8 @@ import { getLogger, Logger, sortTableData } from "../../src/logger.ts";
 import { c8ctl } from "../../src/runtime.ts";
 
 describe("Logger Module", () => {
-	let consoleLogSpy: unknown[];
-	let consoleErrorSpy: unknown[];
+	let consoleLogSpy: string[];
+	let consoleErrorSpy: string[];
 	let originalLog: typeof console.log;
 	let originalError: typeof console.error;
 
@@ -436,8 +436,8 @@ describe("Logger Module", () => {
 
 		test("Logger accepts custom writer", () => {
 			c8ctl.outputMode = "text";
-			const customLogOutput: unknown[] = [];
-			const customErrorOutput: unknown[] = [];
+			const customLogOutput: string[] = [];
+			const customErrorOutput: string[] = [];
 
 			const customWriter = {
 				log(...data: unknown[]): void {
@@ -533,15 +533,15 @@ describe("Logger Module", () => {
 
 		test("Custom writer works with JSON mode", () => {
 			c8ctl.outputMode = "json";
-			const logOutput: unknown[] = [];
-			const errorOutput: unknown[] = [];
+			const logOutput: string[] = [];
+			const errorOutput: string[] = [];
 
 			const customWriter = {
 				log(...data: unknown[]): void {
-					logOutput.push(data[0]);
+					logOutput.push(String(data[0]));
 				},
 				error(...data: unknown[]): void {
-					errorOutput.push(data[0]);
+					errorOutput.push(String(data[0]));
 				},
 			};
 
@@ -585,7 +585,10 @@ describe("Logger Module", () => {
 
 			assert.strictEqual(errorCalls.length, 1);
 			assert.ok(errorCalls[0].length > 1, "Should have multiple arguments");
-			assert.ok(errorCalls[0][0].includes("Debug with args"));
+			const firstArg = errorCalls[0][0];
+			assert.ok(
+				typeof firstArg === "string" && firstArg.includes("Debug with args"),
+			);
 		});
 	});
 });

--- a/tests/unit/profile-management.test.ts
+++ b/tests/unit/profile-management.test.ts
@@ -442,7 +442,10 @@ describe("Profile management", () => {
 			mkdirSync(testDataDir, { recursive: true });
 
 			// Strip all CAMUNDA_* vars from the child env
-			const childEnv = { ...process.env, C8CTL_DATA_DIR: testDataDir };
+			const childEnv: NodeJS.ProcessEnv = {
+				...process.env,
+				C8CTL_DATA_DIR: testDataDir,
+			};
 			delete childEnv.CAMUNDA_BASE_URL;
 			delete childEnv.CAMUNDA_CLIENT_ID;
 			delete childEnv.CAMUNDA_CLIENT_SECRET;

--- a/tests/unit/resource-validation-guard.test.ts
+++ b/tests/unit/resource-validation-guard.test.ts
@@ -14,10 +14,7 @@ import { fileURLToPath } from "node:url";
 import type { CommandDef } from "../../src/command-registry.ts";
 import { COMMAND_REGISTRY } from "../../src/command-registry.ts";
 
-const REGISTRY: Record<string, CommandDef> = COMMAND_REGISTRY as Record<
-	string,
-	CommandDef
->;
+const REGISTRY: Readonly<Record<string, CommandDef>> = COMMAND_REGISTRY;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const indexSrc = readFileSync(join(__dirname, "../../src/index.ts"), "utf-8");

--- a/tests/unit/resource-validation-guard.test.ts
+++ b/tests/unit/resource-validation-guard.test.ts
@@ -11,7 +11,13 @@ import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { describe, test } from "node:test";
 import { fileURLToPath } from "node:url";
+import type { CommandDef } from "../../src/command-registry.ts";
 import { COMMAND_REGISTRY } from "../../src/command-registry.ts";
+
+const REGISTRY: Record<string, CommandDef> = COMMAND_REGISTRY as Record<
+	string,
+	CommandDef
+>;
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const indexSrc = readFileSync(join(__dirname, "../../src/index.ts"), "utf-8");
@@ -22,7 +28,7 @@ const indexSrc = readFileSync(join(__dirname, "../../src/index.ts"), "utf-8");
  */
 function deriveVerbRequiresResource(): Set<string> {
 	return new Set(
-		Object.entries(COMMAND_REGISTRY)
+		Object.entries(REGISTRY)
 			.filter(([, def]) => def.requiresResource)
 			.flatMap(([verb, def]) => [verb, ...(def.aliases ?? [])]),
 	);

--- a/tests/unit/search-feedback.test.ts
+++ b/tests/unit/search-feedback.test.ts
@@ -240,13 +240,11 @@ describe("GLOBAL_FLAGS", () => {
 });
 
 describe("search resourceFlags (from registry)", () => {
-	const rawFlags = COMMAND_REGISTRY.search.resourceFlags as
-		| Record<string, Record<string, unknown>>
-		| undefined;
-	if (!rawFlags) {
-		throw new Error("search.resourceFlags must be defined");
-	}
-	const resourceFlags: Record<string, Record<string, unknown>> = rawFlags;
+	const rawFlags:
+		| Readonly<Record<string, Readonly<Record<string, unknown>>>>
+		| undefined = COMMAND_REGISTRY.search.resourceFlags;
+	assert.ok(rawFlags, "search.resourceFlags must be defined");
+	const resourceFlags = rawFlags;
 
 	test("process-definition includes all expected flags", () => {
 		const flags = resourceFlags["process-definition"];
@@ -361,12 +359,10 @@ describe("Flag scoping — structural invariant", () => {
 	]);
 
 	test("GLOBAL_FLAGS and search resourceFlags do not overlap", () => {
-		const resourceFlags = COMMAND_REGISTRY.search.resourceFlags as
-			| Record<string, Record<string, unknown>>
-			| undefined;
-		if (!resourceFlags) {
-			throw new Error("search.resourceFlags must be defined");
-		}
+		const resourceFlags:
+			| Readonly<Record<string, Readonly<Record<string, unknown>>>>
+			| undefined = COMMAND_REGISTRY.search.resourceFlags;
+		assert.ok(resourceFlags, "search.resourceFlags must be defined");
 		for (const [resource, flags] of Object.entries(resourceFlags)) {
 			for (const flag of Object.keys(flags)) {
 				assert.ok(

--- a/tests/unit/search-feedback.test.ts
+++ b/tests/unit/search-feedback.test.ts
@@ -240,7 +240,13 @@ describe("GLOBAL_FLAGS", () => {
 });
 
 describe("search resourceFlags (from registry)", () => {
-	const resourceFlags = COMMAND_REGISTRY.search.resourceFlags;
+	const rawFlags = COMMAND_REGISTRY.search.resourceFlags as
+		| Record<string, Record<string, unknown>>
+		| undefined;
+	if (!rawFlags) {
+		throw new Error("search.resourceFlags must be defined");
+	}
+	const resourceFlags: Record<string, Record<string, unknown>> = rawFlags;
 
 	test("process-definition includes all expected flags", () => {
 		const flags = resourceFlags["process-definition"];
@@ -355,7 +361,12 @@ describe("Flag scoping — structural invariant", () => {
 	]);
 
 	test("GLOBAL_FLAGS and search resourceFlags do not overlap", () => {
-		const resourceFlags = COMMAND_REGISTRY.search.resourceFlags;
+		const resourceFlags = COMMAND_REGISTRY.search.resourceFlags as
+			| Record<string, Record<string, unknown>>
+			| undefined;
+		if (!resourceFlags) {
+			throw new Error("search.resourceFlags must be defined");
+		}
 		for (const [resource, flags] of Object.entries(resourceFlags)) {
 			for (const flag of Object.keys(flags)) {
 				assert.ok(

--- a/tests/utils/polling.ts
+++ b/tests/utils/polling.ts
@@ -81,3 +81,35 @@ export async function pollUntil(
 		);
 	return false;
 }
+
+/**
+ * Poll until an async function returns a defined value; returns that value.
+ * Throws with a descriptive message on timeout.
+ *
+ * Prefer over `let x: T | undefined` + `pollUntil` + non-null assertion:
+ * the return type is narrowed to `T`, eliminating `!` at call sites.
+ */
+export async function pollUntilValue<T>(
+	fetchValue: () => Promise<T | undefined | null>,
+	maxDuration: number,
+	interval: number,
+	label = "value",
+): Promise<T> {
+	let captured: T | undefined;
+	const found = await pollUntil(
+		async () => {
+			const result = await fetchValue();
+			if (result === undefined || result === null) return false;
+			captured = result;
+			return true;
+		},
+		maxDuration,
+		interval,
+	);
+	if (!found || captured === undefined) {
+		throw new Error(
+			`pollUntilValue: timed out waiting for ${label} after ${maxDuration}ms`,
+		);
+	}
+	return captured;
+}


### PR DESCRIPTION
Enables `tsc --noEmit -p tsconfig.check.json` to pass cleanly on the full test suite, which was previously blocked by 110 errors across 12 files. Unblocks work-item 3 of #257 (add tsc to the pre-commit hook).

## Summary of fixes (by file / count)

- **logger.test.ts** (41): tighten `unknown[]` spy arrays to `string[]`; narrow with `typeof` before `.includes()`
- **fetch-all-pages.test.ts** (18): export `PagedResponse` / `SearchConsistencyOpts` from `src/client.ts`; add typed `makePage<T>` helper so mocks return the full `PagedResponse<T>` shape; tighten mock signatures
- **process-instances.test.ts / output-mode.test.ts** (12): wrap `processDefinitionId` literals with `ProcessDefinitionId.assumeExists(...)`
- **command-validation.test.ts / command-registry.test.ts / resource-validation-guard.test.ts / search-feedback.test.ts** (24): introduce locally-widened views (`Record<string, CommandDef|FlagDef>`) for iteration / indexing of `const` registries
- **cluster-plugin.test.ts** (7): remove unused `@ts-expect-error` directives whose target code now typechecks; widen inline config literals to include `_hintPromise?: Promise<unknown>`; move Logger-mock directive onto the correct line
- **profile-management.test.ts** (5): annotate spread child-env as `NodeJS.ProcessEnv`
- **lazy-client.test.ts** (2): mock `resolveTenantId` returns `string`
- **help.test.ts** (2): tighten spy array to `string[]`

## Exports added to `src/client.ts`

- `PagedResponse<T>` — shape returned by every paginated SDK search call
- `SearchConsistencyOpts` — consistency options passed inside `fetchAllPages`

Already consumed by the test suite; no runtime behaviour change.

## Validation

- `npx tsc --noEmit -p tsconfig.check.json` → 0 errors (was 110)
- `npm run test:unit` → 1064/1064 pass
- `npx biome check src/ tests/` → 0 errors

Part of #257.
