### PR TITLE
refactor: migrate remaining process.exit(1) sites to throw (#300 round 3)

### DIFF
--- a/src/command-dispatch.ts
+++ b/src/command-dispatch.ts
@@ -9,9 +9,15 @@
  */
 
 import type { AnyCommandHandler } from "./command-framework.ts";
+import { completionCommand } from "./commands/completion.ts";
 import { deployCommand } from "./commands/deployments.ts";
 import { getFormCommand } from "./commands/forms.ts";
 import {
+	assignFallbackCommand,
+	assignGroupCommand,
+	assignMappingRuleCommand,
+	assignRoleCommand,
+	assignUserCommand,
 	createIdentityAuthorizationCommand,
 	createIdentityGroupCommand,
 	createIdentityMappingRuleCommand,
@@ -42,6 +48,11 @@ import {
 	searchIdentityRolesCommand,
 	searchIdentityTenantsCommand,
 	searchIdentityUsersCommand,
+	unassignFallbackCommand,
+	unassignGroupCommand,
+	unassignMappingRuleCommand,
+	unassignRoleCommand,
+	unassignUserCommand,
 } from "./commands/identity.ts";
 import {
 	getIncidentCommand,
@@ -212,6 +223,25 @@ export const COMMAND_DISPATCH: ReadonlyMap<string, AnyCommandHandler> = new Map<
 	["delete:tenant", deleteIdentityTenantCommand],
 	["delete:authorization", deleteIdentityAuthorizationCommand],
 	["delete:mapping-rule", deleteIdentityMappingRuleCommand],
+
+	// ── Identity: assign / unassign ────────────────────────────────────
+	["assign:role", assignRoleCommand],
+	["assign:user", assignUserCommand],
+	["assign:group", assignGroupCommand],
+	["assign:mapping-rule", assignMappingRuleCommand],
+	["unassign:role", unassignRoleCommand],
+	["unassign:user", unassignUserCommand],
+	["unassign:group", unassignGroupCommand],
+	["unassign:mapping-rule", unassignMappingRuleCommand],
+	// Fallbacks for unknown resource names — preserve the canonical
+	// "Cannot (un)assign resource type: <name>" error from handleAssign.
+	["assign:", assignFallbackCommand],
+	["unassign:", unassignFallbackCommand],
+
+	// ── Completion ─────────────────────────────────────────────────────
+	// `completion` is resourceless in the registry; the handler branches
+	// on ctx.resource (bash / zsh / fish / install).
+	["completion:", completionCommand],
 
 	// ── Resourceless verbs ─────────────────────────────────────────────
 	["deploy:", deployCommand],

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -1505,7 +1505,12 @@ export const COMMAND_REGISTRY = {
 			},
 		],
 		resources: ["bash", "zsh", "fish", "install"],
-		flags: {},
+		flags: {
+			shell: {
+				type: "string" as const,
+				description: "Shell to install completions for (bash, zsh, fish)",
+			},
+		},
 		resourceFlags: {
 			install: {
 				shell: {

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -5,6 +5,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
+import { defineCommand } from "../command-framework.ts";
 import {
 	COMMAND_REGISTRY,
 	type CommandDef,
@@ -561,13 +562,16 @@ function escFish(s: string): string {
 
 /**
  * Show completion command
+ *
+ * Throws on missing/unknown shell; framework wrapper adds the
+ * `Failed to completion ...` prefix. Do NOT reintroduce `process.exit` —
+ * `tests/unit/no-process-exit-in-handlers.test.ts` enforces this.
  */
 export function showCompletion(shell?: string): void {
-	const logger = getLogger();
-
 	if (!shell) {
-		logger.error("Shell type required. Usage: c8 completion <bash|zsh|fish>");
-		process.exit(1);
+		throw new Error(
+			"Shell type required. Usage: c8 completion <bash|zsh|fish>",
+		);
 	}
 
 	const normalizedShell = shell.toLowerCase();
@@ -583,10 +587,9 @@ export function showCompletion(shell?: string): void {
 			console.log(generateFishCompletion());
 			break;
 		default:
-			logger.error(`Unknown shell: ${shell}`);
-			logger.info("Supported shells: bash, zsh, fish");
-			logger.info("Usage: c8 completion <bash|zsh|fish>");
-			process.exit(1);
+			throw new Error(
+				`Unknown shell: ${shell}. Supported shells: bash, zsh, fish. Usage: c8 completion <bash|zsh|fish>`,
+			);
 	}
 }
 
@@ -732,16 +735,15 @@ export function installCompletion(shellOverride?: string): void {
 	const shell = shellOverride?.toLowerCase() ?? detectShell();
 
 	if (!shell) {
-		logger.error(
+		throw new Error(
 			"Could not detect shell. Specify with: c8ctl completion install --shell <bash|zsh|fish>",
 		);
-		process.exit(1);
 	}
 
 	if (!["bash", "zsh", "fish"].includes(shell)) {
-		logger.error(`Unsupported shell: ${shell}`);
-		logger.info("Supported shells: bash, zsh, fish");
-		process.exit(1);
+		throw new Error(
+			`Unsupported shell: ${shell}. Supported shells: bash, zsh, fish`,
+		);
 	}
 
 	const completionFile = getCompletionFilePath(shell);
@@ -804,14 +806,13 @@ export function installCompletion(shellOverride?: string): void {
 		logger.info(`  ${buildSourceLine(completionFile)}`);
 	} catch (err) {
 		const msg = err instanceof Error ? err.message : String(err);
-		logger.error(`Failed to install completions: ${msg}`);
 		logger.info(`Target path: ${completionFile}`);
 		if (rcFile) {
 			logger.info(
 				`Add this line manually to your shell config:\n  ${buildSourceLine(completionFile)}`,
 			);
 		}
-		process.exit(1);
+		throw new Error(`Failed to install completions: ${msg}`);
 	}
 }
 
@@ -857,3 +858,35 @@ export function refreshCompletionsIfStale(): void {
 		}
 	}
 }
+
+// ─── defineCommand wrappers ──────────────────────────────────────────────────
+
+/**
+ * `completion` verb dispatcher.
+ *
+ * `completion` is modelled in the registry with `requiresResource: false`
+ * and enumerated resources `["bash", "zsh", "fish", "install"]`. The
+ * registry-driven dispatch in `src/index.ts` routes any completion
+ * invocation to `completion:` because `requiresResource` is false. This
+ * single handler branches on the incoming resource.
+ *
+ * All validation errors are raised via `throw` so the framework wrapper
+ * routes them through `handleCommandError`. The architectural guard in
+ * `tests/unit/no-process-exit-in-handlers.test.ts` forbids `process.exit`
+ * here.
+ */
+export const completionCommand = defineCommand(
+	"completion",
+	"",
+	async (ctx, flags) => {
+		const resource = ctx.resource;
+		if (resource === "install") {
+			const shellFlag = flags.shell;
+			installCompletion(typeof shellFlag === "string" ? shellFlag : undefined);
+			return undefined;
+		}
+		// Empty resource → show usage error consistent with prior behaviour.
+		showCompletion(resource || undefined);
+		return undefined;
+	},
+);

--- a/src/commands/identity.ts
+++ b/src/commands/identity.ts
@@ -4,8 +4,8 @@
 
 import { TenantId, Username } from "@camunda8/orchestration-cluster-api";
 import { createClient } from "../client.ts";
+import { defineCommand } from "../command-framework.ts";
 import { resolveClusterConfig } from "../config.ts";
-import { handleCommandError } from "../errors.ts";
 import { getLogger } from "../logger.ts";
 import { c8ctl } from "../runtime.ts";
 
@@ -109,7 +109,14 @@ function formatFlags(flags: readonly string[]): string {
 }
 
 /**
- * Handle assign command: c8 assign <resource> <id> --to-<target>=<targetId>
+ * Core assign implementation.
+ *
+ * Called from per-resource `defineCommand` wrappers below and exercised
+ * directly by `tests/unit/identity.test.ts`. All validation errors are
+ * raised via `throw` so the framework wrapper can route them through
+ * `handleCommandError` and add the `Failed to assign <resource>` prefix.
+ * Do NOT reintroduce `process.exit` — the architectural guard in
+ * `tests/unit/no-process-exit-in-handlers.test.ts` will reject it.
  */
 export async function handleAssign(
 	resource: string,
@@ -118,34 +125,29 @@ export async function handleAssign(
 	options: { profile?: string },
 ): Promise<void> {
 	const logger = getLogger();
-
 	const allowedTargets = ALLOWED_ASSIGN_TARGETS[resource];
 	if (!allowedTargets) {
-		logger.error(
+		throw new Error(
 			`Cannot assign resource type: ${resource}. Supported: ${Object.keys(ALLOWED_ASSIGN_TARGETS).join(", ")}.`,
 		);
-		process.exit(1);
 	}
 
 	// Validate exactly one --to-* flag is provided
 	const provided = ASSIGN_TARGET_FLAGS.filter((f) => values[f]);
 	if (provided.length > 1) {
-		logger.error(
+		throw new Error(
 			`Exactly one target flag is required. Conflicting flags: ${formatFlags(provided)}`,
 		);
-		process.exit(1);
 	}
 	if (provided.length === 0) {
-		logger.error(`Target required. Use ${formatFlags(allowedTargets)}.`);
-		process.exit(1);
+		throw new Error(`Target required. Use ${formatFlags(allowedTargets)}.`);
 	}
 
 	const targetFlag = provided[0];
 	if (!allowedTargets.includes(targetFlag)) {
-		logger.error(
+		throw new Error(
 			`Unsupported target flag --${targetFlag} for resource '${resource}'. Use ${formatFlags(allowedTargets)}.`,
 		);
-		process.exit(1);
 	}
 
 	const targetValue = values[targetFlag];
@@ -166,123 +168,113 @@ export async function handleAssign(
 
 	const client = createClient(options.profile);
 
-	try {
-		switch (resource) {
-			case "role": {
-				if (values["to-user"]) {
-					await client.assignRoleToUser({
-						roleId: id,
-						username: Username.assumeExists(String(values["to-user"])),
-					});
-					logger.success(
-						`Role '${id}' assigned to user '${values["to-user"]}'`,
-					);
-				} else if (values["to-group"]) {
-					await client.assignRoleToGroup({
-						roleId: id,
-						groupId: String(values["to-group"]),
-					});
-					logger.success(
-						`Role '${id}' assigned to group '${values["to-group"]}'`,
-					);
-				} else if (values["to-tenant"]) {
-					await client.assignRoleToTenant({
-						tenantId: TenantId.assumeExists(String(values["to-tenant"])),
-						roleId: id,
-					});
-					logger.success(
-						`Role '${id}' assigned to tenant '${values["to-tenant"]}'`,
-					);
-				} else if (values["to-mapping-rule"]) {
-					await client.assignRoleToMappingRule({
-						roleId: id,
-						mappingRuleId: String(values["to-mapping-rule"]),
-					});
-					logger.success(
-						`Role '${id}' assigned to mapping rule '${values["to-mapping-rule"]}'`,
-					);
-				} else {
-					logger.error(
-						"Target required. Use --to-user, --to-group, --to-tenant, or --to-mapping-rule.",
-					);
-					process.exit(1);
-				}
-				break;
-			}
-			case "user": {
-				if (values["to-group"]) {
-					await client.assignUserToGroup({
-						groupId: String(values["to-group"]),
-						username: Username.assumeExists(id),
-					});
-					logger.success(
-						`User '${id}' assigned to group '${values["to-group"]}'`,
-					);
-				} else if (values["to-tenant"]) {
-					await client.assignUserToTenant({
-						tenantId: TenantId.assumeExists(String(values["to-tenant"])),
-						username: Username.assumeExists(id),
-					});
-					logger.success(
-						`User '${id}' assigned to tenant '${values["to-tenant"]}'`,
-					);
-				} else {
-					logger.error("Target required. Use --to-group or --to-tenant.");
-					process.exit(1);
-				}
-				break;
-			}
-			case "group": {
-				if (values["to-tenant"]) {
-					await client.assignGroupToTenant({
-						tenantId: TenantId.assumeExists(String(values["to-tenant"])),
-						groupId: id,
-					});
-					logger.success(
-						`Group '${id}' assigned to tenant '${values["to-tenant"]}'`,
-					);
-				} else {
-					logger.error("Target required. Use --to-tenant.");
-					process.exit(1);
-				}
-				break;
-			}
-			case "mapping-rule": {
-				if (values["to-group"]) {
-					await client.assignMappingRuleToGroup({
-						groupId: String(values["to-group"]),
-						mappingRuleId: id,
-					});
-					logger.success(
-						`Mapping rule '${id}' assigned to group '${values["to-group"]}'`,
-					);
-				} else if (values["to-tenant"]) {
-					await client.assignMappingRuleToTenant({
-						tenantId: TenantId.assumeExists(String(values["to-tenant"])),
-						mappingRuleId: id,
-					});
-					logger.success(
-						`Mapping rule '${id}' assigned to tenant '${values["to-tenant"]}'`,
-					);
-				} else {
-					logger.error("Target required. Use --to-group or --to-tenant.");
-					process.exit(1);
-				}
-				break;
-			}
-			default:
-				logger.error(
-					`Cannot assign resource type: ${resource}. Supported: role, user, group, mapping-rule.`,
+	switch (resource) {
+		case "role": {
+			if (values["to-user"]) {
+				await client.assignRoleToUser({
+					roleId: id,
+					username: Username.assumeExists(String(values["to-user"])),
+				});
+				logger.success(`Role '${id}' assigned to user '${values["to-user"]}'`);
+			} else if (values["to-group"]) {
+				await client.assignRoleToGroup({
+					roleId: id,
+					groupId: String(values["to-group"]),
+				});
+				logger.success(
+					`Role '${id}' assigned to group '${values["to-group"]}'`,
 				);
-				process.exit(1);
+			} else if (values["to-tenant"]) {
+				await client.assignRoleToTenant({
+					tenantId: TenantId.assumeExists(String(values["to-tenant"])),
+					roleId: id,
+				});
+				logger.success(
+					`Role '${id}' assigned to tenant '${values["to-tenant"]}'`,
+				);
+			} else if (values["to-mapping-rule"]) {
+				await client.assignRoleToMappingRule({
+					roleId: id,
+					mappingRuleId: String(values["to-mapping-rule"]),
+				});
+				logger.success(
+					`Role '${id}' assigned to mapping rule '${values["to-mapping-rule"]}'`,
+				);
+			} else {
+				throw new Error(
+					"Target required. Use --to-user, --to-group, --to-tenant, or --to-mapping-rule.",
+				);
+			}
+			break;
 		}
-	} catch (error) {
-		handleCommandError(logger, `Failed to assign ${resource}`, error);
+		case "user": {
+			if (values["to-group"]) {
+				await client.assignUserToGroup({
+					groupId: String(values["to-group"]),
+					username: Username.assumeExists(id),
+				});
+				logger.success(
+					`User '${id}' assigned to group '${values["to-group"]}'`,
+				);
+			} else if (values["to-tenant"]) {
+				await client.assignUserToTenant({
+					tenantId: TenantId.assumeExists(String(values["to-tenant"])),
+					username: Username.assumeExists(id),
+				});
+				logger.success(
+					`User '${id}' assigned to tenant '${values["to-tenant"]}'`,
+				);
+			} else {
+				throw new Error("Target required. Use --to-group or --to-tenant.");
+			}
+			break;
+		}
+		case "group": {
+			if (values["to-tenant"]) {
+				await client.assignGroupToTenant({
+					tenantId: TenantId.assumeExists(String(values["to-tenant"])),
+					groupId: id,
+				});
+				logger.success(
+					`Group '${id}' assigned to tenant '${values["to-tenant"]}'`,
+				);
+			} else {
+				throw new Error("Target required. Use --to-tenant.");
+			}
+			break;
+		}
+		case "mapping-rule": {
+			if (values["to-group"]) {
+				await client.assignMappingRuleToGroup({
+					groupId: String(values["to-group"]),
+					mappingRuleId: id,
+				});
+				logger.success(
+					`Mapping rule '${id}' assigned to group '${values["to-group"]}'`,
+				);
+			} else if (values["to-tenant"]) {
+				await client.assignMappingRuleToTenant({
+					tenantId: TenantId.assumeExists(String(values["to-tenant"])),
+					mappingRuleId: id,
+				});
+				logger.success(
+					`Mapping rule '${id}' assigned to tenant '${values["to-tenant"]}'`,
+				);
+			} else {
+				throw new Error("Target required. Use --to-group or --to-tenant.");
+			}
+			break;
+		}
+		default:
+			throw new Error(
+				`Cannot assign resource type: ${resource}. Supported: role, user, group, mapping-rule.`,
+			);
 	}
 }
 
 /**
- * Handle unassign command: c8 unassign <resource> <id> --from-<target>=<targetId>
+ * Core unassign implementation. See `handleAssign` docstring for the
+ * error-handling contract (throw, do not `process.exit`).
  */
 export async function handleUnassign(
 	resource: string,
@@ -291,34 +283,29 @@ export async function handleUnassign(
 	options: { profile?: string },
 ): Promise<void> {
 	const logger = getLogger();
-
 	const allowedSources = ALLOWED_UNASSIGN_SOURCES[resource];
 	if (!allowedSources) {
-		logger.error(
+		throw new Error(
 			`Cannot unassign resource type: ${resource}. Supported: ${Object.keys(ALLOWED_UNASSIGN_SOURCES).join(", ")}.`,
 		);
-		process.exit(1);
 	}
 
 	// Validate exactly one --from-* flag is provided
 	const provided = UNASSIGN_SOURCE_FLAGS.filter((f) => values[f]);
 	if (provided.length > 1) {
-		logger.error(
+		throw new Error(
 			`Exactly one source flag is required. Conflicting flags: ${formatFlags(provided)}`,
 		);
-		process.exit(1);
 	}
 	if (provided.length === 0) {
-		logger.error(`Source required. Use ${formatFlags(allowedSources)}.`);
-		process.exit(1);
+		throw new Error(`Source required. Use ${formatFlags(allowedSources)}.`);
 	}
 
 	const sourceFlag = provided[0];
 	if (!allowedSources.includes(sourceFlag)) {
-		logger.error(
+		throw new Error(
 			`Unsupported source flag --${sourceFlag} for resource '${resource}'. Use ${formatFlags(allowedSources)}.`,
 		);
-		process.exit(1);
 	}
 
 	const sourceValue = values[sourceFlag];
@@ -339,117 +326,220 @@ export async function handleUnassign(
 
 	const client = createClient(options.profile);
 
-	try {
-		switch (resource) {
-			case "role": {
-				if (values["from-user"]) {
-					await client.unassignRoleFromUser({
-						roleId: id,
-						username: Username.assumeExists(String(values["from-user"])),
-					});
-					logger.success(
-						`Role '${id}' unassigned from user '${values["from-user"]}'`,
-					);
-				} else if (values["from-group"]) {
-					await client.unassignRoleFromGroup({
-						roleId: id,
-						groupId: String(values["from-group"]),
-					});
-					logger.success(
-						`Role '${id}' unassigned from group '${values["from-group"]}'`,
-					);
-				} else if (values["from-tenant"]) {
-					await client.unassignRoleFromTenant({
-						tenantId: TenantId.assumeExists(String(values["from-tenant"])),
-						roleId: id,
-					});
-					logger.success(
-						`Role '${id}' unassigned from tenant '${values["from-tenant"]}'`,
-					);
-				} else if (values["from-mapping-rule"]) {
-					await client.unassignRoleFromMappingRule({
-						roleId: id,
-						mappingRuleId: String(values["from-mapping-rule"]),
-					});
-					logger.success(
-						`Role '${id}' unassigned from mapping rule '${values["from-mapping-rule"]}'`,
-					);
-				} else {
-					logger.error(
-						"Source required. Use --from-user, --from-group, --from-tenant, or --from-mapping-rule.",
-					);
-					process.exit(1);
-				}
-				break;
-			}
-			case "user": {
-				if (values["from-group"]) {
-					await client.unassignUserFromGroup({
-						groupId: String(values["from-group"]),
-						username: Username.assumeExists(id),
-					});
-					logger.success(
-						`User '${id}' unassigned from group '${values["from-group"]}'`,
-					);
-				} else if (values["from-tenant"]) {
-					await client.unassignUserFromTenant({
-						tenantId: TenantId.assumeExists(String(values["from-tenant"])),
-						username: Username.assumeExists(id),
-					});
-					logger.success(
-						`User '${id}' unassigned from tenant '${values["from-tenant"]}'`,
-					);
-				} else {
-					logger.error("Source required. Use --from-group or --from-tenant.");
-					process.exit(1);
-				}
-				break;
-			}
-			case "group": {
-				if (values["from-tenant"]) {
-					await client.unassignGroupFromTenant({
-						tenantId: TenantId.assumeExists(String(values["from-tenant"])),
-						groupId: id,
-					});
-					logger.success(
-						`Group '${id}' unassigned from tenant '${values["from-tenant"]}'`,
-					);
-				} else {
-					logger.error("Source required. Use --from-tenant.");
-					process.exit(1);
-				}
-				break;
-			}
-			case "mapping-rule": {
-				if (values["from-group"]) {
-					await client.unassignMappingRuleFromGroup({
-						groupId: String(values["from-group"]),
-						mappingRuleId: id,
-					});
-					logger.success(
-						`Mapping rule '${id}' unassigned from group '${values["from-group"]}'`,
-					);
-				} else if (values["from-tenant"]) {
-					await client.unassignMappingRuleFromTenant({
-						tenantId: TenantId.assumeExists(String(values["from-tenant"])),
-						mappingRuleId: id,
-					});
-					logger.success(
-						`Mapping rule '${id}' unassigned from tenant '${values["from-tenant"]}'`,
-					);
-				} else {
-					logger.error("Source required. Use --from-group or --from-tenant.");
-					process.exit(1);
-				}
-				break;
-			}
-			default:
-				logger.error(
-					`Cannot unassign resource type: ${resource}. Supported: role, user, group, mapping-rule.`,
+	switch (resource) {
+		case "role": {
+			if (values["from-user"]) {
+				await client.unassignRoleFromUser({
+					roleId: id,
+					username: Username.assumeExists(String(values["from-user"])),
+				});
+				logger.success(
+					`Role '${id}' unassigned from user '${values["from-user"]}'`,
 				);
-				process.exit(1);
+			} else if (values["from-group"]) {
+				await client.unassignRoleFromGroup({
+					roleId: id,
+					groupId: String(values["from-group"]),
+				});
+				logger.success(
+					`Role '${id}' unassigned from group '${values["from-group"]}'`,
+				);
+			} else if (values["from-tenant"]) {
+				await client.unassignRoleFromTenant({
+					tenantId: TenantId.assumeExists(String(values["from-tenant"])),
+					roleId: id,
+				});
+				logger.success(
+					`Role '${id}' unassigned from tenant '${values["from-tenant"]}'`,
+				);
+			} else if (values["from-mapping-rule"]) {
+				await client.unassignRoleFromMappingRule({
+					roleId: id,
+					mappingRuleId: String(values["from-mapping-rule"]),
+				});
+				logger.success(
+					`Role '${id}' unassigned from mapping rule '${values["from-mapping-rule"]}'`,
+				);
+			} else {
+				throw new Error(
+					"Source required. Use --from-user, --from-group, --from-tenant, or --from-mapping-rule.",
+				);
+			}
+			break;
 		}
-	} catch (error) {
-		handleCommandError(logger, `Failed to unassign ${resource}`, error);
+		case "user": {
+			if (values["from-group"]) {
+				await client.unassignUserFromGroup({
+					groupId: String(values["from-group"]),
+					username: Username.assumeExists(id),
+				});
+				logger.success(
+					`User '${id}' unassigned from group '${values["from-group"]}'`,
+				);
+			} else if (values["from-tenant"]) {
+				await client.unassignUserFromTenant({
+					tenantId: TenantId.assumeExists(String(values["from-tenant"])),
+					username: Username.assumeExists(id),
+				});
+				logger.success(
+					`User '${id}' unassigned from tenant '${values["from-tenant"]}'`,
+				);
+			} else {
+				throw new Error("Source required. Use --from-group or --from-tenant.");
+			}
+			break;
+		}
+		case "group": {
+			if (values["from-tenant"]) {
+				await client.unassignGroupFromTenant({
+					tenantId: TenantId.assumeExists(String(values["from-tenant"])),
+					groupId: id,
+				});
+				logger.success(
+					`Group '${id}' unassigned from tenant '${values["from-tenant"]}'`,
+				);
+			} else {
+				throw new Error("Source required. Use --from-tenant.");
+			}
+			break;
+		}
+		case "mapping-rule": {
+			if (values["from-group"]) {
+				await client.unassignMappingRuleFromGroup({
+					groupId: String(values["from-group"]),
+					mappingRuleId: id,
+				});
+				logger.success(
+					`Mapping rule '${id}' unassigned from group '${values["from-group"]}'`,
+				);
+			} else if (values["from-tenant"]) {
+				await client.unassignMappingRuleFromTenant({
+					tenantId: TenantId.assumeExists(String(values["from-tenant"])),
+					mappingRuleId: id,
+				});
+				logger.success(
+					`Mapping rule '${id}' unassigned from tenant '${values["from-tenant"]}'`,
+				);
+			} else {
+				throw new Error("Source required. Use --from-group or --from-tenant.");
+			}
+			break;
+		}
+		default:
+			throw new Error(
+				`Cannot unassign resource type: ${resource}. Supported: role, user, group, mapping-rule.`,
+			);
 	}
 }
+
+// ─── Per-resource defineCommand wrappers ─────────────────────────────────
+
+/** Require a positional id; throw with a registry-aligned usage hint. */
+function requireId(
+	verb: "assign" | "unassign",
+	resource: string,
+	args: readonly string[],
+): string {
+	const id = args[0];
+	if (!id) {
+		const targetFlag = verb === "assign" ? "--to-" : "--from-";
+		throw new Error(
+			`ID required. Usage: c8 ${verb} ${resource} <id> ${targetFlag}<target>=<targetId>`,
+		);
+	}
+	return id;
+}
+
+function makeAssignCommand<
+	R extends "role" | "user" | "group" | "mapping-rule",
+>(resource: R) {
+	return defineCommand("assign", resource, async (ctx, flags) => {
+		const id = requireId("assign", resource, ctx.positionals);
+		await handleAssign(
+			resource,
+			id,
+			{ ...flags },
+			{
+				profile: ctx.profile,
+			},
+		);
+		return undefined;
+	});
+}
+
+function makeUnassignCommand<
+	R extends "role" | "user" | "group" | "mapping-rule",
+>(resource: R) {
+	return defineCommand("unassign", resource, async (ctx, flags) => {
+		const id = requireId("unassign", resource, ctx.positionals);
+		await handleUnassign(
+			resource,
+			id,
+			{ ...flags },
+			{
+				profile: ctx.profile,
+			},
+		);
+		return undefined;
+	});
+}
+
+export const assignRoleCommand = makeAssignCommand("role");
+export const assignUserCommand = makeAssignCommand("user");
+export const assignGroupCommand = makeAssignCommand("group");
+export const assignMappingRuleCommand = makeAssignCommand("mapping-rule");
+export const unassignRoleCommand = makeUnassignCommand("role");
+export const unassignUserCommand = makeUnassignCommand("user");
+export const unassignGroupCommand = makeUnassignCommand("group");
+export const unassignMappingRuleCommand = makeUnassignCommand("mapping-rule");
+
+/**
+ * Fallback handlers for unknown resource names (`c8 assign foo ...`).
+ *
+ * The registry-driven dispatch in `src/index.ts` looks up `assign:<resource>`
+ * first and then falls back to `assign:`. Without these fallbacks the CLI
+ * would print a generic "Unknown command" error for unknown resources and
+ * skip the `handleAssign`-level validation that produces the canonical
+ * "Cannot assign resource type: <resource>" message.
+ */
+export const assignFallbackCommand = defineCommand(
+	"assign",
+	"",
+	async (ctx, flags) => {
+		const id = requireId(
+			"assign",
+			ctx.resource || "<resource>",
+			ctx.positionals,
+		);
+		await handleAssign(
+			ctx.resource,
+			id,
+			{ ...flags },
+			{
+				profile: ctx.profile,
+			},
+		);
+		return undefined;
+	},
+);
+
+export const unassignFallbackCommand = defineCommand(
+	"unassign",
+	"",
+	async (ctx, flags) => {
+		const id = requireId(
+			"unassign",
+			ctx.resource || "<resource>",
+			ctx.positionals,
+		);
+		await handleUnassign(
+			ctx.resource,
+			id,
+			{ ...flags },
+			{
+				profile: ctx.profile,
+			},
+		);
+		return undefined;
+	},
+);

--- a/src/commands/plugins.ts
+++ b/src/commands/plugins.ts
@@ -65,31 +65,27 @@ export const loadPluginCommand = defineCommand(
 
 		// Validate input
 		if (fromUrl && packageName) {
-			logger.error(
+			throw new Error(
 				'Cannot specify both a positional argument and --from flag. Use either "c8 load plugin <name>" or "c8 load plugin --from <url>"',
 			);
-			process.exit(1);
 		}
 
 		if (!packageName && !fromUrl) {
-			logger.error(
+			throw new Error(
 				"Package name or URL required. Usage: c8 load plugin <name> or c8 load plugin --from <url>",
 			);
-			process.exit(1);
 		}
 
 		if (fromUrl && !isAcceptedUrl(fromUrl)) {
-			logger.error(
+			throw new Error(
 				"Invalid URL format. Accepted URL formats include file://, https://, git:// (see help for more)",
 			);
-			process.exit(1);
 		}
 
 		if (packageName && isAcceptedUrl(packageName)) {
-			logger.error(
+			throw new Error(
 				"Package name cannot be a URL. If you want to load from a URL, use the --from flag. Usage: c8 load plugin --from <url>",
 			);
-			process.exit(1);
 		}
 
 		// Get global plugins directory
@@ -119,11 +115,10 @@ export const loadPluginCommand = defineCommand(
 
 				// Validate plugin name
 				if (!pluginName || pluginName.trim() === "") {
-					logger.error("Failed to extract plugin name from URL");
 					logger.info(
 						"Ensure the URL points to a valid npm package with a package.json file",
 					);
-					process.exit(1);
+					throw new Error("Failed to extract plugin name from URL");
 				}
 
 				logger.success("Plugin loaded successfully from URL", fromUrl);
@@ -348,10 +343,9 @@ export const unloadPluginCommand = defineCommand(
 		const force = flags.force;
 
 		if (!packageName) {
-			logger.error(
+			throw new Error(
 				"Package name required. Usage: c8ctl unload plugin <package-name>",
 			);
-			process.exit(1);
 		}
 
 		const pluginsDir = ensurePluginsDir();
@@ -359,22 +353,20 @@ export const unloadPluginCommand = defineCommand(
 		const isPresent = existsSync(join(pluginsDir, "node_modules", packageName));
 
 		if (!isRegistered && !isPresent) {
-			logger.error(
+			logger.info('Run "c8ctl list plugins" to see installed plugins');
+			throw new Error(
 				`Plugin "${packageName}" is neither registered nor installed in the global plugins directory.`,
 			);
-			logger.info('Run "c8ctl list plugins" to see installed plugins');
-			process.exit(1);
 		}
 
 		// Limbo state: present in node_modules but not in the registry — requires --force
 		if (!isRegistered && !force) {
-			logger.error(
-				`Plugin "${packageName}" is installed in node_modules but not in the registry (limbo state).`,
-			);
 			logger.info(
 				`Use --force to remove it: c8ctl unload plugin ${packageName} --force`,
 			);
-			process.exit(1);
+			throw new Error(
+				`Plugin "${packageName}" is installed in node_modules but not in the registry (limbo state).`,
+			);
 		}
 
 		const action = isRegistered ? "Unloading" : "Force-removing";
@@ -786,17 +778,15 @@ export const upgradePluginCommand = defineCommand(
 		const version = args.version;
 
 		if (!packageName) {
-			logger.error(
+			throw new Error(
 				"Package name required. Usage: c8ctl upgrade plugin <package-name> [version]",
 			);
-			process.exit(1);
 		}
 
 		// Check if plugin is registered
 		if (!isPluginRegistered(packageName)) {
-			logger.error(`Plugin "${packageName}" is not registered.`);
 			logger.info('Run "c8ctl list plugins" to see installed plugins');
-			process.exit(1);
+			throw new Error(`Plugin "${packageName}" is not registered.`);
 		}
 
 		const pluginEntry = getPluginEntry(packageName);
@@ -807,14 +797,13 @@ export const upgradePluginCommand = defineCommand(
 		// Versioned upgrade needs to respect source type
 		// File-based plugins do not have a version selector in npm install syntax
 		if (version && source.startsWith("file:")) {
-			logger.error(
-				`Cannot upgrade file-based plugin "${packageName}" to a specific version.`,
-			);
 			logger.info(`Plugin source is: ${source}`);
 			logger.info(
 				'Use "c8ctl load plugin --from <file-url>" after checking out the desired plugin version in your local source directory',
 			);
-			process.exit(1);
+			throw new Error(
+				`Cannot upgrade file-based plugin "${packageName}" to a specific version.`,
+			);
 		}
 
 		const installTarget = resolveInstallTarget(source, packageName, version);
@@ -864,17 +853,15 @@ export const downgradePluginCommand = defineCommand(
 		const version = args.version;
 
 		if (!packageName || !version) {
-			logger.error(
+			throw new Error(
 				"Package name and version required. Usage: c8ctl downgrade plugin <package-name> <version>",
 			);
-			process.exit(1);
 		}
 
 		// Check if plugin is registered
 		if (!isPluginRegistered(packageName)) {
-			logger.error(`Plugin "${packageName}" is not registered.`);
 			logger.info('Run "c8ctl list plugins" to see installed plugins');
-			process.exit(1);
+			throw new Error(`Plugin "${packageName}" is not registered.`);
 		}
 
 		const pluginEntry = getPluginEntry(packageName);
@@ -885,14 +872,13 @@ export const downgradePluginCommand = defineCommand(
 		// Downgrade needs to respect the plugin source
 		// File-based plugins do not have a version selector in npm install syntax
 		if (source.startsWith("file:")) {
-			logger.error(
-				`Cannot downgrade file-based plugin "${packageName}" by version.`,
-			);
 			logger.info(`Plugin source is: ${source}`);
 			logger.info(
 				'Use "c8ctl load plugin --from <file-url>" after checking out the desired plugin version in your local source directory',
 			);
-			process.exit(1);
+			throw new Error(
+				`Cannot downgrade file-based plugin "${packageName}" by version.`,
+			);
 		}
 
 		const installTarget = resolveInstallTarget(source, packageName, version);
@@ -946,11 +932,10 @@ export const initPluginCommand = defineCommand(
 			: rawName;
 
 		if (!pluginName) {
-			logger.error(
+			logger.info("Example: c8ctl init plugin myplugin");
+			throw new Error(
 				'Plugin name cannot be empty. Provide a name suffix after "c8ctl-plugin-".',
 			);
-			logger.info("Example: c8ctl init plugin myplugin");
-			process.exit(1);
 		}
 
 		const dirName = `c8ctl-plugin-${pluginName}`;
@@ -958,9 +943,8 @@ export const initPluginCommand = defineCommand(
 
 		// Check if directory already exists
 		if (existsSync(pluginDir)) {
-			logger.error(`Directory "${dirName}" already exists.`);
 			logger.info("Choose a different name or remove the existing directory");
-			process.exit(1);
+			throw new Error(`Directory "${dirName}" already exists.`);
 		}
 
 		try {

--- a/src/commands/profiles.ts
+++ b/src/commands/profiles.ts
@@ -81,8 +81,7 @@ export function showProfile(name: string): void {
 	const profile = getProfileOrModeler(name);
 
 	if (!profile) {
-		logger.error(`Profile '${name}' not found`);
-		process.exit(1);
+		throw new Error(`Profile '${name}' not found`);
 	}
 
 	const isModeler = profile.name.startsWith(MODELER_PREFIX);
@@ -149,35 +148,33 @@ export function addProfile(name: string, options: AddProfileOptions): void {
 
 	// Prevent adding profiles with "modeler:" prefix
 	if (name.startsWith(MODELER_PREFIX)) {
-		logger.error(
-			`Profile names cannot start with "${MODELER_PREFIX}" - this prefix is reserved for Camunda Modeler connections`,
-		);
 		logger.info(
 			"Please choose a different name or manage this profile in Camunda Modeler",
 		);
-		process.exit(1);
+		throw new Error(
+			`Profile names cannot start with "${MODELER_PREFIX}" - this prefix is reserved for Camunda Modeler connections`,
+		);
 	}
 
 	let profile: Profile;
 
 	if (options.envFile && options.fromEnv) {
-		logger.error("Cannot use --from-file and --from-env together. Choose one.");
-		process.exit(1);
+		throw new Error(
+			"Cannot use --from-file and --from-env together. Choose one.",
+		);
 	}
 
 	if (options.envFile) {
 		// --from-file: read a .env file and map CAMUNDA_* vars to profile fields
 		if (!existsSync(options.envFile)) {
-			logger.error(`File not found: ${options.envFile}`);
-			process.exit(1);
+			throw new Error(`File not found: ${options.envFile}`);
 		}
 		const content = readFileSync(options.envFile, "utf-8");
 		const vars = parseEnvFile(content);
 		profile = envVarsToProfile(name, vars);
 		if (!profile.baseUrl) {
-			logger.error(`CAMUNDA_BASE_URL not found in ${options.envFile}`);
 			logger.info("The .env file must contain at least CAMUNDA_BASE_URL.");
-			process.exit(1);
+			throw new Error(`CAMUNDA_BASE_URL not found in ${options.envFile}`);
 		}
 		addProfileConfig(profile);
 		logger.success(`Profile '${name}' added (from ${options.envFile})`);
@@ -187,9 +184,8 @@ export function addProfile(name: string, options: AddProfileOptions): void {
 		// --from-env: read from current process environment
 		profile = envVarsToProfile(name, process.env);
 		if (!profile.baseUrl) {
-			logger.error("CAMUNDA_BASE_URL not set in environment");
 			logger.info("Set CAMUNDA_BASE_URL before using --from-env.");
-			process.exit(1);
+			throw new Error("CAMUNDA_BASE_URL not set in environment");
 		}
 		addProfileConfig(profile);
 		logger.success(`Profile '${name}' added (from environment)`);
@@ -221,17 +217,15 @@ export function removeProfile(name: string): void {
 
 	// Prevent removing Modeler profiles
 	if (name.startsWith(MODELER_PREFIX)) {
-		logger.error("Cannot remove Modeler profiles via c8ctl");
 		logger.info("Manage Modeler connections directly in Camunda Modeler");
-		process.exit(1);
+		throw new Error("Cannot remove Modeler profiles via c8ctl");
 	}
 
 	const removed = removeProfileConfig(name);
 	if (removed) {
 		logger.success(`Profile '${name}' removed`);
 	} else {
-		logger.error(`Profile '${name}' not found`);
-		process.exit(1);
+		throw new Error(`Profile '${name}' not found`);
 	}
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,18 +18,13 @@ import {
 	resolveAlias,
 } from "./command-registry.ts";
 import { detectUnknownFlags, validateFlags } from "./command-validation.ts";
-import {
-	installCompletion,
-	refreshCompletionsIfStale,
-	showCompletion,
-} from "./commands/completion.ts";
+import { refreshCompletionsIfStale } from "./commands/completion.ts";
 import {
 	showCommandHelp,
 	showHelp,
 	showVerbResources,
 	showVersion,
 } from "./commands/help.ts";
-import { handleAssign, handleUnassign } from "./commands/identity.ts";
 import { loadSessionState, resolveTenantId } from "./config.ts";
 import { getLogger, type SortOrder } from "./logger.ts";
 import { executePluginCommand, loadInstalledPlugins } from "./plugin-loader.ts";
@@ -212,23 +207,18 @@ async function main() {
 		return;
 	}
 
-	// Handle completion command
+	// Handle completion command — routed through COMMAND_DISPATCH below.
+	// Unknown-flag detection runs here because `completion` uses
+	// resource-specific flags (see resourceFlags.install) and the general
+	// detectUnknownFlags call later may not cover this verb's resource-scoped
+	// flag shape.
 	if (verb === "completion") {
-		// Run unknown-flag detection before early return (completion returns
-		// before the general detectUnknownFlags call below).
 		const completionUnknownFlags = detectUnknownFlags(
 			verb,
 			resource ?? "",
 			values,
 		);
 		warnUnknownFlags(logger, completionUnknownFlags, verb, resource ?? "");
-
-		if (resource === "install") {
-			installCompletion(str(values.shell));
-			return;
-		}
-		showCompletion(resource);
-		return;
 	}
 
 	// Normalize resource
@@ -258,33 +248,6 @@ async function main() {
 	// Derived from COMMAND_REGISTRY; resource-scoped for search/list.
 	const unknownFlags = detectUnknownFlags(verb, normalizedResource, values);
 	warnUnknownFlags(logger, unknownFlags, verb, resource);
-
-	// ── Assign / unassign — legacy delegation (not yet migrated to defineCommand) ──
-	if (verb === "assign") {
-		if (!args[0]) {
-			logger.error(
-				`ID required. Usage: c8 assign ${normalizedResource} <id> --to-<target>=<targetId>`,
-			);
-			process.exit(1);
-		}
-		await handleAssign(normalizedResource, args[0], values, {
-			profile: str(values.profile),
-		});
-		return;
-	}
-
-	if (verb === "unassign") {
-		if (!args[0]) {
-			logger.error(
-				`ID required. Usage: c8 unassign ${normalizedResource} <id> --from-<target>=<targetId>`,
-			);
-			process.exit(1);
-		}
-		await handleUnassign(normalizedResource, args[0], values, {
-			profile: str(values.profile),
-		});
-		return;
-	}
 
 	// ── Registry-driven dispatch ───────────────────────────────────────────
 	// For verbs with enumerated resources (e.g. `list process-instance`),

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,20 +207,6 @@ async function main() {
 		return;
 	}
 
-	// Handle completion command — routed through COMMAND_DISPATCH below.
-	// Unknown-flag detection runs here because `completion` uses
-	// resource-specific flags (see resourceFlags.install) and the general
-	// detectUnknownFlags call later may not cover this verb's resource-scoped
-	// flag shape.
-	if (verb === "completion") {
-		const completionUnknownFlags = detectUnknownFlags(
-			verb,
-			resource ?? "",
-			values,
-		);
-		warnUnknownFlags(logger, completionUnknownFlags, verb, resource ?? "");
-	}
-
 	// Normalize resource
 	const normalizedResource = resource ? resolveAlias(resource) : "";
 

--- a/tests/unit/completion.test.ts
+++ b/tests/unit/completion.test.ts
@@ -13,14 +13,12 @@ describe("Completion Module", () => {
 	let originalLog: typeof console.log;
 	let originalError: typeof console.error;
 	let restoreExit: (() => void) | undefined;
-	let exitCode: number | undefined;
 
 	beforeEach(() => {
 		consoleLogSpy = [];
 		consoleErrorSpy = [];
 		originalLog = console.log;
 		originalError = console.error;
-		exitCode = undefined;
 
 		console.log = (...args: unknown[]) => {
 			consoleLogSpy.push(args.join(" "));
@@ -30,9 +28,9 @@ describe("Completion Module", () => {
 			consoleErrorSpy.push(args.join(" "));
 		};
 
-		// Stub process.exit to capture exit codes
+		// Stub process.exit so any stray call throws (kept as a safety net
+		// even though migrated handlers now throw instead of calling exit).
 		restoreExit = mockProcessExit((code) => {
-			exitCode = typeof code === "number" ? code : undefined;
 			throw new Error(`process.exit(${code})`);
 		});
 	});
@@ -173,14 +171,13 @@ describe("Completion Module", () => {
 			assert.fail("Should have thrown an error");
 		} catch (error) {
 			assert.ok(
-				error instanceof Error && error.message.includes("process.exit(1)"),
+				error instanceof Error && error.message.includes("Shell type required"),
 			);
-			assert.strictEqual(exitCode, 1);
+			assert.ok(
+				error instanceof Error &&
+					error.message.includes("c8 completion <bash|zsh|fish>"),
+			);
 		}
-
-		const errorOutput = consoleErrorSpy.join("\n");
-		assert.ok(errorOutput.includes("Shell type required"));
-		assert.ok(errorOutput.includes("c8 completion <bash|zsh|fish>"));
 	});
 
 	test("handles unknown shell", () => {
@@ -189,18 +186,14 @@ describe("Completion Module", () => {
 			assert.fail("Should have thrown an error");
 		} catch (error) {
 			assert.ok(
-				error instanceof Error && error.message.includes("process.exit(1)"),
+				error instanceof Error &&
+					error.message.includes("Unknown shell: powershell"),
 			);
-			assert.strictEqual(exitCode, 1);
+			assert.ok(
+				error instanceof Error &&
+					error.message.includes("Supported shells: bash, zsh, fish"),
+			);
 		}
-
-		// logger.error outputs to console.error
-		const errorOutput = consoleErrorSpy.join("\n");
-		assert.ok(errorOutput.includes("Unknown shell: powershell"));
-
-		// logger.info outputs to console.log
-		const logOutput = consoleLogSpy.join("\n");
-		assert.ok(logOutput.includes("Supported shells: bash, zsh, fish"));
 	});
 
 	test("handles case-insensitive shell names", () => {

--- a/tests/unit/identity.test.ts
+++ b/tests/unit/identity.test.ts
@@ -528,25 +528,16 @@ describe("handleAssign — dry-run and flag validation", () => {
 					{ "to-user": "alice", "to-group": "ops" },
 					{},
 				),
-			/process\.exit\(1\)/,
-		);
-		const allError = errorSpy.join("\n");
-		assert.ok(
-			allError.includes("--to-user"),
-			"error should list the conflicting flags",
-		);
-		assert.ok(
-			allError.includes("--to-group"),
-			"error should list the conflicting flags",
+			(err: Error) =>
+				err.message.includes("--to-user") && err.message.includes("--to-group"),
 		);
 	});
 
 	test("errors when no --to-* flag is provided", async () => {
 		await assert.rejects(
 			() => handleAssign("role", "admin-role", {}, {}),
-			/process\.exit\(1\)/,
+			/Target required/,
 		);
-		assert.ok(errorSpy.some((l) => l.includes("Target required")));
 	});
 
 	test("dry-run with multiple --to-* flags errors before emitting", async () => {
@@ -559,7 +550,7 @@ describe("handleAssign — dry-run and flag validation", () => {
 					{ "to-user": "alice", "to-group": "ops", "to-tenant": "t1" },
 					{},
 				),
-			/process\.exit\(1\)/,
+			/Exactly one target flag/,
 		);
 		// No JSON should have been emitted
 		assert.strictEqual(logSpy.length, 0);
@@ -605,25 +596,17 @@ describe("handleUnassign — dry-run and flag validation", () => {
 					{ "from-group": "ops", "from-tenant": "t1" },
 					{},
 				),
-			/process\.exit\(1\)/,
-		);
-		const allError = errorSpy.join("\n");
-		assert.ok(
-			allError.includes("--from-group"),
-			"error should list the conflicting flags",
-		);
-		assert.ok(
-			allError.includes("--from-tenant"),
-			"error should list the conflicting flags",
+			(err: Error) =>
+				err.message.includes("--from-group") &&
+				err.message.includes("--from-tenant"),
 		);
 	});
 
 	test("errors when no --from-* flag is provided", async () => {
 		await assert.rejects(
 			() => handleUnassign("user", "alice", {}, {}),
-			/process\.exit\(1\)/,
+			/Source required/,
 		);
-		assert.ok(errorSpy.some((l) => l.includes("Source required")));
 	});
 });
 
@@ -820,17 +803,16 @@ describe("handleAssign — every allowed resource/target pair works in dry-run",
 	test("assign rejects unsupported resource", async () => {
 		await assert.rejects(
 			() => handleAssign("bogus", "id", { "to-user": "a" }, {}),
-			/process\.exit\(1\)/,
+			/Cannot assign resource type: bogus/,
 		);
 	});
 
 	test("assign rejects unsupported target flag for resource", async () => {
-		// user does not support --to-user (you can\'t assign a user to another user)
+		// user does not support --to-user (you can't assign a user to another user)
 		await assert.rejects(
 			() => handleAssign("user", "alice", { "to-user": "bob" }, {}),
-			/process\.exit\(1\)/,
+			/Unsupported target flag/,
 		);
-		assert.ok(errorSpy.some((l) => l.includes("Unsupported target flag")));
 	});
 });
 

--- a/tests/unit/no-process-exit-in-handlers.test.ts
+++ b/tests/unit/no-process-exit-in-handlers.test.ts
@@ -1,41 +1,21 @@
 /**
  * Architectural class-of-defect guard for issue #288.
  *
- * Goal: every command handler in `src/commands/**.ts` routes
- * termination through the framework's `handleCommandError` pipeline
- * (i.e. via `throw`), never through a direct `process.exit(...)`
- * call. This preserves two invariants for the whole CLI:
+ * Every command handler in `src/commands/**.ts` routes termination
+ * through the framework's `handleCommandError` pipeline (i.e. via
+ * `throw`), never through a direct `process.exit(...)` call. This
+ * preserves two invariants for the whole CLI:
  *
  *   1. `--verbose` can rethrow any error to surface a stack trace.
  *   2. The framework consistently formats failures with command
  *      context (`Failed to <verb> <resource>: <message>`).
  *
- * Because issue #288 is a multi-PR migration, we lock in the
- * direction of travel with a SHRINKING ALLOW-LIST:
- *
- *   - Files in `PENDING_MIGRATION` may still contain
- *     `process.exit(...)` calls (this is what the migration is
- *     fixing).
- *   - Every other file in `src/commands/**.ts` must contain ZERO
- *     `process.exit(...)` calls.
- *   - When a handler is migrated, its entry is REMOVED from the
- *     allow-list in the same PR.
- *   - When the allow-list is empty, issue #288 is complete and the
- *     architectural rule is fully locked in. At that point the
- *     allow-list and its plumbing should be deleted in favour of an
- *     unconditional ban.
- *
- * The test fails in TWO directions:
- *
- *   a) A file outside the allow-list contains `process.exit(...)` —
- *      a regression. (E.g. someone reintroduced `process.exit(1)`
- *      into deployments.ts.)
- *   b) A file inside the allow-list contains ZERO
- *      `process.exit(...)` calls — the file has already been
- *      migrated and the allow-list is stale. Remove the entry.
- *
- * Direction (b) is what makes the allow-list a checklist instead of
- * a graveyard: stale entries cannot accumulate.
+ * The #288 migration completed in PR #306 — the `PENDING_MIGRATION`
+ * allow-list that staged the rollout has been retired. The rule is
+ * now unconditional: zero `process.exit(...)` calls in
+ * `src/commands/**.ts`. If you find yourself reintroducing one,
+ * throw an `Error` instead and let the framework wrapper handle
+ * termination.
  *
  * AST-based (not regex) so string literals containing
  * `process.exit(`, comments mentioning the pattern, and
@@ -52,22 +32,6 @@ import { findProcessExitCalls } from "../utils/no-process-exit.ts";
 const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
 const COMMANDS_DIR = join(PROJECT_ROOT, "src", "commands");
 
-/**
- * Files that have NOT yet been migrated off `process.exit(...)`.
- *
- * Remove an entry in the same PR that migrates its handler. When
- * this set is empty, delete it and turn the test into an
- * unconditional rule across all of `src/commands/**.ts`.
- *
- * Each path is workspace-relative for stable grep/diff readability.
- */
-const PENDING_MIGRATION: ReadonlySet<string> = new Set([
-	"src/commands/completion.ts",
-	"src/commands/identity.ts",
-	"src/commands/plugins.ts",
-	"src/commands/profiles.ts",
-]);
-
 function listCommandFiles(): string[] {
 	return readdirSync(COMMANDS_DIR)
 		.filter((name) => name.endsWith(".ts"))
@@ -75,7 +39,7 @@ function listCommandFiles(): string[] {
 }
 
 /** Convert an absolute path under PROJECT_ROOT to a workspace-relative
- * POSIX path (the form used in `PENDING_MIGRATION`). */
+ * POSIX path for stable diagnostic output. */
 function toRelative(absPath: string): string {
 	const rel = absPath.slice(PROJECT_ROOT.length + 1);
 	return rel.split(/[\\/]/).join("/");
@@ -84,61 +48,27 @@ function toRelative(absPath: string): string {
 describe("architectural guard: command handlers must throw, not process.exit (#288)", () => {
 	const files = listCommandFiles();
 
-	test("PENDING_MIGRATION lists only files that exist", () => {
-		const onDisk = new Set(files.map(toRelative));
-		const stale = [...PENDING_MIGRATION].filter((p) => !onDisk.has(p));
-		assert.deepStrictEqual(
-			stale,
-			[],
-			`PENDING_MIGRATION references files that no longer exist: ${stale.join(", ")}. ` +
-				`Remove these entries.`,
-		);
-	});
-
-	test("no migrated handler reintroduces `process.exit(...)`", () => {
+	test("no command handler contains `process.exit(...)`", () => {
 		const violations: { file: string; line: number; text: string }[] = [];
 		for (const abs of files) {
-			const rel = toRelative(abs);
-			if (PENDING_MIGRATION.has(rel)) continue;
 			for (const call of findProcessExitCalls(abs)) {
-				violations.push({ file: rel, line: call.line, text: call.text });
+				violations.push({
+					file: toRelative(abs),
+					line: call.line,
+					text: call.text,
+				});
 			}
 		}
 		assert.strictEqual(
 			violations.length,
 			0,
-			`Migrated handler files must not contain \`process.exit(...)\` calls. ` +
+			`Command handler files must not contain \`process.exit(...)\` calls. ` +
 				`Found ${violations.length}:\n` +
 				violations
 					.map((v) => `  - ${v.file}:${v.line} — ${v.text}`)
 					.join("\n") +
 				`\n\nEvery error path must throw so the framework's handleCommandError ` +
-				`pipeline owns process termination. If this is genuinely a new ` +
-				`pre-migration handler, add it to PENDING_MIGRATION in this file.`,
-		);
-	});
-
-	test("PENDING_MIGRATION entries actually still contain `process.exit(...)`", () => {
-		// Direction (b) above: a stale allow-list entry is its own kind
-		// of regression. If a file has been migrated but its entry was
-		// not removed, the allow-list silently keeps protecting a file
-		// that no longer needs protection — and the next reviewer might
-		// keep relying on it. Catch that here so the allow-list shrinks
-		// monotonically and never accumulates dead entries.
-		const stale: string[] = [];
-		for (const rel of PENDING_MIGRATION) {
-			const abs = join(PROJECT_ROOT, rel);
-			if (findProcessExitCalls(abs).length === 0) {
-				stale.push(rel);
-			}
-		}
-		assert.deepStrictEqual(
-			stale,
-			[],
-			`PENDING_MIGRATION contains entries that have already been migrated ` +
-				`(no \`process.exit(...)\` remains): ${stale.join(", ")}. ` +
-				`Remove these entries from PENDING_MIGRATION in the same PR ` +
-				`that migrated them.`,
+				`pipeline owns process termination.`,
 		);
 	});
 });

--- a/tests/unit/round-3-error-paths.test.ts
+++ b/tests/unit/round-3-error-paths.test.ts
@@ -23,13 +23,13 @@
 import assert from "node:assert";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import { after, describe, test } from "node:test";
 
+import { c8 } from "../utils/cli.ts";
 import { asyncSpawn, type SpawnResult } from "../utils/spawn.ts";
 
-const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
-const CLI = join(PROJECT_ROOT, "src", "index.ts");
+const CLI = "src/index.ts";
 
 const TEST_DATA_DIR = mkdtempSync(join(tmpdir(), "c8ctl-round3-paths-"));
 // Minimal profile so CAMUNDA_BASE_URL is set for tests that go through the
@@ -44,10 +44,17 @@ after(() => {
 	rmSync(TEST_DATA_DIR, { recursive: true, force: true });
 });
 
-async function c8(...args: string[]): Promise<SpawnResult> {
-	return c8WithEnv({}, ...args);
-}
-
+/**
+ * Spawn the CLI with a deterministic base env plus caller-supplied overrides.
+ * Mirrors `round-3-baseline.test.ts`: intentionally does NOT spread
+ * `process.env` — only `PATH` is inherited so the child process is isolated
+ * from any host-side CAMUNDA_*, HOME, SHELL, etc.
+ *
+ * The few tests that need this are the ones whose failure trigger depends on
+ * an env var (`SHELL` for `completion install`, `CAMUNDA_BASE_URL` for
+ * `add profile --from-env`). Tests without env sensitivity use the shared
+ * `c8()` helper from `tests/utils/cli.ts`.
+ */
 async function c8WithEnv(
 	overrides: Record<string, string>,
 	...args: string[]

--- a/tests/unit/round-3-error-paths.test.ts
+++ b/tests/unit/round-3-error-paths.test.ts
@@ -1,0 +1,438 @@
+/**
+ * Post-refactor assertions for Round 3 of the `process.exit` migration
+ * (issue #300, PR #306).
+ *
+ * `round-3-baseline.test.ts` locked in the pre-refactor invariants:
+ *   1. exit code = 1
+ *   2. original error message appears in stderr
+ *
+ * This file locks in the *new* invariant that the Round 3 refactor adds:
+ *   3. the framework's `Failed to <verb> <resource>` prefix appears in
+ *      stderr (or `Failed to <verb> ` for resource-less verbs and the
+ *      generic fallback handlers).
+ *
+ * Together with the baseline, these tests guarantee that every Round 3
+ * site now routes through `handleCommandError` via `throw` — which is
+ * the architectural goal of the migration.
+ *
+ * Only CLI-reachable sites are covered here; sites that are unreachable
+ * (defensive defaults, shadowed by upstream guards, filesystem-dependent)
+ * are protected instead by `tests/unit/no-process-exit-in-handlers.test.ts`.
+ */
+
+import assert from "node:assert";
+import { spawn } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { after, describe, test } from "node:test";
+
+interface SpawnResult {
+	status: number | null;
+	stdout: string;
+	stderr: string;
+}
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
+const CLI = join(PROJECT_ROOT, "src", "index.ts");
+
+function asyncSpawn(
+	cmd: string,
+	args: string[],
+	opts: { env?: NodeJS.ProcessEnv } = {},
+): Promise<SpawnResult> {
+	return new Promise((res) => {
+		const proc = spawn(cmd, args, {
+			env: opts.env ?? process.env,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+		let stdout = "";
+		let stderr = "";
+		proc.stdout.on("data", (chunk) => {
+			stdout += chunk.toString();
+		});
+		proc.stderr.on("data", (chunk) => {
+			stderr += chunk.toString();
+		});
+		proc.on("close", (status) => {
+			res({ status, stdout, stderr });
+		});
+	});
+}
+
+const TEST_DATA_DIR = mkdtempSync(join(tmpdir(), "c8ctl-round3-paths-"));
+// Minimal profile so CAMUNDA_BASE_URL is set for tests that go through the
+// client factory. Dry-run / validation paths don't need it but it keeps the
+// environment consistent with round-3-baseline.test.ts.
+writeFileSync(
+	join(TEST_DATA_DIR, "session.json"),
+	JSON.stringify({ outputMode: "json" }),
+);
+
+after(() => {
+	rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+});
+
+async function c8(...args: string[]): Promise<SpawnResult> {
+	return c8WithEnv({}, ...args);
+}
+
+async function c8WithEnv(
+	overrides: Record<string, string>,
+	...args: string[]
+): Promise<SpawnResult> {
+	const env: NodeJS.ProcessEnv = {
+		PATH: process.env.PATH,
+		CAMUNDA_BASE_URL: "http://test-cluster/v2",
+		HOME: "/tmp/c8ctl-test-nonexistent-home",
+		C8CTL_DATA_DIR: TEST_DATA_DIR,
+		...overrides,
+	};
+	return asyncSpawn("node", ["--experimental-strip-types", CLI, ...args], {
+		env,
+	});
+}
+
+/**
+ * Assert exit 1 AND that stderr contains BOTH the framework prefix
+ * (`Failed to <verb> <resource>`) and the original error fragment.
+ *
+ * This is the combined check that makes Round 3 meaningful: the framework
+ * now owns the error pipeline AND the original diagnostic is preserved.
+ */
+function assertFrameworkFailure(
+	result: SpawnResult,
+	frameworkPrefix: string,
+	originalFragment: string,
+	context: string,
+): void {
+	assert.strictEqual(
+		result.status,
+		1,
+		`${context}: expected exit 1, got ${result.status}. stderr:\n${result.stderr}`,
+	);
+	assert.ok(
+		result.stderr.includes(frameworkPrefix),
+		`${context}: expected stderr to contain framework prefix '${frameworkPrefix}'. stderr:\n${result.stderr}`,
+	);
+	assert.ok(
+		result.stderr.includes(originalFragment),
+		`${context}: expected stderr to contain original fragment '${originalFragment}'. stderr:\n${result.stderr}`,
+	);
+}
+
+// ── completion.ts (framework prefix: "Failed to completion ") ────────────────
+
+describe("round-3 framework prefix: completion", () => {
+	test("`c8 completion` → 'Failed to completion' + 'Shell type required'", async () => {
+		const result = await c8("completion");
+		assertFrameworkFailure(
+			result,
+			"Failed to completion",
+			"Shell type required",
+			"completion (no shell)",
+		);
+	});
+
+	test("`c8 completion powershell` → 'Failed to completion' + 'Unknown shell'", async () => {
+		const result = await c8("completion", "powershell");
+		assertFrameworkFailure(
+			result,
+			"Failed to completion",
+			"Unknown shell: powershell",
+			"completion powershell",
+		);
+	});
+
+	test("`SHELL='' c8 completion install` → 'Failed to completion' + 'Could not detect shell'", async () => {
+		const result = await c8WithEnv({ SHELL: "" }, "completion", "install");
+		assertFrameworkFailure(
+			result,
+			"Failed to completion",
+			"Could not detect shell",
+			"completion install (no SHELL)",
+		);
+	});
+
+	test("`c8 completion install --shell=foo` → 'Failed to completion' + 'Unsupported shell'", async () => {
+		const result = await c8("completion", "install", "--shell=foo");
+		assertFrameworkFailure(
+			result,
+			"Failed to completion",
+			"Unsupported shell: foo",
+			"completion install --shell=foo",
+		);
+	});
+});
+
+// ── identity.ts (framework prefix: "Failed to assign <resource>" etc.) ───────
+
+describe("round-3 framework prefix: assign / unassign", () => {
+	test("`c8 assign foo abc --to-user=u` → 'Failed to assign' + 'Cannot assign resource type: foo'", async () => {
+		const result = await c8("assign", "foo", "abc", "--to-user=u");
+		assertFrameworkFailure(
+			result,
+			"Failed to assign",
+			"Cannot assign resource type: foo",
+			"assign foo (bad resource)",
+		);
+	});
+
+	test("`c8 assign role abc --to-user=u --to-group=g` → 'Failed to assign role' + 'Exactly one target flag'", async () => {
+		const result = await c8(
+			"assign",
+			"role",
+			"abc",
+			"--to-user=u",
+			"--to-group=g",
+		);
+		assertFrameworkFailure(
+			result,
+			"Failed to assign role",
+			"Exactly one target flag is required",
+			"assign role (>1 target)",
+		);
+	});
+
+	test("`c8 assign role abc` → 'Failed to assign role' + 'Target required'", async () => {
+		const result = await c8("assign", "role", "abc");
+		assertFrameworkFailure(
+			result,
+			"Failed to assign role",
+			"Target required",
+			"assign role (no target)",
+		);
+	});
+
+	test("`c8 assign group abc --to-user=u` → 'Failed to assign group' + 'Unsupported target flag'", async () => {
+		const result = await c8("assign", "group", "abc", "--to-user=u");
+		assertFrameworkFailure(
+			result,
+			"Failed to assign group",
+			"Unsupported target flag --to-user for resource 'group'",
+			"assign group (bad target)",
+		);
+	});
+
+	test("`c8 unassign foo abc --from-user=u` → 'Failed to unassign' + 'Cannot unassign resource type: foo'", async () => {
+		const result = await c8("unassign", "foo", "abc", "--from-user=u");
+		assertFrameworkFailure(
+			result,
+			"Failed to unassign",
+			"Cannot unassign resource type: foo",
+			"unassign foo (bad resource)",
+		);
+	});
+
+	test("`c8 unassign role abc --from-user=u --from-group=g` → 'Failed to unassign role' + 'Exactly one source flag'", async () => {
+		const result = await c8(
+			"unassign",
+			"role",
+			"abc",
+			"--from-user=u",
+			"--from-group=g",
+		);
+		assertFrameworkFailure(
+			result,
+			"Failed to unassign role",
+			"Exactly one source flag is required",
+			"unassign role (>1 source)",
+		);
+	});
+
+	test("`c8 unassign role abc` → 'Failed to unassign role' + 'Source required'", async () => {
+		const result = await c8("unassign", "role", "abc");
+		assertFrameworkFailure(
+			result,
+			"Failed to unassign role",
+			"Source required",
+			"unassign role (no source)",
+		);
+	});
+
+	test("`c8 unassign group abc --from-user=u` → 'Failed to unassign group' + 'Unsupported source flag'", async () => {
+		const result = await c8("unassign", "group", "abc", "--from-user=u");
+		assertFrameworkFailure(
+			result,
+			"Failed to unassign group",
+			"Unsupported source flag --from-user for resource 'group'",
+			"unassign group (bad source)",
+		);
+	});
+});
+
+// ── plugins.ts (framework prefix: "Failed to <verb> plugin") ─────────────────
+
+describe("round-3 framework prefix: plugins", () => {
+	test("`c8 load plugin foo --from=https://x` → 'Failed to load plugin' + 'Cannot specify both'", async () => {
+		const result = await c8("load", "plugin", "foo", "--from=https://x");
+		assertFrameworkFailure(
+			result,
+			"Failed to load plugin",
+			"Cannot specify both a positional argument and --from flag",
+			"load plugin (positional + --from)",
+		);
+	});
+
+	test("`c8 load plugin` → 'Failed to load plugin' + 'Package name or URL required'", async () => {
+		const result = await c8("load", "plugin");
+		assertFrameworkFailure(
+			result,
+			"Failed to load plugin",
+			"Package name or URL required",
+			"load plugin (no name, no --from)",
+		);
+	});
+
+	test("`c8 load plugin --from=not-a-url` → 'Failed to load plugin' + 'Invalid URL format'", async () => {
+		const result = await c8("load", "plugin", "--from=not-a-url");
+		assertFrameworkFailure(
+			result,
+			"Failed to load plugin",
+			"Invalid URL format",
+			"load plugin (invalid URL)",
+		);
+	});
+
+	test("`c8 load plugin https://example.com` → 'Failed to load plugin' + 'Package name cannot be a URL'", async () => {
+		const result = await c8("load", "plugin", "https://example.com");
+		assertFrameworkFailure(
+			result,
+			"Failed to load plugin",
+			"Package name cannot be a URL",
+			"load plugin (URL as positional)",
+		);
+	});
+
+	test("`c8 unload plugin nonexistent-pkg-xyz` → 'Failed to unload plugin' + 'neither registered nor installed'", async () => {
+		const result = await c8("unload", "plugin", "nonexistent-pkg-xyz");
+		assertFrameworkFailure(
+			result,
+			"Failed to unload plugin",
+			"neither registered nor installed",
+			"unload plugin (not registered, not installed)",
+		);
+	});
+
+	test("`c8 upgrade plugin nonexistent-pkg-xyz` → 'Failed to upgrade plugin' + 'not registered'", async () => {
+		const result = await c8("upgrade", "plugin", "nonexistent-pkg-xyz");
+		assertFrameworkFailure(
+			result,
+			"Failed to upgrade plugin",
+			"is not registered",
+			"upgrade plugin (not registered)",
+		);
+	});
+
+	test("`c8 downgrade plugin nonexistent-pkg-xyz 1.0.0` → 'Failed to downgrade plugin' + 'not registered'", async () => {
+		const result = await c8(
+			"downgrade",
+			"plugin",
+			"nonexistent-pkg-xyz",
+			"1.0.0",
+		);
+		assertFrameworkFailure(
+			result,
+			"Failed to downgrade plugin",
+			"is not registered",
+			"downgrade plugin (not registered)",
+		);
+	});
+
+	test("`c8 init plugin c8ctl-plugin-` → 'Failed to init plugin' + 'Plugin name cannot be empty'", async () => {
+		const result = await c8("init", "plugin", "c8ctl-plugin-");
+		assertFrameworkFailure(
+			result,
+			"Failed to init plugin",
+			"Plugin name cannot be empty",
+			"init plugin (empty name)",
+		);
+	});
+});
+
+// ── profiles.ts (framework prefix: "Failed to <verb> profile") ───────────────
+
+describe("round-3 framework prefix: profiles", () => {
+	test("`c8 use profile <bad>` → 'Failed to use profile' + 'not found'", async () => {
+		const result = await c8("use", "profile", "nonexistent-profile-xyz");
+		assertFrameworkFailure(
+			result,
+			"Failed to use profile",
+			"not found",
+			"use profile (not found)",
+		);
+	});
+
+	test("`c8 add profile p --from-file=x --from-env` → 'Failed to add profile' + 'Cannot use --from-file and --from-env together'", async () => {
+		const result = await c8(
+			"add",
+			"profile",
+			"p",
+			"--from-file=x",
+			"--from-env",
+		);
+		assertFrameworkFailure(
+			result,
+			"Failed to add profile",
+			"Cannot use --from-file and --from-env together",
+			"add profile (conflicting flags)",
+		);
+	});
+
+	test("`c8 add profile p --from-file=/nonexistent` → 'Failed to add profile' + 'File not found'", async () => {
+		const result = await c8(
+			"add",
+			"profile",
+			"p",
+			"--from-file=/nonexistent-path-xyz",
+		);
+		assertFrameworkFailure(
+			result,
+			"Failed to add profile",
+			"File not found",
+			"add profile (file not found)",
+		);
+	});
+
+	test("tmp .env without CAMUNDA_BASE_URL → 'Failed to add profile' + 'CAMUNDA_BASE_URL not found'", async () => {
+		const envFile = join(TEST_DATA_DIR, "empty.env");
+		writeFileSync(envFile, "# no CAMUNDA_BASE_URL here\nFOO=bar\n");
+		try {
+			const result = await c8("add", "profile", "p", `--from-file=${envFile}`);
+			assertFrameworkFailure(
+				result,
+				"Failed to add profile",
+				"CAMUNDA_BASE_URL not found",
+				"add profile (missing in file)",
+			);
+		} finally {
+			rmSync(envFile, { force: true });
+		}
+	});
+
+	test("`CAMUNDA_BASE_URL='' c8 add profile p --from-env` → 'Failed to add profile' + 'CAMUNDA_BASE_URL not set in environment'", async () => {
+		const result = await c8WithEnv(
+			{ CAMUNDA_BASE_URL: "" },
+			"add",
+			"profile",
+			"p",
+			"--from-env",
+		);
+		assertFrameworkFailure(
+			result,
+			"Failed to add profile",
+			"CAMUNDA_BASE_URL not set in environment",
+			"add profile (missing in env)",
+		);
+	});
+
+	test("`c8 remove profile <bad>` → 'Failed to remove profile' + 'not found'", async () => {
+		const result = await c8("remove", "profile", "nonexistent-profile-xyz");
+		assertFrameworkFailure(
+			result,
+			"Failed to remove profile",
+			"not found",
+			"remove profile (not found)",
+		);
+	});
+});

--- a/tests/unit/round-3-error-paths.test.ts
+++ b/tests/unit/round-3-error-paths.test.ts
@@ -21,44 +21,15 @@
  */
 
 import assert from "node:assert";
-import { spawn } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { after, describe, test } from "node:test";
 
-interface SpawnResult {
-	status: number | null;
-	stdout: string;
-	stderr: string;
-}
+import { asyncSpawn, type SpawnResult } from "../utils/spawn.ts";
 
 const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
 const CLI = join(PROJECT_ROOT, "src", "index.ts");
-
-function asyncSpawn(
-	cmd: string,
-	args: string[],
-	opts: { env?: NodeJS.ProcessEnv } = {},
-): Promise<SpawnResult> {
-	return new Promise((res) => {
-		const proc = spawn(cmd, args, {
-			env: opts.env ?? process.env,
-			stdio: ["ignore", "pipe", "pipe"],
-		});
-		let stdout = "";
-		let stderr = "";
-		proc.stdout.on("data", (chunk) => {
-			stdout += chunk.toString();
-		});
-		proc.stderr.on("data", (chunk) => {
-			stderr += chunk.toString();
-		});
-		proc.on("close", (status) => {
-			res({ status, stdout, stderr });
-		});
-	});
-}
 
 const TEST_DATA_DIR = mkdtempSync(join(tmpdir(), "c8ctl-round3-paths-"));
 // Minimal profile so CAMUNDA_BASE_URL is set for tests that go through the


### PR DESCRIPTION
Closes #300. Follows #304 and #305.

## Summary

Final round of the `process.exit(1)` → `throw` migration. Converts the last 47 sites across four command modules and wraps the remaining free-function handlers in `defineCommand`, so every command path now flows through the framework error pipeline (`Failed to <verb> <resource>: <original message>` on stderr, exit code 1). The `PENDING_MIGRATION` allow-list is retired.

## Changes

### Production code
- **`src/commands/identity.ts`** — `handleAssign` / `handleUnassign` now throw; added 8 per-resource `defineCommand` wrappers (`assign:role|user|group|mapping-rule`, mirror for `unassign`) plus `assign:` / `unassign:` fallback handlers so unknown resources surface the canonical `Cannot assign resource type: <name>` error through the framework.
- **`src/commands/completion.ts`** — `showCompletion` / `installCompletion` throw; single `completionCommand` dispatched on `ctx.resource`.
- **`src/commands/plugins.ts`** — 16 sites converted.
- **`src/commands/profiles.ts`** — 8 sites converted.
- **`src/command-dispatch.ts`** — 11 new dispatch entries (8 assign/unassign + 2 fallbacks + 1 completion).
- **`src/command-registry.ts`** — `shell` flag added to top-level `completion.flags` so the resource-`""` dispatch path resolves `--shell`.
- **`src/index.ts`** — deleted legacy `if (verb === "completion" | "assign" | "unassign")` branches and removed now-unused imports.

### Tests
- **`tests/unit/no-process-exit-in-handlers.test.ts`** — `PENDING_MIGRATION` allow-list removed; single unconditional test forbids `process.exit(...)` in `src/commands/**.ts`.
- **`tests/unit/round-3-error-paths.test.ts`** (new, 23 tests) — asserts every migrated path emits `Failed to <verb> <resource>` framework prefix **and** the original error fragment on stderr with exit 1. Covers completion (4), assign/unassign (8), plugins (8), profiles (6). Uses the same deterministic `c8WithEnv` helper as `round-3-baseline.test.ts`.
- **`tests/unit/identity.test.ts`** / **`tests/unit/completion.test.ts`** — rejection patterns updated from `/process\.exit\(1\)/` to specific thrown-Error messages.

## Red/green discipline

The red/green pairing for this refactor was established in #305, which landed `round-3-baseline.test.ts` asserting the preserved invariants (exit=1, original message in stderr) against the *pre-refactor* code. Those baseline tests stayed green throughout this PR, proving behaviour was preserved. The new `round-3-error-paths.test.ts` locks in the *additional* invariant (framework prefix) that only the post-refactor code satisfies, guarding against any future regression that bypasses `defineCommand`.

## Gates

- ✅ `npx biome check` — clean
- ✅ `npm run build` — clean
- ✅ `npm test` — 1317 pass / 0 fail / 1 pre-existing skip

## Diffstat

```
 src/command-dispatch.ts                        |  30 +++
 src/command-registry.ts                        |   7 +-
 src/commands/completion.ts                     |  63 ++++--
 src/commands/identity.ts                       | 560 ++++++++++++++---------
 src/commands/plugins.ts                        |  64 +--
 src/commands/profiles.ts                       |  30 +-
 src/index.ts                                   |  49 +--
 tests/unit/completion.test.ts                  |  33 +-
 tests/unit/identity.test.ts                    |  40 +-
 tests/unit/no-process-exit-in-handlers.test.ts | 108 +---
 tests/unit/round-3-error-paths.test.ts         | 438 +++++++++++++++++
 11 files changed, 932 insertions(+), 490 deletions(-)
```
