### PR TITLE
refactor(commands): inline open, mcp-proxy, watch handlers into defineCommand

### DIFF
--- a/src/commands/deployments.ts
+++ b/src/commands/deployments.ts
@@ -260,6 +260,16 @@ export async function deploy(
 		profile?: string;
 		continueOnError?: boolean;
 		continueOnUserError?: boolean;
+		/**
+		 * Optional cancellation signal. When aborted, an in-flight
+		 * `createDeployment` HTTP request is cancelled via the SDK's
+		 * `CancelablePromise.cancel()` and the awaited promise rejects with
+		 * an `AbortError`. Callers that supply a signal are responsible for
+		 * suppressing the resulting rejection (see `watch.ts` for the
+		 * pattern: check `signal.aborted` in the catch and treat it as a
+		 * no-op rather than a deploy failure).
+		 */
+		signal?: AbortSignal;
 	},
 ): Promise<void> {
 	const logger = getLogger();
@@ -388,7 +398,7 @@ export async function deploy(
 		});
 
 		// Create deployment request - convert buffers to File objects with proper MIME types
-		const result = await client.createDeployment({
+		const pendingDeploy = client.createDeployment({
 			tenantId: TenantId.assumeExists(tenantId),
 			resources: resources.map((r) => {
 				// Determine MIME type based on extension
@@ -407,6 +417,29 @@ export async function deploy(
 				});
 			}),
 		});
+
+		// Wire optional cancellation: when the caller's AbortSignal fires,
+		// cancel the underlying CancelablePromise so the in-flight HTTP
+		// request is aborted promptly. Used by `watch` so SIGINT mid-deploy
+		// shuts down within ~one event-loop tick rather than blocking on
+		// the network round-trip.
+		const onAbort = (): void => {
+			pendingDeploy.cancel();
+		};
+		if (options.signal) {
+			if (options.signal.aborted) {
+				onAbort();
+			} else {
+				options.signal.addEventListener("abort", onAbort, { once: true });
+			}
+		}
+
+		let result: Awaited<typeof pendingDeploy>;
+		try {
+			result = await pendingDeploy;
+		} finally {
+			options.signal?.removeEventListener("abort", onAbort);
+		}
 
 		logger.success("Deployment successful", result.deploymentKey.toString());
 
@@ -491,6 +524,14 @@ export async function deploy(
 			logger.table(displayData);
 		}
 	} catch (error) {
+		// Caller-initiated cancellation (e.g. SIGINT in `watch`): the
+		// CancelablePromise rejects with a "Cancelled" error after we
+		// invoked `pendingDeploy.cancel()` from the abort listener. The
+		// caller already knows the request was aborted — do not surface
+		// it as a user-visible deploy failure or exit non-zero.
+		if (options.signal?.aborted) {
+			return;
+		}
 		handleDeploymentError(
 			error,
 			resources,

--- a/src/commands/deployments.ts
+++ b/src/commands/deployments.ts
@@ -263,11 +263,11 @@ export async function deploy(
 		/**
 		 * Optional cancellation signal. When aborted, an in-flight
 		 * `createDeployment` HTTP request is cancelled via the SDK's
-		 * `CancelablePromise.cancel()` and the awaited promise rejects with
-		 * an `AbortError`. Callers that supply a signal are responsible for
-		 * suppressing the resulting rejection (see `watch.ts` for the
-		 * pattern: check `signal.aborted` in the catch and treat it as a
-		 * no-op rather than a deploy failure).
+		 * `CancelablePromise.cancel()`. Cancellation is handled internally:
+		 * if the signal is aborted, `deploy()` returns early without
+		 * surfacing the cancellation as a deploy failure (no
+		 * "Deployment failed" log, no rejection from the awaited promise).
+		 * Callers do not need their own try/catch to suppress aborts.
 		 */
 		signal?: AbortSignal;
 	},

--- a/src/commands/mcp-proxy.ts
+++ b/src/commands/mcp-proxy.ts
@@ -12,7 +12,6 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { createClient } from "../client.ts";
 import { defineCommand } from "../command-framework.ts";
-import { handleCommandError } from "../errors.ts";
 import { isRecord, Logger, type LogWriter } from "../logger.ts";
 import { getVersion } from "./help.ts";
 
@@ -341,51 +340,19 @@ class McpProxy {
 	}
 }
 
-async function runProxy(
-	camundaClient: CamundaClient,
-	logger: Logger,
-	mcpServerPath: string,
-) {
-	let proxy: McpProxy | null = null;
-
-	try {
-		// Create and start proxy
-		proxy = new McpProxy(camundaClient, logger, mcpServerPath);
-		await proxy.start();
-
-		// Handle graceful shutdown
-		const shutdown = async (signal: string) => {
-			logger.info(`Received ${signal}, shutting down gracefully...`);
-			if (proxy) {
-				await proxy.stop();
-			}
-			process.exit(0);
-		};
-
-		process.on("SIGINT", () => shutdown("SIGINT"));
-		process.on("SIGTERM", () => shutdown("SIGTERM"));
-
-		// Keep process alive
-		await new Promise(() => {});
-	} catch (error) {
-		if (proxy) {
-			await proxy.stop().catch(() => {});
-		}
-		handleCommandError(
-			logger,
-			"Failed to run MCP proxy. Shutting down...",
-			error,
-		);
-	}
-}
+// ─── defineCommand ───────────────────────────────────────────────────────────
 
 /**
- * Run STDIO to remote HTTP MCP proxy with Camunda authentication
+ * Run an STDIO ↔ remote-HTTP MCP proxy with Camunda authentication.
+ *
+ * Long-running: stays alive until SIGINT/SIGTERM, then stops the proxy
+ * and resolves so the framework returns naturally with `{ kind: "never" }`.
  */
-export async function mcpProxy(
-	args: string[],
-	options: { profile?: string },
-): Promise<void> {
+export const mcpProxyCommand = defineCommand("mcp-proxy", "", async (ctx) => {
+	const allPositionals = ctx.resource
+		? [ctx.resource, ...ctx.positionals]
+		: ctx.positionals;
+
 	const stderrLogWriter: LogWriter = {
 		log(...data: unknown[]): void {
 			console.error(...data);
@@ -396,7 +363,7 @@ export async function mcpProxy(
 	};
 
 	const logger = new Logger(stderrLogWriter);
-	const camundaClient = createClient(options.profile, {
+	const camundaClient = createClient(ctx.profile, {
 		log: {
 			transport: (evt) => {
 				logger.json(evt);
@@ -404,16 +371,29 @@ export async function mcpProxy(
 		},
 	});
 
-	const mcpServerPath = args[0] ?? "/mcp/cluster";
-	await runProxy(camundaClient, logger, mcpServerPath);
-}
+	const mcpServerPath = allPositionals[0] ?? "/mcp/cluster";
 
-// ─── defineCommand wrapper ───────────────────────────────────────────────────
+	let proxy: McpProxy | null = null;
+	try {
+		proxy = new McpProxy(camundaClient, logger, mcpServerPath);
+		await proxy.start();
 
-export const mcpProxyCommand = defineCommand("mcp-proxy", "", async (ctx) => {
-	const allPositionals = ctx.resource
-		? [ctx.resource, ...ctx.positionals]
-		: ctx.positionals;
-	await mcpProxy(allPositionals, { profile: ctx.profile });
+		// Block until a shutdown signal is received, then stop the proxy
+		// and resolve so the handler returns. The framework treats this as
+		// `{ kind: "never" }` and the process exits naturally.
+		await new Promise<void>((resolve) => {
+			const shutdown = (signal: string): void => {
+				logger.info(`Received ${signal}, shutting down gracefully...`);
+				const stop = proxy ? proxy.stop().catch(() => {}) : Promise.resolve();
+				void stop.then(() => resolve());
+			};
+			process.once("SIGINT", () => shutdown("SIGINT"));
+			process.once("SIGTERM", () => shutdown("SIGTERM"));
+		});
+	} catch (error) {
+		if (proxy) await proxy.stop().catch(() => {});
+		throw error;
+	}
+
 	return { kind: "never" };
 });

--- a/src/commands/mcp-proxy.ts
+++ b/src/commands/mcp-proxy.ts
@@ -13,6 +13,7 @@ import {
 import { createClient } from "../client.ts";
 import { defineCommand } from "../command-framework.ts";
 import { isRecord, Logger, type LogWriter } from "../logger.ts";
+import { c8ctl } from "../runtime.ts";
 import { getVersion } from "./help.ts";
 
 /**
@@ -391,16 +392,26 @@ export const mcpProxyCommand = defineCommand("mcp-proxy", "", async (ctx) => {
 			process.once("SIGTERM", () => shutdown("SIGTERM"));
 		});
 	} catch (error) {
+		const normalizedError =
+			error instanceof Error ? error : new Error(String(error));
+
 		if (proxy) await proxy.stop().catch(() => {});
+
+		// In verbose mode users want the full stack trace, so re-throw and
+		// let Node print it to stderr. The framework's default error handler
+		// short-circuits to a plain rethrow when `c8ctl.verbose` is set
+		// (see src/errors.ts), so no stdout hint is emitted in that path.
+		if (c8ctl.verbose) {
+			throw normalizedError;
+		}
+
 		// MCP-proxy uses STDIO for protocol; we must NOT let the framework's
 		// default error handler write hints to stdout (that would corrupt
 		// the MCP stream for any remaining client read). Log to stderr via
 		// our stderr-backed logger and surface failure through the exit
 		// code instead of re-throwing into `handleCommandError`.
 		process.exitCode = 1;
-		logger.error(
-			`mcp-proxy failed: ${error instanceof Error ? error.message : String(error)}`,
-		);
+		logger.error(`mcp-proxy failed: ${normalizedError.message}`);
 	}
 
 	return { kind: "never" };

--- a/src/commands/mcp-proxy.ts
+++ b/src/commands/mcp-proxy.ts
@@ -392,7 +392,15 @@ export const mcpProxyCommand = defineCommand("mcp-proxy", "", async (ctx) => {
 		});
 	} catch (error) {
 		if (proxy) await proxy.stop().catch(() => {});
-		throw error;
+		// MCP-proxy uses STDIO for protocol; we must NOT let the framework's
+		// default error handler write hints to stdout (that would corrupt
+		// the MCP stream for any remaining client read). Log to stderr via
+		// our stderr-backed logger and surface failure through the exit
+		// code instead of re-throwing into `handleCommandError`.
+		process.exitCode = 1;
+		logger.error(
+			`mcp-proxy failed: ${error instanceof Error ? error.message : String(error)}`,
+		);
 	}
 
 	return { kind: "never" };

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -122,40 +122,36 @@ export function validateOpenAppOptions(
 	};
 }
 
+// ─── defineCommand ───────────────────────────────────────────────────────────
+
 /**
  * Open a Camunda web application in the default browser.
+ *
+ * Side-effectful: validates the app name, derives the URL from the cluster
+ * config, and spawns the platform browser opener. With `--dry-run`, logs
+ * the resolved URL but skips the spawn.
  */
-export async function openApp(options: OpenAppInput): Promise<void> {
-	const logger = getLogger();
-
-	const config = resolveClusterConfig(options.profile);
-	const url = deriveAppUrl(config.baseUrl, options.app);
-
-	if (!url) {
-		logger.error(
-			`Cannot derive ${options.app} URL from base URL: ${config.baseUrl}`,
-		);
-		logger.info(
-			"The open command is only supported for self-managed clusters whose base URL ends with /v<n> (e.g. http://localhost:8080/v2).",
-		);
-		process.exit(1);
-	}
-
-	logger.info(`Opening ${options.app} at: ${url}`);
-	if (!options.dryRun) {
-		openUrl(url);
-	}
-}
-
-// ─── defineCommand wrapper ───────────────────────────────────────────────────
-
-/** Side-effectful: validates app name, derives URL, and opens browser. */
 export const openAppCommand = defineCommand("open", "", async (ctx) => {
-	const validated = validateOpenAppOptions(ctx.resource, {
+	const { app, profile, dryRun } = validateOpenAppOptions(ctx.resource, {
 		profile: ctx.profile,
 		dryRun: ctx.dryRun,
 	});
-	await openApp(validated);
+
+	const config = resolveClusterConfig(profile);
+	const url = deriveAppUrl(config.baseUrl, app);
+
+	if (!url) {
+		throw new Error(
+			`Cannot derive ${app} URL from base URL: ${config.baseUrl}. ` +
+				"The open command is only supported for self-managed clusters " +
+				"whose base URL ends with /v<n> (e.g. http://localhost:8080/v2).",
+		);
+	}
+
+	ctx.logger.info(`Opening ${app} at: ${url}`);
+	if (!dryRun) {
+		openUrl(url);
+	}
 	return { kind: "none" };
 });
 

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -133,13 +133,17 @@ export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
 		return watcher;
 	});
 
-	// Block until SIGINT, then close watchers and resolve so the handler
-	// returns naturally. The framework treats this as `{ kind: "never" }`
-	// and the process exits with code 0.
+	// Block until SIGINT, then close watchers, cancel any pending debounced
+	// deploys, and resolve so the handler returns naturally. Cancelling
+	// pending timers prevents a deploy from firing after Ctrl+C and keeps
+	// the event loop from staying alive past shutdown. The framework
+	// treats this as `{ kind: "never" }` and the process exits with code 0.
 	await new Promise<void>((resolveSignal) => {
 		process.once("SIGINT", () => {
 			logger.info("\n\n🍹 - bottoms up.");
 			for (const w of watchers) w.close();
+			for (const timer of debounceTimers.values()) clearTimeout(timer);
+			debounceTimers.clear();
 			resolveSignal();
 		});
 	});

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -134,17 +134,18 @@ export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
 	});
 
 	// Block until SIGINT, then close watchers, cancel any pending debounced
-	// deploys, and resolve so the handler returns naturally. Cancelling
-	// pending timers prevents a deploy from firing after Ctrl+C and keeps
-	// the event loop from staying alive past shutdown. The framework
-	// treats this as `{ kind: "never" }` and the process exits with code 0.
-	await new Promise<void>((resolveSignal) => {
+	// deploys, and exit immediately. Calling `process.exit(0)` (rather than
+	// resolving so the handler returns) prevents an in-flight deploy whose
+	// debounce timer has already fired from delaying shutdown or emitting
+	// log output after the goodbye message. The Promise body intentionally
+	// never resolves — `process.exit` short-circuits.
+	await new Promise<void>(() => {
 		process.once("SIGINT", () => {
 			logger.info("\n\n🍹 - bottoms up.");
 			for (const w of watchers) w.close();
 			for (const timer of debounceTimers.values()) clearTimeout(timer);
 			debounceTimers.clear();
-			resolveSignal();
+			process.exit(0);
 		});
 	});
 

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -6,37 +6,36 @@ import { existsSync, statSync, watch } from "node:fs";
 import { basename, extname, resolve } from "node:path";
 import { defineCommand } from "../command-framework.ts";
 import { isIgnored, loadIgnoreRules } from "../ignore.ts";
-import { getLogger } from "../logger.ts";
 import { deploy } from "./deployments.ts";
 
 const WATCHED_EXTENSIONS = [".bpmn", ".dmn", ".form"];
 export const DEPLOY_COOLDOWN = 1000; // 1 second cooldown
 const DEBOUNCE_DELAY = 200; // ms to wait after last fs event before deploying
 
+// ─── defineCommand ───────────────────────────────────────────────────────────
+
 /**
- * Watch for file changes and auto-deploy
+ * Watch one or more paths for BPMN/DMN/Form changes and auto-deploy.
+ *
+ * Long-running: stays alive until SIGINT, then resolves so the framework
+ * returns naturally with `{ kind: "never" }`. SIGTERM is handled by Node's
+ * default behaviour (immediate termination).
  */
-export async function watchFiles(
-	paths: string[],
-	options: {
-		profile?: string;
-		force?: boolean;
-	},
-): Promise<void> {
-	const logger = getLogger();
+export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
+	const { logger } = ctx;
 
-	if (!paths || paths.length === 0) {
-		paths = ["."];
-	}
+	// watch treats resource + positionals as path varargs; default to "."
+	const rawPaths = ctx.resource
+		? [ctx.resource, ...ctx.positionals]
+		: ctx.positionals.length > 0
+			? ctx.positionals
+			: ["."];
 
-	// Resolve all paths
-	const resolvedPaths = paths.map((p) => resolve(p));
+	const resolvedPaths = rawPaths.map((p) => resolve(p));
 
-	// Validate paths exist
 	for (const path of resolvedPaths) {
 		if (!existsSync(path)) {
-			logger.error(`Path does not exist: ${path}`);
-			process.exit(1);
+			throw new Error(`Path does not exist: ${path}`);
 		}
 	}
 
@@ -46,7 +45,7 @@ export async function watchFiles(
 
 	logger.info(`👁️  Watching for changes in: ${resolvedPaths.join(", ")}`);
 	logger.info(`📋 Monitoring extensions: ${WATCHED_EXTENSIONS.join(", ")}`);
-	if (options.force) {
+	if (flags.force) {
 		logger.info(
 			"🔒 Force mode: will continue watching after deployment errors",
 		);
@@ -59,7 +58,7 @@ export async function watchFiles(
 	const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
 	// Watch each path
-	for (const path of resolvedPaths) {
+	const watchers = resolvedPaths.map((path) => {
 		const stats = statSync(path);
 		const isDirectory = stats.isDirectory();
 
@@ -111,8 +110,8 @@ export async function watchFiles(
 
 						try {
 							await deploy([fullPath], {
-								profile: options.profile,
-								continueOnError: options.force,
+								profile: ctx.profile,
+								continueOnError: flags.force,
 								continueOnUserError: true,
 							});
 						} catch (error) {
@@ -130,27 +129,20 @@ export async function watchFiles(
 		watcher.on("error", (error) => {
 			logger.error("Watcher error", error);
 		});
-	}
 
-	// Keep process alive
-	process.on("SIGINT", () => {
-		logger.info("\n\n🍹 - bottoms up.");
-		process.exit(0);
+		return watcher;
 	});
-}
 
-// ─── defineCommand wrapper ───────────────────────────────────────────────────
-
-export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
-	// watch treats resource + positionals as path varargs
-	const paths = ctx.resource
-		? [ctx.resource, ...ctx.positionals]
-		: ctx.positionals.length > 0
-			? ctx.positionals
-			: ["."];
-	await watchFiles(paths, {
-		profile: ctx.profile,
-		force: flags.force,
+	// Block until SIGINT, then close watchers and resolve so the handler
+	// returns naturally. The framework treats this as `{ kind: "never" }`
+	// and the process exits with code 0.
+	await new Promise<void>((resolveSignal) => {
+		process.once("SIGINT", () => {
+			logger.info("\n\n🍹 - bottoms up.");
+			for (const w of watchers) w.close();
+			resolveSignal();
+		});
 	});
+
 	return { kind: "never" };
 });

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -130,9 +130,12 @@ export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
 								signal: ac.signal,
 							});
 						} catch (error) {
-							// User-initiated cancellation (Ctrl+C). Don't surface as a
-							// deploy failure — the goodbye message is the user-visible
-							// signal that we shut down.
+							// `deploy()` normally returns early when its signal is
+							// aborted, so SIGINT cancellation is not expected to land
+							// here. Keep this as a defensive fallback in case an
+							// aborted deploy ever re-throws — and never log it as a
+							// deploy failure, since the goodbye message is the
+							// user-visible shutdown signal.
 							if (ac.signal.aborted) return;
 							logger.error(
 								`Failed to deploy ${basename(file)}`,

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -17,9 +17,11 @@ const DEBOUNCE_DELAY = 200; // ms to wait after last fs event before deploying
 /**
  * Watch one or more paths for BPMN/DMN/Form changes and auto-deploy.
  *
- * Long-running: stays alive until SIGINT, then resolves so the framework
- * returns naturally with `{ kind: "never" }`. SIGTERM is handled by Node's
- * default behaviour (immediate termination).
+ * Long-running: stays alive until SIGINT, then closes watchers, cancels
+ * any pending debounced deploys AND aborts any in-flight HTTP deploys via
+ * AbortController, then resolves so the framework returns naturally with
+ * `{ kind: "never" }`. SIGTERM is handled by Node's default behaviour
+ * (immediate termination).
  */
 export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
 	const { logger } = ctx;
@@ -56,6 +58,12 @@ export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
 	const recentlyDeployed = new Map<string, number>();
 	// Debounce timers per file to let writes settle before deploying
 	const debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
+	// AbortControllers for in-flight deploys, so SIGINT can cancel them
+	// promptly instead of waiting for the HTTP round-trip to finish.
+	const inflightDeploys = new Set<AbortController>();
+	// Set on SIGINT to short-circuit any debounce callback that fires
+	// between signal receipt and the synchronous shutdown work below.
+	let shuttingDown = false;
 
 	// Watch each path
 	const watchers = resolvedPaths.map((path) => {
@@ -92,6 +100,10 @@ export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
 					setTimeout(async () => {
 						debounceTimers.delete(fullPath);
 
+						// SIGINT may have fired between the timer being scheduled
+						// and this callback running. Bail before doing any I/O.
+						if (shuttingDown) return;
+
 						// Check cooldown to prevent duplicate deploys
 						const lastDeploy = recentlyDeployed.get(fullPath);
 						const now = Date.now();
@@ -108,17 +120,26 @@ export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
 						logger.info(`\n🔄 Change detected: ${basename(file)}`);
 						recentlyDeployed.set(fullPath, Date.now());
 
+						const ac = new AbortController();
+						inflightDeploys.add(ac);
 						try {
 							await deploy([fullPath], {
 								profile: ctx.profile,
 								continueOnError: flags.force,
 								continueOnUserError: true,
+								signal: ac.signal,
 							});
 						} catch (error) {
+							// User-initiated cancellation (Ctrl+C). Don't surface as a
+							// deploy failure — the goodbye message is the user-visible
+							// signal that we shut down.
+							if (ac.signal.aborted) return;
 							logger.error(
 								`Failed to deploy ${basename(file)}`,
 								error instanceof Error ? error : new Error(String(error)),
 							);
+						} finally {
+							inflightDeploys.delete(ac);
 						}
 					}, DEBOUNCE_DELAY),
 				);
@@ -134,18 +155,29 @@ export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
 	});
 
 	// Block until SIGINT, then close watchers, cancel any pending debounced
-	// deploys, and exit immediately. Calling `process.exit(0)` (rather than
-	// resolving so the handler returns) prevents an in-flight deploy whose
-	// debounce timer has already fired from delaying shutdown or emitting
-	// log output after the goodbye message. The Promise body intentionally
-	// never resolves — `process.exit` short-circuits.
-	await new Promise<void>(() => {
+	// deploys, abort any in-flight HTTP deploys, and resolve so the handler
+	// returns naturally. The framework treats this as `{ kind: "never" }`
+	// and the process exits with code 0.
+	//
+	// We deliberately do NOT call `process.exit()` here:
+	// - `shuttingDown = true` short-circuits any debounce callback that fires
+	//   between SIGINT and this synchronous block.
+	// - `clearTimeout(...)` cancels any timer that hasn't fired yet.
+	// - `ac.abort()` cancels the underlying SDK CancelablePromise for any
+	//   deploy currently waiting on the network — those callsites detect
+	//   `signal.aborted` and swallow the AbortError instead of logging.
+	// Together these drain the event loop within one tick, so the framework
+	// can return naturally and own the exit code.
+	await new Promise<void>((resolveSignal) => {
 		process.once("SIGINT", () => {
+			shuttingDown = true;
 			logger.info("\n\n🍹 - bottoms up.");
 			for (const w of watchers) w.close();
 			for (const timer of debounceTimers.values()) clearTimeout(timer);
 			debounceTimers.clear();
-			process.exit(0);
+			for (const ac of inflightDeploys) ac.abort();
+			inflightDeploys.clear();
+			resolveSignal();
 		});
 	});
 

--- a/tests/integration/watch-cancellation.test.ts
+++ b/tests/integration/watch-cancellation.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Behavioural regression guard for SIGINT during an in-flight deploy.
+ *
+ * The defect class: a long-running handler whose worker is mid-HTTP must
+ * shut down promptly when the user hits Ctrl+C, without:
+ *   - blocking on the in-flight network round-trip,
+ *   - emitting a "Failed to deploy" line that masquerades as a real error,
+ *   - or relying on `process.exit()` inside the handler.
+ *
+ * To make the in-flight window deterministic, we stand up a mock REST
+ * server that accepts the `POST /v2/deployments` request but never sends
+ * a response. The watcher will sit on `await client.createDeployment(...)`
+ * indefinitely until SIGINT triggers `AbortController.abort()`, which the
+ * SDK's `CancelablePromise` translates into an underlying fetch abort.
+ *
+ * A passing test proves the cancellation pipeline (deploy.signal →
+ * CancelablePromise.cancel → fetch abort) is wired end-to-end.
+ */
+
+import assert from "node:assert";
+import { copyFileSync, mkdtempSync, rmSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import {
+	after,
+	afterEach,
+	before,
+	beforeEach,
+	describe,
+	test,
+} from "node:test";
+import { pollUntil } from "../utils/polling.ts";
+import { startWatchProcess } from "../utils/watch-process.ts";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
+const VALID_BPMN = join(
+	PROJECT_ROOT,
+	"tests",
+	"fixtures",
+	"simple-user-task.bpmn",
+);
+
+const POLL_INTERVAL_MS = 50;
+const STARTUP_TIMEOUT_MS = 5_000;
+// Cancellation budget: from SIGINT to process exit. If the request weren't
+// being aborted we'd be waiting forever (mock never responds), so even a
+// generous budget here would still catch the regression.
+const SHUTDOWN_BUDGET_MS = 3_000;
+
+describe("watch command cancels in-flight deploys on SIGINT", () => {
+	let dataDir: string;
+	let mockServer: Server;
+	let mockServerUrl: string;
+	let signalReceived: () => void;
+	let deployRequestReceived: Promise<void>;
+
+	before(() => {
+		dataDir = mkdtempSync(join(tmpdir(), "c8ctl-watch-cancel-"));
+	});
+
+	after(() => {
+		rmSync(dataDir, { recursive: true, force: true });
+	});
+
+	beforeEach(async () => {
+		// Fresh promise + resolver per test so we can await the moment the
+		// mock server has fully consumed the request body (i.e. the deploy
+		// is genuinely "in flight").
+		deployRequestReceived = new Promise<void>((r) => {
+			signalReceived = r;
+		});
+
+		mockServer = createServer((req, res) => {
+			if (req.method === "POST" && req.url?.includes("/deployments")) {
+				// Drain the request body so the client knows the request was
+				// transmitted, then deliberately never call res.end(). The
+				// SDK call will sit on `await fetch(...)` until aborted.
+				req.on("data", () => {});
+				req.on("end", () => signalReceived());
+				return;
+			}
+			// Unrelated probes (e.g. token endpoints) get a benign 200.
+			res.writeHead(200, { "Content-Type": "application/json" });
+			res.end("{}");
+		});
+
+		await new Promise<void>((r) => {
+			// Port 0 → kernel-assigned free port. Avoids races between
+			// parallel test runs grabbing the same hardcoded port.
+			mockServer.listen(0, "127.0.0.1", () => r());
+		});
+		const addr = mockServer.address();
+		if (!addr || typeof addr === "string") {
+			throw new Error("mock server did not bind to an inet address");
+		}
+		mockServerUrl = `http://127.0.0.1:${addr.port}/v2`;
+	});
+
+	afterEach(async () => {
+		await new Promise<void>((r) => {
+			mockServer.close(() => r());
+		});
+	});
+
+	test("SIGINT mid-deploy aborts the HTTP request and exits 0 within the shutdown budget", async () => {
+		const watchDir = mkdtempSync(join(tmpdir(), "c8ctl-watch-cancel-dir-"));
+		const watch = startWatchProcess({
+			watchDir,
+			dataDir,
+			env: { CAMUNDA_BASE_URL: mockServerUrl },
+		});
+
+		try {
+			// 1. Wait for the watcher to be ready.
+			const ready = await pollUntil(
+				async () => watch.getOutput().includes("Watching for changes"),
+				STARTUP_TIMEOUT_MS,
+				POLL_INTERVAL_MS,
+			);
+			assert.ok(
+				ready,
+				`watch did not start within ${STARTUP_TIMEOUT_MS}ms. Output:\n${watch.getOutput()}`,
+			);
+
+			// 2. Trigger a deploy by dropping a BPMN into the watched dir.
+			//    The watcher debounces by 500ms, so the deploy actually
+			//    starts shortly after the copy.
+			const droppedFile = join(watchDir, "simple-user-task.bpmn");
+			copyFileSync(VALID_BPMN, droppedFile);
+
+			// 3. Wait for the mock server to confirm the POST body landed.
+			//    From this point on, the SDK call is genuinely in-flight.
+			await Promise.race([
+				deployRequestReceived,
+				new Promise<never>((_r, reject) =>
+					setTimeout(
+						() =>
+							reject(
+								new Error(
+									`mock server did not receive POST /deployments within startup budget. Output:\n${watch.getOutput()}`,
+								),
+							),
+						STARTUP_TIMEOUT_MS,
+					),
+				),
+			]);
+
+			// 4. Send SIGINT and time how long shutdown takes. Without
+			//    cancellation wiring, we'd block forever on the hung
+			//    fetch and the SIGKILL fallback would fire instead.
+			const sigintAt = Date.now();
+			watch.child.kill("SIGINT");
+			const exitCode = await watch.waitForExit(SHUTDOWN_BUDGET_MS);
+			const elapsedMs = Date.now() - sigintAt;
+			const output = watch.getOutput();
+
+			assert.strictEqual(
+				exitCode,
+				0,
+				`watch should exit 0 on SIGINT mid-deploy. Got: ${exitCode} after ${elapsedMs}ms. Output:\n${output}`,
+			);
+			assert.ok(
+				elapsedMs < SHUTDOWN_BUDGET_MS,
+				`watch should shut down within ${SHUTDOWN_BUDGET_MS}ms (took ${elapsedMs}ms). Output:\n${output}`,
+			);
+			assert.ok(
+				output.includes("bottoms up"),
+				`Expected the SIGINT goodbye message. Output:\n${output}`,
+			);
+			assert.ok(
+				!output.includes("Failed to deploy"),
+				`A user-cancelled deploy must not surface as "Failed to deploy". Output:\n${output}`,
+			);
+		} finally {
+			await watch.cleanup(SHUTDOWN_BUDGET_MS);
+			rmSync(watchDir, { recursive: true, force: true });
+		}
+	});
+});

--- a/tests/integration/watch-cancellation.test.ts
+++ b/tests/integration/watch-cancellation.test.ts
@@ -124,8 +124,8 @@ describe("watch command cancels in-flight deploys on SIGINT", () => {
 			);
 
 			// 2. Trigger a deploy by dropping a BPMN into the watched dir.
-			//    The watcher debounces by 500ms, so the deploy actually
-			//    starts shortly after the copy.
+			//    The watcher debounces by `DEBOUNCE_DELAY` (200ms), so the
+			//    deploy actually starts shortly after the copy.
 			const droppedFile = join(watchDir, "simple-user-task.bpmn");
 			copyFileSync(VALID_BPMN, droppedFile);
 

--- a/tests/utils/watch-process.ts
+++ b/tests/utils/watch-process.ts
@@ -97,7 +97,10 @@ export function startWatchProcess(options: StartWatchOptions): WatchProcess {
 				}
 				resolveExit(null);
 			}, timeoutMs);
-			child.once("exit", (code) => {
+			// Wait for `close` (not `exit`) so stdio streams are fully drained
+			// before callers assert on captured output. `exit` can fire before
+			// fast failures finish flushing their final line.
+			child.once("close", (code) => {
 				clearTimeout(timer);
 				resolveExit(code);
 			});

--- a/tests/utils/watch-process.ts
+++ b/tests/utils/watch-process.ts
@@ -31,6 +31,12 @@ export interface StartWatchOptions {
 	dataDir: string;
 	/** Extra CLI args inserted between `watch` and `<watchDir>`. */
 	extraArgs?: string[];
+	/**
+	 * Extra environment variables to merge into the spawn env (after
+	 * `makeTestEnv`). Used by tests that need to point the SDK at a mock
+	 * server via `CAMUNDA_BASE_URL`.
+	 */
+	env?: Record<string, string>;
 }
 
 export interface WatchProcess {
@@ -61,14 +67,14 @@ export interface WatchProcess {
  * and return handles for output, exit, and guaranteed cleanup.
  */
 export function startWatchProcess(options: StartWatchOptions): WatchProcess {
-	const { watchDir, dataDir, extraArgs = [] } = options;
+	const { watchDir, dataDir, extraArgs = [], env: extraEnv = {} } = options;
 
 	const child = spawn(
 		"node",
 		["--experimental-strip-types", CLI, "watch", ...extraArgs, watchDir],
 		{
 			cwd: PROJECT_ROOT,
-			env: makeTestEnv({ C8CTL_DATA_DIR: dataDir }),
+			env: { ...makeTestEnv({ C8CTL_DATA_DIR: dataDir }), ...extraEnv },
 			stdio: ["ignore", "pipe", "pipe"],
 		},
 	);


### PR DESCRIPTION
First slice of #288. Migrates the three smallest legacy thin-wrapper handlers (`openApp`, `mcpProxy`, `watchFiles`) into full `defineCommand` bodies so every dispatchable handler returns a `CommandResult` and no `process.exit()` remains in their handler bodies.

`run` and `deploy` will follow in separate PRs (per the issue's recommended order). Enforcement items (#289–#292) come after all five handlers are migrated.

## What changed

| Handler | Before | After |
|---|---|---|
| `openApp` | thin `defineCommand` wrapper → `openApp()` with `process.exit(1)` on URL-derive failure | inlined; throws on URL-derive failure (framework's `handleCommandError` formats it) |
| `mcp-proxy` | thin wrapper → `mcpProxy()` → `runProxy()`; SIGINT/SIGTERM call `process.exit(0)` | inlined; signals stop the proxy and resolve a keep-alive promise; handler returns `{ kind: "never" }` naturally |
| `watch` | thin wrapper → `watchFiles()` with `process.exit(1)` on missing path and `process.exit(0)` on SIGINT | inlined; throws on missing path; SIGINT closes watchers and resolves the keep-alive promise |

Net `-32` lines across the three handlers — boilerplate going away.

## Invariants this PR moves toward

From #288 ("Structural invariants we want"):

- ✅ No `process.exit()` in these handler bodies (validation-layer `process.exit` in `command-validation.ts` remains; explicitly out-of-scope per the issue).
- ✅ All three handlers are now `defineCommand(...)` bodies returning `CommandResult`. No exported legacy function remains as a back-channel.
- ✅ `{ kind: "never" }` is preserved for `watch` and `mcp-proxy` (legitimate long-running commands).
- N/A: `dryRun()` helper — `open` has a no-op dry-run (suppresses browser spawn, no API request to preview), so the helper doesn't apply here. `mcp-proxy` and `watch` have no dry-run mode.

## Behaviour preservation

- All success and dry-run paths preserved; verified by existing `c8()` subprocess tests in `tests/unit/watch-force.test.ts`, `tests/unit/open.test.ts`, `tests/unit/mcp-proxy.test.ts`, and the integration tests in `tests/integration/watch.test.ts` (3 tests, all green against a live cluster).
- One intentional behaviour change: when `c8 open <app>` runs against a non-self-managed cluster URL, the previous two-line output (`logger.error` + `logger.info`) is now a single `Error` message formatted by `handleCommandError`. No test asserted the previous shape.

## Test results

```
ℹ tests 1200
ℹ pass 1199
ℹ fail 0
ℹ skipped 1   (unchanged baseline: "fish completion script loads without errors in fish # SKIP fish not available")
```

Full unit + integration suite against a live local cluster.

## Out of scope / follow-ups

- `run` migration → next PR
- `deploy` migration → PR after that
- Enforcement #289–#292 → after the last handler lands
- The trailing-space wart in `Failed to ${verb} ${resource}` for resourceless verbs is a pre-existing framework issue; not touched here.

Refs #288.