### PR TITLE
feat(validation): enforce FlagDef.required at the framework boundary

### DIFF
--- a/src/command-framework.ts
+++ b/src/command-framework.ts
@@ -79,11 +79,14 @@ export type ResolvedPositionals<
 /**
  * Map a flag schema to typed handler parameters.
  *
- * - Flags with `validate` → the validator's return type (branded) | undefined
- * - Boolean flags → boolean | undefined
- * - Everything else → string | undefined
+ * - Flags with `validate` → the validator's return type
+ * - Boolean flags → boolean
+ * - Everything else → string
  *
- * All flags are optional because CLI users may omit any flag.
+ * A flag is non-optional in the handler's view iff it is declared
+ * `required: true` in the FlagDef. `required: true` is enforced at the
+ * framework boundary by validateFlags (#308), so the handler is guaranteed
+ * to see a value.
  *
  * The type parameter is unconstrained so conditional types like
  * `ResolvedFlags<V, R>` can be passed through without constraint errors.
@@ -91,10 +94,16 @@ export type ResolvedPositionals<
 // biome-ignore lint/suspicious/noExplicitAny: unconstrained to accept conditional types
 export type InferFlags<F extends Record<string, any>> = {
 	[K in keyof F]: F[K] extends { validate: (v: string) => infer R }
-		? R | undefined
+		? F[K] extends { required: true }
+			? R
+			: R | undefined
 		: F[K] extends { type: "boolean" }
-			? boolean | undefined
-			: string | undefined;
+			? F[K] extends { required: true }
+				? boolean
+				: boolean | undefined
+			: F[K] extends { required: true }
+				? string
+				: string | undefined;
 };
 
 // ─── InferPositionals ────────────────────────────────────────────────────────

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -865,33 +865,6 @@ export const COMMAND_REGISTRY = {
 				description: "Tenant ID",
 				validate: TenantId.assumeExists,
 			},
-			// Identity authorization
-			ownerId: {
-				type: "string",
-				description: "Authorization owner ID",
-				required: true,
-			},
-			ownerType: {
-				type: "string",
-				description: "Authorization owner type",
-				required: true,
-			},
-			resourceType: {
-				type: "string",
-				description: "Authorization resource type",
-				required: true,
-			},
-			resourceId: {
-				type: "string",
-				description: "Authorization resource ID",
-				required: true,
-			},
-			permissions: {
-				type: "string",
-				description: "Comma-separated permissions",
-				required: true,
-				csv: true,
-			},
 			// Identity mapping rule
 			mappingRuleId: {
 				type: "string",
@@ -899,6 +872,40 @@ export const COMMAND_REGISTRY = {
 			},
 			claimName: { type: "string", description: "Claim name" },
 			claimValue: { type: "string", description: "Claim value" },
+		},
+		// Resource-scoped flags: the authorization-specific flags below are
+		// only required when creating an authorization. Declaring them at the
+		// verb level would force every `create <resource>` invocation to
+		// supply them (see #308 — required-flag enforcement).
+		resourceFlags: {
+			authorization: {
+				ownerId: {
+					type: "string",
+					description: "Authorization owner ID",
+					required: true,
+				},
+				ownerType: {
+					type: "string",
+					description: "Authorization owner type",
+					required: true,
+				},
+				resourceType: {
+					type: "string",
+					description: "Authorization resource type",
+					required: true,
+				},
+				resourceId: {
+					type: "string",
+					description: "Authorization resource ID",
+					required: true,
+				},
+				permissions: {
+					type: "string",
+					description: "Comma-separated permissions",
+					required: true,
+					csv: true,
+				},
+			},
 		},
 	},
 
@@ -1671,14 +1678,21 @@ export function getCommandDef(verb: string): CommandDef | undefined {
 }
 
 /**
- * Get all flags accepted for a given verb, including global flags.
+ * Get all flags accepted for a given verb, including global flags and any
+ * resource-scoped flags declared under `resourceFlags`.
  */
 export function getAcceptedFlags(
 	verb: string,
 ): Record<string, FlagDef> | undefined {
 	const def = getCommandDef(verb);
 	if (!def) return undefined;
-	return { ...GLOBAL_FLAGS, ...def.flags };
+	const merged: Record<string, FlagDef> = { ...GLOBAL_FLAGS, ...def.flags };
+	if (def.resourceFlags) {
+		for (const rFlags of Object.values(def.resourceFlags)) {
+			Object.assign(merged, rFlags);
+		}
+	}
+	return merged;
 }
 
 /**

--- a/src/command-validation.ts
+++ b/src/command-validation.ts
@@ -167,11 +167,21 @@ export function validateFlags(
 	for (const [flagName, def] of Object.entries(flagDefs)) {
 		if (!def.validate) continue;
 
+		// Pick the value to validate. As with required-flag enforcement
+		// below, accept the last string from a repeated-flag array so that
+		// `--foo a --foo b` (which `parseArgs({ strict: false })` returns as
+		// `["a","b"]`) is validated rather than silently skipped.
 		const raw = values[flagName];
-		if (raw === undefined || typeof raw !== "string") continue;
+		const value =
+			typeof raw === "string"
+				? raw
+				: Array.isArray(raw)
+					? lastString(raw)
+					: undefined;
+		if (value === undefined) continue;
 
 		try {
-			validated.set(flagName, def.validate(raw));
+			validated.set(flagName, def.validate(value));
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			logger.error(`Invalid --${flagName}: ${message}`);
@@ -182,16 +192,50 @@ export function validateFlags(
 	// Required-flag enforcement (#308). Run after validators so that an
 	// explicitly-invalid value (e.g. bad enum) surfaces its specific error
 	// before the generic "is required" message.
+	//
+	// "Present" means: a non-empty string, OR a non-empty array whose last
+	// element is a non-empty string. node:util `parseArgs({ strict: false })`
+	// returns an array when the same flag is supplied more than once
+	// (`--foo a --foo b` → `["a","b"]`), so a strict `typeof === "string"`
+	// check would incorrectly report a supplied flag as missing.
 	for (const [flagName, def] of Object.entries(flagDefs)) {
 		if (def.required !== true) continue;
 		const raw = values[flagName];
-		if (typeof raw !== "string" || raw.length === 0) {
+		if (!isPresentString(raw)) {
 			logger.error(`--${flagName} is required`);
 			process.exit(1);
 		}
 	}
 
 	return validated;
+}
+
+/**
+ * True iff `raw` is a non-empty string, or an array whose last entry is a
+ * non-empty string. Mirrors the semantics of `--foo` being supplied at least
+ * once with a value (single or repeated).
+ */
+function isPresentString(
+	raw: string | boolean | (string | boolean)[] | undefined,
+): boolean {
+	if (typeof raw === "string") return raw.length > 0;
+	if (Array.isArray(raw)) {
+		const last = lastString(raw);
+		return last !== undefined && last.length > 0;
+	}
+	return false;
+}
+
+/**
+ * Return the last string element of an array (typical "last write wins"
+ * semantics for repeated CLI flags), or undefined if there is none.
+ */
+function lastString(arr: (string | boolean)[]): string | undefined {
+	for (let i = arr.length - 1; i >= 0; i--) {
+		const v = arr[i];
+		if (typeof v === "string") return v;
+	}
+	return undefined;
 }
 
 /** Flag names that are always valid regardless of verb or resource. */

--- a/src/command-validation.ts
+++ b/src/command-validation.ts
@@ -140,14 +140,22 @@ export function requireOneOf<T extends string>(
 }
 
 /**
- * Run all registered validators for provided flag values.
+ * Run all registered validators for provided flag values, and enforce
+ * `required: true` on any declared-required flag.
  *
- * For each flag that has a `validate` function on its FlagDef,
- * calls the validator with the raw string value. On failure,
- * logs the error and exits with code 1.
+ * Enforcement order:
+ *   1. Every flag with a `validate` function has it applied (invalid → exit 1).
+ *   2. Every flag with `required: true` must be present as a non-empty string
+ *      (missing → exit 1 with `--<flag> is required`).
  *
- * Returns a map of flag name → validated value for flags that
- * had validators. Flags without validators are not included.
+ * Returns a map of flag name → validated value for flags that had validators.
+ * Flags without validators are not included.
+ *
+ * Note: `validateFlags` expects the **effective** flag set for the dispatched
+ * (verb, resource), i.e. `commandDef.resourceFlags?.[resource] ?? commandDef.flags`.
+ * Passing the raw top-level `commandDef.flags` for verbs with resource-scoped
+ * flags can over-enforce required flags that are only meaningful for certain
+ * resources.
  */
 export function validateFlags(
 	values: Record<string, string | boolean | (string | boolean)[] | undefined>,
@@ -167,6 +175,18 @@ export function validateFlags(
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			logger.error(`Invalid --${flagName}: ${message}`);
+			process.exit(1);
+		}
+	}
+
+	// Required-flag enforcement (#308). Run after validators so that an
+	// explicitly-invalid value (e.g. bad enum) surfaces its specific error
+	// before the generic "is required" message.
+	for (const [flagName, def] of Object.entries(flagDefs)) {
+		if (def.required !== true) continue;
+		const raw = values[flagName];
+		if (typeof raw !== "string" || raw.length === 0) {
+			logger.error(`--${flagName} is required`);
 			process.exit(1);
 		}
 	}

--- a/src/commands/variables.ts
+++ b/src/commands/variables.ts
@@ -17,13 +17,9 @@ export const setVariableCommand = defineCommand(
 		const { client, profile } = ctx;
 		const key = args.key;
 
-		// Parse variables JSON
+		// `--variables` is declared `required: true` in the registry and enforced
+		// by validateFlags (#308), so rawVariables is guaranteed non-empty here.
 		const rawVariables = flags.variables;
-		if (!rawVariables) {
-			throw new Error(
-				"--variables is required. Provide a JSON object, e.g. --variables='{\"myVar\":42}'",
-			);
-		}
 
 		let parsed: unknown;
 		try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -225,9 +225,12 @@ async function main() {
 
 	// Flag validation — run all registered validators before dispatch.
 	// Validators throw on invalid input; validateFlags catches and exits.
+	// Also enforces `required: true` on the effective flag set (#308).
 	const commandDef = getCommandDef(verb);
 	if (commandDef) {
-		validateFlags(values, commandDef.flags);
+		const effectiveFlags =
+			commandDef.resourceFlags?.[normalizedResource] ?? commandDef.flags;
+		validateFlags(values, effectiveFlags);
 	}
 
 	// Unknown flag detection — warn about flags not recognised for this verb × resource.

--- a/tests/unit/command-validation.test.ts
+++ b/tests/unit/command-validation.test.ts
@@ -252,7 +252,11 @@ describe("requireOneOf", () => {
 // ─── validateFlags ───────────────────────────────────────────────────────────
 
 import type { CommandDef } from "../../src/command-registry.ts";
-import { COMMAND_REGISTRY, GLOBAL_FLAGS } from "../../src/command-registry.ts";
+import {
+	COMMAND_REGISTRY,
+	GLOBAL_FLAGS,
+	resolveAlias,
+} from "../../src/command-registry.ts";
 import { validateFlags } from "../../src/command-validation.ts";
 
 /** Widened read-only view of COMMAND_REGISTRY for iterating with index signatures. */
@@ -428,6 +432,27 @@ function effectiveFlags(
 }
 
 /**
+ * Enumerate every resource bucket we need to test for a verb. The framework's
+ * effective-flag lookup keys on the *canonical* resource name (after
+ * `resolveAlias`), but `def.resources` may list aliases (e.g. `auth` →
+ * `authorization`). To avoid silently skipping `resourceFlags`-only buckets
+ * (which is exactly how the post-#308 move of `create authorization` flags
+ * went uncovered initially), we union:
+ *
+ *   - canonical forms of each entry in `def.resources`
+ *   - explicit `Object.keys(def.resourceFlags ?? {})`
+ *
+ * For resourceless verbs we yield a single empty-string bucket.
+ */
+function effectiveResourceBuckets(def: CommandDef): string[] {
+	const set = new Set<string>();
+	for (const r of def.resources ?? []) set.add(resolveAlias(r));
+	for (const r of Object.keys(def.resourceFlags ?? {})) set.add(r);
+	if (set.size === 0) set.add("");
+	return [...set];
+}
+
+/**
  * Class-scoped regression guard (#308): every flag declared `required: true`
  * in the COMMAND_REGISTRY must be enforced by validateFlags. The framework
  * boundary — not the handler — is the canonical place to reject missing
@@ -454,9 +479,7 @@ describe("validateFlags enforces FlagDef.required (#308)", () => {
 			flagName: string;
 		}> = [];
 		for (const [verb, def] of Object.entries(REGISTRY)) {
-			const resources =
-				def.resources && def.resources.length > 0 ? def.resources : [""];
-			for (const resource of resources) {
+			for (const resource of effectiveResourceBuckets(def)) {
 				const flags = effectiveFlags(def, resource);
 				for (const [flagName, fd] of Object.entries(flags)) {
 					if (fd.required === true) {
@@ -541,9 +564,7 @@ describe("validateFlags enforces FlagDef.required (#308)", () => {
 
 	test("validateFlags passes when all required flags are present", () => {
 		for (const [verb, def] of Object.entries(REGISTRY)) {
-			const resources =
-				def.resources && def.resources.length > 0 ? def.resources : [""];
-			for (const resource of resources) {
+			for (const resource of effectiveResourceBuckets(def)) {
 				const flags = effectiveFlags(def, resource);
 				const values: Record<string, string> = {};
 				for (const [flagName, fd] of Object.entries(flags)) {
@@ -557,6 +578,77 @@ describe("validateFlags enforces FlagDef.required (#308)", () => {
 				);
 			}
 		}
+	});
+});
+
+// ─── validateFlags — repeated flag (array) handling ──────────────────────────
+
+/**
+ * Regression guard for the array-value defect class. node:util `parseArgs`
+ * with `strict: false` returns `string[]` (or `(string|boolean)[]`) when the
+ * same flag is supplied more than once on the command line, e.g.
+ *
+ *   c8ctl create authorization --ownerId a --ownerId b
+ *
+ * Pre-fix, validateFlags treated any non-string value as "missing" for the
+ * required-flag check and silently skipped it for the validator pass. That
+ * meant a supplied flag could be:
+ *   1. incorrectly reported as missing, or
+ *   2. silently bypass its validator (an invalid second occurrence would
+ *      not be rejected).
+ *
+ * Both branches now use last-write-wins semantics on the array.
+ */
+describe("validateFlags handles repeated-flag arrays", () => {
+	beforeEach(setup);
+	afterEach(teardown);
+
+	const requiredFlag: Record<
+		string,
+		import("../../src/command-registry.ts").FlagDef
+	> = {
+		owner: { type: "string", description: "Owner", required: true },
+	};
+
+	test("required flag supplied as a non-empty string array is accepted", () => {
+		assert.doesNotThrow(() =>
+			validateFlags({ owner: ["alice", "bob"] }, requiredFlag),
+		);
+	});
+
+	test("required flag supplied as an empty array is rejected", () => {
+		assert.throws(() => validateFlags({ owner: [] }, requiredFlag));
+		const combined = errorSpy.join("\n");
+		assert.ok(combined.includes("--owner is required"), combined);
+	});
+
+	const validatedFlag: Record<
+		string,
+		import("../../src/command-registry.ts").FlagDef
+	> = {
+		num: {
+			type: "string",
+			description: "Number",
+			validate: (v: string) => {
+				if (!/^[0-9]+$/.test(v)) throw new Error("must be numeric");
+				return v;
+			},
+		},
+	};
+
+	test("validator is applied to the last string in a repeated-flag array", () => {
+		// Last value is invalid — must be rejected, not silently skipped.
+		assert.throws(() => validateFlags({ num: ["123", "abc"] }, validatedFlag));
+		const combined = errorSpy.join("\n");
+		assert.ok(combined.includes("Invalid --num"), combined);
+	});
+
+	test("validator accepts the last string in a repeated-flag array when valid", () => {
+		const result = validateFlags({ num: ["abc", "456"] }, validatedFlag);
+		// Wait — first value would throw before second is reached if we ran
+		// the validator on every element. Last-write-wins means we only run
+		// on "456" which is valid.
+		assert.strictEqual(result.get("num"), "456");
 	});
 });
 

--- a/tests/unit/command-validation.test.ts
+++ b/tests/unit/command-validation.test.ts
@@ -410,6 +410,156 @@ describe("validateFlags behaviour", () => {
 	});
 });
 
+// ─── validateFlags — required-flag enforcement (#308) ────────────────────────
+
+/**
+ * Resolve the effective flag set for a (verb, resource) dispatch, mirroring
+ * the resolution used by the command framework:
+ *   effective = resourceFlags?.[resource] ?? flags
+ */
+function effectiveFlags(
+	def: CommandDef,
+	resource: string | undefined,
+): Record<string, import("../../src/command-registry.ts").FlagDef> {
+	if (def.resourceFlags && resource && def.resourceFlags[resource]) {
+		return def.resourceFlags[resource];
+	}
+	return def.flags;
+}
+
+/**
+ * Class-scoped regression guard (#308): every flag declared `required: true`
+ * in the COMMAND_REGISTRY must be enforced by validateFlags. The framework
+ * boundary — not the handler — is the canonical place to reject missing
+ * required input. Without this guard, a `required: true` in the registry is
+ * pure metadata and handlers have to duplicate the check (or forget to, as
+ * `correlate:message`'s `correlationKey` did pre-#308).
+ */
+describe("validateFlags enforces FlagDef.required (#308)", () => {
+	beforeEach(setup);
+	afterEach(teardown);
+
+	/**
+	 * Enumerate every (verb, resource, requiredFlagName) triple in the
+	 * registry's effective flag sets.
+	 */
+	function collectRequiredFlags(): Array<{
+		verb: string;
+		resource: string;
+		flagName: string;
+	}> {
+		const triples: Array<{
+			verb: string;
+			resource: string;
+			flagName: string;
+		}> = [];
+		for (const [verb, def] of Object.entries(REGISTRY)) {
+			const resources =
+				def.resources && def.resources.length > 0 ? def.resources : [""];
+			for (const resource of resources) {
+				const flags = effectiveFlags(def, resource);
+				for (const [flagName, fd] of Object.entries(flags)) {
+					if (fd.required === true) {
+						triples.push({ verb, resource, flagName });
+					}
+				}
+			}
+		}
+		return triples;
+	}
+
+	test("registry has at least one required flag (sanity — detector is non-vacuous)", () => {
+		assert.ok(
+			collectRequiredFlags().length > 0,
+			"expected at least one required flag in COMMAND_REGISTRY",
+		);
+	});
+
+	test("every required flag is rejected by validateFlags when missing", () => {
+		const failures: string[] = [];
+
+		for (const { verb, resource, flagName } of collectRequiredFlags()) {
+			const def = REGISTRY[verb];
+			if (!def) continue;
+			const flags = effectiveFlags(def, resource);
+
+			// Build values with every OTHER required flag in the effective set
+			// populated with a dummy, so the only missing required flag is `flagName`.
+			const values: Record<string, string> = {};
+			for (const [otherName, otherDef] of Object.entries(flags)) {
+				if (otherName === flagName) continue;
+				if (otherDef.required === true) {
+					values[otherName] = "dummy";
+				}
+			}
+
+			let threw = false;
+			try {
+				validateFlags(values, flags);
+			} catch {
+				threw = true;
+			}
+
+			if (!threw) {
+				failures.push(
+					`${verb}${resource ? ` ${resource}` : ""}: missing --${flagName} was silently accepted`,
+				);
+			}
+		}
+
+		assert.strictEqual(
+			failures.length,
+			0,
+			`required flags not enforced by validateFlags:\n  ${failures.join("\n  ")}`,
+		);
+	});
+
+	test("error message cites the specific missing flag", () => {
+		const triples = collectRequiredFlags();
+		assert.ok(triples.length > 0);
+
+		// Pick a deterministic representative.
+		const sample = triples[0];
+		if (!sample) return;
+		const def = REGISTRY[sample.verb];
+		if (!def) return;
+		const flags = effectiveFlags(def, sample.resource);
+
+		errorSpy = [];
+		try {
+			validateFlags({}, flags);
+		} catch {
+			/* expected process.exit */
+		}
+
+		const combined = errorSpy.join("\n");
+		assert.ok(
+			combined.includes(`--${sample.flagName} is required`),
+			`expected '--${sample.flagName} is required' in stderr; got:\n${combined}`,
+		);
+	});
+
+	test("validateFlags passes when all required flags are present", () => {
+		for (const [verb, def] of Object.entries(REGISTRY)) {
+			const resources =
+				def.resources && def.resources.length > 0 ? def.resources : [""];
+			for (const resource of resources) {
+				const flags = effectiveFlags(def, resource);
+				const values: Record<string, string> = {};
+				for (const [flagName, fd] of Object.entries(flags)) {
+					if (fd.required === true) values[flagName] = "dummy";
+				}
+				// Should not throw — all required present, no validators invoked for "dummy"
+				// values on non-validated flags.
+				assert.doesNotThrow(
+					() => validateFlags(values, flags),
+					`${verb} ${resource}: validateFlags threw with all required flags populated`,
+				);
+			}
+		}
+	});
+});
+
 // ─── detectUnknownFlags ─────────────────────────────────────────────────────
 
 describe("detectUnknownFlags — non-search verbs", () => {

--- a/tests/unit/messages-behaviour.test.ts
+++ b/tests/unit/messages-behaviour.test.ts
@@ -140,4 +140,20 @@ describe("CLI behavioural: correlate message", () => {
 			`stderr: ${result.stderr}`,
 		);
 	});
+
+	// Regression guard for #308: `correlationKey` is the motivating defect for
+	// framework-boundary required-flag enforcement. Pre-#308 the handler
+	// duplicated this check; post-#308 the framework rejects it before the
+	// handler runs. This subprocess test proves the index dispatch actually
+	// invokes validateFlags for this verb (the class-scoped guard in
+	// command-validation.test.ts proves validateFlags itself rejects it).
+	test("rejects missing --correlationKey with exit code 1 (#308)", async () => {
+		const result = await c8("correlate", "msg", "--dry-run", "my-message");
+
+		assert.strictEqual(result.status, 1);
+		assert.ok(
+			result.stderr.includes("--correlationKey is required"),
+			`stderr: ${result.stderr}`,
+		);
+	});
 });

--- a/tests/unit/messages-behaviour.test.ts
+++ b/tests/unit/messages-behaviour.test.ts
@@ -88,7 +88,14 @@ describe("CLI behavioural: publish message", () => {
 
 describe("CLI behavioural: correlate message", () => {
 	test("--dry-run emits POST to /messages/correlation", async () => {
-		const result = await c8("correlate", "message", "--dry-run", "my-message");
+		const result = await c8(
+			"correlate",
+			"message",
+			"--dry-run",
+			"my-message",
+			"--correlationKey",
+			"order-123",
+		);
 
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const out = parseJson(result);
@@ -120,7 +127,12 @@ describe("CLI behavioural: correlate message", () => {
 	});
 
 	test("rejects missing message name with exit code 1", async () => {
-		const result = await c8("correlate", "msg");
+		const result = await c8(
+			"correlate",
+			"msg",
+			"--correlationKey",
+			"order-123",
+		);
 
 		assert.strictEqual(result.status, 1);
 		assert.ok(

--- a/tests/unit/round-2a-error-paths.test.ts
+++ b/tests/unit/round-2a-error-paths.test.ts
@@ -137,6 +137,8 @@ describe("messages: behavioural — invalid --timeToLive flows through the frame
 			"correlate",
 			"message",
 			"some-name",
+			"--correlationKey",
+			"order-123",
 			"--timeToLive=-5",
 		);
 

--- a/tests/unit/variables-behaviour.test.ts
+++ b/tests/unit/variables-behaviour.test.ts
@@ -90,11 +90,10 @@ describe("CLI behavioural: set variable", () => {
 	test("rejects missing --variables flag with exit code 1", async () => {
 		const result = await c8("set", "variable", "2251799813685249", "--dry-run");
 
+		// Missing required flag is enforced at the framework boundary
+		// (validateFlags in src/index.ts), before the handler runs — so the
+		// `Failed to set variable:` prefix is not attached.
 		assert.strictEqual(result.status, 1);
-		assert.ok(
-			result.stderr.includes("Failed to set variable"),
-			`expected framework prefix; stderr: ${result.stderr}`,
-		);
 		assert.ok(
 			result.stderr.includes("--variables is required"),
 			`stderr: ${result.stderr}`,


### PR DESCRIPTION
Closes #308.

## What

`validateFlags` now rejects any missing `required: true` flag with `--<name> is required` + exit 1. Closes the gap where required-flag metadata in `COMMAND_REGISTRY` was pure documentation and had to be duplicated as a runtime check in every handler (or silently skipped, as `correlate:message`'s `--correlationKey` was).

## Why

Surfaced by #294 (`feat(variables): add set variable command`). The `setVariableCommand` handler had to duplicate `if (!rawVariables) throw new Error("--variables is required")` even though the registry declared `required: true`. That's an invariant the framework should enforce.

## Red / green

Two commits:

1. **Red** — `test: red — assert every required flag is enforced by validateFlags` adds a class-scoped walk over every `(verb, resource, required-flag)` triple in `COMMAND_REGISTRY`'s effective flag sets, asserting `validateFlags` rejects missing ones. On the pre-fix tree this test reported **37 silent failures** across `create user/role/group/tenant/auth/mapping-rule`, `correlate:msg`, and `set:variable`.
2. **Green** — `feat(validation): enforce FlagDef.required at the framework boundary` closes the gap. The class-scoped test goes from 37 → 0.

## Changes

- **`src/command-validation.ts`** — `validateFlags` enforces `required: true` on the flag set it receives. Enforcement runs after validators so an invalid-value error (e.g. bad enum) still wins over the generic "is required" message when both apply.
- **`src/index.ts`** — pass the effective flag set (`resourceFlags?.[resource] ?? flags`) so enforcement is resource-scoped and doesn't over-reach into sibling resources.
- **`src/command-registry.ts`** — move the 5 auth-only required flags on the `create` verb (`ownerId`, `ownerType`, `resourceType`, `resourceId`, `permissions`) from the shared `flags` bag into `resourceFlags.authorization`. Before: `create user` would have been forced to supply them once enforcement went live. After: they only apply to `create authorization`.
- **`src/command-registry.ts`** — extend `getAcceptedFlags` to include `resourceFlags`, keeping its "all flags accepted by this verb" contract accurate.
- **`src/command-framework.ts`** — narrow `InferFlags` for `required: true` flags so handlers see `string` / `boolean` / `R` (not `| undefined`) for values the framework now guarantees.
- **`src/commands/variables.ts`** — drop the now-dead runtime `if (!rawVariables)` check in `setVariableCommand`; the framework boundary rejects it first.

## Test fallout (all legitimate)

- `tests/unit/messages-behaviour.test.ts` — three `correlate msg` cases were invoking without `--correlationKey`. They were relying on the gap being open. Fixed by supplying the flag.
- `tests/unit/round-2a-error-paths.test.ts` — same pattern.
- `tests/unit/variables-behaviour.test.ts` — drop the `Failed to set variable` prefix assertion on the missing-flag case; the error now originates at the framework boundary, before `handleCommandError` would wrap it. (Other error paths through the handler still keep the prefix assertion.)

## Verification

- `npm test` — 1335 pass / 0 fail / 1 skip
- `npm run build` — green (lint + tsc + copy-plugins)
- `npm run typecheck` — green (narrowed `InferFlags` compiles cleanly across every handler)