### PR TITLE
feat(variables): add set variable command

### DIFF
--- a/src/command-dispatch.ts
+++ b/src/command-dispatch.ts
@@ -116,6 +116,7 @@ import {
 	completeUserTaskCommand,
 	listUserTasksCommand,
 } from "./commands/user-tasks.ts";
+import { setVariableCommand } from "./commands/variables.ts";
 import { watchCommand } from "./commands/watch.ts";
 
 /**
@@ -242,6 +243,9 @@ export const COMMAND_DISPATCH: ReadonlyMap<string, AnyCommandHandler> = new Map<
 	// `completion` is resourceless in the registry; the handler branches
 	// on ctx.resource (bash / zsh / fish / install).
 	["completion:", completionCommand],
+
+	// ── Variables ───────────────────────────────────────────────────────
+	["set:variable", setVariableCommand],
 
 	// ── Resourceless verbs ─────────────────────────────────────────────
 	["deploy:", deployCommand],

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -8,6 +8,7 @@
 
 import {
 	AuthorizationKey,
+	ElementInstanceKey,
 	IncidentKey,
 	JobKey,
 	ProcessDefinitionId,
@@ -126,6 +127,7 @@ export const RESOURCE_ALIASES: Record<string, string> = {
 	msg: "message",
 	vars: "variable",
 	variables: "variable",
+	var: "variable",
 	profile: "profile",
 	profiles: "profile",
 	plugin: "plugin",
@@ -1131,6 +1133,55 @@ export const COMMAND_REGISTRY = {
 		resourcePositionals: {
 			message: [
 				{ name: "name", required: true },
+			] as const satisfies readonly PositionalDef[],
+		},
+	},
+
+	set: {
+		description: "Set variables on an element instance",
+		helpDescription:
+			"Set variables on an element instance (process instance or flow element scope). Variables are propagated to the outermost scope by default; use --local to restrict to the specified scope.",
+		helpResource: "variable <key>",
+		hasDetailedHelp: true,
+		helpFooterLabel: "Show set command with all flags",
+		mutating: true,
+		requiresResource: true,
+		helpExamples: [
+			{
+				command:
+					'c8ctl set variable 2251799813685249 --variables=\'{"status":"approved"}\'',
+				description: "Set variables on a process instance",
+			},
+			{
+				command:
+					"c8ctl set variable 2251799813685249 --variables='{\"x\":1}' --local",
+				description: "Set variables in local scope only",
+			},
+		],
+		resources: ["variable"],
+		flags: {
+			variables: {
+				type: "string",
+				description: "JSON object of variables to set (required)",
+				required: true,
+				showInTopLevelHelp: true,
+				helpHint: "use with 'set variable'",
+			},
+			local: {
+				type: "boolean",
+				description:
+					"Set variables in local scope only (default: propagate to outermost scope)",
+				showInTopLevelHelp: true,
+				helpHint: "use with 'set variable'",
+			},
+		},
+		resourcePositionals: {
+			variable: [
+				{
+					name: "key",
+					required: true,
+					validate: ElementInstanceKey.assumeExists,
+				},
 			] as const satisfies readonly PositionalDef[],
 		},
 	},

--- a/src/commands/variables.ts
+++ b/src/commands/variables.ts
@@ -1,0 +1,62 @@
+/**
+ * Variable commands
+ */
+
+import { defineCommand, dryRun } from "../command-framework.ts";
+import { isRecord } from "../logger.ts";
+
+/**
+ * Set variables on an element instance (process instance or flow element).
+ *
+ * Maps to: PUT /v2/element-instances/{elementInstanceKey}/variables
+ */
+export const setVariableCommand = defineCommand(
+	"set",
+	"variable",
+	async (ctx, flags, args) => {
+		const { client, profile } = ctx;
+		const key = args.key;
+
+		// Parse variables JSON
+		const rawVariables = flags.variables;
+		if (!rawVariables) {
+			throw new Error(
+				"--variables is required. Provide a JSON object, e.g. --variables='{\"myVar\":42}'",
+			);
+		}
+
+		let variables: Record<string, unknown>;
+		try {
+			const parsed: unknown = JSON.parse(rawVariables);
+			if (!isRecord(parsed)) {
+				throw new Error("variables must be a JSON object (not an array)");
+			}
+			variables = parsed;
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			throw new Error(`Invalid JSON for --variables: ${msg}`);
+		}
+
+		const local = flags.local === true;
+
+		const dr = dryRun({
+			command: "set variable",
+			method: "PUT",
+			endpoint: `/element-instances/${key}/variables`,
+			profile,
+			body: { variables, ...(local && { local: true }) },
+		});
+		if (dr) return dr;
+
+		await client.createElementInstanceVariables({
+			elementInstanceKey: key,
+			variables,
+			...(local && { local: true }),
+		});
+
+		return {
+			kind: "success",
+			message: `Variables set on element instance ${key}`,
+		};
+	},
+);

--- a/src/commands/variables.ts
+++ b/src/commands/variables.ts
@@ -25,17 +25,22 @@ export const setVariableCommand = defineCommand(
 			);
 		}
 
-		let variables: Record<string, unknown>;
+		let parsed: unknown;
 		try {
-			const parsed: unknown = JSON.parse(rawVariables);
-			if (!isRecord(parsed)) {
-				throw new Error("variables must be a JSON object (not an array)");
-			}
-			variables = parsed;
+			parsed = JSON.parse(rawVariables);
 		} catch (err) {
 			const msg = err instanceof Error ? err.message : String(err);
 			throw new Error(`Invalid JSON for --variables: ${msg}`);
 		}
+
+		if (!isRecord(parsed)) {
+			throw new Error(
+				Array.isArray(parsed)
+					? "--variables must be a JSON object (not an array)"
+					: "--variables must be a JSON object",
+			);
+		}
+		const variables: Record<string, unknown> = parsed;
 
 		const local = flags.local === true;
 

--- a/tests/unit/command-registry.test.ts
+++ b/tests/unit/command-registry.test.ts
@@ -65,6 +65,7 @@ describe("COMMAND_REGISTRY completeness", () => {
 		"assign",
 		"unassign",
 		"which",
+		"set",
 	];
 
 	test("every expected verb has a registry entry", () => {

--- a/tests/unit/variables-behaviour.test.ts
+++ b/tests/unit/variables-behaviour.test.ts
@@ -1,0 +1,141 @@
+/**
+ * CLI behavioural tests for the "set variable" command.
+ *
+ * These tests exercise the full dispatch path by spawning the CLI
+ * as a subprocess with --dry-run. They verify that CLI flags flow
+ * correctly through index.ts dispatch → validation → handler → JSON output.
+ */
+
+import assert from "node:assert";
+import { describe, test } from "node:test";
+import { c8, parseJson } from "../utils/cli.ts";
+import { asRecord, getUrl } from "../utils/guards.ts";
+
+describe("CLI behavioural: set variable", () => {
+	test("--dry-run emits PUT to /element-instances/{key}/variables", async () => {
+		const result = await c8(
+			"set",
+			"variable",
+			"2251799813685249",
+			"--variables",
+			'{"status":"approved"}',
+			"--dry-run",
+		);
+
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const out = parseJson(result);
+
+		assert.strictEqual(out.dryRun, true);
+		assert.strictEqual(out.method, "PUT");
+		assert.ok(
+			getUrl(out).includes("/element-instances/2251799813685249/variables"),
+			`URL: ${getUrl(out)}`,
+		);
+
+		const body = asRecord(out.body, "dry-run body");
+		assert.deepStrictEqual(body.variables, { status: "approved" });
+	});
+
+	test("--dry-run includes local=true when --local is passed", async () => {
+		const result = await c8(
+			"set",
+			"variable",
+			"2251799813685249",
+			"--variables",
+			'{"x":1}',
+			"--local",
+			"--dry-run",
+		);
+
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const body = asRecord(parseJson(result).body, "dry-run body");
+		assert.strictEqual(body.local, true);
+	});
+
+	test("--dry-run does not include local when --local is not passed", async () => {
+		const result = await c8(
+			"set",
+			"variable",
+			"2251799813685249",
+			"--variables",
+			'{"x":1}',
+			"--dry-run",
+		);
+
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const body = asRecord(parseJson(result).body, "dry-run body");
+		assert.strictEqual(body.local, undefined);
+	});
+
+	test("accepts 'var' alias for 'variable'", async () => {
+		const result = await c8(
+			"set",
+			"var",
+			"2251799813685249",
+			"--variables",
+			'{"y":2}',
+			"--dry-run",
+		);
+
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		assert.ok(getUrl(parseJson(result)).includes("/element-instances/"));
+	});
+
+	test("rejects missing element instance key with exit code 1", async () => {
+		const result = await c8("set", "variable", "--variables", '{"x":1}');
+
+		assert.strictEqual(result.status, 1);
+	});
+
+	test("rejects missing --variables flag with exit code 1", async () => {
+		const result = await c8("set", "variable", "2251799813685249", "--dry-run");
+
+		assert.strictEqual(result.status, 1);
+		assert.ok(
+			result.stderr.includes("Failed to set variable"),
+			`expected framework prefix; stderr: ${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("--variables is required"),
+			`stderr: ${result.stderr}`,
+		);
+	});
+
+	test("rejects invalid JSON in --variables with exit code 1", async () => {
+		const result = await c8(
+			"set",
+			"variable",
+			"2251799813685249",
+			"--variables",
+			"not-json",
+			"--dry-run",
+		);
+
+		assert.strictEqual(result.status, 1);
+		assert.ok(
+			result.stderr.includes("Failed to set variable"),
+			`expected framework prefix; stderr: ${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("Invalid JSON"),
+			`stderr: ${result.stderr}`,
+		);
+	});
+
+	test("rejects JSON array in --variables with exit code 1", async () => {
+		const result = await c8(
+			"set",
+			"variable",
+			"2251799813685249",
+			"--variables",
+			"[1,2,3]",
+			"--dry-run",
+		);
+
+		assert.strictEqual(result.status, 1);
+		assert.ok(
+			result.stderr.includes("Invalid JSON"),
+			`stderr: ${result.stderr}`,
+		);
+	});
+});

--- a/tests/unit/variables-behaviour.test.ts
+++ b/tests/unit/variables-behaviour.test.ts
@@ -134,8 +134,38 @@ describe("CLI behavioural: set variable", () => {
 
 		assert.strictEqual(result.status, 1);
 		assert.ok(
-			result.stderr.includes("Invalid JSON"),
+			result.stderr.includes("Failed to set variable"),
+			`expected framework prefix; stderr: ${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("must be a JSON object (not an array)"),
 			`stderr: ${result.stderr}`,
+		);
+	});
+
+	test("rejects JSON primitive in --variables with exit code 1", async () => {
+		const result = await c8(
+			"set",
+			"variable",
+			"2251799813685249",
+			"--variables",
+			"42",
+			"--dry-run",
+		);
+
+		assert.strictEqual(result.status, 1);
+		assert.ok(
+			result.stderr.includes("Failed to set variable"),
+			`expected framework prefix; stderr: ${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("--variables must be a JSON object"),
+			`stderr: ${result.stderr}`,
+		);
+		// Primitive should NOT report as an array.
+		assert.ok(
+			!result.stderr.includes("(not an array)"),
+			`primitive misreported as array; stderr: ${result.stderr}`,
 		);
 	});
 });


### PR DESCRIPTION
Add a new `set variable` command to c8ctl that allows users to set variables on a process instance or flow element scope via the Orchestration Cluster API.

The command maps to: PUT /v2/element-instances/{elementInstanceKey}/variables

Changes:
- Add `setVariableCommand` handler in src/commands/variables.ts
- Register "set:variable" in COMMAND_DISPATCH
- Add "set" verb to COMMAND_REGISTRY with:
  - Required `--variables` flag (JSON object)
  - Optional `--local` flag for local scope (no propagation)
  - ElementInstanceKey branded type validation
  - Detailed help and usage examples
- Add "var" alias to RESOURCE_ALIASES (alongside existing "vars")
- Add comprehensive CLI behavioural tests in tests/unit/variables-behaviour.test.ts
- Update command-registry.test.ts to include "set" in EXPECTED_VERBS

The implementation:
- Validates JSON input and rejects non-object types
- Supports --dry-run for preview
- Returns success message on completion
- Uses isRecord() type guard (no `as` casts per style guide)