### PR TITLE
chore: format biome.json with tabs to match 'biome check --fix'

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,26 +1,26 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
-  "files": {
-    "includes": ["src/**/*.ts", "!src/templates", "tests/**/*.ts"]
-  },
-  "linter": {
-    "enabled": true,
-    "includes": ["src/**/*.ts", "!/src/templates/**", "tests/**/*.ts"],
-    "rules": {
-      "recommended": true,
-      "suspicious": {
-        "noExplicitAny": "error",
-        "noImplicitAnyLet": "error",
-        "noEvolvingTypes": "error"
-      }
-    },
-    "domains": {
-      "react": "none",
-      "solid": "none",
-      "next": "none",
-      "qwik": "none",
-      "vue": "none"
-    }
-  },
-  "plugins": ["./plugins/no-unsafe-type-assertion.grit"]
+	"$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+	"files": {
+		"includes": ["src/**/*.ts", "!src/templates", "tests/**/*.ts"]
+	},
+	"linter": {
+		"enabled": true,
+		"includes": ["src/**/*.ts", "!/src/templates/**", "tests/**/*.ts"],
+		"rules": {
+			"recommended": true,
+			"suspicious": {
+				"noExplicitAny": "error",
+				"noImplicitAnyLet": "error",
+				"noEvolvingTypes": "error"
+			}
+		},
+		"domains": {
+			"react": "none",
+			"solid": "none",
+			"next": "none",
+			"qwik": "none",
+			"vue": "none"
+		}
+	},
+	"plugins": ["./plugins/no-unsafe-type-assertion.grit"]
 }


### PR DESCRIPTION
`biome.json` was committed with 2-space indentation, but `biome check --fix` reformats it to tabs (Biome's own default). That meant the agent instructions would re-indent the file whenever it ran over it, producing spurious diffs.

Reformat once now so the committed version matches what the formatter produces. **No config changes** \u2014 only whitespace.