### PR TITLE
test(deploy): pin defaults-to-cwd and multi-path forwarding (pre-#288)

### DIFF
--- a/tests/unit/deploy-behaviour.test.ts
+++ b/tests/unit/deploy-behaviour.test.ts
@@ -9,10 +9,32 @@
 import assert from "node:assert";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, test } from "node:test";
 import { c8, parseJson } from "../utils/cli.ts";
 import { asRecord, asRecordArray } from "../utils/guards.ts";
+import { asyncSpawn } from "../utils/spawn.ts";
+
+const CLI = resolve(import.meta.dirname, "..", "..", "src", "index.ts");
+
+/**
+ * Spawn the CLI with a custom cwd. The standard `c8()` helper does not
+ * support cwd; tests that must exercise the "default to current directory"
+ * path or path-relative resolution use this thin wrapper directly.
+ */
+async function c8In(
+	cwd: string,
+	...args: string[]
+): Promise<{ stdout: string; stderr: string; status: number | null }> {
+	return asyncSpawn("node", ["--experimental-strip-types", CLI, ...args], {
+		cwd,
+		env: {
+			...process.env,
+			CAMUNDA_BASE_URL: "http://test-cluster/v2",
+			HOME: "/tmp/c8ctl-test-nonexistent-home",
+		},
+	});
+}
 
 const MINIMAL_BPMN = `<?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
@@ -75,6 +97,59 @@ describe("CLI behavioural: deploy", () => {
 			result.stderr.includes("No BPMN/DMN/Form files found") ||
 				result.stderr.includes("No deployable"),
 			`stderr: ${result.stderr}`,
+		);
+	});
+
+	// ── Pre-#288 coverage guards ────────────────────────────────────────────
+	// These pin the public observable behaviour of the dispatch wrapper so
+	// the planned move of the deploy body into the defineCommand handler
+	// (issue #288) cannot silently regress argument forwarding.
+
+	test("no positional args defaults to current working directory", async () => {
+		// Write a BPMN file at the root of a temp dir, invoke `c8 deploy --dry-run`
+		// from that dir with no path argument, and assert the file is picked up.
+		writeFileSync(join(tempDir, "root.bpmn"), MINIMAL_BPMN);
+
+		const result = await c8In(tempDir, "deploy", "--dry-run");
+
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const out = JSON.parse(result.stdout);
+		const body = asRecord(out.body, "dry-run body");
+		const resources = asRecordArray(body.resources, "body.resources");
+		const names = resources.map((r) => r.name);
+		assert.ok(
+			names.includes("root.bpmn"),
+			`expected root.bpmn in resources, got: ${JSON.stringify(names)}`,
+		);
+	});
+
+	test("multiple positional path args are all collected", async () => {
+		// Two BPMN files in separate dirs to prove both positionals are forwarded
+		// (regression guard for `[ctx.resource, ...ctx.positionals]` shape).
+		const dirA = join(tempDir, "a");
+		const dirB = join(tempDir, "b");
+		const { mkdirSync } = await import("node:fs");
+		mkdirSync(dirA, { recursive: true });
+		mkdirSync(dirB, { recursive: true });
+		const fileA = join(dirA, "alpha.bpmn");
+		const fileB = join(dirB, "beta.bpmn");
+		writeFileSync(fileA, MINIMAL_BPMN.replace("test-process", "alpha-process"));
+		writeFileSync(fileB, MINIMAL_BPMN.replace("test-process", "beta-process"));
+
+		const result = await c8("deploy", fileA, fileB, "--dry-run");
+
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const out = parseJson(result);
+		const body = asRecord(out.body, "dry-run body");
+		const resources = asRecordArray(body.resources, "body.resources");
+		const names = resources.map((r) => r.name);
+		assert.ok(
+			names.includes("alpha.bpmn"),
+			`expected alpha.bpmn in resources, got: ${JSON.stringify(names)}`,
+		);
+		assert.ok(
+			names.includes("beta.bpmn"),
+			`expected beta.bpmn in resources, got: ${JSON.stringify(names)}`,
 		);
 	});
 });

--- a/tests/unit/deploy-behaviour.test.ts
+++ b/tests/unit/deploy-behaviour.test.ts
@@ -7,13 +7,13 @@
  */
 
 import assert from "node:assert";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, test } from "node:test";
 import { c8, parseJson } from "../utils/cli.ts";
 import { asRecord, asRecordArray } from "../utils/guards.ts";
-import { asyncSpawn } from "../utils/spawn.ts";
+import { asyncSpawn, type SpawnResult } from "../utils/spawn.ts";
 
 const CLI = resolve(import.meta.dirname, "..", "..", "src", "index.ts");
 
@@ -21,17 +21,27 @@ const CLI = resolve(import.meta.dirname, "..", "..", "src", "index.ts");
  * Spawn the CLI with a custom cwd. The standard `c8()` helper does not
  * support cwd; tests that must exercise the "default to current directory"
  * path or path-relative resolution use this thin wrapper directly.
+ *
+ * Hermeticity: each call gets its own throwaway data dir with a
+ * `session.json` pinning `outputMode: "json"` (mirroring the shared
+ * `c8()` helper), and the env is reduced to `PATH` plus the explicit
+ * test overrides. This isolates the test from any host
+ * `C8CTL_DATA_DIR` and from concurrent `node --test` workers.
  */
-async function c8In(
-	cwd: string,
-	...args: string[]
-): Promise<{ stdout: string; stderr: string; status: number | null }> {
+async function c8In(cwd: string, ...args: string[]): Promise<SpawnResult> {
+	const dataDir = mkdtempSync(join(cwd, ".c8ctl-data-"));
+	writeFileSync(
+		join(dataDir, "session.json"),
+		JSON.stringify({ outputMode: "json" }),
+	);
+
 	return asyncSpawn("node", ["--experimental-strip-types", CLI, ...args], {
 		cwd,
 		env: {
-			...process.env,
+			PATH: process.env.PATH,
 			CAMUNDA_BASE_URL: "http://test-cluster/v2",
 			HOME: "/tmp/c8ctl-test-nonexistent-home",
+			C8CTL_DATA_DIR: dataDir,
 		},
 	});
 }
@@ -87,7 +97,6 @@ describe("CLI behavioural: deploy", () => {
 		// Create an empty subdirectory
 		const emptyDir = join(tempDir, "empty");
 		rmSync(emptyDir, { recursive: true, force: true });
-		const { mkdirSync } = await import("node:fs");
 		mkdirSync(emptyDir, { recursive: true });
 
 		const result = await c8("deploy", emptyDir, "--dry-run");
@@ -113,7 +122,7 @@ describe("CLI behavioural: deploy", () => {
 		const result = await c8In(tempDir, "deploy", "--dry-run");
 
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const out = JSON.parse(result.stdout);
+		const out = parseJson(result);
 		const body = asRecord(out.body, "dry-run body");
 		const resources = asRecordArray(body.resources, "body.resources");
 		const names = resources.map((r) => r.name);
@@ -128,7 +137,6 @@ describe("CLI behavioural: deploy", () => {
 		// (regression guard for `[ctx.resource, ...ctx.positionals]` shape).
 		const dirA = join(tempDir, "a");
 		const dirB = join(tempDir, "b");
-		const { mkdirSync } = await import("node:fs");
 		mkdirSync(dirA, { recursive: true });
 		mkdirSync(dirB, { recursive: true });
 		const fileA = join(dirA, "alpha.bpmn");


### PR DESCRIPTION
## Summary

Pre-refactor coverage guards for the planned `deployCommand` migration in #288.

Per AGENTS.md "Coverage analysis before a behaviour-preserving refactor":

> Land the guard tests in a separate PR off `main`, and merge that PR to `main` before the refactor PR merges. A guard test that lands together with the change it is supposed to guard is weaker — there is no recorded moment at which it passed against the old code.

This is that PR.

## Coverage gaps closed

| Behaviour | Existing guard? |
|---|---|
| `c8 deploy` with no positional args defaults to cwd | ❌ → ✅ added |
| `c8 deploy fileA fileB` forwards both positionals | ❌ → ✅ added |

Both new tests pass against `main` (i.e. the pre-#288 dispatch shape `[ctx.resource, ...ctx.positionals]` / `["."]`). They will continue to pass after the body is moved into the `defineCommand` handler — that's the green/green discipline at work.

## What was already covered

| Behaviour | Guard |
|---|---|
| Structural: zero `process.exit` in deployments.ts | `deploy-error-paths.test.ts` |
| `--dry-run` emits POST /deployments | `deploy-behaviour.test.ts` |
| Empty-paths: framework `Failed to deploy` prefix appears | `deploy-error-paths.test.ts` |
| Duplicate IDs: SilentError suppresses framework prefix | `deploy-error-paths.test.ts` |
| `.c8ignore` patterns flow through dry-run (extensive) | `c8ignore.test.ts` |
| File traversal / sorting / building blocks | `deploy-traversal.test.ts` |
| Process-application grouping & resource counts | `deployment-logging.test.ts` |
| Duplicate-ID validation message format | `deployment-validation.test.ts` |

## Verification

- `npm run build` — green
- `npm run test:unit` — 1204/1204 pass (was 1202; +2 new guards)
- New guards pass on `main` ✅