### PR TITLE
fix(tests): use kernel-assigned ports in mcp-proxy mock (#316)

### DIFF
--- a/tests/integration/mcp-proxy-mock.test.ts
+++ b/tests/integration/mcp-proxy-mock.test.ts
@@ -16,15 +16,32 @@ import { makeMockClient, makeMockLogger } from "../utils/mocks.ts";
 
 describe("MCP Proxy Mock Server Integration Tests", () => {
 	let mockServer: Server;
-	let mockServerPort: number;
 	let mockServerUrl: string;
 	let mockLogger: Logger;
 
-	beforeEach(async () => {
-		// Find an available port and start mock server
-		mockServerPort = 9876 + Math.floor(Math.random() * 1000);
-		mockServerUrl = `http://localhost:${mockServerPort}`;
+	/**
+	 * Stand up a mock HTTP server bound to a kernel-assigned port on
+	 * 127.0.0.1 and publish its URL to `mockServerUrl`. See issue #316
+	 * for why hardcoded or randomly-derived ports are unsafe (port
+	 * collision → silent hang; landing on undici's restricted-ports
+	 * list — e.g. 10080 — → `fetch failed: bad port`). The class-of-defect
+	 * guard lives at `tests/unit/no-hardcoded-listen-port.test.ts`.
+	 */
+	async function startMockServer(
+		handler: (req: IncomingMessage, res: ServerResponse) => void,
+	): Promise<void> {
+		mockServer = createServer(handler);
+		await new Promise<void>((resolve) => {
+			mockServer.listen(0, "127.0.0.1", () => resolve());
+		});
+		const addr = mockServer.address();
+		if (!addr || typeof addr === "string") {
+			throw new Error("mock server did not bind to an inet address");
+		}
+		mockServerUrl = `http://127.0.0.1:${addr.port}`;
+	}
 
+	beforeEach(() => {
 		mockLogger = makeMockLogger();
 	});
 
@@ -39,14 +56,10 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 	test("sends auth headers to remote server", async () => {
 		let capturedAuthHeader: string | string[] | undefined;
 
-		mockServer = createServer((req: IncomingMessage, res: ServerResponse) => {
+		await startMockServer((req: IncomingMessage, res: ServerResponse) => {
 			capturedAuthHeader = req.headers.authorization;
 			res.writeHead(200, { "Content-Type": "application/json" });
 			res.end(JSON.stringify({ success: true }));
-		});
-
-		await new Promise<void>((resolve) => {
-			mockServer.listen(mockServerPort, () => resolve());
 		});
 
 		const mockCamundaClient = makeMockClient({
@@ -62,13 +75,9 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 	});
 
 	test("handles 404 response from server", async () => {
-		mockServer = createServer((_req: IncomingMessage, res: ServerResponse) => {
+		await startMockServer((_req: IncomingMessage, res: ServerResponse) => {
 			res.writeHead(404, { "Content-Type": "text/plain" });
 			res.end("Not Found");
-		});
-
-		await new Promise<void>((resolve) => {
-			mockServer.listen(mockServerPort, () => resolve());
 		});
 
 		const mockCamundaClient = makeMockClient({
@@ -83,13 +92,9 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 	});
 
 	test("handles 500 error from server", async () => {
-		mockServer = createServer((_req: IncomingMessage, res: ServerResponse) => {
+		await startMockServer((_req: IncomingMessage, res: ServerResponse) => {
 			res.writeHead(500, { "Content-Type": "text/plain" });
 			res.end("Internal Server Error");
-		});
-
-		await new Promise<void>((resolve) => {
-			mockServer.listen(mockServerPort, () => resolve());
 		});
 
 		const mockCamundaClient = makeMockClient({
@@ -108,7 +113,7 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 		let firstAuthHeader: string | string[] | undefined;
 		let secondAuthHeader: string | string[] | undefined;
 
-		mockServer = createServer((req: IncomingMessage, res: ServerResponse) => {
+		await startMockServer((req: IncomingMessage, res: ServerResponse) => {
 			if (requestCount === 0) {
 				firstAuthHeader = req.headers.authorization;
 				requestCount++;
@@ -119,10 +124,6 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 				res.writeHead(200, { "Content-Type": "application/json" });
 				res.end(JSON.stringify({ success: true }));
 			}
-		});
-
-		await new Promise<void>((resolve) => {
-			mockServer.listen(mockServerPort, () => resolve());
 		});
 
 		const mockCamundaClient = makeMockClient({
@@ -173,7 +174,7 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 	});
 
 	test("handles slow server response with timeout", async () => {
-		mockServer = createServer(
+		await startMockServer(
 			async (_req: IncomingMessage, res: ServerResponse) => {
 				// Simulate slow response (200ms)
 				await new Promise((resolve) => setTimeout(resolve, 200));
@@ -181,10 +182,6 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 				res.end(JSON.stringify({ success: true }));
 			},
 		);
-
-		await new Promise<void>((resolve) => {
-			mockServer.listen(mockServerPort, () => resolve());
-		});
 
 		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),
@@ -204,14 +201,10 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 	});
 
 	test("successfully completes request within timeout", async () => {
-		mockServer = createServer((_req: IncomingMessage, res: ServerResponse) => {
+		await startMockServer((_req: IncomingMessage, res: ServerResponse) => {
 			// Fast response
 			res.writeHead(200, { "Content-Type": "application/json" });
 			res.end(JSON.stringify({ success: true }));
-		});
-
-		await new Promise<void>((resolve) => {
-			mockServer.listen(mockServerPort, () => resolve());
 		});
 
 		const mockCamundaClient = makeMockClient({
@@ -232,15 +225,11 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 		let capturedContentType: string | string[] | undefined;
 		let capturedCustomHeader: string | string[] | undefined;
 
-		mockServer = createServer((req: IncomingMessage, res: ServerResponse) => {
+		await startMockServer((req: IncomingMessage, res: ServerResponse) => {
 			capturedContentType = req.headers["content-type"];
 			capturedCustomHeader = req.headers["x-custom-header"];
 			res.writeHead(200);
 			res.end();
-		});
-
-		await new Promise<void>((resolve) => {
-			mockServer.listen(mockServerPort, () => resolve());
 		});
 
 		const mockCamundaClient = makeMockClient({
@@ -264,7 +253,7 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 		let capturedBody = "";
 		let capturedMethod: string | undefined;
 
-		mockServer = createServer((req: IncomingMessage, res: ServerResponse) => {
+		await startMockServer((req: IncomingMessage, res: ServerResponse) => {
 			capturedMethod = req.method;
 			req.on("data", (chunk) => {
 				capturedBody += chunk.toString();
@@ -273,10 +262,6 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 				res.writeHead(200, { "Content-Type": "application/json" });
 				res.end(JSON.stringify({ received: true }));
 			});
-		});
-
-		await new Promise<void>((resolve) => {
-			mockServer.listen(mockServerPort, () => resolve());
 		});
 
 		const mockCamundaClient = makeMockClient({

--- a/tests/unit/no-hardcoded-listen-port.test.ts
+++ b/tests/unit/no-hardcoded-listen-port.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Class-of-defect guard for issue #316.
+ *
+ * Every integration test that stands up a mock HTTP server must
+ * call `.listen(0, ...)` and read the kernel-assigned port off
+ * `server.address()`. Picking a port any other way (hardcoded
+ * constant, environment variable, or `Math.random()` over a
+ * numeric range) is unsafe for two reasons documented in
+ * `tests/utils/no-hardcoded-listen-port.ts`:
+ *
+ *   1. The chosen port may collide with another listener and the
+ *      test will silently hang on the resolve callback that never
+ *      fires.
+ *   2. The chosen port may land on undici's restricted-ports list
+ *      (inherited from Chromium's "bad ports") — e.g. 10080,
+ *      6666–6669 — and `fetch()` will reject with
+ *      `TypeError: fetch failed` / `cause: Error: bad port`.
+ *
+ * Issue #316: `mcp-proxy-mock.test.ts` originally used
+ * `9876 + Math.floor(Math.random() * 1000)`, a range that includes
+ * 10080. This guard prevents the same defect class from being
+ * reintroduced in any sibling integration test.
+ *
+ * AST-based (see `no-hardcoded-listen-port.ts` for rationale).
+ */
+
+import assert from "node:assert";
+import { readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, test } from "node:test";
+import { findHardcodedListenPortCalls } from "../utils/no-hardcoded-listen-port.ts";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
+const INTEGRATION_DIR = join(PROJECT_ROOT, "tests", "integration");
+
+function listIntegrationTestFiles(): string[] {
+	return readdirSync(INTEGRATION_DIR)
+		.filter((name) => name.endsWith(".ts"))
+		.map((name) => join(INTEGRATION_DIR, name));
+}
+
+function toRelative(absPath: string): string {
+	const rel = absPath.slice(PROJECT_ROOT.length + 1);
+	return rel.split(/[\\/]/).join("/");
+}
+
+describe("architectural guard: integration tests must use kernel-assigned ports (#316)", () => {
+	const files = listIntegrationTestFiles();
+
+	test("no integration test calls `.listen(<non-zero>, ...)`", () => {
+		const violations: {
+			file: string;
+			line: number;
+			firstArgText: string;
+			text: string;
+		}[] = [];
+		for (const abs of files) {
+			for (const call of findHardcodedListenPortCalls(abs)) {
+				violations.push({
+					file: toRelative(abs),
+					line: call.line,
+					firstArgText: call.firstArgText,
+					text: call.text,
+				});
+			}
+		}
+		assert.strictEqual(
+			violations.length,
+			0,
+			`Integration tests must call \`.listen(0, ...)\` and read the assigned port off ` +
+				`\`server.address()\`. Found ${violations.length} violation(s):\n` +
+				violations
+					.map(
+						(v) => `  - ${v.file}:${v.line} — first arg: \`${v.firstArgText}\``,
+					)
+					.join("\n") +
+				`\n\nA non-zero port can collide with an in-use port (silent hang) or ` +
+				`land on undici's restricted-ports list (e.g. 10080) and fail with ` +
+				`\`fetch failed: bad port\`. See \`tests/integration/watch-cancellation.test.ts\` ` +
+				`for the canonical pattern.`,
+		);
+	});
+});

--- a/tests/utils/no-hardcoded-listen-port.ts
+++ b/tests/utils/no-hardcoded-listen-port.ts
@@ -1,0 +1,129 @@
+/**
+ * AST-based scanner that finds every `<server>.listen(<port>, ...)`
+ * call in a TypeScript source file whose first argument is not the
+ * literal numeric `0`.
+ *
+ * Why this matters
+ * ----------------
+ * A mock HTTP server in an integration test that picks its own port
+ * (hardcoded constant, environment variable, or `Math.random()` over
+ * a numeric range) has two failure modes:
+ *
+ *   1. **Port collision.** If the chosen port is already in use, the
+ *      `listen()` call emits an `EADDRINUSE` error. Tests typically
+ *      pass `() => resolve()` as the callback with no error handler,
+ *      so the resolve never fires and the test hangs until the suite
+ *      timeout — a slow, opaque failure mode.
+ *   2. **Restricted ports.** Node's built-in `fetch` (undici) refuses
+ *      to connect to a hardcoded list of ports inherited from
+ *      Chromium's "bad ports" list (e.g. 10080, 6666–6669). A range
+ *      that overlaps any of those will lottery-fail with
+ *      `TypeError: fetch failed` / `cause: Error: bad port`. See
+ *      issue #316 for the historical incident that motivated this
+ *      guard.
+ *
+ * The deterministic fix is to call `.listen(0, ...)` and read the
+ * kernel-assigned port off `server.address()`. `tests/integration/
+ * watch-cancellation.test.ts` is the canonical example of the
+ * pattern.
+ *
+ * AST-based (not regex) for the same reasons documented in
+ * `no-process-exit.ts`: string literals, comments, and template
+ * literals can produce false positives or false negatives with a
+ * regex over file text.
+ */
+
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+
+export interface HardcodedListenCall {
+	/** 1-based line number of the call. */
+	line: number;
+	/** 1-based column number of the call. */
+	column: number;
+	/** The full call text, e.g. `mockServer.listen(mockServerPort, () => resolve())`. */
+	text: string;
+	/** The text of the first argument as it appeared in source. */
+	firstArgText: string;
+}
+
+/**
+ * Parse a TypeScript file and return every `.listen(<arg>, ...)`
+ * call whose first argument is not the literal numeric `0`.
+ *
+ * Calls with no arguments, or whose first argument is a string
+ * literal (e.g. a Unix socket path), are ignored — those are not
+ * the defect class this guard targets.
+ */
+export function findHardcodedListenPortCalls(
+	filePath: string,
+): HardcodedListenCall[] {
+	const source = readFileSync(filePath, "utf8");
+	const sf = ts.createSourceFile(
+		filePath,
+		source,
+		ts.ScriptTarget.Latest,
+		/* setParentNodes */ true,
+		ts.ScriptKind.TS,
+	);
+
+	const hits: HardcodedListenCall[] = [];
+
+	const visit = (node: ts.Node): void => {
+		if (ts.isCallExpression(node) && isListenCall(node.expression)) {
+			const firstArg = node.arguments[0];
+			if (
+				firstArg &&
+				!isPortZeroLiteral(firstArg) &&
+				!isStringLikeArg(firstArg)
+			) {
+				const { line, character } = sf.getLineAndCharacterOfPosition(
+					node.getStart(sf),
+				);
+				hits.push({
+					line: line + 1,
+					column: character + 1,
+					text: node.getText(sf),
+					firstArgText: firstArg.getText(sf),
+				});
+			}
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(sf);
+
+	return hits;
+}
+
+/**
+ * True iff the given expression is a member access ending in
+ * `.listen` (e.g. `server.listen`, `mockServer.listen`,
+ * `this.server.listen`). We deliberately do NOT match a bare
+ * `listen(...)` identifier — that would catch unrelated functions
+ * named `listen` (event listeners, etc.).
+ */
+function isListenCall(expr: ts.Expression): boolean {
+	if (!ts.isPropertyAccessExpression(expr)) return false;
+	return expr.name.text === "listen";
+}
+
+/**
+ * True iff the argument is the literal numeric `0` — the only
+ * value that asks the kernel to assign a free port.
+ */
+function isPortZeroLiteral(arg: ts.Expression): boolean {
+	return ts.isNumericLiteral(arg) && arg.text === "0";
+}
+
+/**
+ * True iff the argument is a string literal or template literal —
+ * i.e. a Unix-socket path or pipe name. These are not the port-lottery
+ * defect class.
+ */
+function isStringLikeArg(arg: ts.Expression): boolean {
+	return (
+		ts.isStringLiteral(arg) ||
+		ts.isNoSubstitutionTemplateLiteral(arg) ||
+		ts.isTemplateExpression(arg)
+	);
+}


### PR DESCRIPTION
Closes #316.

## Problem

`tests/integration/mcp-proxy-mock.test.ts` intermittently failed in CI with:

```
[TypeError: fetch failed]
[cause]: Error: bad port
```

Observed on PR #313 CI run https://github.com/camunda/c8ctl/actions/runs/24705728123 (Node 24 Integration). Per AGENTS.md "There are no flaky tests" — this is a real test defect.

## Root cause

The original beforeEach hook picked a random port from a fixed range:

```ts
mockServerPort = 9876 + Math.floor(Math.random() * 1000);
```

The range is `[9876, 10875]`. **Port 10080 falls inside this range** and is on undici's restricted-ports list (inherited from Chromium's "bad port" list). When the random draw lands on 10080, every `fetch(mockServerUrl, ...)` rejects with `Error: bad port` before any network I/O.

Per-`beforeEach` probability: ~0.1%. With ~9 tests in the file and a wide CI matrix, it materialised as an intermittent failure.

## Fix

Replaces the random-port scheme with a `startMockServer(handler)` helper that binds on port `0` and reads the kernel-assigned port off `server.address()`. This mirrors the pattern already used by `tests/integration/watch-cancellation.test.ts`.

Each test now calls `await startMockServer(handler)` instead of the previous `mockServer = createServer(...); await new Promise(... mockServer.listen(mockServerPort, ...))` pair.

## Class-of-defect guard (red/green)

Per AGENTS.md "Test scope: target the defect class, not just the instance":

- **`tests/utils/no-hardcoded-listen-port.ts`** — AST scanner that finds every `<server>.listen(<arg>, ...)` call in a TS file whose first argument is not the literal numeric `0`.
- **`tests/unit/no-hardcoded-listen-port.test.ts`** — class-scoped guard that runs the scanner over every file under `tests/integration/` and fails if any non-zero port is found.

The test was authored **red first**: with the original mcp-proxy-mock.test.ts in place, the guard reported 8 violations. After the fix, the guard is green.

## Verification

- `npm run typecheck` — clean
- `npx biome check tests/...` — clean
- `npm run test:unit` — 1205/1205 pass (including the new guard)
- `node --experimental-strip-types --test tests/integration/mcp-proxy-mock.test.ts` — 9/9 pass

## Scope

Test-only change; no production code touched. The `unreachablePort = 9999` literal in the "handles connection refused" test is intentionally unbound and is not flagged by the guard (it never appears as the first argument of `.listen()`).