### PR TITLE
refactor(commands): route identity-{groups,roles,tenants,users} + messages errors through framework (#300)

### DIFF
--- a/src/commands/identity-groups.ts
+++ b/src/commands/identity-groups.ts
@@ -4,7 +4,7 @@
 
 import { fetchAllPages } from "../client.ts";
 import { defineCommand, dryRun } from "../command-framework.ts";
-import { getLogger, sortTableData } from "../logger.ts";
+import { sortTableData } from "../logger.ts";
 import { toStringFilter } from "./search.ts";
 
 /**
@@ -121,12 +121,10 @@ export const createIdentityGroupCommand = defineCommand(
 		const { client, profile } = ctx;
 
 		if (!flags.groupId) {
-			getLogger().error("--groupId is required");
-			process.exit(1);
+			throw new Error("--groupId is required");
 		}
 		if (!flags.name) {
-			getLogger().error("--name is required");
-			process.exit(1);
+			throw new Error("--name is required");
 		}
 
 		const body = { groupId: flags.groupId, name: flags.name };

--- a/src/commands/identity-roles.ts
+++ b/src/commands/identity-roles.ts
@@ -4,7 +4,7 @@
 
 import { fetchAllPages } from "../client.ts";
 import { defineCommand, dryRun } from "../command-framework.ts";
-import { getLogger, sortTableData } from "../logger.ts";
+import { sortTableData } from "../logger.ts";
 
 /**
  * List all roles
@@ -120,12 +120,10 @@ export const createIdentityRoleCommand = defineCommand(
 		const { client, profile } = ctx;
 
 		if (!flags.roleId) {
-			getLogger().error("--roleId is required");
-			process.exit(1);
+			throw new Error("--roleId is required");
 		}
 		if (!flags.name) {
-			getLogger().error("--name is required");
-			process.exit(1);
+			throw new Error("--name is required");
 		}
 
 		const body = { roleId: flags.roleId, name: flags.name };

--- a/src/commands/identity-tenants.ts
+++ b/src/commands/identity-tenants.ts
@@ -4,7 +4,7 @@
 
 import { fetchAllPages } from "../client.ts";
 import { defineCommand, dryRun } from "../command-framework.ts";
-import { getLogger, sortTableData } from "../logger.ts";
+import { sortTableData } from "../logger.ts";
 
 /**
  * List all tenants
@@ -124,12 +124,10 @@ export const createIdentityTenantCommand = defineCommand(
 		const { client, profile } = ctx;
 
 		if (!flags.tenantId) {
-			getLogger().error("--tenantId is required");
-			process.exit(1);
+			throw new Error("--tenantId is required");
 		}
 		if (!flags.name) {
-			getLogger().error("--name is required");
-			process.exit(1);
+			throw new Error("--name is required");
 		}
 
 		const body = {

--- a/src/commands/identity-users.ts
+++ b/src/commands/identity-users.ts
@@ -120,15 +120,13 @@ export const createIdentityUserCommand = defineCommand(
 	"create",
 	"user",
 	async (ctx, flags, _args) => {
-		const { client, logger, profile } = ctx;
+		const { client, profile } = ctx;
 
 		if (!flags.username) {
-			logger.error("--username is required");
-			process.exit(1);
+			throw new Error("--username is required");
 		}
 		if (!flags.password) {
-			logger.error("--password is required");
-			process.exit(1);
+			throw new Error("--password is required");
 		}
 
 		const body = {

--- a/src/commands/messages.ts
+++ b/src/commands/messages.ts
@@ -32,10 +32,9 @@ export const publishMessageCommand = defineCommand(
 			: undefined;
 		if (timeToLive !== undefined) {
 			if (Number.isNaN(timeToLive) || timeToLive < 0) {
-				ctx.logger.error(
+				throw new Error(
 					"--timeToLive must be a non-negative integer (milliseconds)",
 				);
-				process.exit(1);
 			}
 			body.timeToLive = timeToLive;
 		}
@@ -88,10 +87,9 @@ export const correlateMessageCommand = defineCommand(
 			: undefined;
 		if (timeToLive !== undefined) {
 			if (Number.isNaN(timeToLive) || timeToLive < 0) {
-				ctx.logger.error(
+				throw new Error(
 					"--timeToLive must be a non-negative integer (milliseconds)",
 				);
-				process.exit(1);
 			}
 			body.timeToLive = timeToLive;
 		}

--- a/tests/unit/no-process-exit-in-handlers.test.ts
+++ b/tests/unit/no-process-exit-in-handlers.test.ts
@@ -63,14 +63,9 @@ const COMMANDS_DIR = join(PROJECT_ROOT, "src", "commands");
  */
 const PENDING_MIGRATION: ReadonlySet<string> = new Set([
 	"src/commands/completion.ts",
-	"src/commands/identity-groups.ts",
 	"src/commands/identity-mapping-rules.ts",
-	"src/commands/identity-roles.ts",
-	"src/commands/identity-tenants.ts",
-	"src/commands/identity-users.ts",
 	"src/commands/identity.ts",
 	"src/commands/jobs.ts",
-	"src/commands/messages.ts",
 	"src/commands/plugins.ts",
 	"src/commands/process-instances.ts",
 	"src/commands/profiles.ts",

--- a/tests/unit/round-2a-error-paths.test.ts
+++ b/tests/unit/round-2a-error-paths.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Behavioural guards for Round 2a of the `process.exit` migration (issue #300,
+ * follow-on to #288). Five files migrated, each with two `process.exit(1)`
+ * sites in mechanical validation guards (required-flag checks for the four
+ * `create` identity commands; non-negative integer check for `--timeToLive`
+ * on the two message commands):
+ *
+ *   - `src/commands/identity-groups.ts`  — `--groupId`, `--name` required
+ *   - `src/commands/identity-roles.ts`   — `--roleId`, `--name` required
+ *   - `src/commands/identity-tenants.ts` — `--tenantId`, `--name` required
+ *   - `src/commands/identity-users.ts`   — `--username`, `--password` required
+ *   - `src/commands/messages.ts`         — `--timeToLive` non-negative
+ *
+ * After migration each path must `throw` so the framework's `handleCommandError`
+ * pipeline owns process termination. The cross-handler architectural guard
+ * (`tests/unit/no-process-exit-in-handlers.test.ts`) is the durable
+ * class-of-defect catch — these behavioural tests prove each individual
+ * migration is actually wired through the framework by asserting the
+ * framework's `Failed to ${verb} ${resource}` prefix appears in stderr.
+ *
+ * One assertion per migrated file is sufficient: the architectural guard
+ * already proves the OTHER throw site in each file is exit-free, and both
+ * sites in each file route through the same handler wrapper, so one
+ * end-to-end behavioural confirmation per file pins the wiring.
+ */
+
+import assert from "node:assert";
+import { describe, test } from "node:test";
+import { c8 } from "../utils/cli.ts";
+
+describe("identity-groups: behavioural — required-flag error flows through the framework", () => {
+	test("create group without --groupId: framework prefix appears", async () => {
+		const result = await c8("create", "group");
+
+		assert.strictEqual(
+			result.status,
+			1,
+			`expected exit 1, got ${result.status}. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("--groupId is required"),
+			`expected original error message in stderr. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("Failed to create group"),
+			`expected framework prefix 'Failed to create group' in stderr, proving the error flowed through handleCommandError instead of process.exit(1). stderr:\n${result.stderr}`,
+		);
+	});
+});
+
+describe("identity-roles: behavioural — required-flag error flows through the framework", () => {
+	test("create role without --roleId: framework prefix appears", async () => {
+		const result = await c8("create", "role");
+
+		assert.strictEqual(
+			result.status,
+			1,
+			`expected exit 1, got ${result.status}. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("--roleId is required"),
+			`expected original error message in stderr. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("Failed to create role"),
+			`expected framework prefix 'Failed to create role' in stderr, proving the error flowed through handleCommandError instead of process.exit(1). stderr:\n${result.stderr}`,
+		);
+	});
+});
+
+describe("identity-tenants: behavioural — required-flag error flows through the framework", () => {
+	test("create tenant without --tenantId: framework prefix appears", async () => {
+		const result = await c8("create", "tenant");
+
+		assert.strictEqual(
+			result.status,
+			1,
+			`expected exit 1, got ${result.status}. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("--tenantId is required"),
+			`expected original error message in stderr. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("Failed to create tenant"),
+			`expected framework prefix 'Failed to create tenant' in stderr, proving the error flowed through handleCommandError instead of process.exit(1). stderr:\n${result.stderr}`,
+		);
+	});
+});
+
+describe("identity-users: behavioural — required-flag error flows through the framework", () => {
+	test("create user without --username: framework prefix appears", async () => {
+		const result = await c8("create", "user");
+
+		assert.strictEqual(
+			result.status,
+			1,
+			`expected exit 1, got ${result.status}. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("--username is required"),
+			`expected original error message in stderr. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("Failed to create user"),
+			`expected framework prefix 'Failed to create user' in stderr, proving the error flowed through handleCommandError instead of process.exit(1). stderr:\n${result.stderr}`,
+		);
+	});
+});
+
+describe("messages: behavioural — invalid --timeToLive flows through the framework", () => {
+	test("publish message with negative --timeToLive: framework prefix appears", async () => {
+		const result = await c8(
+			"publish",
+			"message",
+			"some-name",
+			"--timeToLive=-5",
+		);
+
+		assert.strictEqual(
+			result.status,
+			1,
+			`expected exit 1, got ${result.status}. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("--timeToLive must be a non-negative integer"),
+			`expected original error message in stderr. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("Failed to publish message"),
+			`expected framework prefix 'Failed to publish message' in stderr, proving the error flowed through handleCommandError instead of process.exit(1). stderr:\n${result.stderr}`,
+		);
+	});
+
+	test("correlate message with negative --timeToLive: framework prefix appears", async () => {
+		const result = await c8(
+			"correlate",
+			"message",
+			"some-name",
+			"--timeToLive=-5",
+		);
+
+		assert.strictEqual(
+			result.status,
+			1,
+			`expected exit 1, got ${result.status}. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("--timeToLive must be a non-negative integer"),
+			`expected original error message in stderr. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("Failed to correlate message"),
+			`expected framework prefix 'Failed to correlate message' in stderr, proving the error flowed through handleCommandError instead of process.exit(1). stderr:\n${result.stderr}`,
+		);
+	});
+});


### PR DESCRIPTION
Round 2a of the cross-handler `process.exit` migration tracked in #300 (follow-on to #288 / #299 / #301).

## What changed

Five files migrated, 10 `process.exit(1)` sites → `throw new Error(...)`. All sites are mechanical validation guards inside `defineCommand` handlers.

| File | Sites | Pattern |
| --- | --- | --- |
| `src/commands/identity-groups.ts` | 2 | required-flag check (`--groupId`, `--name`) |
| `src/commands/identity-roles.ts` | 2 | required-flag check (`--roleId`, `--name`) |
| `src/commands/identity-tenants.ts` | 2 | required-flag check (`--tenantId`, `--name`) |
| `src/commands/identity-users.ts` | 2 | required-flag check (`--username`, `--password`) |
| `src/commands/messages.ts` | 2 | non-negative integer check on `--timeToLive` (publish + correlate) |

Each migration also drops the now-unused `getLogger` import (3 files) or `logger` destructure (1 handler).

## What this unlocks

For each path:
- `--verbose` re-throws the error with a Node stack trace.
- The framework's `Failed to <verb> <resource>` prefix appears in stderr.

Exit code unchanged (`1`) in all cases.

## Behavioural change in normal output

Same shape as #299 / #301: non-verbose stderr now adds two lines on top of the original message — the framework prefix (`✗ Failed to ...`) and the verbose hint.

## Tests

- `tests/unit/round-2a-error-paths.test.ts` (new) — one behavioural assertion per migrated file. The cross-handler architectural guard already proves the OTHER throw site in each file is exit-free, and both sites in each file route through the same handler wrapper, so one end-to-end behavioural confirmation per file pins the wiring.
- `tests/unit/no-process-exit-in-handlers.test.ts` — the 5 files are removed from `PENDING_MIGRATION`. The shrinking allow-list invariant catches stale entries automatically.

`npm run typecheck && npx biome check && npm run test:unit` clean: 1096/1096 pass.

## Migration progress

Allow-list shrinks from **14 → 9** entries. Remaining work tracked in #300.

Round 2b (jobs / process-instances / search / session / identity-mapping-rules — 21 sites) will follow.

Refs #288, #292, #299, #300, #301.