### PR TITLE
refactor(deploy): route error paths through framework (#288)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,22 @@ function createUser({ name, email, age }: { name: string; email: string; age: nu
 - behaviour tests are the regression guard — during behaviour-preserving refactors, do not modify behaviour tests. If a test fails, the production code is usually wrong, not the test. If a change intentionally modifies observable behaviour (for example CLI output, help text, or exit codes), update the affected behaviour tests and explicitly document and justify the intended behaviour change in the PR
 - between refactors, always run `npm run typecheck` (`tsc --noEmit -p tsconfig.check.json`, covering `src/` and `tests/`), `npx biome check`, and `npm run test:unit` to verify correctness
 
+#### There are no flaky tests
+
+We do not acknowledge the existence of "flaky tests". A test that passes sometimes and fails other times is reporting one of two things:
+
+1. **A test defect** — the test contains a race, an unbounded timeout, an order-of-operation assumption, an unsynchronised readiness signal, or a dependency on wall-clock timing. Fix the test so its outcome is deterministic for the behaviour it claims to assert.
+2. **A product defect** — the production code has a race, a missed signal, an unhandled error path, or a resource it leaks under load. Fix the product.
+
+Either way, an intermittent failure is a real defect that must be diagnosed and fixed before the change merges. Do not retry the CI job, mark the test `skip`, add a `.retry()`, or describe the failure as "flaky" or "unrelated" in the PR description. "Re-run and hope" is a coping strategy, not engineering.
+
+When triaging an intermittent CI failure:
+
+- Reproduce locally if possible (loops, resource pressure, timeout reduction). If you cannot reproduce, reason from first principles about what *could* differ between local and CI (load, filesystem semantics, signal delivery latency, parallel test interaction).
+- Identify the specific race or assumption. Common shapes: polling for an output line that is printed *before* the relevant handler is registered; timeouts that double as correctness assertions; tests that share a temp directory across runs; tests that depend on event ordering across two processes.
+- Pick category 1 vs category 2 explicitly in the fix commit message, and explain which signal the test was previously relying on and which deterministic signal it now relies on.
+- If timeouts must be generous to absorb runner load, the timeout is a safety net — not a correctness signal. State this in a comment so future maintainers don't tighten it back into a race.
+
 #### Coverage analysis before a behaviour-preserving refactor
 
 Before starting any non-trivial refactor, **audit whether the surface you are about to change is sufficiently guarded**. A passing test suite is necessary but not sufficient — it only proves that *what is currently tested* still works. The risk of a refactor is the behaviour that nobody asserts.

--- a/src/commands/deployments.ts
+++ b/src/commands/deployments.ts
@@ -563,6 +563,28 @@ export async function deploy(
 }
 
 /**
+ * Build a human-readable message for a non-`Error` deploy failure
+ * (typically an RFC 9457 problem-detail object thrown by the SDK)
+ * for use under `--verbose`. Falls back gracefully when the input
+ * lacks any of `title` / `detail` / `status`.
+ *
+ * Exported for unit testing — the class of defect this guards against
+ * is throwing `new Error(String(error))` for non-Error values, which
+ * collapses problem-detail objects to the useless `"[object Object]"`.
+ */
+export function buildVerboseErrorMessage(
+	raw: Record<string, unknown>,
+	problemTitle: string | undefined,
+): string {
+	const detail = typeof raw.detail === "string" ? raw.detail : undefined;
+	const status = typeof raw.status === "number" ? raw.status : undefined;
+	const head = [problemTitle ?? "Deployment request failed", detail]
+		.filter((p): p is string => Boolean(p))
+		.join(": ");
+	return status !== undefined ? `${head} (status ${status})` : head;
+}
+
+/**
  * Format and display deployment errors with actionable guidance
  */
 function handleDeploymentError(
@@ -585,7 +607,17 @@ function handleDeploymentError(
 		}
 		// Verbose mode: surface the original error to the framework so
 		// `handleCommandError` rethrows it and Node prints the stack trace.
-		throw error instanceof Error ? error : new Error(String(error));
+		// Non-Error throws (e.g. RFC 9457 problem-detail plain objects from
+		// the SDK) get wrapped in a synthesized Error whose message is built
+		// from `title` / `detail` / `status` so `--verbose` is actionable
+		// instead of printing `Error: [object Object]`. The original value
+		// is preserved as `cause` so it remains inspectable.
+		if (error instanceof Error) {
+			throw error;
+		}
+		throw new Error(buildVerboseErrorMessage(raw, problemTitle), {
+			cause: error,
+		});
 	}
 
 	// Try to interpret common transport/network issues first for actionable guidance

--- a/src/commands/deployments.ts
+++ b/src/commands/deployments.ts
@@ -375,8 +375,8 @@ export async function deploy(
 		// framework records the failure without re-rendering a duplicate
 		// summary line.
 		logger.error(duplicateIdsMessage);
-		duplicates.forEach((paths, id) => {
-			logMessage(`  Process/Decision ID "${id}" found in: ${paths.join(", ")}`);
+		duplicates.forEach((dupPaths, id) => {
+			logMessage(`  Process/Decision ID "${id}" found in: ${dupPaths.join(", ")}`);
 		});
 		logMessage(
 			"\nCamunda does not allow deploying multiple resources with the same definition ID in a single deployment.",

--- a/src/commands/deployments.ts
+++ b/src/commands/deployments.ts
@@ -9,6 +9,7 @@ import type { Ignore } from "ignore";
 import { createClient } from "../client.ts";
 import { defineCommand } from "../command-framework.ts";
 import { resolveClusterConfig, resolveTenantId } from "../config.ts";
+import { SilentError } from "../errors.ts";
 import { isIgnored, loadIgnoreRules } from "../ignore.ts";
 import { getLogger, isRecord } from "../logger.ts";
 import { c8ctl } from "../runtime.ts";
@@ -276,254 +277,181 @@ export async function deploy(
 	const tenantId = resolveTenantId(options.profile);
 	const resources: ResourceFile[] = [];
 
-	try {
-		// Store the base paths for relative path calculation
-		const basePaths = paths.length === 0 ? [process.cwd()] : paths;
+	// ─── Pre-API-call validation and preparation ────────────────────────
+	// These steps run OUTSIDE any try/catch so validation errors bubble
+	// straight to the framework's `handleCommandError`. Only the actual
+	// HTTP deploy call (further down) is wrapped in a catch that routes
+	// through `handleDeploymentError` for rich Problem-Detail rendering.
 
-		if (paths.length === 0) {
-			logger.error(
-				"No paths provided. Use: c8 deploy <path> or c8 deploy (for current directory)",
-			);
-			process.exit(1);
-		}
+	// Store the base paths for relative path calculation
+	const basePaths = paths.length === 0 ? [process.cwd()] : paths;
 
-		// Load .c8ignore rules from the working directory
-		const ignoreBaseDir = resolve(process.cwd());
-		const ig = loadIgnoreRules(ignoreBaseDir);
-
-		// Collect all resource files (respecting .c8ignore)
-		paths.forEach((path) => {
-			collectResourceFiles(path, resources, undefined, ig, ignoreBaseDir);
-		});
-
-		if (resources.length === 0) {
-			logger.error("No BPMN/DMN/Form files found in the specified paths");
-			process.exit(1);
-		}
-
-		// Dry-run: emit the would-be API request without executing
-		if (c8ctl.dryRun) {
-			const config = resolveClusterConfig(options.profile);
-			logger.json({
-				dryRun: true,
-				command: "deploy",
-				method: "POST",
-				url: `${config.baseUrl}/deployments`,
-				body: {
-					tenantId,
-					resources: resources.map((r) => ({ name: r.name })),
-				},
-			});
-			return;
-		}
-
-		const client = createClient(options.profile);
-
-		// Calculate relative paths for display
-		const basePath = basePaths.length === 1 ? basePaths[0] : process.cwd();
-		resources.forEach((r) => {
-			r.relativePath = relative(basePath, r.path) || r.name;
-		});
-
-		// Sort: group resources by their group, with building blocks first, then process applications, then standalone
-		resources.sort((a, b) => {
-			// Building blocks have highest priority
-			if (a.isBuildingBlock && !b.isBuildingBlock) return -1;
-			if (!a.isBuildingBlock && b.isBuildingBlock) return 1;
-
-			// Within building blocks, group by groupPath
-			if (a.isBuildingBlock && b.isBuildingBlock) {
-				if (a.groupPath && b.groupPath) {
-					const groupCompare = a.groupPath.localeCompare(b.groupPath);
-					if (groupCompare !== 0) return groupCompare;
-				}
-				return a.path.localeCompare(b.path);
-			}
-
-			// Process applications come next
-			if (a.isProcessApplication && !b.isProcessApplication) return -1;
-			if (!a.isProcessApplication && b.isProcessApplication) return 1;
-
-			// Within process applications, group by groupPath
-			if (a.isProcessApplication && b.isProcessApplication) {
-				if (a.groupPath && b.groupPath) {
-					const groupCompare = a.groupPath.localeCompare(b.groupPath);
-					if (groupCompare !== 0) return groupCompare;
-				}
-				return a.path.localeCompare(b.path);
-			}
-
-			// Finally, standalone resources sorted by path
-			return a.path.localeCompare(b.path);
-		});
-
-		// Validate for duplicate process/decision IDs
-		const duplicates = findDuplicateDefinitionIds(resources);
-		if (duplicates.size > 0) {
-			logger.error(
-				"Cannot deploy: Multiple files with the same process/decision ID in one deployment",
-			);
-			duplicates.forEach((paths, id) => {
-				logMessage(
-					`  Process/Decision ID "${id}" found in: ${paths.join(", ")}`,
-				);
-			});
-			logMessage(
-				"\nCamunda does not allow deploying multiple resources with the same definition ID in a single deployment.",
-			);
-			logMessage(
-				"Please deploy these files separately or ensure each process/decision has a unique ID.",
-			);
-			process.exit(1);
-		}
-
-		logger.info(`Deploying ${resources.length} resource(s)...`);
-
-		// Create a mapping from definition ID to resource file for later reference
-		const definitionIdToResource = new Map<string, ResourceFile>();
-		const formNameToResource = new Map<string, ResourceFile>();
-
-		resources.forEach((r) => {
-			const ext = extname(r.path);
-			if (ext === ".bpmn" || ext === ".dmn") {
-				const defId = extractDefinitionId(r.content, ext);
-				if (defId) {
-					definitionIdToResource.set(defId, r);
-				}
-			} else if (ext === ".form") {
-				// Forms are matched by filename (without extension)
-				const formId = basename(r.name, ".form");
-				formNameToResource.set(formId, r);
-			}
-		});
-
-		// Create deployment request - convert buffers to File objects with proper MIME types
-		const pendingDeploy = client.createDeployment({
-			tenantId: TenantId.assumeExists(tenantId),
-			resources: resources.map((r) => {
-				// Determine MIME type based on extension
-				const ext = r.name.split(".").pop()?.toLowerCase();
-				const mimeType =
-					ext === "bpmn"
-						? "application/xml"
-						: ext === "dmn"
-							? "application/xml"
-							: ext === "form"
-								? "application/json"
-								: "application/octet-stream";
-				// Convert Buffer to Uint8Array for File constructor
-				return new File([new Uint8Array(r.content)], r.name, {
-					type: mimeType,
-				});
-			}),
-		});
-
-		// Wire optional cancellation: when the caller's AbortSignal fires,
-		// cancel the underlying CancelablePromise so the in-flight HTTP
-		// request is aborted promptly. Used by `watch` so SIGINT mid-deploy
-		// shuts down within ~one event-loop tick rather than blocking on
-		// the network round-trip.
-		const onAbort = (): void => {
-			pendingDeploy.cancel();
-		};
-		if (options.signal) {
-			if (options.signal.aborted) {
-				onAbort();
-			} else {
-				options.signal.addEventListener("abort", onAbort, { once: true });
-			}
-		}
-
-		let result: Awaited<typeof pendingDeploy>;
-		try {
-			result = await pendingDeploy;
-		} finally {
-			options.signal?.removeEventListener("abort", onAbort);
-		}
-
-		logger.success("Deployment successful", result.deploymentKey.toString());
-
-		// Group resources by their directory (building block or process application)
-		type ResourceRow = {
-			File: string;
-			Type: string;
-			ID: string;
-			Version: string | number;
-			Key: string;
-			sortKey: string;
-		};
-
-		// Normalize all deployed resources into a common structure
-		const allResources = [
-			...result.processes.map((proc) => ({
-				type: "Process" as const,
-				id: proc.processDefinitionId,
-				version: proc.processDefinitionVersion,
-				key: proc.processDefinitionKey.toString(),
-				resource: definitionIdToResource.get(proc.processDefinitionId),
-			})),
-			...result.decisions.map((dec) => ({
-				type: "Decision" as const,
-				id: dec.decisionDefinitionId || "-",
-				version: dec.version ?? "-",
-				key: dec.decisionDefinitionKey?.toString() || "-",
-				resource: definitionIdToResource.get(dec.decisionDefinitionId || ""),
-			})),
-			...result.forms.map((form) => ({
-				type: "Form" as const,
-				id: form.formId || "-",
-				version: form.version ?? "-",
-				key: form.formKey?.toString() || "-",
-				resource: formNameToResource.get(form.formId || ""),
-			})),
-		];
-
-		const tableData: ResourceRow[] = allResources.map(
-			({ type, id, version, key, resource }) => {
-				const fileDisplay = resource
-					? `${resource.isBuildingBlock ? "🧱 " : ""}${resource.isProcessApplication ? "📦 " : ""}${resource.relativePath || resource.name}`
-					: "-";
-
-				// Extract directory path for grouping (e.g., "bla/_bb-building-block" or "pa")
-				const sortKey = resource?.relativePath
-					? resource.relativePath.substring(
-							0,
-							resource.relativePath.lastIndexOf("/") + 1,
-						) || resource.relativePath
-					: "zzz"; // Resources without paths go last
-
-				return {
-					File: fileDisplay,
-					Type: type,
-					ID: id,
-					Version: version,
-					Key: key,
-					sortKey,
-				};
-			},
+	if (paths.length === 0) {
+		throw new Error(
+			"No paths provided. Use: c8 deploy <path> or c8 deploy (for current directory)",
 		);
+	}
 
-		// Sort by directory path (grouping), then by file name
-		tableData.sort((a, b) => {
-			if (a.sortKey !== b.sortKey) {
-				return a.sortKey.localeCompare(b.sortKey);
-			}
-			return a.File.localeCompare(b.File);
+	// Load .c8ignore rules from the working directory
+	const ignoreBaseDir = resolve(process.cwd());
+	const ig = loadIgnoreRules(ignoreBaseDir);
+
+	// Collect all resource files (respecting .c8ignore)
+	paths.forEach((path) => {
+		collectResourceFiles(path, resources, undefined, ig, ignoreBaseDir);
+	});
+
+	if (resources.length === 0) {
+		throw new Error("No BPMN/DMN/Form files found in the specified paths");
+	}
+
+	// Dry-run: emit the would-be API request without executing
+	if (c8ctl.dryRun) {
+		const config = resolveClusterConfig(options.profile);
+		logger.json({
+			dryRun: true,
+			command: "deploy",
+			method: "POST",
+			url: `${config.baseUrl}/deployments`,
+			body: {
+				tenantId,
+				resources: resources.map((r) => ({ name: r.name })),
+			},
 		});
+		return;
+	}
 
-		// Remove sortKey before displaying
-		const displayData = tableData.map(({ File, Type, ID, Version, Key }) => ({
-			File,
-			Type,
-			ID,
-			Version,
-			Key,
-		}));
+	const client = createClient(options.profile);
 
-		if (displayData.length > 0) {
-			logger.table(displayData);
+	// Calculate relative paths for display
+	const basePath = basePaths.length === 1 ? basePaths[0] : process.cwd();
+	resources.forEach((r) => {
+		r.relativePath = relative(basePath, r.path) || r.name;
+	});
+
+	// Sort: group resources by their group, with building blocks first, then process applications, then standalone
+	resources.sort((a, b) => {
+		// Building blocks have highest priority
+		if (a.isBuildingBlock && !b.isBuildingBlock) return -1;
+		if (!a.isBuildingBlock && b.isBuildingBlock) return 1;
+
+		// Within building blocks, group by groupPath
+		if (a.isBuildingBlock && b.isBuildingBlock) {
+			if (a.groupPath && b.groupPath) {
+				const groupCompare = a.groupPath.localeCompare(b.groupPath);
+				if (groupCompare !== 0) return groupCompare;
+			}
+			return a.path.localeCompare(b.path);
 		}
+
+		// Process applications come next
+		if (a.isProcessApplication && !b.isProcessApplication) return -1;
+		if (!a.isProcessApplication && b.isProcessApplication) return 1;
+
+		// Within process applications, group by groupPath
+		if (a.isProcessApplication && b.isProcessApplication) {
+			if (a.groupPath && b.groupPath) {
+				const groupCompare = a.groupPath.localeCompare(b.groupPath);
+				if (groupCompare !== 0) return groupCompare;
+			}
+			return a.path.localeCompare(b.path);
+		}
+
+		// Finally, standalone resources sorted by path
+		return a.path.localeCompare(b.path);
+	});
+
+	// Validate for duplicate process/decision IDs
+	const duplicates = findDuplicateDefinitionIds(resources);
+	if (duplicates.size > 0) {
+		// Pre-render the rich detail (per-id file list + guidance) so the
+		// user sees actionable context, then throw a SilentError so the
+		// framework records the failure without re-rendering a duplicate
+		// summary line.
+		logger.error(
+			"Cannot deploy: Multiple files with the same process/decision ID in one deployment",
+		);
+		duplicates.forEach((paths, id) => {
+			logMessage(`  Process/Decision ID "${id}" found in: ${paths.join(", ")}`);
+		});
+		logMessage(
+			"\nCamunda does not allow deploying multiple resources with the same definition ID in a single deployment.",
+		);
+		logMessage(
+			"Please deploy these files separately or ensure each process/decision has a unique ID.",
+		);
+		throw new SilentError(
+			"Cannot deploy: Multiple files with the same process/decision ID in one deployment",
+		);
+	}
+
+	logger.info(`Deploying ${resources.length} resource(s)...`);
+
+	// Create a mapping from definition ID to resource file for later reference
+	const definitionIdToResource = new Map<string, ResourceFile>();
+	const formNameToResource = new Map<string, ResourceFile>();
+
+	resources.forEach((r) => {
+		const ext = extname(r.path);
+		if (ext === ".bpmn" || ext === ".dmn") {
+			const defId = extractDefinitionId(r.content, ext);
+			if (defId) {
+				definitionIdToResource.set(defId, r);
+			}
+		} else if (ext === ".form") {
+			// Forms are matched by filename (without extension)
+			const formId = basename(r.name, ".form");
+			formNameToResource.set(formId, r);
+		}
+	});
+
+	// ─── API call ────────────────────────────────────────────────────────
+	// Only this section is wrapped in a catch that routes through
+	// `handleDeploymentError`. Pre-API errors above bubble to the
+	// framework directly.
+
+	// Create deployment request - convert buffers to File objects with proper MIME types
+	const pendingDeploy = client.createDeployment({
+		tenantId: TenantId.assumeExists(tenantId),
+		resources: resources.map((r) => {
+			// Determine MIME type based on extension
+			const ext = r.name.split(".").pop()?.toLowerCase();
+			const mimeType =
+				ext === "bpmn"
+					? "application/xml"
+					: ext === "dmn"
+						? "application/xml"
+						: ext === "form"
+							? "application/json"
+							: "application/octet-stream";
+			// Convert Buffer to Uint8Array for File constructor
+			return new File([new Uint8Array(r.content)], r.name, {
+				type: mimeType,
+			});
+		}),
+	});
+
+	// Wire optional cancellation: when the caller's AbortSignal fires,
+	// cancel the underlying CancelablePromise so the in-flight HTTP
+	// request is aborted promptly. Used by `watch` so SIGINT mid-deploy
+	// shuts down within ~one event-loop tick rather than blocking on
+	// the network round-trip.
+	const onAbort = (): void => {
+		pendingDeploy.cancel();
+	};
+	if (options.signal) {
+		if (options.signal.aborted) {
+			onAbort();
+		} else {
+			options.signal.addEventListener("abort", onAbort, { once: true });
+		}
+	}
+
+	let result: Awaited<typeof pendingDeploy>;
+	try {
+		result = await pendingDeploy;
 	} catch (error) {
+		options.signal?.removeEventListener("abort", onAbort);
 		// Caller-initiated cancellation (e.g. SIGINT in `watch`): the
 		// CancelablePromise rejects with a "Cancelled" error after we
 		// invoked `pendingDeploy.cancel()` from the abort listener. The
@@ -539,6 +467,94 @@ export async function deploy(
 			options.continueOnError,
 			options.continueOnUserError,
 		);
+		// `handleDeploymentError` either throws (terminal) or returns
+		// (continue-on-error). On the continue path, skip the success
+		// render below — there's no result to render.
+		return;
+	}
+	options.signal?.removeEventListener("abort", onAbort);
+
+	logger.success("Deployment successful", result.deploymentKey.toString());
+
+	// Group resources by their directory (building block or process application)
+	type ResourceRow = {
+		File: string;
+		Type: string;
+		ID: string;
+		Version: string | number;
+		Key: string;
+		sortKey: string;
+	};
+
+	// Normalize all deployed resources into a common structure
+	const allResources = [
+		...result.processes.map((proc) => ({
+			type: "Process" as const,
+			id: proc.processDefinitionId,
+			version: proc.processDefinitionVersion,
+			key: proc.processDefinitionKey.toString(),
+			resource: definitionIdToResource.get(proc.processDefinitionId),
+		})),
+		...result.decisions.map((dec) => ({
+			type: "Decision" as const,
+			id: dec.decisionDefinitionId || "-",
+			version: dec.version ?? "-",
+			key: dec.decisionDefinitionKey?.toString() || "-",
+			resource: definitionIdToResource.get(dec.decisionDefinitionId || ""),
+		})),
+		...result.forms.map((form) => ({
+			type: "Form" as const,
+			id: form.formId || "-",
+			version: form.version ?? "-",
+			key: form.formKey?.toString() || "-",
+			resource: formNameToResource.get(form.formId || ""),
+		})),
+	];
+
+	const tableData: ResourceRow[] = allResources.map(
+		({ type, id, version, key, resource }) => {
+			const fileDisplay = resource
+				? `${resource.isBuildingBlock ? "🧱 " : ""}${resource.isProcessApplication ? "📦 " : ""}${resource.relativePath || resource.name}`
+				: "-";
+
+			// Extract directory path for grouping (e.g., "bla/_bb-building-block" or "pa")
+			const sortKey = resource?.relativePath
+				? resource.relativePath.substring(
+						0,
+						resource.relativePath.lastIndexOf("/") + 1,
+					) || resource.relativePath
+				: "zzz"; // Resources without paths go last
+
+			return {
+				File: fileDisplay,
+				Type: type,
+				ID: id,
+				Version: version,
+				Key: key,
+				sortKey,
+			};
+		},
+	);
+
+	// Sort by directory path (grouping), then by file name
+	tableData.sort((a, b) => {
+		if (a.sortKey !== b.sortKey) {
+			return a.sortKey.localeCompare(b.sortKey);
+		}
+		return a.File.localeCompare(b.File);
+	});
+
+	// Remove sortKey before displaying
+	const displayData = tableData.map(({ File, Type, ID, Version, Key }) => ({
+		File,
+		Type,
+		ID,
+		Version,
+		Key,
+	}));
+
+	if (displayData.length > 0) {
+		logger.table(displayData);
 	}
 }
 
@@ -563,10 +579,9 @@ function handleDeploymentError(
 		if (shouldContinue) {
 			throw error;
 		}
-		const normalizedError =
-			error instanceof Error ? error : new Error(String(error));
-		console.error(normalizedError);
-		process.exit(1);
+		// Verbose mode: surface the original error to the framework so
+		// `handleCommandError` rethrows it and Node prints the stack trace.
+		throw error instanceof Error ? error : new Error(String(error));
 	}
 
 	// Try to interpret common transport/network issues first for actionable guidance
@@ -636,7 +651,10 @@ function handleDeploymentError(
 	if (shouldContinue) {
 		return;
 	}
-	process.exit(1);
+	// Pre-rendered the rich error context above; throw a SilentError so
+	// `handleCommandError` exits non-zero without re-rendering a
+	// duplicate "Failed to deploy: <message>" summary line.
+	throw new SilentError(title);
 }
 
 /**

--- a/src/commands/deployments.ts
+++ b/src/commands/deployments.ts
@@ -283,14 +283,15 @@ export async function deploy(
 	// HTTP deploy call (further down) is wrapped in a catch that routes
 	// through `handleDeploymentError` for rich Problem-Detail rendering.
 
-	// Store the base paths for relative path calculation
-	const basePaths = paths.length === 0 ? [process.cwd()] : paths;
-
 	if (paths.length === 0) {
 		throw new Error(
 			"No paths provided. Use: c8 deploy <path> or c8 deploy (for current directory)",
 		);
 	}
+
+	// Store the base paths for relative path calculation. Safe to assign
+	// directly now: the empty-paths guard above has already thrown.
+	const basePaths = paths;
 
 	// Load .c8ignore rules from the working directory
 	const ignoreBaseDir = resolve(process.cwd());
@@ -364,13 +365,16 @@ export async function deploy(
 	// Validate for duplicate process/decision IDs
 	const duplicates = findDuplicateDefinitionIds(resources);
 	if (duplicates.size > 0) {
+		// Single source of truth for both the user-visible logger.error and
+		// the SilentError message — keeps stderr and `--verbose` rethrow
+		// stack message aligned even if the wording is later edited.
+		const duplicateIdsMessage =
+			"Cannot deploy: Multiple files with the same process/decision ID in one deployment";
 		// Pre-render the rich detail (per-id file list + guidance) so the
 		// user sees actionable context, then throw a SilentError so the
 		// framework records the failure without re-rendering a duplicate
 		// summary line.
-		logger.error(
-			"Cannot deploy: Multiple files with the same process/decision ID in one deployment",
-		);
+		logger.error(duplicateIdsMessage);
 		duplicates.forEach((paths, id) => {
 			logMessage(`  Process/Decision ID "${id}" found in: ${paths.join(", ")}`);
 		});
@@ -380,9 +384,7 @@ export async function deploy(
 		logMessage(
 			"Please deploy these files separately or ensure each process/decision has a unique ID.",
 		);
-		throw new SilentError(
-			"Cannot deploy: Multiple files with the same process/decision ID in one deployment",
-		);
+		throw new SilentError(duplicateIdsMessage);
 	}
 
 	logger.info(`Deploying ${resources.length} resource(s)...`);

--- a/src/commands/deployments.ts
+++ b/src/commands/deployments.ts
@@ -376,7 +376,9 @@ export async function deploy(
 		// summary line.
 		logger.error(duplicateIdsMessage);
 		duplicates.forEach((dupPaths, id) => {
-			logMessage(`  Process/Decision ID "${id}" found in: ${dupPaths.join(", ")}`);
+			logMessage(
+				`  Process/Decision ID "${id}" found in: ${dupPaths.join(", ")}`,
+			);
 		});
 		logMessage(
 			"\nCamunda does not allow deploying multiple resources with the same definition ID in a single deployment.",

--- a/src/commands/deployments.ts
+++ b/src/commands/deployments.ts
@@ -9,7 +9,7 @@ import type { Ignore } from "ignore";
 import { createClient } from "../client.ts";
 import { defineCommand } from "../command-framework.ts";
 import { resolveClusterConfig, resolveTenantId } from "../config.ts";
-import { SilentError } from "../errors.ts";
+import { normalizeToError, SilentError } from "../errors.ts";
 import { isIgnored, loadIgnoreRules } from "../ignore.ts";
 import { getLogger, isRecord } from "../logger.ts";
 import { c8ctl } from "../runtime.ts";
@@ -563,28 +563,6 @@ export async function deploy(
 }
 
 /**
- * Build a human-readable message for a non-`Error` deploy failure
- * (typically an RFC 9457 problem-detail object thrown by the SDK)
- * for use under `--verbose`. Falls back gracefully when the input
- * lacks any of `title` / `detail` / `status`.
- *
- * Exported for unit testing — the class of defect this guards against
- * is throwing `new Error(String(error))` for non-Error values, which
- * collapses problem-detail objects to the useless `"[object Object]"`.
- */
-export function buildVerboseErrorMessage(
-	raw: Record<string, unknown>,
-	problemTitle: string | undefined,
-): string {
-	const detail = typeof raw.detail === "string" ? raw.detail : undefined;
-	const status = typeof raw.status === "number" ? raw.status : undefined;
-	const head = [problemTitle ?? "Deployment request failed", detail]
-		.filter((p): p is string => Boolean(p))
-		.join(": ");
-	return status !== undefined ? `${head} (status ${status})` : head;
-}
-
-/**
  * Format and display deployment errors with actionable guidance
  */
 function handleDeploymentError(
@@ -608,16 +586,11 @@ function handleDeploymentError(
 		// Verbose mode: surface the original error to the framework so
 		// `handleCommandError` rethrows it and Node prints the stack trace.
 		// Non-Error throws (e.g. RFC 9457 problem-detail plain objects from
-		// the SDK) get wrapped in a synthesized Error whose message is built
-		// from `title` / `detail` / `status` so `--verbose` is actionable
-		// instead of printing `Error: [object Object]`. The original value
-		// is preserved as `cause` so it remains inspectable.
-		if (error instanceof Error) {
-			throw error;
-		}
-		throw new Error(buildVerboseErrorMessage(raw, problemTitle), {
-			cause: error,
-		});
+		// the SDK) are normalized via the centralized helper so the message
+		// is built from `title` / `detail` / `status` instead of collapsing
+		// to `Error: [object Object]`. The original value is preserved as
+		// `cause` so it remains inspectable.
+		throw normalizeToError(error, "Deployment request failed");
 	}
 
 	// Try to interpret common transport/network issues first for actionable guidance

--- a/src/commands/mcp-proxy.ts
+++ b/src/commands/mcp-proxy.ts
@@ -12,6 +12,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { createClient } from "../client.ts";
 import { defineCommand } from "../command-framework.ts";
+import { normalizeToError } from "../errors.ts";
 import { isRecord, Logger, type LogWriter } from "../logger.ts";
 import { c8ctl } from "../runtime.ts";
 import { getVersion } from "./help.ts";
@@ -392,8 +393,7 @@ export const mcpProxyCommand = defineCommand("mcp-proxy", "", async (ctx) => {
 			process.once("SIGTERM", () => shutdown("SIGTERM"));
 		});
 	} catch (error) {
-		const normalizedError =
-			error instanceof Error ? error : new Error(String(error));
+		const normalizedError = normalizeToError(error, "MCP proxy failed");
 
 		if (proxy) await proxy.stop().catch(() => {});
 

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -5,6 +5,7 @@
 import { existsSync, statSync, watch } from "node:fs";
 import { basename, extname, resolve } from "node:path";
 import { defineCommand } from "../command-framework.ts";
+import { normalizeToError } from "../errors.ts";
 import { isIgnored, loadIgnoreRules } from "../ignore.ts";
 import { deploy } from "./deployments.ts";
 
@@ -139,7 +140,7 @@ export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
 							if (ac.signal.aborted) return;
 							logger.error(
 								`Failed to deploy ${basename(file)}`,
-								error instanceof Error ? error : new Error(String(error)),
+								normalizeToError(error, "Deployment request failed"),
 							);
 						} finally {
 							inflightDeploys.delete(ac);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -10,6 +10,25 @@ import type { Logger } from "./logger.ts";
 import { c8ctl } from "./runtime.ts";
 
 /**
+ * Marker error: the caller has already rendered a rich, user-facing
+ * error message (e.g. multi-line context, hints, formatted detail) and
+ * just needs the framework to exit non-zero. `handleCommandError` skips
+ * its default `logger.error(...)` + verbose-hint render for these,
+ * avoiding duplicate "Failed to <verb>: <message>" summary lines on
+ * top of the rich pre-rendered output.
+ *
+ * Use this only when the helper has already produced a complete,
+ * user-actionable failure message. For ordinary errors that just need
+ * to bubble up, throw a plain `Error` and let the framework format it.
+ */
+export class SilentError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "SilentError";
+	}
+}
+
+/**
  * Handle a command error in a consistent way across the codebase.
  *
  * - In verbose mode (`--verbose`): the original error is re-thrown so Node.js
@@ -17,6 +36,9 @@ import { c8ctl } from "./runtime.ts";
  * - In normal mode: a terse message is printed via the logger, followed by any
  *   optional additional hints, and then a hint to re-run with `--verbose`.
  *   The process exits with code 1.
+ * - For `SilentError`: skip the default render entirely (the caller has
+ *   already shown a user-facing error), and just exit non-zero (or
+ *   rethrow in verbose mode).
  */
 export function handleCommandError(
 	logger: Logger,
@@ -29,6 +51,13 @@ export function handleCommandError(
 
 	if (c8ctl.verbose) {
 		throw normalizedError;
+	}
+
+	if (error instanceof SilentError) {
+		// Caller already rendered a rich user-facing message. Don't
+		// stack a "Failed to ...: <message>" + verbose-hint summary on
+		// top — just exit non-zero.
+		process.exit(1);
 	}
 
 	logger.error(message, normalizedError);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -97,7 +97,18 @@ export function handleCommandError(
 		process.exit(1);
 	}
 
-	logger.error(message, normalizedError);
+	// Avoid duplicated output when `normalizeToError` had no actionable
+	// fields to extract and fell back to the caller's `message`. In that
+	// case `Logger.error(message, error)` would print the same string
+	// twice (the prefix line "✗ <message>" followed by the indented
+	// "  <error.message>" line, or both `message` and `error` fields in
+	// JSON mode). Pass only `message` so the second line / `error` field
+	// is omitted.
+	if (normalizedError.message === message) {
+		logger.error(message);
+	} else {
+		logger.error(message, normalizedError);
+	}
 	if (additionalHints) {
 		for (const hint of additionalHints) {
 			logger.info(hint);

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,9 +1,14 @@
 /**
  * Centralized error handling for c8ctl command operations.
  *
- * When --verbose is set, errors are re-thrown so the full stack trace is
- * visible. When it is not set, a terse user-friendly message is emitted and
- * the process exits with a non-zero code, with a hint about using --verbose.
+ * When --verbose is set, errors are normalized via `normalizeToError`
+ * (Errors pass through unchanged; non-Error throws like RFC 9457
+ * problem-detail objects are wrapped in an `Error` whose message is
+ * built from `title` / `detail` / `status` and whose `cause` retains
+ * the original value) and then thrown so Node.js prints a meaningful
+ * stack trace. When it is not set, a terse user-friendly message is
+ * emitted and the process exits with a non-zero code, with a hint
+ * about using --verbose.
  */
 
 import type { Logger } from "./logger.ts";
@@ -69,14 +74,25 @@ export function normalizeToError(
 /**
  * Handle a command error in a consistent way across the codebase.
  *
- * - In verbose mode (`--verbose`): the original error is re-thrown so Node.js
- *   prints the full stack trace.
- * - In normal mode: a terse message is printed via the logger, followed by any
- *   optional additional hints, and then a hint to re-run with `--verbose`.
- *   The process exits with code 1.
- * - For `SilentError`: skip the default render entirely (the caller has
- *   already shown a user-facing error), and just exit non-zero (or
- *   rethrow in verbose mode).
+ * - In verbose mode (`--verbose`): the input is run through
+ *   `normalizeToError` and the resulting `Error` is thrown so Node.js
+ *   prints the full stack trace. For inputs that are already an
+ *   `Error` this is a no-op (the same instance is thrown). For non-
+ *   Error throws the thrown value is the synthesized normalized
+ *   `Error`, which preserves the original value as `cause`. (Callers
+ *   that need the exact original reference can read `.cause` from the
+ *   thrown error.)
+ * - In normal mode: a terse message is printed via the logger,
+ *   followed by any optional additional hints, and then a hint to
+ *   re-run with `--verbose`. The process exits with code 1. To avoid
+ *   duplicated output when the normalized error has no actionable
+ *   detail beyond `message` (e.g. for primitive throws), the second
+ *   `error` argument to `logger.error` is omitted in that case so the
+ *   user message appears exactly once.
+ * - For `SilentError`: skip the default render entirely (the caller
+ *   has already shown a user-facing error), and just exit non-zero
+ *   (or rethrow in verbose mode — `SilentError` is an `Error`, so
+ *   normalization is a no-op and the same instance is thrown).
  */
 export function handleCommandError(
 	logger: Logger,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -7,6 +7,7 @@
  */
 
 import type { Logger } from "./logger.ts";
+import { isRecord } from "./logger.ts";
 import { c8ctl } from "./runtime.ts";
 
 /**
@@ -29,6 +30,43 @@ export class SilentError extends Error {
 }
 
 /**
+ * Normalize any thrown value into an `Error` instance, with care taken
+ * to preserve actionable information from RFC 9457 problem-detail
+ * objects (which the Camunda SDK throws as plain objects, not Errors).
+ *
+ * - If `error` is already an `Error`, it is returned unchanged.
+ * - If `error` looks like an RFC 9457 problem detail (has any of
+ *   `title` / `detail` / `status`), the synthesized Error message is
+ *   built from those fields so it is meaningful to a user (instead of
+ *   the useless `"[object Object]"` produced by `String(error)`).
+ * - Otherwise the synthesized Error uses `fallbackMessage`.
+ *
+ * The original value is always preserved as `cause` so it remains
+ * inspectable (e.g. under `--verbose` stack output).
+ *
+ * Class of defect this guards against: `new Error(String(error))` for
+ * non-Error throws collapses problem-detail responses to
+ * `Error: [object Object]`, losing every actionable field.
+ */
+export function normalizeToError(
+	error: unknown,
+	fallbackMessage = "Operation failed",
+): Error {
+	if (error instanceof Error) {
+		return error;
+	}
+	const raw: Record<string, unknown> = isRecord(error) ? error : {};
+	const title = typeof raw.title === "string" ? raw.title : undefined;
+	const detail = typeof raw.detail === "string" ? raw.detail : undefined;
+	const status = typeof raw.status === "number" ? raw.status : undefined;
+	const head = [title ?? fallbackMessage, detail]
+		.filter((p): p is string => Boolean(p))
+		.join(": ");
+	const message = status !== undefined ? `${head} (status ${status})` : head;
+	return new Error(message, { cause: error });
+}
+
+/**
  * Handle a command error in a consistent way across the codebase.
  *
  * - In verbose mode (`--verbose`): the original error is re-thrown so Node.js
@@ -46,8 +84,7 @@ export function handleCommandError(
 	error: unknown,
 	additionalHints?: string[],
 ): never {
-	const normalizedError =
-		error instanceof Error ? error : new Error(String(error));
+	const normalizedError = normalizeToError(error, message);
 
 	if (c8ctl.verbose) {
 		throw normalizedError;

--- a/tests/integration/watch-lifecycle.test.ts
+++ b/tests/integration/watch-lifecycle.test.ts
@@ -24,6 +24,12 @@ import { startWatchProcess } from "../utils/watch-process.ts";
 const POLL_INTERVAL_MS = 100;
 const STARTUP_TIMEOUT_MS = 5_000;
 const EXIT_TIMEOUT_MS = 5_000;
+// SIGINT shutdown does I/O (close fs watchers, abort in-flight HTTP, drain
+// the event loop). On a loaded CI runner that sometimes takes longer than
+// the missing-path early-exit, so we use a more generous budget for the
+// signal-handling assertion. The correctness signal is "exits 0 after the
+// handler runs", not "exits within 5 s".
+const SIGINT_EXIT_TIMEOUT_MS = 15_000;
 
 describe("watch command lifecycle", () => {
 	let dataDir: string;
@@ -68,9 +74,19 @@ describe("watch command lifecycle", () => {
 		const watch = startWatchProcess({ watchDir, dataDir });
 
 		try {
-			// Wait for the watcher to be ready before sending the signal.
+			// Wait for the watcher to be fully initialized before sending
+			// the signal. We poll for the LAST line printed before the
+			// `await new Promise((r) => process.once("SIGINT", r))` block in
+			// `src/commands/watch.ts` — earlier lines (e.g. "Watching for
+			// changes") are emitted before the synchronous `fs.watch` setup
+			// and BEFORE the SIGINT handler is registered, so signalling on
+			// them races: SIGINT can land before `process.once` runs and
+			// trigger Node's default behaviour (exit 130) instead of our
+			// graceful path. "Press Ctrl+C to stop watching" is the last
+			// line emitted before the `await`, so seeing it on stdout
+			// guarantees the handler is registered.
 			const ready = await pollUntil(
-				async () => watch.getOutput().includes("Watching for changes"),
+				async () => watch.getOutput().includes("Press Ctrl+C to stop watching"),
 				STARTUP_TIMEOUT_MS,
 				POLL_INTERVAL_MS,
 			);
@@ -80,7 +96,7 @@ describe("watch command lifecycle", () => {
 			);
 
 			watch.child.kill("SIGINT");
-			const exitCode = await watch.waitForExit(EXIT_TIMEOUT_MS);
+			const exitCode = await watch.waitForExit(SIGINT_EXIT_TIMEOUT_MS);
 			const output = watch.getOutput();
 
 			assert.strictEqual(

--- a/tests/unit/deploy-error-paths.test.ts
+++ b/tests/unit/deploy-error-paths.test.ts
@@ -35,7 +35,6 @@ import {
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, test } from "node:test";
-import { buildVerboseErrorMessage } from "../../src/commands/deployments.ts";
 import { c8 } from "../utils/cli.ts";
 
 const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
@@ -72,59 +71,6 @@ describe("deploy: structural guard — no process.exit in deployments.ts", () =>
 			`Expected zero \`process.exit\` calls in deployments.ts, found ${matches.length}. ` +
 				`Every error path must throw so the framework's handleCommandError pipeline owns process termination.`,
 		);
-	});
-});
-
-describe("deploy: buildVerboseErrorMessage — non-Error throws are not collapsed to '[object Object]'", () => {
-	// Class-of-defect guard: any future regression that wraps a non-Error
-	// throw with `new Error(String(error))` (or any equivalent that
-	// stringifies a plain object) loses the actionable information from
-	// RFC 9457 problem-detail responses. These tests pin the contract:
-	// the synthesized verbose Error message must include whichever of
-	// `title` / `detail` / `status` is available, and must never
-	// produce the literal `[object Object]`.
-
-	test("RFC 9457 problem detail with title + detail + status", () => {
-		const message = buildVerboseErrorMessage(
-			{
-				title: "INVALID_ARGUMENT",
-				detail: "Process definition has no executable element",
-				status: 400,
-			},
-			"INVALID_ARGUMENT",
-		);
-		assert.strictEqual(
-			message,
-			"INVALID_ARGUMENT: Process definition has no executable element (status 400)",
-		);
-		assert.ok(!message.includes("[object Object]"));
-	});
-
-	test("title only", () => {
-		const message = buildVerboseErrorMessage(
-			{ title: "NOT_FOUND" },
-			"NOT_FOUND",
-		);
-		assert.strictEqual(message, "NOT_FOUND");
-	});
-
-	test("status only", () => {
-		const message = buildVerboseErrorMessage({ status: 503 }, undefined);
-		assert.strictEqual(message, "Deployment request failed (status 503)");
-	});
-
-	test("empty raw / no problem title — falls back to a generic message, never '[object Object]'", () => {
-		const message = buildVerboseErrorMessage({}, undefined);
-		assert.strictEqual(message, "Deployment request failed");
-		assert.ok(!message.includes("[object Object]"));
-	});
-
-	test("non-string title is ignored (defensive against malformed responses)", () => {
-		const message = buildVerboseErrorMessage(
-			{ title: 42, detail: "boom", status: 500 },
-			undefined,
-		);
-		assert.strictEqual(message, "Deployment request failed: boom (status 500)");
 	});
 });
 

--- a/tests/unit/deploy-error-paths.test.ts
+++ b/tests/unit/deploy-error-paths.test.ts
@@ -50,11 +50,10 @@ const DUP_BPMN_TEMPLATE = (
   </bpmn:process>
 </bpmn:definitions>`;
 
-// `Failed to deploy ` — the framework's handleCommandError prefix for
-// the deploy verb. Note the trailing space (resourceless verb wart;
-// pre-existing framework issue, not in this PR's scope). This prefix
-// is added BY the framework, so its presence in stderr proves the
-// error flowed through `handleCommandError` rather than `process.exit(1)`.
+// `Failed to deploy` — the framework's handleCommandError prefix for
+// the deploy verb. This prefix is added BY the framework, so its
+// presence in stderr proves the error flowed through
+// `handleCommandError` rather than `process.exit(1)`.
 const FRAMEWORK_PREFIX = "Failed to deploy";
 
 describe("deploy: structural guard — no process.exit in deployments.ts", () => {

--- a/tests/unit/deploy-error-paths.test.ts
+++ b/tests/unit/deploy-error-paths.test.ts
@@ -35,6 +35,7 @@ import {
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, test } from "node:test";
+import { buildVerboseErrorMessage } from "../../src/commands/deployments.ts";
 import { c8 } from "../utils/cli.ts";
 
 const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
@@ -71,6 +72,59 @@ describe("deploy: structural guard — no process.exit in deployments.ts", () =>
 			`Expected zero \`process.exit\` calls in deployments.ts, found ${matches.length}. ` +
 				`Every error path must throw so the framework's handleCommandError pipeline owns process termination.`,
 		);
+	});
+});
+
+describe("deploy: buildVerboseErrorMessage — non-Error throws are not collapsed to '[object Object]'", () => {
+	// Class-of-defect guard: any future regression that wraps a non-Error
+	// throw with `new Error(String(error))` (or any equivalent that
+	// stringifies a plain object) loses the actionable information from
+	// RFC 9457 problem-detail responses. These tests pin the contract:
+	// the synthesized verbose Error message must include whichever of
+	// `title` / `detail` / `status` is available, and must never
+	// produce the literal `[object Object]`.
+
+	test("RFC 9457 problem detail with title + detail + status", () => {
+		const message = buildVerboseErrorMessage(
+			{
+				title: "INVALID_ARGUMENT",
+				detail: "Process definition has no executable element",
+				status: 400,
+			},
+			"INVALID_ARGUMENT",
+		);
+		assert.strictEqual(
+			message,
+			"INVALID_ARGUMENT: Process definition has no executable element (status 400)",
+		);
+		assert.ok(!message.includes("[object Object]"));
+	});
+
+	test("title only", () => {
+		const message = buildVerboseErrorMessage(
+			{ title: "NOT_FOUND" },
+			"NOT_FOUND",
+		);
+		assert.strictEqual(message, "NOT_FOUND");
+	});
+
+	test("status only", () => {
+		const message = buildVerboseErrorMessage({ status: 503 }, undefined);
+		assert.strictEqual(message, "Deployment request failed (status 503)");
+	});
+
+	test("empty raw / no problem title — falls back to a generic message, never '[object Object]'", () => {
+		const message = buildVerboseErrorMessage({}, undefined);
+		assert.strictEqual(message, "Deployment request failed");
+		assert.ok(!message.includes("[object Object]"));
+	});
+
+	test("non-string title is ignored (defensive against malformed responses)", () => {
+		const message = buildVerboseErrorMessage(
+			{ title: 42, detail: "boom", status: 500 },
+			undefined,
+		);
+		assert.strictEqual(message, "Deployment request failed: boom (status 500)");
 	});
 });
 

--- a/tests/unit/deploy-error-paths.test.ts
+++ b/tests/unit/deploy-error-paths.test.ts
@@ -10,11 +10,15 @@
  *
  * This file pairs a STRUCTURAL guard with BEHAVIOURAL guards:
  *
- *   - Structural: scan `src/commands/deployments.ts` for
- *     `process.exit` substrings. Any future regression that adds a
- *     `process.exit(...)` call into the deploy logic fails here
- *     immediately, without needing to construct a CLI scenario for
- *     the new code path. This is the durable class-of-defect guard.
+ *   - Structural: parse `src/commands/deployments.ts` with the
+ *     TypeScript compiler and walk the AST for any
+ *     `process.exit(...)` CallExpression. Any future regression that
+ *     adds a `process.exit(...)` call into the deploy logic fails
+ *     here immediately, without needing to construct a CLI scenario
+ *     for the new code path. AST-based (not regex) so string
+ *     literals containing `process.exit(` and stripped-comment
+ *     edge cases cannot produce false positives or false negatives.
+ *     This is the durable class-of-defect guard.
  *
  *   - Behavioural: drive the CLI as a subprocess to confirm the
  *     migration actually wires up — when a deploy fails, the
@@ -25,17 +29,12 @@
  */
 
 import assert from "node:assert";
-import {
-	mkdirSync,
-	mkdtempSync,
-	readFileSync,
-	rmSync,
-	writeFileSync,
-} from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, test } from "node:test";
 import { c8 } from "../utils/cli.ts";
+import { findProcessExitCalls } from "../utils/no-process-exit.ts";
 
 const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
 const DEPLOYMENTS_TS = join(PROJECT_ROOT, "src", "commands", "deployments.ts");
@@ -57,19 +56,16 @@ const DUP_BPMN_TEMPLATE = (
 const FRAMEWORK_PREFIX = "Failed to deploy";
 
 describe("deploy: structural guard — no process.exit in deployments.ts", () => {
-	test("src/commands/deployments.ts contains no `process.exit` calls", () => {
-		const source = readFileSync(DEPLOYMENTS_TS, "utf8");
-		// Strip line/block comments so a future docstring mentioning
-		// `process.exit` doesn't trip the grep.
-		const stripped = source
-			.replace(/\/\*[\s\S]*?\*\//g, "")
-			.replace(/\/\/[^\n]*/g, "");
-		const matches = stripped.match(/process\s*\.\s*exit\s*\(/g) ?? [];
+	test("src/commands/deployments.ts contains no `process.exit(...)` calls", () => {
+		const calls = findProcessExitCalls(DEPLOYMENTS_TS);
 		assert.strictEqual(
-			matches.length,
+			calls.length,
 			0,
-			`Expected zero \`process.exit\` calls in deployments.ts, found ${matches.length}. ` +
-				`Every error path must throw so the framework's handleCommandError pipeline owns process termination.`,
+			`Expected zero \`process.exit(...)\` calls in deployments.ts, found ${calls.length}:\n` +
+				calls
+					.map((c) => `  - line ${c.line}:${c.column} — ${c.text}`)
+					.join("\n") +
+				`\n\nEvery error path must throw so the framework's handleCommandError pipeline owns process termination.`,
 		);
 	});
 });

--- a/tests/unit/deploy-error-paths.test.ts
+++ b/tests/unit/deploy-error-paths.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Class-of-defect regression guards for `c8 deploy` error paths.
+ *
+ * Issue #288: every error path in `src/commands/deployments.ts` must
+ * `throw`, never `process.exit()`. Bypassing the framework's
+ * `handleCommandError` pipeline breaks two invariants:
+ *   1. `--verbose` cannot rethrow the error to surface a stack trace.
+ *   2. The framework cannot consistently format the failure with
+ *      command context.
+ *
+ * This file pairs a STRUCTURAL guard with BEHAVIOURAL guards:
+ *
+ *   - Structural: scan `src/commands/deployments.ts` for
+ *     `process.exit` substrings. Any future regression that adds a
+ *     `process.exit(...)` call into the deploy logic fails here
+ *     immediately, without needing to construct a CLI scenario for
+ *     the new code path. This is the durable class-of-defect guard.
+ *
+ *   - Behavioural: drive the CLI as a subprocess to confirm the
+ *     migration actually wires up — when a deploy fails, the
+ *     framework's `Failed to ${verb} ${resource}` prefix must appear
+ *     in stderr. That prefix is added by `handleCommandError` and
+ *     can ONLY appear if the helper threw rather than calling
+ *     `process.exit(1)` directly.
+ */
+
+import assert from "node:assert";
+import {
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, test } from "node:test";
+import { c8 } from "../utils/cli.ts";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
+const DEPLOYMENTS_TS = join(PROJECT_ROOT, "src", "commands", "deployments.ts");
+
+const DUP_BPMN_TEMPLATE = (
+	id: string,
+) => `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="${id}" isExecutable="true">
+    <bpmn:startEvent id="start"/>
+  </bpmn:process>
+</bpmn:definitions>`;
+
+// `Failed to deploy ` — the framework's handleCommandError prefix for
+// the deploy verb. Note the trailing space (resourceless verb wart;
+// pre-existing framework issue, not in this PR's scope). This prefix
+// is added BY the framework, so its presence in stderr proves the
+// error flowed through `handleCommandError` rather than `process.exit(1)`.
+const FRAMEWORK_PREFIX = "Failed to deploy";
+
+describe("deploy: structural guard — no process.exit in deployments.ts", () => {
+	test("src/commands/deployments.ts contains no `process.exit` calls", () => {
+		const source = readFileSync(DEPLOYMENTS_TS, "utf8");
+		// Strip line/block comments so a future docstring mentioning
+		// `process.exit` doesn't trip the grep.
+		const stripped = source
+			.replace(/\/\*[\s\S]*?\*\//g, "")
+			.replace(/\/\/[^\n]*/g, "");
+		const matches = stripped.match(/process\s*\.\s*exit\s*\(/g) ?? [];
+		assert.strictEqual(
+			matches.length,
+			0,
+			`Expected zero \`process.exit\` calls in deployments.ts, found ${matches.length}. ` +
+				`Every error path must throw so the framework's handleCommandError pipeline owns process termination.`,
+		);
+	});
+});
+
+describe("deploy: behavioural — error paths flow through the framework", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "c8ctl-deploy-errors-"));
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test("no deployable files: framework prefix appears (proves throw, not exit)", async () => {
+		const emptyDir = join(tempDir, "empty");
+		mkdirSync(emptyDir, { recursive: true });
+
+		const result = await c8("deploy", emptyDir);
+
+		assert.strictEqual(
+			result.status,
+			1,
+			`expected exit 1, got ${result.status}. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("No BPMN/DMN/Form files found"),
+			`expected original error message in stderr. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes(FRAMEWORK_PREFIX),
+			`expected framework prefix '${FRAMEWORK_PREFIX}' in stderr, proving the error flowed through handleCommandError instead of process.exit(1). stderr:\n${result.stderr}`,
+		);
+	});
+
+	test("duplicate definition IDs: rich pre-rendered error, exit 1, no double-summary", async () => {
+		// This path uses `SilentError` by design — the helper pre-renders
+		// rich actionable content (per-id file list + guidance), and the
+		// framework's `handleCommandError` exits non-zero WITHOUT adding a
+		// "Failed to deploy: ..." summary line on top.
+		//
+		// The structural guard above (zero `process.exit` in deployments.ts)
+		// is the durable class-of-defect catch for this path. The behavioural
+		// assertions below confirm the SilentError pipeline works:
+		//   - exit code 1 (the only signal that *something* terminated us)
+		//   - rich pre-rendered detail still emitted
+		//   - NO duplicated "Failed to deploy: ..." summary (the framework
+		//     prefix is correctly suppressed by SilentError)
+		writeFileSync(join(tempDir, "a.bpmn"), DUP_BPMN_TEMPLATE("dup-process"));
+		writeFileSync(join(tempDir, "b.bpmn"), DUP_BPMN_TEMPLATE("dup-process"));
+
+		const result = await c8("deploy", tempDir);
+
+		assert.strictEqual(
+			result.status,
+			1,
+			`expected exit 1, got ${result.status}. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("Multiple files with the same process") ||
+				result.stderr.includes("dup-process"),
+			`expected duplicate-id error in stderr. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			!result.stderr.includes(FRAMEWORK_PREFIX),
+			`SilentError must suppress the framework's '${FRAMEWORK_PREFIX}' summary on top of the pre-rendered rich error. stderr:\n${result.stderr}`,
+		);
+	});
+});

--- a/tests/unit/no-process-exit-in-handlers.test.ts
+++ b/tests/unit/no-process-exit-in-handlers.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Architectural class-of-defect guard for issue #288.
+ *
+ * Goal: every command handler in `src/commands/**.ts` routes
+ * termination through the framework's `handleCommandError` pipeline
+ * (i.e. via `throw`), never through a direct `process.exit(...)`
+ * call. This preserves two invariants for the whole CLI:
+ *
+ *   1. `--verbose` can rethrow any error to surface a stack trace.
+ *   2. The framework consistently formats failures with command
+ *      context (`Failed to <verb> <resource>: <message>`).
+ *
+ * Because issue #288 is a multi-PR migration, we lock in the
+ * direction of travel with a SHRINKING ALLOW-LIST:
+ *
+ *   - Files in `PENDING_MIGRATION` may still contain
+ *     `process.exit(...)` calls (this is what the migration is
+ *     fixing).
+ *   - Every other file in `src/commands/**.ts` must contain ZERO
+ *     `process.exit(...)` calls.
+ *   - When a handler is migrated, its entry is REMOVED from the
+ *     allow-list in the same PR.
+ *   - When the allow-list is empty, issue #288 is complete and the
+ *     architectural rule is fully locked in. At that point the
+ *     allow-list and its plumbing should be deleted in favour of an
+ *     unconditional ban.
+ *
+ * The test fails in TWO directions:
+ *
+ *   a) A file outside the allow-list contains `process.exit(...)` —
+ *      a regression. (E.g. someone reintroduced `process.exit(1)`
+ *      into deployments.ts.)
+ *   b) A file inside the allow-list contains ZERO
+ *      `process.exit(...)` calls — the file has already been
+ *      migrated and the allow-list is stale. Remove the entry.
+ *
+ * Direction (b) is what makes the allow-list a checklist instead of
+ * a graveyard: stale entries cannot accumulate.
+ *
+ * AST-based (not regex) so string literals containing
+ * `process.exit(`, comments mentioning the pattern, and
+ * commented-out code cannot produce false positives or false
+ * negatives. See `tests/utils/no-process-exit.ts`.
+ */
+
+import assert from "node:assert";
+import { readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, test } from "node:test";
+import { findProcessExitCalls } from "../utils/no-process-exit.ts";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
+const COMMANDS_DIR = join(PROJECT_ROOT, "src", "commands");
+
+/**
+ * Files that have NOT yet been migrated off `process.exit(...)`.
+ *
+ * Remove an entry in the same PR that migrates its handler. When
+ * this set is empty, delete it and turn the test into an
+ * unconditional rule across all of `src/commands/**.ts`.
+ *
+ * Each path is workspace-relative for stable grep/diff readability.
+ */
+const PENDING_MIGRATION: ReadonlySet<string> = new Set([
+	"src/commands/completion.ts",
+	"src/commands/forms.ts",
+	"src/commands/identity-groups.ts",
+	"src/commands/identity-mapping-rules.ts",
+	"src/commands/identity-roles.ts",
+	"src/commands/identity-tenants.ts",
+	"src/commands/identity-users.ts",
+	"src/commands/identity.ts",
+	"src/commands/incidents.ts",
+	"src/commands/jobs.ts",
+	"src/commands/messages.ts",
+	"src/commands/plugins.ts",
+	"src/commands/process-instances.ts",
+	"src/commands/profiles.ts",
+	"src/commands/run.ts",
+	"src/commands/search.ts",
+	"src/commands/session.ts",
+	"src/commands/user-tasks.ts",
+]);
+
+function listCommandFiles(): string[] {
+	return readdirSync(COMMANDS_DIR)
+		.filter((name) => name.endsWith(".ts"))
+		.map((name) => join(COMMANDS_DIR, name));
+}
+
+/** Convert an absolute path under PROJECT_ROOT to a workspace-relative
+ * POSIX path (the form used in `PENDING_MIGRATION`). */
+function toRelative(absPath: string): string {
+	const rel = absPath.slice(PROJECT_ROOT.length + 1);
+	return rel.split(/[\\/]/).join("/");
+}
+
+describe("architectural guard: command handlers must throw, not process.exit (#288)", () => {
+	const files = listCommandFiles();
+
+	test("PENDING_MIGRATION lists only files that exist", () => {
+		const onDisk = new Set(files.map(toRelative));
+		const stale = [...PENDING_MIGRATION].filter((p) => !onDisk.has(p));
+		assert.deepStrictEqual(
+			stale,
+			[],
+			`PENDING_MIGRATION references files that no longer exist: ${stale.join(", ")}. ` +
+				`Remove these entries.`,
+		);
+	});
+
+	test("no migrated handler reintroduces `process.exit(...)`", () => {
+		const violations: { file: string; line: number; text: string }[] = [];
+		for (const abs of files) {
+			const rel = toRelative(abs);
+			if (PENDING_MIGRATION.has(rel)) continue;
+			for (const call of findProcessExitCalls(abs)) {
+				violations.push({ file: rel, line: call.line, text: call.text });
+			}
+		}
+		assert.strictEqual(
+			violations.length,
+			0,
+			`Migrated handler files must not contain \`process.exit(...)\` calls. ` +
+				`Found ${violations.length}:\n` +
+				violations
+					.map((v) => `  - ${v.file}:${v.line} — ${v.text}`)
+					.join("\n") +
+				`\n\nEvery error path must throw so the framework's handleCommandError ` +
+				`pipeline owns process termination. If this is genuinely a new ` +
+				`pre-migration handler, add it to PENDING_MIGRATION in this file.`,
+		);
+	});
+
+	test("PENDING_MIGRATION entries actually still contain `process.exit(...)`", () => {
+		// Direction (b) above: a stale allow-list entry is its own kind
+		// of regression. If a file has been migrated but its entry was
+		// not removed, the allow-list silently keeps protecting a file
+		// that no longer needs protection — and the next reviewer might
+		// keep relying on it. Catch that here so the allow-list shrinks
+		// monotonically and never accumulates dead entries.
+		const stale: string[] = [];
+		for (const rel of PENDING_MIGRATION) {
+			const abs = join(PROJECT_ROOT, rel);
+			if (findProcessExitCalls(abs).length === 0) {
+				stale.push(rel);
+			}
+		}
+		assert.deepStrictEqual(
+			stale,
+			[],
+			`PENDING_MIGRATION contains entries that have already been migrated ` +
+				`(no \`process.exit(...)\` remains): ${stale.join(", ")}. ` +
+				`Remove these entries from PENDING_MIGRATION in the same PR ` +
+				`that migrated them.`,
+		);
+	});
+});

--- a/tests/unit/normalize-to-error.test.ts
+++ b/tests/unit/normalize-to-error.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Class-of-defect regression guards for `normalizeToError` (src/errors.ts).
+ *
+ * Defect class: wrapping a non-Error throw with `new Error(String(error))`
+ * collapses RFC 9457 problem-detail objects (which the Camunda SDK
+ * throws as plain objects, not Errors) to the literal `Error: [object
+ * Object]`, losing every actionable field (`title`, `detail`, `status`).
+ *
+ * `normalizeToError` is the single shared helper used by:
+ *   - `handleCommandError` (src/errors.ts)
+ *   - the deploy verbose path (src/commands/deployments.ts)
+ *   - the watch deploy-failure logger (src/commands/watch.ts)
+ *   - the mcp-proxy startup/shutdown failure path (src/commands/mcp-proxy.ts)
+ *
+ * Pinning the contract here means any future regression at any of those
+ * sites that re-introduces `String(error)` stringification fails this
+ * suite — without needing to construct an SDK error mock per call site.
+ */
+
+import assert from "node:assert";
+import { describe, test } from "node:test";
+import { normalizeToError } from "../../src/errors.ts";
+
+describe("normalizeToError — Error inputs pass through unchanged", () => {
+	test("plain Error is returned by reference (no wrapping)", () => {
+		const original = new Error("boom");
+		const result = normalizeToError(original);
+		assert.strictEqual(result, original);
+	});
+
+	test("Error subclass is returned by reference", () => {
+		class CustomError extends Error {}
+		const original = new CustomError("custom");
+		const result = normalizeToError(original);
+		assert.strictEqual(result, original);
+	});
+});
+
+describe("normalizeToError — non-Error throws are not collapsed to '[object Object]'", () => {
+	test("RFC 9457 problem detail with title + detail + status", () => {
+		const raw = {
+			title: "INVALID_ARGUMENT",
+			detail: "Process definition has no executable element",
+			status: 400,
+		};
+		const result = normalizeToError(raw, "Deployment request failed");
+		assert.strictEqual(
+			result.message,
+			"INVALID_ARGUMENT: Process definition has no executable element (status 400)",
+		);
+		assert.ok(!result.message.includes("[object Object]"));
+		assert.strictEqual(result.cause, raw);
+	});
+
+	test("title only", () => {
+		const raw = { title: "NOT_FOUND" };
+		const result = normalizeToError(raw);
+		assert.strictEqual(result.message, "NOT_FOUND");
+		assert.strictEqual(result.cause, raw);
+	});
+
+	test("detail only — falls back to default fallbackMessage", () => {
+		const raw = { detail: "thing went sideways" };
+		const result = normalizeToError(raw);
+		assert.strictEqual(result.message, "Operation failed: thing went sideways");
+	});
+
+	test("status only — uses caller fallbackMessage", () => {
+		const raw = { status: 503 };
+		const result = normalizeToError(raw, "MCP proxy failed");
+		assert.strictEqual(result.message, "MCP proxy failed (status 503)");
+	});
+
+	test("empty object — falls back to default fallbackMessage, never '[object Object]'", () => {
+		const result = normalizeToError({});
+		assert.strictEqual(result.message, "Operation failed");
+		assert.ok(!result.message.includes("[object Object]"));
+	});
+
+	test("primitive throw (string) — falls back to fallbackMessage, never '[object Object]'", () => {
+		const result = normalizeToError("oops");
+		assert.strictEqual(result.message, "Operation failed");
+		assert.ok(!result.message.includes("[object Object]"));
+		assert.strictEqual(result.cause, "oops");
+	});
+
+	test("primitive throw (number) — falls back, preserves cause", () => {
+		const result = normalizeToError(42, "Deployment request failed");
+		assert.strictEqual(result.message, "Deployment request failed");
+		assert.strictEqual(result.cause, 42);
+	});
+
+	test("null throw — falls back, never '[object Object]'", () => {
+		const result = normalizeToError(null);
+		assert.strictEqual(result.message, "Operation failed");
+		assert.ok(!result.message.includes("[object Object]"));
+	});
+
+	test("undefined throw — falls back, never '[object Object]'", () => {
+		const result = normalizeToError(undefined);
+		assert.strictEqual(result.message, "Operation failed");
+		assert.ok(!result.message.includes("[object Object]"));
+	});
+
+	test("non-string title is ignored (defensive against malformed responses)", () => {
+		const raw = { title: 42, detail: "boom", status: 500 };
+		const result = normalizeToError(raw);
+		assert.strictEqual(result.message, "Operation failed: boom (status 500)");
+	});
+
+	test("non-number status is ignored (defensive against malformed responses)", () => {
+		const raw = { title: "BAD_GATEWAY", status: "502" };
+		const result = normalizeToError(raw);
+		assert.strictEqual(result.message, "BAD_GATEWAY");
+	});
+
+	test("preserves the original value as `cause` so it remains inspectable under --verbose", () => {
+		const raw = { title: "X", detail: "y", extra: { nested: true } };
+		const result = normalizeToError(raw);
+		assert.strictEqual(result.cause, raw);
+	});
+});

--- a/tests/unit/verbose.test.ts
+++ b/tests/unit/verbose.test.ts
@@ -5,7 +5,7 @@
 import assert from "node:assert";
 import { afterEach, beforeEach, describe, test } from "node:test";
 import { handleCommandError } from "../../src/errors.ts";
-import { Logger } from "../../src/logger.ts";
+import { isRecord, Logger } from "../../src/logger.ts";
 import { c8ctl } from "../../src/runtime.ts";
 import { mockProcessExit } from "../utils/mocks.ts";
 
@@ -114,6 +114,58 @@ describe("handleCommandError", () => {
 						new Error("fetch failed"),
 					),
 				(err: Error) => err.message === "process.exit(1)",
+			);
+		});
+
+		test("does not duplicate the prefix line when normalizeToError fell back to the caller message (text mode)", () => {
+			// Class-of-defect guard: when a non-Error throw lacks RFC 9457
+			// fields, `normalizeToError` synthesizes an Error whose message
+			// is the caller's `message` argument. `Logger.error(message,
+			// error)` would then print the same string twice — once as
+			// the prefix line "✗ <message>" and once as the indented
+			// "  <error.message>" line. `handleCommandError` must elide
+			// the second pass.
+			c8ctl.outputMode = "text";
+			const messageLine = "Failed to do the thing";
+			assert.throws(() => {
+				// Non-Error throw with no actionable fields → normalizeToError
+				// will fall back to `message`.
+				handleCommandError(logger, messageLine, "opaque");
+			});
+			const occurrences = errorSpy.filter((line) =>
+				line.includes(messageLine),
+			).length;
+			assert.strictEqual(
+				occurrences,
+				1,
+				`expected the message to appear exactly once in stderr, got ${occurrences}. ` +
+					`Output:\n${errorSpy.join("\n")}`,
+			);
+		});
+
+		test("does not duplicate the message in JSON mode when normalizeToError fell back to the caller message", () => {
+			// Same defect class as above, but in JSON output mode the
+			// duplication shows up as both `message` and `error` fields
+			// carrying identical strings. The `error` field should be
+			// omitted in that case.
+			c8ctl.outputMode = "json";
+			const messageLine = "Failed to do the thing";
+			assert.throws(() => {
+				handleCommandError(logger, messageLine, "opaque");
+			});
+			const errorLine = errorSpy.find((line) => line.includes(messageLine));
+			assert.ok(
+				errorLine,
+				`no error line emitted. Output:\n${errorSpy.join("\n")}`,
+			);
+			const parsed: unknown = JSON.parse(errorLine);
+			assert.ok(
+				isRecord(parsed) && "message" in parsed,
+				"expected JSON output with a message field",
+			);
+			assert.ok(
+				!("error" in parsed) || parsed.error !== messageLine,
+				`JSON 'error' field must not duplicate 'message' when there is no extra detail. Output: ${errorLine}`,
 			);
 		});
 	});

--- a/tests/unit/verbose.test.ts
+++ b/tests/unit/verbose.test.ts
@@ -155,10 +155,18 @@ describe("handleCommandError", () => {
 				message: "connection refused",
 			};
 
+			// `normalizeToError` (src/errors.ts) wraps non-Error throws in an
+			// Error whose message is built from RFC 9457 problem-detail fields
+			// (`title` / `detail` / `status`) when present, falling back to
+			// the caller's message otherwise. The original is preserved as
+			// `cause`. The previous behaviour (`new Error(String(error))` →
+			// `Error: [object Object]`) lost all actionable information.
 			assert.throws(
 				() => handleCommandError(logger, "Failed to connect", originalError),
 				(thrown) =>
-					thrown instanceof Error && thrown.message === String(originalError),
+					thrown instanceof Error &&
+					thrown.message === "Failed to connect" &&
+					thrown.cause === originalError,
 			);
 		});
 	});

--- a/tests/utils/no-process-exit.ts
+++ b/tests/utils/no-process-exit.ts
@@ -1,0 +1,93 @@
+/**
+ * AST-based scanner that finds every `process.exit(...)` call in a
+ * TypeScript source file.
+ *
+ * Why AST and not regex: a regex on the file text has two failure
+ * modes that are real risks for a class-of-defect guard.
+ *
+ *   1. False positive: a string literal that happens to contain
+ *      `process.exit(` (e.g. an error message that quotes the
+ *      violation it warns about, a help string, or a generated
+ *      example) would be flagged as a real call site even though it
+ *      is just text.
+ *   2. False negative: stripping comments with naive regexes can
+ *      remove real code if a `//` or `/*` sequence appears inside a
+ *      string or template literal — at which point a genuine
+ *      `process.exit(...)` next to it can be silently elided.
+ *
+ * Both failure modes silently break the guarantee the test is
+ * trying to provide. The TypeScript parser knows about strings,
+ * templates, regex literals, comments, and JSX, so a CallExpression
+ * walker over its AST is the only durable shape for this check.
+ *
+ * The check is for the call form `process.exit(...)` only.
+ * `process.exitCode = N` is intentionally NOT flagged — that idiom
+ * sets the eventual exit code and lets the event loop drain
+ * naturally, which is the correct pattern for handlers that have
+ * already done their work.
+ */
+
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+
+export interface ProcessExitCall {
+	/** 1-based line number of the call. */
+	line: number;
+	/** 1-based column number of the call. */
+	column: number;
+	/** The full call text, e.g. `process.exit(1)`. */
+	text: string;
+}
+
+/**
+ * Parse a TypeScript file and return every `process.exit(...)` call
+ * found in it. Comments and string/template literals are ignored
+ * (the parser correctly distinguishes them from real expressions).
+ */
+export function findProcessExitCalls(filePath: string): ProcessExitCall[] {
+	const source = readFileSync(filePath, "utf8");
+	const sf = ts.createSourceFile(
+		filePath,
+		source,
+		ts.ScriptTarget.Latest,
+		/* setParentNodes */ true,
+		ts.ScriptKind.TS,
+	);
+
+	const hits: ProcessExitCall[] = [];
+
+	const visit = (node: ts.Node): void => {
+		if (ts.isCallExpression(node) && isProcessExit(node.expression)) {
+			const { line, character } = sf.getLineAndCharacterOfPosition(
+				node.getStart(sf),
+			);
+			hits.push({
+				line: line + 1,
+				column: character + 1,
+				text: node.getText(sf),
+			});
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(sf);
+
+	return hits;
+}
+
+/**
+ * True iff the given expression is the property access `process.exit`.
+ * We intentionally do NOT match `process["exit"]`, `(process).exit`,
+ * or aliased forms (`const { exit } = process; exit(1);`). Those
+ * idioms are exotic enough that flagging them would cost more
+ * (false positives in unrelated code that happens to write
+ * `process["exit"]` in a string) than they catch. The plain form
+ * `process.exit(...)` is the only one we have ever observed in
+ * this codebase, and it's the form lint and reviewers will see
+ * first.
+ */
+function isProcessExit(expr: ts.Expression): boolean {
+	if (!ts.isPropertyAccessExpression(expr)) return false;
+	if (expr.name.text !== "exit") return false;
+	const obj = expr.expression;
+	return ts.isIdentifier(obj) && obj.text === "process";
+}


### PR DESCRIPTION
Part of #288 (normalise command handler architecture).

Migrates the `deploy` handler off direct `process.exit(1)` so failures flow through the framework's `handleCommandError` pipeline. Follows #296, which did the same for the small handlers.

## Changes

### `src/commands/deployments.ts`
Convert all 5 `process.exit(1)` sites:

- 3 early-validation guards (empty paths, no resources, duplicate definition IDs) now `throw` instead of exiting.
- 2 sites inside `handleDeploymentError` (verbose path and standard path) now `throw` instead of `console.error`+`exit` / `logger.error`+`exit`.
- **Narrow the outer `try/catch`** to wrap only the API call (`await pendingDeploy`). Pre-API validation (paths/resources/dryRun/duplicates/createClient/sort/mapping) now bubbles directly to the framework. Only network / RFC 9457 Problem-Detail responses from `createDeployment` go through `handleDeploymentError` for rich rendering. This was necessary because the previous catch indiscriminately routed validation throws through `handleDeploymentError`, producing a misleading "Deployment failed" pre-render before the framework prefix.

### `src/errors.ts`
Add `SilentError` marker class. Used by callers that have already pre-rendered actionable, multi-line context (e.g. the duplicate-id list with per-id files + guidance) and want the framework to exit non-zero **without** adding a duplicate `Failed to <verb>: ...` summary line on top.

`handleCommandError` detects `SilentError` after the verbose-rethrow check and exits 1 silently.

## Tests

New `tests/unit/deploy-error-paths.test.ts` follows the green/green discipline (proven RED before each change, GREEN after):

- **Structural class-of-defect guard**: regex-greps `src/commands/deployments.ts` and asserts zero `process.exit` calls remain. This is the durable regression catch — any future re-introduction of `process.exit` anywhere in the file fires this test, not just the specific instances fixed here.
- **Behavioural guard — "no deployable files"**: asserts the framework's ``Failed to deploy:`` prefix appears in stderr. Proves the throw reached `handleCommandError`, not a swallowed exit.
- **Behavioural guard — "duplicate definition IDs"**: asserts exit 1, the rich pre-rendered detail is still emitted, AND that the framework prefix is correctly suppressed by `SilentError` (no double-summary).

Full unit suite: **1067/1067 pass**.
