### PR TITLE
refactor(deploy): inline body into defineCommand handler (#288)

### DIFF
--- a/src/commands/deployments.ts
+++ b/src/commands/deployments.ts
@@ -253,9 +253,6 @@ function findDuplicateDefinitionIds(
 }
 
 /**
- * Deploy resources
- */
-/**
  * Collect deployable resources from the given paths, applying `.c8ignore`
  * rules. Throws on the two pre-API guard failures so callers (deploy
  * handler, watch, dry-run preview) all surface the same errors with the
@@ -808,29 +805,29 @@ export const deployCommand = defineCommand("deploy", "", async (ctx) => {
 	// Dry-run preview. Collect resources first so the preview body
 	// reflects what would actually be sent — and so the empty-paths /
 	// no-files guards still surface as thrown errors before we emit.
-	// `dryRun()` returns null when `c8ctl.dryRun` is false, so this whole
-	// block is a no-op outside dry-run mode.
-	if (c8ctl.dryRun) {
+	// Uses `ctx.dryRun` and `ctx.tenantId` from the framework rather
+	// than reaching into the global runtime/config layer.
+	if (ctx.dryRun) {
 		const previewResources = collectResourcesForPaths(paths);
-		const tenantId = resolveTenantId(ctx.profile);
 		const dr = dryRun({
 			command: "deploy",
 			method: "POST",
 			endpoint: "/deployments",
 			profile: ctx.profile,
 			body: {
-				tenantId,
+				tenantId: ctx.tenantId,
 				resources: previewResources.map((r) => ({ name: r.name })),
 			},
 		});
 		if (dr) return dr;
 	}
 
-	// Execute path: `deployResources` re-runs `collectResourcesForPaths`
-	// internally and renders the success table. The double-walk in
-	// dry-run mode is intentional: keeping the helper self-contained
-	// avoids threading pre-collected state between the handler and the
-	// shared helper used by `watch`.
+	// Execute path: only reached when not in dry-run mode (the branch
+	// above returns early). `deployResources` runs its own
+	// `collectResourcesForPaths` internally and renders the success
+	// table. Keeping the helper self-contained avoids threading
+	// pre-collected state between the handler and the shared helper
+	// used by `watch`.
 	await deployResources(paths, { profile: ctx.profile });
 	return { kind: "none" };
 });

--- a/src/commands/deployments.ts
+++ b/src/commands/deployments.ts
@@ -7,8 +7,8 @@ import { basename, dirname, extname, join, relative, resolve } from "node:path";
 import { TenantId } from "@camunda8/orchestration-cluster-api";
 import type { Ignore } from "ignore";
 import { createClient } from "../client.ts";
-import { defineCommand } from "../command-framework.ts";
-import { resolveClusterConfig, resolveTenantId } from "../config.ts";
+import { defineCommand, dryRun } from "../command-framework.ts";
+import { resolveTenantId } from "../config.ts";
 import { normalizeToError, SilentError } from "../errors.ts";
 import { isIgnored, loadIgnoreRules } from "../ignore.ts";
 import { getLogger, isRecord } from "../logger.ts";
@@ -255,7 +255,50 @@ function findDuplicateDefinitionIds(
 /**
  * Deploy resources
  */
-export async function deploy(
+/**
+ * Collect deployable resources from the given paths, applying `.c8ignore`
+ * rules. Throws on the two pre-API guard failures so callers (deploy
+ * handler, watch, dry-run preview) all surface the same errors with the
+ * same wording.
+ *
+ * Shared between `deployCommand` (used for both the dry-run preview and
+ * the execute path via `deployResources`) and `deployResources` itself.
+ */
+function collectResourcesForPaths(paths: string[]): ResourceFile[] {
+	if (paths.length === 0) {
+		throw new Error(
+			"No paths provided. Use: c8 deploy <path> or c8 deploy (for current directory)",
+		);
+	}
+
+	// Load .c8ignore rules from the working directory
+	const ignoreBaseDir = resolve(process.cwd());
+	const ig = loadIgnoreRules(ignoreBaseDir);
+
+	const resources: ResourceFile[] = [];
+	paths.forEach((path) => {
+		collectResourceFiles(path, resources, undefined, ig, ignoreBaseDir);
+	});
+
+	if (resources.length === 0) {
+		throw new Error("No BPMN/DMN/Form files found in the specified paths");
+	}
+
+	return resources;
+}
+
+/**
+ * Internal helper: deploy the given paths to the cluster and render the
+ * result table. Used by `deployCommand` (the standard CLI entry point)
+ * and by `watchCommand` (for change-triggered re-deploys).
+ *
+ * Does NOT consult `c8ctl.dryRun` — dry-run handling lives in the
+ * `deployCommand` handler so the framework's `dryRun()` helper owns
+ * preview emission. Watch never triggers a dry-run, so this split also
+ * removes a footgun where a stale dry-run flag could suppress a watch
+ * deploy.
+ */
+export async function deployResources(
 	paths: string[],
 	options: {
 		profile?: string;
@@ -265,8 +308,8 @@ export async function deploy(
 		 * Optional cancellation signal. When aborted, an in-flight
 		 * `createDeployment` HTTP request is cancelled via the SDK's
 		 * `CancelablePromise.cancel()`. Cancellation is handled internally:
-		 * if the signal is aborted, `deploy()` returns early without
-		 * surfacing the cancellation as a deploy failure (no
+		 * if the signal is aborted, `deployResources()` returns early
+		 * without surfacing the cancellation as a deploy failure (no
 		 * "Deployment failed" log, no rejection from the awaited promise).
 		 * Callers do not need their own try/catch to suppress aborts.
 		 */
@@ -275,7 +318,6 @@ export async function deploy(
 ): Promise<void> {
 	const logger = getLogger();
 	const tenantId = resolveTenantId(options.profile);
-	const resources: ResourceFile[] = [];
 
 	// ─── Pre-API-call validation and preparation ────────────────────────
 	// These steps run OUTSIDE any try/catch so validation errors bubble
@@ -283,44 +325,12 @@ export async function deploy(
 	// HTTP deploy call (further down) is wrapped in a catch that routes
 	// through `handleDeploymentError` for rich Problem-Detail rendering.
 
-	if (paths.length === 0) {
-		throw new Error(
-			"No paths provided. Use: c8 deploy <path> or c8 deploy (for current directory)",
-		);
-	}
+	const resources = collectResourcesForPaths(paths);
 
 	// Store the base paths for relative path calculation. Safe to assign
-	// directly now: the empty-paths guard above has already thrown.
+	// directly now: the empty-paths guard inside `collectResourcesForPaths`
+	// has already thrown.
 	const basePaths = paths;
-
-	// Load .c8ignore rules from the working directory
-	const ignoreBaseDir = resolve(process.cwd());
-	const ig = loadIgnoreRules(ignoreBaseDir);
-
-	// Collect all resource files (respecting .c8ignore)
-	paths.forEach((path) => {
-		collectResourceFiles(path, resources, undefined, ig, ignoreBaseDir);
-	});
-
-	if (resources.length === 0) {
-		throw new Error("No BPMN/DMN/Form files found in the specified paths");
-	}
-
-	// Dry-run: emit the would-be API request without executing
-	if (c8ctl.dryRun) {
-		const config = resolveClusterConfig(options.profile);
-		logger.json({
-			dryRun: true,
-			command: "deploy",
-			method: "POST",
-			url: `${config.baseUrl}/deployments`,
-			body: {
-				tenantId,
-				resources: resources.map((r) => ({ name: r.name })),
-			},
-		});
-		return;
-	}
 
 	const client = createClient(options.profile);
 
@@ -775,15 +785,52 @@ function printDeploymentHints(
 	});
 }
 
-// ─── defineCommand wrapper ───────────────────────────────────────────────────
+// ─── defineCommand ───────────────────────────────────────────────────────────
 
-/** Side-effectful: collects files, validates, deploys, and renders its own table output. */
+/**
+ * Side-effectful: collects files, validates, deploys, and renders its own
+ * table output.
+ *
+ * The body lives directly in the handler (per #288): argument-shape
+ * resolution, dry-run preview via the framework's `dryRun()` helper,
+ * and the call into the shared `deployResources` helper that watch also
+ * uses for change-triggered re-deploys.
+ */
 export const deployCommand = defineCommand("deploy", "", async (ctx) => {
+	// Argument shape: `c8 deploy [path...]`. With no positional, default
+	// to cwd. Pinned by tests/unit/deploy-behaviour.test.ts.
 	const paths = ctx.resource
 		? [ctx.resource, ...ctx.positionals]
 		: ctx.positionals.length > 0
 			? ctx.positionals
 			: ["."];
-	await deploy(paths, { profile: ctx.profile });
+
+	// Dry-run preview. Collect resources first so the preview body
+	// reflects what would actually be sent — and so the empty-paths /
+	// no-files guards still surface as thrown errors before we emit.
+	// `dryRun()` returns null when `c8ctl.dryRun` is false, so this whole
+	// block is a no-op outside dry-run mode.
+	if (c8ctl.dryRun) {
+		const previewResources = collectResourcesForPaths(paths);
+		const tenantId = resolveTenantId(ctx.profile);
+		const dr = dryRun({
+			command: "deploy",
+			method: "POST",
+			endpoint: "/deployments",
+			profile: ctx.profile,
+			body: {
+				tenantId,
+				resources: previewResources.map((r) => ({ name: r.name })),
+			},
+		});
+		if (dr) return dr;
+	}
+
+	// Execute path: `deployResources` re-runs `collectResourcesForPaths`
+	// internally and renders the success table. The double-walk in
+	// dry-run mode is intentional: keeping the helper self-contained
+	// avoids threading pre-collected state between the handler and the
+	// shared helper used by `watch`.
+	await deployResources(paths, { profile: ctx.profile });
 	return { kind: "none" };
 });

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -7,7 +7,7 @@ import { basename, extname, resolve } from "node:path";
 import { defineCommand } from "../command-framework.ts";
 import { normalizeToError } from "../errors.ts";
 import { isIgnored, loadIgnoreRules } from "../ignore.ts";
-import { deploy } from "./deployments.ts";
+import { deployResources } from "./deployments.ts";
 
 const WATCHED_EXTENSIONS = [".bpmn", ".dmn", ".form"];
 export const DEPLOY_COOLDOWN = 1000; // 1 second cooldown
@@ -124,15 +124,15 @@ export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
 						const ac = new AbortController();
 						inflightDeploys.add(ac);
 						try {
-							await deploy([fullPath], {
+							await deployResources([fullPath], {
 								profile: ctx.profile,
 								continueOnError: flags.force,
 								continueOnUserError: true,
 								signal: ac.signal,
 							});
 						} catch (error) {
-							// `deploy()` normally returns early when its signal is
-							// aborted, so SIGINT cancellation is not expected to land
+							// `deployResources()` normally returns early when its signal
+							// is aborted, so SIGINT cancellation is not expected to land
 							// here. Keep this as a defensive fallback in case an
 							// aborted deploy ever re-throws — and never log it as a
 							// deploy failure, since the goodbye message is the

--- a/tests/integration/deploy.test.ts
+++ b/tests/integration/deploy.test.ts
@@ -7,7 +7,7 @@ import assert from "node:assert";
 import { existsSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, test } from "node:test";
-import { deploy } from "../../src/commands/deployments.ts";
+import { deployResources as deploy } from "../../src/commands/deployments.ts";
 import { getUserDataDir } from "../../src/config.ts";
 
 describe("Deployment Integration Tests (requires Camunda 8 at localhost:8080)", () => {

--- a/tests/integration/process-instances.test.ts
+++ b/tests/integration/process-instances.test.ts
@@ -18,7 +18,7 @@ import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, test } from "node:test";
 import { ProcessDefinitionId } from "@camunda8/orchestration-cluster-api";
 import { createClient } from "../../src/client.ts";
-import { deploy } from "../../src/commands/deployments.ts";
+import { deployResources as deploy } from "../../src/commands/deployments.ts";
 import { todayRange } from "../utils/date-helpers.ts";
 import { makeTestEnv } from "../utils/mocks.ts";
 import { pollUntil } from "../utils/polling.ts";

--- a/tests/integration/process-instances.test.ts
+++ b/tests/integration/process-instances.test.ts
@@ -2,7 +2,10 @@
  * Integration tests for process instances
  * NOTE: These tests require a running Camunda 8 instance at http://localhost:8080
  *
- * These tests validate end-to-end CLI behaviour, not internal function signatures.
+ * These tests primarily validate end-to-end CLI behaviour. The setup phase
+ * imports the internal `deployResources` helper from `src/commands/deployments.ts`
+ * to seed process definitions before each test, but every assertion exercises
+ * the CLI subprocess.
  */
 
 import assert from "node:assert";


### PR DESCRIPTION
Closes the `deploy` slice of #288. Stacked on #310 (coverage guards) — merge that first.

## What changed

The previous shape was a thin `defineCommand` wrapper delegating to a separate exported `deploy()` function with inline `c8ctl.dryRun` JSON emission. After this refactor:

- **`deployCommand`'s body lives directly in the handler.** Argument-shape resolution and dry-run preview happen in the handler; only the actual deploy work (file collection + sort + duplicate-id check + HTTP + table render) is delegated to a helper.
- **Dry-run preview goes through the framework's `dryRun()` helper** instead of an inline `logger.json(...)` call. This is the structural invariant #288 wants — once all handlers comply, a grep-based lint can forbid ad-hoc dry-run emission.
- **The shared logic that watch also needs is exposed as `deployResources`** — an internal helper used by both the deploy handler and watch's change-triggered re-deploy. Renamed from `deploy` so the intent ("internal cross-handler helper", not "legacy thin-wrapper target") is clear from the call site.
- **The `c8ctl.dryRun` check is removed from `deployResources` itself.** Dry-run is purely a deploy-handler concern; watch never triggers a preview, so this also closes a footgun where a stale dry-run flag could have suppressed a watch-triggered deploy.
- **File-collection + path-validation extracted into `collectResourcesForPaths()`** so the dry-run preview and the execute path emit the same errors with the same wording.

## Behaviour preserved

- Empty paths → throw, framework prints `Failed to deploy:` prefix.
- Duplicate IDs → `SilentError`, no duplicate framework prefix.
- `.c8ignore` rules apply identically (same helper).
- No positional → defaults to cwd. **Pinned by #310.**
- Multiple positionals → all collected. **Pinned by #310.**
- Watch's signal-driven cancellation contract preserved (same helper body, just renamed).

## Imports renamed

- `src/commands/watch.ts` → `import { deployResources }`
- `tests/integration/deploy.test.ts` → `import { deployResources as deploy }` (alias keeps test bodies untouched)
- `tests/integration/process-instances.test.ts` → same alias pattern

Migrating those integration tests to the `c8()` subprocess helper (#288 step 5) is left as a separate cleanup since they exercise a real Camunda server and aren't on the hot path of this refactor.

## Verification

- `npm run build` — green
- `npm run test:unit` — **1204/1204 pass**
- Structural guard in `deploy-error-paths.test.ts` still passes (zero `process.exit` in `deployments.ts`).
- The two coverage guards added in #310 (defaults-to-cwd and multi-path forwarding) both pass against the refactored code, proving the behaviour they pin survived.

## Stacked PR

Base is **#310**, not `main`. After #310 merges, GitHub will auto-rebase this onto `main`.