### PR TITLE
feat: structural test that all COMMAND_DISPATCH entries come from defineCommand (#290)

### DIFF
--- a/src/command-framework.ts
+++ b/src/command-framework.ts
@@ -243,6 +243,20 @@ export interface CommandContext {
 // ─── CommandHandler ──────────────────────────────────────────────────────────
 
 /**
+ * Brand symbol stamped on every value returned by `defineCommand`.
+ *
+ * This is the structural seam tested by `command-dispatch-structure.test.ts`
+ * (#290): every value in `COMMAND_DISPATCH` must carry this marker, which
+ * guarantees the entry was produced by the framework factory and therefore
+ * goes through flag deserialization, dry-run handling, result rendering, and
+ * the `handleCommandError` wrapper. A hand-rolled function with the right
+ * signature cannot satisfy this marker.
+ */
+export const DEFINE_COMMAND_MARKER: unique symbol = Symbol(
+	"c8ctl.defineCommand",
+);
+
+/**
  * Return type of `defineCommand`. Stores the verb, resource, and an
  * `execute` method that deserializes raw CLI input and calls the handler
  * with fully typed flags and positionals.
@@ -255,6 +269,16 @@ export interface CommandHandler<V extends keyof Registry, R extends string> {
 		rawValues: Record<string, unknown>,
 		rawArgs: string[],
 	) => Promise<void>;
+	/** Brand attached by `defineCommand`. See `DEFINE_COMMAND_MARKER`. */
+	readonly [DEFINE_COMMAND_MARKER]: true;
+}
+
+/**
+ * Test-time guard: returns true iff `value` was produced by `defineCommand`.
+ */
+export function isDefinedCommand(value: unknown): value is AnyCommandHandler {
+	if (typeof value !== "object" || value === null) return false;
+	return Reflect.get(value, DEFINE_COMMAND_MARKER) === true;
 }
 
 /**
@@ -298,9 +322,13 @@ export function defineCommand<V extends keyof Registry, R extends string>(
 	const flagDefs = entry.resourceFlags?.[resource] ?? entry.flags;
 	const positionalDefs = entry.resourcePositionals?.[resource] ?? [];
 
-	return {
+	const handler_: CommandHandler<V, R> = {
 		verb,
 		resource,
+		// Non-enumerable brand: present at runtime, not visible in JSON or
+		// `Object.keys`, so test-only structural checks can detect it without
+		// polluting normal iteration.
+		[DEFINE_COMMAND_MARKER]: true,
 		execute: async (ctx, rawValues, rawArgs) => {
 			const flags = deserializeFlags(rawValues, flagDefs);
 			const args = deserializePositionals(
@@ -327,6 +355,7 @@ export function defineCommand<V extends keyof Registry, R extends string>(
 			}
 		},
 	};
+	return handler_;
 }
 
 // ─── deserializeFlags ────────────────────────────────────────────────────────

--- a/src/command-framework.ts
+++ b/src/command-framework.ts
@@ -275,9 +275,14 @@ export interface CommandHandler<V extends keyof Registry, R extends string> {
 
 /**
  * Test-time guard: returns true iff `value` was produced by `defineCommand`.
+ *
+ * Uses an own-property check so a forged marker on a prototype cannot satisfy
+ * the brand — only objects that explicitly carry the symbol on themselves
+ * (i.e. those produced by `defineCommand`) pass.
  */
 export function isDefinedCommand(value: unknown): value is AnyCommandHandler {
 	if (typeof value !== "object" || value === null) return false;
+	if (!Object.hasOwn(value, DEFINE_COMMAND_MARKER)) return false;
 	return Reflect.get(value, DEFINE_COMMAND_MARKER) === true;
 }
 
@@ -322,40 +327,47 @@ export function defineCommand<V extends keyof Registry, R extends string>(
 	const flagDefs = entry.resourceFlags?.[resource] ?? entry.flags;
 	const positionalDefs = entry.resourcePositionals?.[resource] ?? [];
 
-	const handler_: CommandHandler<V, R> = {
-		verb,
-		resource,
-		// Non-enumerable brand: present at runtime, not visible in JSON or
-		// `Object.keys`, so test-only structural checks can detect it without
-		// polluting normal iteration.
-		[DEFINE_COMMAND_MARKER]: true,
-		execute: async (ctx, rawValues, rawArgs) => {
-			const flags = deserializeFlags(rawValues, flagDefs);
-			const args = deserializePositionals(
-				rawArgs,
-				positionalDefs,
-				verb,
-				resource,
+	// Build the handler and stamp the brand as a non-enumerable own property
+	// so it doesn't appear in `Object.keys`, spreads, or JSON output but is
+	// still detectable by `isDefinedCommand` via `Object.hasOwn`.
+	const execute: CommandHandler<V, R>["execute"] = async (
+		ctx,
+		rawValues,
+		rawArgs,
+	) => {
+		const flags = deserializeFlags(rawValues, flagDefs);
+		const args = deserializePositionals(
+			rawArgs,
+			positionalDefs,
+			verb,
+			resource,
+		);
+		try {
+			const result = await handler(
+				ctx,
+				// biome-ignore lint/plugin: framework-internal assertion — flagDefs resolved from COMMAND_REGISTRY[V][R]
+				flags as InferFlags<ResolvedFlags<V, R>>,
+				// biome-ignore lint/plugin: framework-internal assertion — positionalDefs resolved from COMMAND_REGISTRY[V][R]
+				args as InferPositionals<ResolvedPositionals<V, R>>,
 			);
-			try {
-				const result = await handler(
-					ctx,
-					// biome-ignore lint/plugin: framework-internal assertion — flagDefs resolved from COMMAND_REGISTRY[V][R]
-					flags as InferFlags<ResolvedFlags<V, R>>,
-					// biome-ignore lint/plugin: framework-internal assertion — positionalDefs resolved from COMMAND_REGISTRY[V][R]
-					args as InferPositionals<ResolvedPositionals<V, R>>,
-				);
-				if (result) renderResult(result, ctx);
-			} catch (error) {
-				handleCommandError(
-					ctx.logger,
-					`Failed to ${verb} ${resource.replace(/-/g, " ")}`,
-					error,
-				);
-			}
-		},
+			if (result) renderResult(result, ctx);
+		} catch (error) {
+			handleCommandError(
+				ctx.logger,
+				`Failed to ${verb} ${resource.replace(/-/g, " ")}`,
+				error,
+			);
+		}
 	};
-	return handler_;
+	const handler_ = { verb, resource, execute };
+	Object.defineProperty(handler_, DEFINE_COMMAND_MARKER, {
+		value: true,
+		enumerable: false,
+		writable: false,
+		configurable: false,
+	});
+	// biome-ignore lint/plugin: framework-internal assertion — brand stamped via defineProperty above to satisfy CommandHandler's required marker
+	return handler_ as CommandHandler<V, R>;
 }
 
 // ─── deserializeFlags ────────────────────────────────────────────────────────

--- a/tests/unit/command-dispatch-structure.test.ts
+++ b/tests/unit/command-dispatch-structure.test.ts
@@ -18,7 +18,10 @@ import assert from "node:assert";
 import { describe, test } from "node:test";
 
 import { COMMAND_DISPATCH } from "../../src/command-dispatch.ts";
-import { isDefinedCommand } from "../../src/command-framework.ts";
+import {
+	DEFINE_COMMAND_MARKER,
+	isDefinedCommand,
+} from "../../src/command-framework.ts";
 
 describe("COMMAND_DISPATCH structural invariant (#290)", () => {
 	test("every dispatch entry is produced by defineCommand()", () => {
@@ -69,6 +72,36 @@ describe("COMMAND_DISPATCH structural invariant (#290)", () => {
 		assert.strictEqual(
 			isDefinedCommand(() => {}),
 			false,
+		);
+	});
+
+	test("isDefinedCommand rejects an inherited (prototype) marker", () => {
+		// Forging the brand on a prototype must NOT satisfy the guard — only
+		// own-property markers (which `defineCommand` stamps) should pass. This
+		// closes the prototype-pollution-style false-positive class.
+		const proto: Record<PropertyKey, unknown> = {};
+		proto[DEFINE_COMMAND_MARKER] = true;
+		const inheriting = Object.create(proto);
+		assert.strictEqual(isDefinedCommand(inheriting), false);
+	});
+
+	test("the brand stamped by defineCommand is non-enumerable", () => {
+		// Pick any dispatch entry — the brand should exist as an own property
+		// but be invisible to `Object.keys`, spread, and `JSON.stringify`.
+		const [, sample] = [...COMMAND_DISPATCH][0];
+		assert.ok(Object.hasOwn(sample, DEFINE_COMMAND_MARKER));
+		const descriptor = Object.getOwnPropertyDescriptor(
+			sample,
+			DEFINE_COMMAND_MARKER,
+		);
+		assert.ok(descriptor, "expected an own descriptor for the brand");
+		assert.strictEqual(descriptor.enumerable, false);
+		assert.strictEqual(
+			Object.getOwnPropertySymbols(sample).filter(
+				(s) => Object.getOwnPropertyDescriptor(sample, s)?.enumerable,
+			).length,
+			0,
+			"brand symbol should not appear among enumerable symbol keys",
 		);
 	});
 });

--- a/tests/unit/command-dispatch-structure.test.ts
+++ b/tests/unit/command-dispatch-structure.test.ts
@@ -97,10 +97,10 @@ describe("COMMAND_DISPATCH structural invariant (#290)", () => {
 		assert.ok(descriptor, "expected an own descriptor for the brand");
 		assert.strictEqual(descriptor.enumerable, false);
 		assert.strictEqual(
-			Object.getOwnPropertySymbols(sample).filter(
-				(s) => Object.getOwnPropertyDescriptor(sample, s)?.enumerable,
-			).length,
-			0,
+			Object.getOwnPropertySymbols(sample)
+				.filter((s) => Object.getOwnPropertyDescriptor(sample, s)?.enumerable)
+				.includes(DEFINE_COMMAND_MARKER),
+			false,
 			"brand symbol should not appear among enumerable symbol keys",
 		);
 	});

--- a/tests/unit/command-dispatch-structure.test.ts
+++ b/tests/unit/command-dispatch-structure.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Structural test: every value in COMMAND_DISPATCH must be produced by
+ * `defineCommand(...)` (issue #290).
+ *
+ * COMMAND_DISPATCH is the seam between argument parsing and business logic.
+ * Hand-rolled handlers can drift past the framework — skipping flag
+ * deserialization, dry-run handling, result rendering, and the
+ * `handleCommandError` wrapper. This test enforces that every dispatch entry
+ * carries the `DEFINE_COMMAND_MARKER` brand stamped by `defineCommand`.
+ *
+ * It catches drift in both directions:
+ *   1. An existing handler being downgraded to a hand-rolled function.
+ *   2. A new handler being added to the dispatch map without going through
+ *      `defineCommand` (e.g. plugin handlers, forgotten migrations).
+ */
+
+import assert from "node:assert";
+import { describe, test } from "node:test";
+
+import { COMMAND_DISPATCH } from "../../src/command-dispatch.ts";
+import { isDefinedCommand } from "../../src/command-framework.ts";
+
+describe("COMMAND_DISPATCH structural invariant (#290)", () => {
+	test("every dispatch entry is produced by defineCommand()", () => {
+		const offenders: string[] = [];
+
+		for (const [key, handler] of COMMAND_DISPATCH) {
+			if (!isDefinedCommand(handler)) {
+				offenders.push(key);
+			}
+		}
+
+		assert.deepStrictEqual(
+			offenders,
+			[],
+			[
+				"COMMAND_DISPATCH contains entries that were not produced by `defineCommand(...)`:",
+				...offenders.map((k) => `  - ${k}`),
+				"",
+				"Wrap each offending handler with `defineCommand(verb, resource, handler)`",
+				"so it goes through the framework's flag deserialization, dry-run handling,",
+				"result rendering, and `handleCommandError` wrapper.",
+				"",
+				"See src/command-framework.ts and existing handlers in src/commands/ for examples.",
+			].join("\n"),
+		);
+	});
+
+	test("dispatch map is non-empty (sanity)", () => {
+		assert.ok(
+			COMMAND_DISPATCH.size > 0,
+			"COMMAND_DISPATCH is empty — the structural test would trivially pass",
+		);
+	});
+
+	test("isDefinedCommand rejects hand-rolled handlers (detector self-test)", () => {
+		// A hand-rolled object with the same shape as CommandHandler but no
+		// `DEFINE_COMMAND_MARKER` brand — exactly the drift this test guards
+		// against. If `isDefinedCommand` ever returns true for this, the
+		// structural assertion above becomes a no-op.
+		const handRolled = {
+			verb: "list",
+			resource: "process-instance",
+			execute: async () => {},
+		};
+		assert.strictEqual(isDefinedCommand(handRolled), false);
+		assert.strictEqual(isDefinedCommand(null), false);
+		assert.strictEqual(isDefinedCommand(undefined), false);
+		assert.strictEqual(
+			isDefinedCommand(() => {}),
+			false,
+		);
+	});
+});


### PR DESCRIPTION
Closes #290.

## Summary

Adds a structural invariant that every value in `COMMAND_DISPATCH` is the product of `defineCommand(...)` — not a hand-rolled function with the right signature. This locks in the architectural normalisation finished in #306 (Round 3 of #300) and prevents any future drift past the framework.

## Why

`COMMAND_DISPATCH` is the seam between argument parsing and business logic. A hand-rolled entry skips:

- flag-type validation derived from `COMMAND_REGISTRY`
- the `dryRun()` helper
- centralised `CommandResult` rendering
- the `handleCommandError` wrapper (the very pipeline #306 just unified)

A type signature alone can't enforce this — any function with the right shape would satisfy it. We need a runtime brand the structural test can read.

## Approach

1. Stamp a `unique symbol` brand (`DEFINE_COMMAND_MARKER`) onto every object returned by `defineCommand`.
2. Export an `isDefinedCommand(value)` type guard that checks for the brand.
3. New `tests/unit/command-dispatch-structure.test.ts` iterates `COMMAND_DISPATCH.values()` and fails listing the offending keys, with a remediation hint pointing to `defineCommand`.

The brand is non-trivial to forge accidentally: a plugin or a forgotten migration can't satisfy it without explicitly importing the symbol and assigning `true` to it (which would be visible in review).

## Red/green discipline

The test file includes a **detector self-test** (`isDefinedCommand rejects hand-rolled handlers`) that asserts the brand check returns `false` for plain objects, `null`, `undefined`, and bare functions. This is the "red" half: it proves the structural test is capable of catching the defect class. Without it, the main assertion could silently degrade to a no-op.

## Changes

- `src/command-framework.ts`
  - Add `DEFINE_COMMAND_MARKER: unique symbol`
  - Add brand property to `CommandHandler` interface
  - Stamp the brand inside `defineCommand`'s returned object
  - Add `isDefinedCommand(value): value is AnyCommandHandler`
- `tests/unit/command-dispatch-structure.test.ts` (new, 3 tests)
  - main invariant + sanity check (non-empty map) + detector self-test

## Gates

- ✅ `npx biome check` — clean
- ✅ `npm run typecheck` — clean
- ✅ `npm run build` — clean
- ✅ `npm test` — 1320 pass / 0 fail / 1 pre-existing skip (3 new tests)
