### PR TITLE
refactor(commands): route forms/incidents/run/user-tasks errors through framework (#300)

### DIFF
--- a/src/commands/forms.ts
+++ b/src/commands/forms.ts
@@ -30,7 +30,7 @@ export const getFormCommand = defineCommand(
 	"get",
 	"form",
 	async (ctx, flags, args) => {
-		const { client, logger, profile } = ctx;
+		const { client, profile } = ctx;
 		const key = args.key;
 
 		const isUserTask = flags.userTask === true || flags.ut === true;
@@ -39,10 +39,9 @@ export const getFormCommand = defineCommand(
 
 		// If both flags specified, error
 		if (isUserTask && isProcessDefinition) {
-			logger.error(
+			throw new Error(
 				"Cannot specify both --userTask|--ut and --processDefinition|--pd. Use one or the other, or omit both to search both types.",
 			);
-			process.exit(1);
 		}
 
 		if (isUserTask) {

--- a/src/commands/incidents.ts
+++ b/src/commands/incidents.ts
@@ -13,7 +13,7 @@ export const listIncidentsCommand = defineCommand(
 	"list",
 	"incident",
 	async (ctx, flags) => {
-		const { client, logger, tenantId, profile, limit, between } = ctx;
+		const { client, tenantId, profile, limit, between } = ctx;
 
 		const filter: { filter: Record<string, unknown> } = {
 			filter: {
@@ -34,10 +34,9 @@ export const listIncidentsCommand = defineCommand(
 			if (parsed) {
 				filter.filter.creationTime = buildDateFilter(parsed.from, parsed.to);
 			} else {
-				logger.error(
+				throw new Error(
 					"Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)",
 				);
-				process.exit(1);
 			}
 		}
 

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -52,8 +52,7 @@ export async function run(
 		const processId = extractProcessId(content);
 
 		if (!processId) {
-			logger.error("Could not extract process ID from BPMN file");
-			process.exit(1);
+			throw new Error("Could not extract process ID from BPMN file");
 		}
 
 		logger.info(`Deploying ${path}...`);

--- a/src/commands/user-tasks.ts
+++ b/src/commands/user-tasks.ts
@@ -13,16 +13,7 @@ export const listUserTasksCommand = defineCommand(
 	"list",
 	"user-task",
 	async (ctx, flags) => {
-		const {
-			client,
-			logger,
-			tenantId,
-			profile,
-			limit,
-			all,
-			between,
-			dateField,
-		} = ctx;
+		const { client, tenantId, profile, limit, all, between, dateField } = ctx;
 
 		const filter: { filter: Record<string, unknown> } = {
 			filter: {
@@ -47,10 +38,9 @@ export const listUserTasksCommand = defineCommand(
 				const field = dateField ?? "creationDate";
 				filter.filter[field] = buildDateFilter(parsed.from, parsed.to);
 			} else {
-				logger.error(
+				throw new Error(
 					"Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)",
 				);
-				process.exit(1);
 			}
 		}
 

--- a/tests/unit/no-process-exit-in-handlers.test.ts
+++ b/tests/unit/no-process-exit-in-handlers.test.ts
@@ -63,23 +63,19 @@ const COMMANDS_DIR = join(PROJECT_ROOT, "src", "commands");
  */
 const PENDING_MIGRATION: ReadonlySet<string> = new Set([
 	"src/commands/completion.ts",
-	"src/commands/forms.ts",
 	"src/commands/identity-groups.ts",
 	"src/commands/identity-mapping-rules.ts",
 	"src/commands/identity-roles.ts",
 	"src/commands/identity-tenants.ts",
 	"src/commands/identity-users.ts",
 	"src/commands/identity.ts",
-	"src/commands/incidents.ts",
 	"src/commands/jobs.ts",
 	"src/commands/messages.ts",
 	"src/commands/plugins.ts",
 	"src/commands/process-instances.ts",
 	"src/commands/profiles.ts",
-	"src/commands/run.ts",
 	"src/commands/search.ts",
 	"src/commands/session.ts",
-	"src/commands/user-tasks.ts",
 ]);
 
 function listCommandFiles(): string[] {

--- a/tests/unit/round-1-error-paths.test.ts
+++ b/tests/unit/round-1-error-paths.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Behavioural guards for Round 1 of the `process.exit` migration (issue #300,
+ * follow-on to issue #288). These four commands each had exactly one
+ * `process.exit(1)` site in a validation guard:
+ *
+ *   - `src/commands/forms.ts`       — mutex flag check (`--userTask` vs `--processDefinition`)
+ *   - `src/commands/incidents.ts`   — invalid `--between` value
+ *   - `src/commands/run.ts`         — BPMN file with no extractable process id
+ *   - `src/commands/user-tasks.ts`  — invalid `--between` value
+ *
+ * After migration each path must `throw` so the framework's `handleCommandError`
+ * pipeline owns process termination. The cross-handler architectural guard
+ * (`tests/unit/no-process-exit-in-handlers.test.ts`) is the durable
+ * class-of-defect catch — these behavioural tests prove each individual
+ * migration is actually wired through the framework by asserting the
+ * framework's `Failed to ${verb} ${resource}` prefix appears in stderr.
+ * That prefix is added by `handleCommandError` and CANNOT appear if the
+ * helper called `process.exit(1)` directly.
+ */
+
+import assert from "node:assert";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, test } from "node:test";
+import { c8 } from "../utils/cli.ts";
+
+describe("forms: behavioural — mutex flag error flows through the framework", () => {
+	test("--userTask + --processDefinition: framework prefix appears (proves throw, not exit)", async () => {
+		const result = await c8(
+			"get",
+			"form",
+			"some-key",
+			"--userTask",
+			"--processDefinition",
+		);
+
+		assert.strictEqual(
+			result.status,
+			1,
+			`expected exit 1, got ${result.status}. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("Cannot specify both"),
+			`expected original error message in stderr. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("Failed to get form"),
+			`expected framework prefix 'Failed to get form' in stderr, proving the error flowed through handleCommandError instead of process.exit(1). stderr:\n${result.stderr}`,
+		);
+	});
+});
+
+describe("incidents: behavioural — invalid --between flows through the framework", () => {
+	test("invalid --between: framework prefix appears (proves throw, not exit)", async () => {
+		const result = await c8(
+			"list",
+			"incidents",
+			"--between",
+			"not-a-valid-range",
+		);
+
+		assert.strictEqual(
+			result.status,
+			1,
+			`expected exit 1, got ${result.status}. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("Invalid --between"),
+			`expected original error message in stderr. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("Failed to list incident"),
+			`expected framework prefix 'Failed to list incident' in stderr, proving the error flowed through handleCommandError instead of process.exit(1). stderr:\n${result.stderr}`,
+		);
+	});
+});
+
+describe("user-tasks: behavioural — invalid --between flows through the framework", () => {
+	test("invalid --between: framework prefix appears (proves throw, not exit)", async () => {
+		const result = await c8(
+			"list",
+			"user-tasks",
+			"--between",
+			"not-a-valid-range",
+		);
+
+		assert.strictEqual(
+			result.status,
+			1,
+			`expected exit 1, got ${result.status}. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("Invalid --between"),
+			`expected original error message in stderr. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("Failed to list user task"),
+			`expected framework prefix 'Failed to list user task' in stderr, proving the error flowed through handleCommandError instead of process.exit(1). stderr:\n${result.stderr}`,
+		);
+	});
+});
+
+describe("run: behavioural — unextractable process id flows through the framework", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "c8ctl-run-errors-"));
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test("BPMN file with no <process id=…>: 'Failed to run process' prefix appears", async () => {
+		// BPMN with definitions but no <process> — extractProcessId returns null.
+		const bpmnPath = join(tempDir, "no-process-id.bpmn");
+		writeFileSync(
+			bpmnPath,
+			`<?xml version="1.0" encoding="UTF-8"?>\n<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn"/>\n`,
+		);
+
+		const result = await c8("run", bpmnPath);
+
+		assert.strictEqual(
+			result.status,
+			1,
+			`expected exit 1, got ${result.status}. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("Could not extract process ID from BPMN file"),
+			`expected original error message in stderr. stderr:\n${result.stderr}`,
+		);
+		// `run.ts` has its own try/catch wrapping the inner async function; the
+		// inner `handleCommandError(logger, "Failed to run process", error)`
+		// fires first. Its presence in stderr proves the throw replaced the
+		// previous `process.exit(1)` (which would have killed the process
+		// before the inner catch could format anything).
+		assert.ok(
+			result.stderr.includes("Failed to run process"),
+			`expected framework prefix 'Failed to run process' in stderr, proving the error flowed through handleCommandError instead of process.exit(1). stderr:\n${result.stderr}`,
+		);
+	});
+});


### PR DESCRIPTION
Round 1 of the cross-handler `process.exit` migration tracked in #300 (follow-on to #288 / #299).

## What changed

Each of these handlers had exactly one `process.exit(1)` site in a validation guard. All four now `throw` so the framework's `handleCommandError` pipeline owns process termination.

| File | Site | Trigger |
| --- | --- | --- |
| `src/commands/forms.ts` | mutex flag check | `c8 get form <key> --userTask --processDefinition` |
| `src/commands/incidents.ts` | invalid `--between` value | `c8 list incidents --between not-a-range` |
| `src/commands/run.ts` | BPMN file with no extractable process id | `c8 run <bpmn-without-process>` |
| `src/commands/user-tasks.ts` | invalid `--between` value | `c8 list user-tasks --between not-a-range` |

Each migration also removes the now-unused `logger` destructure from the handler.

## What this unlocks

For each path:
- `--verbose` re-throws the error with a Node stack trace (previously: silent `exit 1`).
- The framework's `Failed to <verb> <resource>` prefix now appears in stderr (previously: bare `logger.error` line, then exit).

Exit code is unchanged (`1`) in all four cases.

## Behavioural change in normal output

For the three `defineCommand`-wrapped handlers (forms, incidents, user-tasks) non-verbose stderr now adds two lines on top of the original message: the framework prefix (`✗ Failed to ...`) and the verbose hint. This is the same shape as the deploy migration in #299. Exit code is unchanged.

For `run`, the inner `try/catch` in `run()` already produced `Failed to run process` previously when other errors were caught — the migrated path now goes through the same code path instead of bypassing it via `process.exit(1)`.

## Tests

- `tests/unit/round-1-error-paths.test.ts` (new) — one behavioural guard per command. Each asserts the original error message *and* the framework prefix appear in stderr, proving the throw was wired through `handleCommandError`. The framework prefix is added by `handleCommandError` and cannot appear if the helper called `process.exit(1)` directly.
- `tests/unit/no-process-exit-in-handlers.test.ts` — the 4 files are removed from `PENDING_MIGRATION`. The cross-handler architectural guard now requires zero `process.exit` calls in these files. The allow-list's "must still have calls" invariant guarantees this is monotonic — stale entries fail the test.

`npm run typecheck && npx biome check && npm run test:unit` clean: 1090/1090 pass.

## Migration progress

Allow-list shrinks from **18 → 14** entries. Remaining work tracked in #300.

Refs #288, #292, #299, #300.