### PR TITLE
refactor: migrate Round 2b process.exit to throw (#300)

### DIFF
--- a/src/commands/identity-mapping-rules.ts
+++ b/src/commands/identity-mapping-rules.ts
@@ -4,7 +4,7 @@
 
 import { fetchAllPages } from "../client.ts";
 import { defineCommand, dryRun } from "../command-framework.ts";
-import { getLogger, sortTableData } from "../logger.ts";
+import { sortTableData } from "../logger.ts";
 
 /**
  * List all mapping rules
@@ -128,20 +128,16 @@ export const createIdentityMappingRuleCommand = defineCommand(
 		const { client, profile } = ctx;
 
 		if (!flags.mappingRuleId) {
-			getLogger().error("--mappingRuleId is required");
-			process.exit(1);
+			throw new Error("--mappingRuleId is required");
 		}
 		if (!flags.name) {
-			getLogger().error("--name is required");
-			process.exit(1);
+			throw new Error("--name is required");
 		}
 		if (!flags.claimName) {
-			getLogger().error("--claimName is required");
-			process.exit(1);
+			throw new Error("--claimName is required");
 		}
 		if (!flags.claimValue) {
-			getLogger().error("--claimValue is required");
-			process.exit(1);
+			throw new Error("--claimValue is required");
 		}
 
 		const body = {

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -14,8 +14,7 @@ export const listJobsCommand = defineCommand(
 	"list",
 	"jobs",
 	async (ctx, flags) => {
-		const { client, logger, tenantId, profile, limit, between, dateField } =
-			ctx;
+		const { client, tenantId, profile, limit, between, dateField } = ctx;
 
 		const filter: { filter: Record<string, unknown> } = {
 			filter: {
@@ -37,10 +36,9 @@ export const listJobsCommand = defineCommand(
 				const field = dateField ?? "creationTime";
 				filter.filter[field] = buildDateFilter(parsed.from, parsed.to);
 			} else {
-				logger.error(
+				throw new Error(
 					"Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)",
 				);
-				process.exit(1);
 			}
 		}
 
@@ -92,12 +90,10 @@ export const activateJobsCommand = defineCommand(
 		const worker = flags.worker || "c8ctl";
 
 		if (Number.isNaN(maxJobsToActivate) || maxJobsToActivate < 1) {
-			ctx.logger.error("--maxJobsToActivate must be a positive integer");
-			process.exit(1);
+			throw new Error("--maxJobsToActivate must be a positive integer");
 		}
 		if (Number.isNaN(timeout) || timeout < 1) {
-			ctx.logger.error("--timeout must be a positive integer (milliseconds)");
-			process.exit(1);
+			throw new Error("--timeout must be a positive integer (milliseconds)");
 		}
 
 		const dr = dryRun({
@@ -191,8 +187,7 @@ export const failJobCommand = defineCommand(
 		const errorMessage = flags.errorMessage || "Job failed via c8ctl";
 
 		if (Number.isNaN(retries) || retries < 0) {
-			ctx.logger.error("--retries must be a non-negative integer");
-			process.exit(1);
+			throw new Error("--retries must be a non-negative integer");
 		}
 
 		const dr = dryRun({

--- a/src/commands/process-instances.ts
+++ b/src/commands/process-instances.ts
@@ -19,16 +19,7 @@ export const listProcessInstancesCommand = defineCommand(
 	"list",
 	"process-instance",
 	async (ctx, flags) => {
-		const {
-			client,
-			logger,
-			tenantId,
-			profile,
-			limit,
-			all,
-			between,
-			dateField,
-		} = ctx;
+		const { client, tenantId, profile, limit, all, between, dateField } = ctx;
 
 		const filter: { filter: Record<string, unknown> } = {
 			filter: {
@@ -70,10 +61,9 @@ export const listProcessInstancesCommand = defineCommand(
 				const field = dateField ?? "startDate";
 				filter.filter[field] = buildDateFilter(parsed.from, parsed.to);
 			} else {
-				logger.error(
+				throw new Error(
 					"Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)",
 				);
-				process.exit(1);
 			}
 		}
 
@@ -171,10 +161,9 @@ export const createProcessInstanceCommand = defineCommand(
 			flags.id || flags.processDefinitionId || flags.bpmnProcessId;
 
 		if (!processDefinitionId) {
-			logger.error(
+			throw new Error(
 				"processDefinitionId is required. Use --processDefinitionId or --bpmnProcessId or --id flag",
 			);
-			process.exit(1);
 		}
 
 		const version = ctx.version;
@@ -206,8 +195,9 @@ export const createProcessInstanceCommand = defineCommand(
 
 		// Validate: fetchVariables requires awaitCompletion
 		if (fetchVariables && !awaitCompletion) {
-			logger.error("--fetchVariables can only be used with --awaitCompletion");
-			process.exit(1);
+			throw new Error(
+				"--fetchVariables can only be used with --awaitCompletion",
+			);
 		}
 
 		// Note: fetchVariables parameter is reserved for future API enhancement
@@ -276,10 +266,9 @@ export const awaitProcessInstanceCommand = defineCommand(
 			flags.id || flags.processDefinitionId || flags.bpmnProcessId;
 
 		if (!processDefinitionId) {
-			logger.error(
+			throw new Error(
 				"processDefinitionId is required. Use --processDefinitionId or --bpmnProcessId or --id flag",
 			);
-			process.exit(1);
 		}
 
 		const version = ctx.version;

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -402,10 +402,9 @@ export const searchProcessInstancesCommand = defineCommand(
 				const field = ctx.dateField ?? "startDate";
 				filter.filter[field] = buildDateFilter(parsed.from, parsed.to);
 			} else {
-				logger.error(
+				throw new Error(
 					"Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)",
 				);
-				process.exit(1);
 			}
 		}
 
@@ -532,10 +531,9 @@ export const searchUserTasksCommand = defineCommand(
 				const field = ctx.dateField ?? "creationDate";
 				filter.filter[field] = buildDateFilter(parsed.from, parsed.to);
 			} else {
-				logger.error(
+				throw new Error(
 					"Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)",
 				);
-				process.exit(1);
 			}
 		}
 
@@ -685,10 +683,9 @@ export const searchIncidentsCommand = defineCommand(
 			if (parsed) {
 				filter.filter.creationTime = buildDateFilter(parsed.from, parsed.to);
 			} else {
-				logger.error(
+				throw new Error(
 					"Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)",
 				);
-				process.exit(1);
 			}
 		}
 
@@ -823,10 +820,9 @@ export const searchJobsCommand = defineCommand(
 				const field = ctx.dateField ?? "creationTime";
 				filter.filter[field] = buildDateFilter(parsed.from, parsed.to);
 			} else {
-				logger.error(
+				throw new Error(
 					"Invalid --between value. Expected format: <from>..<to> (e.g. 2024-01-01..2024-12-31, ISO 8601 datetimes, or open-ended: ..2024-12-31 or 2024-01-01..)",
 				);
-				process.exit(1);
 			}
 		}
 

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -29,8 +29,7 @@ export function useProfile(name: string): void {
 	// Verify profile exists (checks both c8ctl and Modeler profiles)
 	const profile = getProfileOrModeler(name);
 	if (!profile) {
-		logger.error(`Profile '${name}' not found`);
-		process.exit(1);
+		throw new Error(`Profile '${name}' not found`);
 	}
 
 	setActiveProfile(name);
@@ -53,8 +52,7 @@ export function setOutputFormat(mode: string): void {
 	const logger = getLogger();
 
 	if (mode !== "json" && mode !== "text") {
-		logger.error(`Invalid output mode: ${mode}. Must be 'json' or 'text'`);
-		process.exit(1);
+		throw new Error(`Invalid output mode: ${mode}. Must be 'json' or 'text'`);
 	}
 
 	setOutputMode(mode);
@@ -96,14 +94,13 @@ export const outputCommand = defineCommand("output", "", async (ctx) => {
 export const useProfileCommand = defineCommand(
 	"use",
 	"profile",
-	async (ctx, flags, args) => {
+	async (_ctx, flags, args) => {
 		if (flags.none) {
 			useProfile("--none");
 			return { kind: "none" };
 		}
 		if (!args.name) {
-			ctx.logger.error("Profile name required. Usage: c8 use profile <name>");
-			process.exit(1);
+			throw new Error("Profile name required. Usage: c8 use profile <name>");
 		}
 		useProfile(args.name);
 		return { kind: "none" };

--- a/tests/unit/no-process-exit-in-handlers.test.ts
+++ b/tests/unit/no-process-exit-in-handlers.test.ts
@@ -63,14 +63,9 @@ const COMMANDS_DIR = join(PROJECT_ROOT, "src", "commands");
  */
 const PENDING_MIGRATION: ReadonlySet<string> = new Set([
 	"src/commands/completion.ts",
-	"src/commands/identity-mapping-rules.ts",
 	"src/commands/identity.ts",
-	"src/commands/jobs.ts",
 	"src/commands/plugins.ts",
-	"src/commands/process-instances.ts",
 	"src/commands/profiles.ts",
-	"src/commands/search.ts",
-	"src/commands/session.ts",
 ]);
 
 function listCommandFiles(): string[] {

--- a/tests/unit/round-2b-error-paths.test.ts
+++ b/tests/unit/round-2b-error-paths.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Post-refactor framework-prefix assertions for Round 2b of the
+ * `process.exit` migration (issue #300).
+ *
+ * The companion baseline file `tests/unit/round-2b-baseline.test.ts`
+ * locks in the invariants that must hold both BEFORE and AFTER the
+ * refactor (exit code + original error message). This file adds the
+ * single new assertion the refactor enables: the framework's
+ * `Failed to <verb> <resource>` prefix now appears in stderr.
+ *
+ * That prefix is added by `handleCommandError` in `command-framework.ts`
+ * and CANNOT appear if the helper called `process.exit(1)` directly.
+ * Its presence is the durable behavioural confirmation that each migrated
+ * call site is wired through the framework's error pipeline.
+ *
+ * One assertion per migrated handler is sufficient (the cross-handler
+ * architectural guard in `tests/unit/no-process-exit-in-handlers.test.ts`
+ * is the durable class-of-defect catch for the exit-vs-throw invariant).
+ *
+ * For the two `session.ts` free functions (`useProfile`, `setOutputFormat`)
+ * the throw is caught by the `defineCommand` wrapper around them
+ * (`useProfileCommand`, `outputCommand`), so the framework prefix
+ * applies to those paths too.
+ */
+
+import assert from "node:assert";
+import { describe, test } from "node:test";
+import { c8 } from "../utils/cli.ts";
+import type { SpawnResult } from "../utils/spawn.ts";
+
+function assertFrameworkPrefix(
+	result: SpawnResult,
+	prefix: string,
+	context: string,
+): void {
+	assert.ok(
+		result.stderr.includes(prefix),
+		`${context}: expected framework prefix '${prefix}' in stderr, proving the error flowed through handleCommandError instead of process.exit(1). stderr:\n${result.stderr}`,
+	);
+}
+
+describe("identity-mapping-rules: framework prefix for create mapping-rule", () => {
+	test("create mapping-rule (no flags) shows 'Failed to create mapping rule'", async () => {
+		const result = await c8("create", "mapping-rule");
+		assertFrameworkPrefix(
+			result,
+			"Failed to create mapping rule",
+			"create mapping-rule",
+		);
+	});
+});
+
+describe("jobs: framework prefix for migrated handlers", () => {
+	test("list jobs --between bad shows 'Failed to list jobs'", async () => {
+		const result = await c8("list", "jobs", "--between", "not-a-valid-range");
+		assertFrameworkPrefix(result, "Failed to list jobs", "list jobs");
+	});
+
+	test("activate jobs --maxJobsToActivate=0 shows 'Failed to activate jobs'", async () => {
+		const result = await c8(
+			"activate",
+			"jobs",
+			"some-type",
+			"--maxJobsToActivate=0",
+		);
+		assertFrameworkPrefix(result, "Failed to activate jobs", "activate jobs");
+	});
+
+	test("fail job --retries=-1 shows 'Failed to fail job'", async () => {
+		const result = await c8("fail", "job", "1234567890", "--retries=-1");
+		assertFrameworkPrefix(result, "Failed to fail job", "fail job");
+	});
+});
+
+describe("process-instances: framework prefix for migrated handlers", () => {
+	test("list process-instances --between bad shows 'Failed to list process instance'", async () => {
+		const result = await c8(
+			"list",
+			"process-instances",
+			"--between",
+			"not-a-valid-range",
+		);
+		assertFrameworkPrefix(
+			result,
+			"Failed to list process instance",
+			"list process-instances",
+		);
+	});
+
+	test("create process-instance (no id) shows 'Failed to create process instance'", async () => {
+		const result = await c8("create", "process-instance", "--dry-run");
+		assertFrameworkPrefix(
+			result,
+			"Failed to create process instance",
+			"create process-instance",
+		);
+	});
+
+	test("await process-instance (no id) shows 'Failed to await process instance'", async () => {
+		const result = await c8("await", "process-instance", "--dry-run");
+		assertFrameworkPrefix(
+			result,
+			"Failed to await process instance",
+			"await process-instance",
+		);
+	});
+});
+
+describe("search: framework prefix for migrated handlers", () => {
+	test("search process-instances --between bad shows 'Failed to search process instance'", async () => {
+		const result = await c8(
+			"search",
+			"process-instances",
+			"--between",
+			"not-a-valid-range",
+		);
+		assertFrameworkPrefix(
+			result,
+			"Failed to search process instance",
+			"search process-instances",
+		);
+	});
+});
+
+describe("session: framework prefix for migrated handlers", () => {
+	test("use profile <nonexistent> shows 'Failed to use profile' (free function caught by defineCommand wrapper)", async () => {
+		const result = await c8(
+			"use",
+			"profile",
+			"definitely-not-a-real-profile-name-xyz",
+		);
+		assertFrameworkPrefix(
+			result,
+			"Failed to use profile",
+			"use profile <nonexistent>",
+		);
+	});
+
+	test("output yaml shows 'Failed to output' (free function caught by defineCommand wrapper)", async () => {
+		const result = await c8("output", "yaml");
+		assertFrameworkPrefix(result, "Failed to output", "output yaml");
+	});
+
+	test("use profile (no args) shows 'Failed to use profile'", async () => {
+		const result = await c8("use", "profile");
+		assertFrameworkPrefix(
+			result,
+			"Failed to use profile",
+			"use profile (no args)",
+		);
+	});
+});

--- a/tests/unit/round-2b-error-paths.test.ts
+++ b/tests/unit/round-2b-error-paths.test.ts
@@ -120,6 +120,41 @@ describe("search: framework prefix for migrated handlers", () => {
 			"search process-instances",
 		);
 	});
+
+	test("search user-tasks --between bad shows 'Failed to search user task'", async () => {
+		const result = await c8(
+			"search",
+			"user-tasks",
+			"--between",
+			"not-a-valid-range",
+		);
+		assertFrameworkPrefix(
+			result,
+			"Failed to search user task",
+			"search user-tasks",
+		);
+	});
+
+	test("search incidents --between bad shows 'Failed to search incident'", async () => {
+		const result = await c8(
+			"search",
+			"incidents",
+			"--between",
+			"not-a-valid-range",
+		);
+		assertFrameworkPrefix(
+			result,
+			"Failed to search incident",
+			"search incidents",
+		);
+	});
+
+	// Note: registered resource is `jobs` (plural), so the prefix is
+	// `Failed to search jobs` — not `search job` as Copilot's suggestion had.
+	test("search jobs --between bad shows 'Failed to search jobs'", async () => {
+		const result = await c8("search", "jobs", "--between", "not-a-valid-range");
+		assertFrameworkPrefix(result, "Failed to search jobs", "search jobs");
+	});
 });
 
 describe("session: framework prefix for migrated handlers", () => {

--- a/tests/unit/round-2b-error-paths.test.ts
+++ b/tests/unit/round-2b-error-paths.test.ts
@@ -8,8 +8,10 @@
  * single new assertion the refactor enables: the framework's
  * `Failed to <verb> <resource>` prefix now appears in stderr.
  *
- * That prefix is added by `handleCommandError` in `command-framework.ts`
- * and CANNOT appear if the helper called `process.exit(1)` directly.
+ * That prefix string is constructed by `defineCommand` in
+ * `command-framework.ts` and passed into `handleCommandError` in
+ * `src/errors.ts`, and CANNOT appear if the helper called
+ * `process.exit(1)` directly.
  * Its presence is the durable behavioural confirmation that each migrated
  * call site is wired through the framework's error pipeline.
  *


### PR DESCRIPTION
Round 2b of the `process.exit(1)` migration tracked in #300.

Converts **19 validation guards** across 5 command handler files from `logger.error + process.exit(1)` to `throw new Error(...)`, routing them through the framework's `handleCommandError` pipeline.

## Sites migrated (19)

| File | Sites |
|---|---|
| `src/commands/identity-mapping-rules.ts` | 4 |
| `src/commands/jobs.ts` | 4 |
| `src/commands/process-instances.ts` | 4 |
| `src/commands/search.ts` | 4 (bulk-replaced via regex — 4 identical `--between` blocks) |
| `src/commands/session.ts` | 3 (2 in free functions called from `defineCommand` wrappers) |

The two `session.ts` free-function migrations (`useProfile`, `setOutputFormat`) throw up to their `defineCommand` wrappers (`useProfileCommand`, `outputCommand`), so the framework prefix applies there too.

## Allow-list shrinks 9 → 4

`PENDING_MIGRATION` in `tests/unit/no-process-exit-in-handlers.test.ts` now contains only the Round 3 fat files: `completion`, `identity`, `plugins`, `profiles`.

## Coverage discipline

This PR is the refactor that the **green/green baseline guards from #303** were purpose-built to protect:

1. **Baseline guards (`tests/unit/round-2b-baseline.test.ts`, from #303)** — remain green throughout. They assert only the invariants that must hold both before and after: exit code 1 + original error message in stderr.
2. **New `tests/unit/round-2b-error-paths.test.ts`** — adds the single assertion the refactor enables: the framework's `` `Failed to <verb> <resource>` `` prefix now appears in stderr. That prefix is added by `handleCommandError` and **cannot** appear if the helper called `process.exit(1)` directly. One assertion per migrated handler is sufficient since the architectural guard catches the exit-vs-throw class.
3. **Architectural guard (`no-process-exit-in-handlers.test.ts`)** — refuses any future `process.exit` reintroduction in the now-migrated files.

## Cleanup

- Dropped now-unused `logger` destructure in `jobs.ts`.
- Dropped now-unused `logger` destructure in `process-instances.ts` (`listProcessInstancesCommand`).
- Dropped now-unused `getLogger` import in `identity-mapping-rules.ts`.
- Renamed `ctx` → `_ctx` in `useProfileCommand` (no longer references `ctx.logger`).

## Gates

- `npm run typecheck` ✅
- `npx biome check` ✅ (0 warnings)
- `npm run test:unit` ✅ (1126/1126)
- `npm run build` ✅

Refs: #300, #303