### PR TITLE
docs: generate README command reference from COMMAND_REGISTRY

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ c8ctl --version
 
 <!-- command-reference:start -->
 
-## Command Reference
+### Command Reference
 
 > Auto-generated from [`COMMAND_REGISTRY`](src/command-registry.ts). Do not edit manually.
 > Run `node --experimental-strip-types scripts/sync-readme-commands.ts` to update.
 
-### Global Flags
+#### Global Flags
 
 These flags are accepted by every command.
 
@@ -93,7 +93,7 @@ These flags are accepted by every command.
 | `--verbose` | boolean |  | Show verbose output |
 | `--fields` | string |  | Comma-separated list of fields to display |
 
-### Resource Aliases
+#### Resource Aliases
 
 | Alias | Resource |
 |-------|----------|
@@ -107,7 +107,7 @@ These flags are accepted by every command.
 | `vars` | `variable` |
 | `var` | `variable` |
 
-### Search Flags
+#### Search Flags
 
 These flags are available on `list` and `search` commands.
 
@@ -120,9 +120,9 @@ These flags are available on `list` and `search` commands.
 | `--between` | string |  | Date range filter (e.g. 7d, 30d, 2024-01-01..2024-12-31) |
 | `--dateField` | string |  | Date field for --between filter |
 
-### Commands
+#### Commands
 
-#### `list`
+##### `list`
 
 List resources
 
@@ -287,7 +287,7 @@ c8ctl list users                                            # List users
 
 ---
 
-#### `search`
+##### `search`
 
 Search resources with filters (wildcards, date ranges, case-insensitive)
 
@@ -470,7 +470,7 @@ c8ctl search ut --iassignee=John                            # Case-insensitive s
 
 ---
 
-#### `get`
+##### `get`
 
 Get a resource by key
 
@@ -536,7 +536,7 @@ c8ctl get user john                                         # Get user by userna
 
 ---
 
-#### `create`
+##### `create`
 
 Create a resource (process instance, identity)
 
@@ -589,7 +589,7 @@ c8ctl create user --username=john --name='John Doe' --email=john@example.com --p
 
 ---
 
-#### `delete`
+##### `delete`
 
 Delete a resource by key
 
@@ -614,7 +614,7 @@ c8ctl delete user john                                      # Delete user
 
 ---
 
-#### `cancel`
+##### `cancel`
 
 Cancel a process instance
 
@@ -628,7 +628,7 @@ Cancel a process instance
 
 ---
 
-#### `await`
+##### `await`
 
 Create and await process instance completion (server-side waiting)
 
@@ -655,7 +655,7 @@ c8ctl await pi --id=myProcess                               # Create and wait fo
 
 ---
 
-#### `complete`
+##### `complete`
 
 Complete a user task or job
 
@@ -676,7 +676,7 @@ Complete a user task or job
 
 ---
 
-#### `fail`
+##### `fail`
 
 Mark a job as failed with optional error message and retry count
 
@@ -695,7 +695,7 @@ Mark a job as failed with optional error message and retry count
 
 ---
 
-#### `activate`
+##### `activate`
 
 Activate jobs of a specific type for processing
 
@@ -715,7 +715,7 @@ Activate jobs of a specific type for processing
 
 ---
 
-#### `resolve`
+##### `resolve`
 
 Resolve an incident (marks resolved, allows process to continue)
 
@@ -727,7 +727,7 @@ Resolve an incident (marks resolved, allows process to continue)
 
 ---
 
-#### `publish`
+##### `publish`
 
 Publish a message for message correlation
 
@@ -747,7 +747,7 @@ Publish a message for message correlation
 
 ---
 
-#### `correlate`
+##### `correlate`
 
 Correlate a message to a specific process instance
 
@@ -767,7 +767,7 @@ Correlate a message to a specific process instance
 
 ---
 
-#### `set`
+##### `set`
 
 Set variables on an element instance (process instance or flow element scope). Variables are propagated to the outermost scope by default; use --local to restrict to the specified scope.
 
@@ -795,7 +795,7 @@ c8ctl set variable 2251799813685249 --variables='{"x":1}' --local  # Set variabl
 
 ---
 
-#### `deploy`
+##### `deploy`
 
 Deploy files to Camunda (auto-discovers deployable files in directories)
 
@@ -815,7 +815,7 @@ c8ctl deploy ./my-process.bpmn                              # Deploy a BPMN file
 
 ---
 
-#### `run`
+##### `run`
 
 Deploy and start a process instance from a BPMN file
 
@@ -836,7 +836,7 @@ c8ctl run ./my-process.bpmn                                 # Deploy and start p
 
 ---
 
-#### `assign`
+##### `assign`
 
 Assign a resource to a target (--to-user, --to-group, etc.)
 
@@ -868,7 +868,7 @@ c8ctl assign role admin --to-user=john                      # Assign role to use
 
 ---
 
-#### `unassign`
+##### `unassign`
 
 Unassign a resource from a target (--from-user, --from-group, etc.)
 
@@ -900,7 +900,7 @@ c8ctl unassign role admin --from-user=john                  # Unassign role from
 
 ---
 
-#### `watch`
+##### `watch`
 
 Watch files for changes and auto-deploy
 
@@ -923,7 +923,7 @@ c8ctl watch ./src                                           # Watch directory fo
 
 ---
 
-#### `open`
+##### `open`
 
 Open Camunda web app in browser
 
@@ -941,7 +941,7 @@ c8ctl open operate --profile=prod                           # Open Operate using
 
 ---
 
-#### `add`
+##### `add`
 
 Add a profile
 
@@ -968,7 +968,7 @@ Add a profile
 
 ---
 
-#### `remove`
+##### `remove`
 
 Remove a profile (alias: rm)
 
@@ -991,7 +991,7 @@ Remove a profile (alias: rm)
 
 ---
 
-#### `load`
+##### `load`
 
 Load a c8ctl plugin (npm registry or URL)
 
@@ -1018,7 +1018,7 @@ c8ctl load plugin --from https://github.com/org/plugin      # Load plugin from U
 
 ---
 
-#### `unload`
+##### `unload`
 
 Unload a c8ctl plugin (npm uninstall wrapper)
 
@@ -1040,7 +1040,7 @@ Unload a c8ctl plugin (npm uninstall wrapper)
 
 ---
 
-#### `upgrade`
+##### `upgrade`
 
 Upgrade a plugin (respects source type)
 
@@ -1061,7 +1061,7 @@ c8ctl upgrade plugin my-plugin 1.2.3                        # Upgrade plugin to 
 
 ---
 
-#### `downgrade`
+##### `downgrade`
 
 Downgrade a plugin to a specific version
 
@@ -1075,7 +1075,7 @@ Downgrade a plugin to a specific version
 
 ---
 
-#### `sync`
+##### `sync`
 
 Synchronize plugins from registry (rebuild/reinstall)
 
@@ -1089,7 +1089,7 @@ c8ctl sync plugin                                           # Synchronize plugin
 
 ---
 
-#### `init`
+##### `init`
 
 Create a new plugin from TypeScript template
 
@@ -1107,7 +1107,7 @@ c8ctl init plugin my-plugin                                 # Create new plugin 
 
 ---
 
-#### `use`
+##### `use`
 
 Set active profile or tenant
 
@@ -1134,7 +1134,7 @@ c8ctl use profile prod                                      # Set active profile
 
 ---
 
-#### `output`
+##### `output`
 
 Show or set output format
 
@@ -1150,7 +1150,7 @@ c8ctl output json                                           # Switch to JSON out
 
 ---
 
-#### `completion`
+##### `completion`
 
 Generate shell completion script
 
@@ -1179,7 +1179,7 @@ c8ctl completion install --shell zsh                        # Install completion
 
 ---
 
-#### `mcp-proxy`
+##### `mcp-proxy`
 
 Start a STDIO MCP proxy (bridges local MCP clients to remote Camunda 8)
 
@@ -1187,13 +1187,13 @@ Start a STDIO MCP proxy (bridges local MCP clients to remote Camunda 8)
 
 ---
 
-#### `feedback`
+##### `feedback`
 
 Open the feedback page to report issues or request features
 
 ---
 
-#### `help`
+##### `help`
 
 Show help (run 'c8ctl help <command>' for details)
 
@@ -1203,7 +1203,7 @@ Show help (run 'c8ctl help <command>' for details)
 
 ---
 
-#### `which`
+##### `which`
 
 Show active profile
 

--- a/README.md
+++ b/README.md
@@ -593,6 +593,8 @@ c8ctl create user --username=john --name='John Doe' --email=john@example.com --p
 
 Delete a resource by key
 
+**Usage:** `c8ctl delete <resource> <key>`
+
 **Resources:** user, role, group, tenant, auth (authorization), mapping-rule
 
 **Positional arguments:**
@@ -616,6 +618,8 @@ c8ctl delete user john                                      # Delete user
 
 Cancel a process instance
 
+**Usage:** `c8ctl cancel <resource> <key>`
+
 **Resources:** pi (process-instance)
 
 **Positional arguments:**
@@ -627,6 +631,8 @@ Cancel a process instance
 #### `await`
 
 Create and await process instance completion (server-side waiting)
+
+**Usage:** `c8ctl await <resource>`
 
 **Resources:** pi (process-instance)
 
@@ -652,6 +658,8 @@ c8ctl await pi --id=myProcess                               # Create and wait fo
 #### `complete`
 
 Complete a user task or job
+
+**Usage:** `c8ctl complete <resource> <key>`
 
 **Resources:** ut (user-task), job
 
@@ -763,6 +771,8 @@ Correlate a message to a specific process instance
 
 Set variables on an element instance (process instance or flow element scope). Variables are propagated to the outermost scope by default; use --local to restrict to the specified scope.
 
+**Usage:** `c8ctl set variable <key>`
+
 **Resources:** variable
 
 **Positional arguments:**
@@ -789,6 +799,8 @@ c8ctl set variable 2251799813685249 --variables='{"x":1}' --local  # Set variabl
 
 Deploy files to Camunda (auto-discovers deployable files in directories)
 
+**Usage:** `c8ctl deploy [path...]`
+
 **Flags:**
 
 | Flag | Type | Required | Description |
@@ -806,6 +818,8 @@ c8ctl deploy ./my-process.bpmn                              # Deploy a BPMN file
 #### `run`
 
 Deploy and start a process instance from a BPMN file
+
+**Usage:** `c8ctl run <path>`
 
 **Flags:**
 
@@ -825,6 +839,8 @@ c8ctl run ./my-process.bpmn                                 # Deploy and start p
 #### `assign`
 
 Assign a resource to a target (--to-user, --to-group, etc.)
+
+**Usage:** `c8ctl assign <resource> <id>`
 
 **Resources:** role, user, group, mapping-rule
 
@@ -856,6 +872,8 @@ c8ctl assign role admin --to-user=john                      # Assign role to use
 
 Unassign a resource from a target (--from-user, --from-group, etc.)
 
+**Usage:** `c8ctl unassign <resource> <id>`
+
 **Resources:** role, user, group, mapping-rule
 
 **Positional arguments:**
@@ -886,6 +904,8 @@ c8ctl unassign role admin --from-user=john                  # Unassign role from
 
 Watch files for changes and auto-deploy
 
+**Usage:** `c8ctl watch [path...]`
+
 **Aliases:** `w`
 
 **Flags:**
@@ -906,6 +926,8 @@ c8ctl watch ./src                                           # Watch directory fo
 #### `open`
 
 Open Camunda web app in browser
+
+**Usage:** `c8ctl open <app>`
 
 **Resources:** operate, tasklist, modeler, optimize
 
@@ -950,6 +972,8 @@ Add a profile
 
 Remove a profile (alias: rm)
 
+**Usage:** `c8ctl remove profile <name>`
+
 **Aliases:** `rm`
 
 **Resources:** profile, plugin
@@ -970,6 +994,8 @@ Remove a profile (alias: rm)
 #### `load`
 
 Load a c8ctl plugin (npm registry or URL)
+
+**Usage:** `c8ctl load plugin [name|--from url]`
 
 **Resources:** plugin
 
@@ -996,6 +1022,8 @@ c8ctl load plugin --from https://github.com/org/plugin      # Load plugin from U
 
 Unload a c8ctl plugin (npm uninstall wrapper)
 
+**Usage:** `c8ctl unload plugin <name>`
+
 **Aliases:** `rm`
 
 **Resources:** plugin
@@ -1016,6 +1044,8 @@ Unload a c8ctl plugin (npm uninstall wrapper)
 
 Upgrade a plugin (respects source type)
 
+**Usage:** `c8ctl upgrade plugin <name> [version]`
+
 **Resources:** plugin
 
 **Positional arguments:**
@@ -1034,6 +1064,8 @@ c8ctl upgrade plugin my-plugin 1.2.3                        # Upgrade plugin to 
 #### `downgrade`
 
 Downgrade a plugin to a specific version
+
+**Usage:** `c8ctl downgrade plugin <name> <version>`
 
 **Resources:** plugin
 
@@ -1079,6 +1111,8 @@ c8ctl init plugin my-plugin                                 # Create new plugin 
 
 Set active profile or tenant
 
+**Usage:** `c8ctl use profile|tenant`
+
 **Resources:** profile, tenant
 
 **Positional arguments:**
@@ -1104,6 +1138,8 @@ c8ctl use profile prod                                      # Set active profile
 
 Show or set output format
 
+**Usage:** `c8ctl output [json|text]`
+
 **Resources:** json, text
 
 **Examples:**
@@ -1117,6 +1153,8 @@ c8ctl output json                                           # Switch to JSON out
 #### `completion`
 
 Generate shell completion script
+
+**Usage:** `c8ctl completion bash|zsh|fish|install`
 
 **Resources:** bash, zsh, fish, install
 
@@ -1145,6 +1183,8 @@ c8ctl completion install --shell zsh                        # Install completion
 
 Start a STDIO MCP proxy (bridges local MCP clients to remote Camunda 8)
 
+**Usage:** `c8ctl mcp-proxy [mcp-path]`
+
 ---
 
 #### `feedback`
@@ -1156,6 +1196,8 @@ Open the feedback page to report issues or request features
 #### `help`
 
 Show help (run 'c8ctl help <command>' for details)
+
+**Usage:** `c8ctl help [command]`
 
 **Aliases:** `menu`
 

--- a/README.md
+++ b/README.md
@@ -73,1151 +73,6 @@ c8ctl help plugin     # Shows plugin management help
 c8ctl --version
 ```
 
-<!-- command-reference:start -->
-
-### Command Reference
-
-> Auto-generated from [`COMMAND_REGISTRY`](https://github.com/camunda/c8ctl/blob/main/src/command-registry.ts). Do not edit manually.
-> Run `node --experimental-strip-types scripts/sync-readme-commands.ts` to update.
-
-#### Global Flags
-
-These flags are accepted by every command.
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--help` / `-h` | boolean |  | Show help |
-| `--version` / `-v` | string |  | Show CLI version, or filter by process definition version on supported commands |
-| `--profile` | string |  | Use a specific profile |
-| `--dry-run` | boolean |  | Preview the API request without executing |
-| `--verbose` | boolean |  | Show verbose output |
-| `--fields` | string |  | Comma-separated list of fields to display |
-
-#### Resource Aliases
-
-| Alias | Resource |
-|-------|----------|
-| `auth` | `authorization` |
-| `inc` | `incident` |
-| `mr` | `mapping-rule` |
-| `msg` | `message` |
-| `pd` | `process-definition` |
-| `pi` | `process-instance` |
-| `ut` | `user-task` |
-| `vars` | `variable` |
-| `var` | `variable` |
-
-#### Search Flags
-
-These flags are available on `list` and `search` commands.
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--sortBy` | string |  | Sort results by field |
-| `--asc` | boolean |  | Sort ascending |
-| `--desc` | boolean |  | Sort descending |
-| `--limit` | string |  | Maximum number of results |
-| `--between` | string |  | Date range filter (e.g. 7d, 30d, 2024-01-01..2024-12-31) |
-| `--dateField` | string |  | Date field for --between filter |
-
-#### Commands
-
-##### `list`
-
-List resources
-
-**Resources:** pi (process-instance), pd (process-definition), ut (user-task), inc (incident), jobs, profiles (profile), plugins (plugin), users (user), roles (role), groups (group), tenants (tenant), auth (authorization), mapping-rules (mapping-rule)
-
-**Verb-level flags:**
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--all` | boolean |  | List all (disable pagination limit) |
-
-**Resource-specific flags:**
-
-<details>
-<summary><code>process-definition</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
-| `--id` | string |  | Filter by BPMN process ID (alias) |
-| `--processDefinitionId` | string |  | Filter by process definition ID |
-| `--name` | string |  | Filter by name |
-| `--key` | string |  | Filter by key |
-| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
-| `--iname` | string |  | Case-insensitive filter by name |
-
-</details>
-
-<details>
-<summary><code>process-instance</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
-| `--id` | string |  | Filter by BPMN process ID (alias) |
-| `--processDefinitionId` | string |  | Filter by process definition ID |
-| `--processDefinitionKey` | string |  | Filter by process definition key |
-| `--state` | string |  | Filter by state (ACTIVE, COMPLETED, etc) |
-| `--key` | string |  | Filter by key |
-| `--parentProcessInstanceKey` | string |  | Filter by parent process instance key |
-| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
-
-</details>
-
-<details>
-<summary><code>user-task</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--state` | string |  | Filter by state |
-| `--assignee` | string |  | Filter by assignee |
-| `--processInstanceKey` | string |  | Filter by process instance key |
-| `--processDefinitionKey` | string |  | Filter by process definition key |
-| `--elementId` | string |  | Filter by element ID |
-| `--iassignee` | string |  | Case-insensitive filter by assignee |
-
-</details>
-
-<details>
-<summary><code>incident</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--state` | string |  | Filter by state |
-| `--processInstanceKey` | string |  | Filter by process instance key |
-| `--processDefinitionKey` | string |  | Filter by process definition key |
-| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
-| `--id` | string |  | Filter by BPMN process ID (alias) |
-| `--processDefinitionId` | string |  | Filter by process definition ID |
-| `--errorType` | string |  | Filter by error type |
-| `--errorMessage` | string |  | Filter by error message |
-| `--ierrorMessage` | string |  | Case-insensitive filter by error message |
-| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
-
-</details>
-
-<details>
-<summary><code>jobs</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--state` | string |  | Filter by state |
-| `--type` | string |  | Filter by job type |
-| `--processInstanceKey` | string |  | Filter by process instance key |
-| `--processDefinitionKey` | string |  | Filter by process definition key |
-| `--itype` | string |  | Case-insensitive filter by job type |
-
-</details>
-
-<details>
-<summary><code>user</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--username` | string |  | Filter by username |
-| `--name` | string |  | Filter by name |
-| `--email` | string |  | Filter by email |
-
-</details>
-
-<details>
-<summary><code>role</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--roleId` | string |  | Filter by role ID |
-| `--name` | string |  | Filter by name |
-
-</details>
-
-<details>
-<summary><code>group</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--groupId` | string |  | Filter by group ID |
-| `--name` | string |  | Filter by name |
-
-</details>
-
-<details>
-<summary><code>tenant</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--tenantId` | string |  | Filter by tenant ID |
-| `--name` | string |  | Filter by name |
-
-</details>
-
-<details>
-<summary><code>authorization</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--ownerId` | string |  | Filter by owner ID |
-| `--ownerType` | string |  | Filter by owner type |
-| `--resourceType` | string |  | Filter by resource type |
-| `--resourceId` | string |  | Filter by resource ID |
-
-</details>
-
-<details>
-<summary><code>mapping-rule</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--mappingRuleId` | string |  | Filter by mapping rule ID |
-| `--name` | string |  | Filter by name |
-| `--claimName` | string |  | Filter by claim name |
-| `--claimValue` | string |  | Filter by claim value |
-
-</details>
-
-**Examples:**
-
-```bash
-c8ctl list pi                                               # List process instances
-c8ctl list pd                                               # List process definitions
-c8ctl list users                                            # List users
-```
-
----
-
-##### `search`
-
-Search resources with filters (wildcards, date ranges, case-insensitive)
-
-**Resources:** pi (process-instance), pd (process-definition), ut (user-task), inc (incident), jobs, vars (variable), users (user), roles (role), groups (group), tenants (tenant), auth (authorization), mapping-rules (mapping-rule)
-
-**Resource-specific flags:**
-
-<details>
-<summary><code>process-definition</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
-| `--id` | string |  | Filter by BPMN process ID (alias) |
-| `--processDefinitionId` | string |  | Filter by process definition ID |
-| `--name` | string |  | Filter by name |
-| `--key` | string |  | Filter by key |
-| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
-| `--iname` | string |  | Case-insensitive filter by name |
-
-</details>
-
-<details>
-<summary><code>process-instance</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
-| `--id` | string |  | Filter by BPMN process ID (alias) |
-| `--processDefinitionId` | string |  | Filter by process definition ID |
-| `--processDefinitionKey` | string |  | Filter by process definition key |
-| `--state` | string |  | Filter by state (ACTIVE, COMPLETED, etc) |
-| `--key` | string |  | Filter by key |
-| `--parentProcessInstanceKey` | string |  | Filter by parent process instance key |
-| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
-
-</details>
-
-<details>
-<summary><code>user-task</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--state` | string |  | Filter by state |
-| `--assignee` | string |  | Filter by assignee |
-| `--processInstanceKey` | string |  | Filter by process instance key |
-| `--processDefinitionKey` | string |  | Filter by process definition key |
-| `--elementId` | string |  | Filter by element ID |
-| `--iassignee` | string |  | Case-insensitive filter by assignee |
-
-</details>
-
-<details>
-<summary><code>incident</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--state` | string |  | Filter by state |
-| `--processInstanceKey` | string |  | Filter by process instance key |
-| `--processDefinitionKey` | string |  | Filter by process definition key |
-| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
-| `--id` | string |  | Filter by BPMN process ID (alias) |
-| `--processDefinitionId` | string |  | Filter by process definition ID |
-| `--errorType` | string |  | Filter by error type |
-| `--errorMessage` | string |  | Filter by error message |
-| `--ierrorMessage` | string |  | Case-insensitive filter by error message |
-| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
-
-</details>
-
-<details>
-<summary><code>jobs</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--state` | string |  | Filter by state |
-| `--type` | string |  | Filter by job type |
-| `--processInstanceKey` | string |  | Filter by process instance key |
-| `--processDefinitionKey` | string |  | Filter by process definition key |
-| `--itype` | string |  | Case-insensitive filter by job type |
-
-</details>
-
-<details>
-<summary><code>variable</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--name` | string |  | Filter by variable name |
-| `--value` | string |  | Filter by value |
-| `--processInstanceKey` | string |  | Filter by process instance key |
-| `--scopeKey` | string |  | Filter by scope key |
-| `--fullValue` | boolean |  | Return full variable values (not truncated) |
-| `--iname` | string |  | Case-insensitive filter by name |
-| `--ivalue` | string |  | Case-insensitive filter by value |
-
-</details>
-
-<details>
-<summary><code>user</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--username` | string |  | Filter by username |
-| `--name` | string |  | Filter by name |
-| `--email` | string |  | Filter by email |
-
-</details>
-
-<details>
-<summary><code>role</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--roleId` | string |  | Filter by role ID |
-| `--name` | string |  | Filter by name |
-
-</details>
-
-<details>
-<summary><code>group</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--groupId` | string |  | Filter by group ID |
-| `--name` | string |  | Filter by name |
-
-</details>
-
-<details>
-<summary><code>tenant</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--tenantId` | string |  | Filter by tenant ID |
-| `--name` | string |  | Filter by name |
-
-</details>
-
-<details>
-<summary><code>authorization</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--ownerId` | string |  | Filter by owner ID |
-| `--ownerType` | string |  | Filter by owner type |
-| `--resourceType` | string |  | Filter by resource type |
-| `--resourceId` | string |  | Filter by resource ID |
-
-</details>
-
-<details>
-<summary><code>mapping-rule</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--mappingRuleId` | string |  | Filter by mapping rule ID |
-| `--name` | string |  | Filter by name |
-| `--claimName` | string |  | Filter by claim name |
-| `--claimValue` | string |  | Filter by claim value |
-
-</details>
-
-**Examples:**
-
-```bash
-c8ctl search pi --state=ACTIVE                              # Search for active process instances
-c8ctl search pd --bpmnProcessId=myProcess                   # Search process definitions by ID
-c8ctl search pd --name='*main*'                             # Search process definitions with wildcard
-c8ctl search ut --assignee=john                             # Search user tasks assigned to john
-c8ctl search inc --state=ACTIVE                             # Search for active incidents
-c8ctl search jobs --type=myJobType                          # Search jobs by type
-c8ctl search jobs --type='*service*'                        # Search jobs with type containing "service"
-c8ctl search variables --name=myVar                         # Search for variables by name
-c8ctl search variables --value=foo                          # Search for variables by value
-c8ctl search variables --processInstanceKey=123 --fullValue  # Search variables with full values
-c8ctl search pd --iname='*order*'                           # Case-insensitive search by name
-c8ctl search ut --iassignee=John                            # Case-insensitive search by assignee
-```
-
----
-
-##### `get`
-
-Get a resource by key
-
-**Resources:** pi (process-instance), pd (process-definition), inc (incident), topology, form, user, role, group, tenant, auth (authorization), mapping-rule
-
-**Positional arguments:**
-
-- **process-definition:** `<key>` (required)
-- **process-instance:** `<key>` (required)
-- **incident:** `<key>` (required)
-- **user:** `<username>` (required)
-- **role:** `<roleId>` (required)
-- **group:** `<groupId>` (required)
-- **tenant:** `<tenantId>` (required)
-- **authorization:** `<authorizationKey>` (required)
-- **mapping-rule:** `<mappingRuleId>` (required)
-- **form:** `<key>` (required)
-
-**Resource-specific flags:**
-
-<details>
-<summary><code>process-definition</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--xml` | boolean |  | Get BPMN XML (process definitions) |
-
-</details>
-
-<details>
-<summary><code>form</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--userTask` | boolean |  | Get form for user task |
-| `--ut` | boolean |  | Alias for --userTask |
-| `--processDefinition` | boolean |  | Get form for process definition |
-| `--pd` | boolean |  | Alias for --processDefinition |
-
-</details>
-
-<details>
-<summary><code>process-instance</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--variables` | boolean |  | Include variables in output |
-
-</details>
-
-**Examples:**
-
-```bash
-c8ctl get pi 123456                                         # Get process instance by key
-c8ctl get pi 123456 --variables                             # Get process instance with variables
-c8ctl get pd 123456                                         # Get process definition by key
-c8ctl get pd 123456 --xml                                   # Get process definition XML
-c8ctl get form 123456                                       # Get form (searches both user task and process definition)
-c8ctl get form 123456 --ut                                  # Get form for user task only
-c8ctl get form 123456 --pd                                  # Get start form for process definition only
-c8ctl get user john                                         # Get user by username
-```
-
----
-
-##### `create`
-
-Create a resource (process instance, identity)
-
-**Resources:** pi (process-instance), user, role, group, tenant, auth (authorization), mapping-rule
-
-**Verb-level flags:**
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--processDefinitionId` | string |  | Process definition ID (BPMN process ID) |
-| `--id` | string |  | Process definition ID (alias for --processDefinitionId) |
-| `--bpmnProcessId` | string |  | BPMN process ID (alias for --processDefinitionId) |
-| `--variables` | string |  | JSON variables |
-| `--awaitCompletion` | boolean |  | Wait for process to complete |
-| `--fetchVariables` | boolean |  | Fetch result variables on completion |
-| `--requestTimeout` | string |  | Await timeout in milliseconds |
-| `--username` | string |  | Username |
-| `--name` | string |  | Display name |
-| `--email` | string |  | Email address |
-| `--password` | string |  | Password |
-| `--roleId` | string |  | Role ID |
-| `--groupId` | string |  | Group ID |
-| `--tenantId` | string |  | Tenant ID |
-| `--mappingRuleId` | string |  | Mapping rule ID |
-| `--claimName` | string |  | Claim name |
-| `--claimValue` | string |  | Claim value |
-
-**Resource-specific flags:**
-
-<details>
-<summary><code>authorization</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--ownerId` | string | Yes | Authorization owner ID |
-| `--ownerType` | string | Yes | Authorization owner type |
-| `--resourceType` | string | Yes | Authorization resource type |
-| `--resourceId` | string | Yes | Authorization resource ID |
-| `--permissions` | string | Yes | Comma-separated permissions |
-
-</details>
-
-**Examples:**
-
-```bash
-c8ctl create pi --id=myProcess                              # Create a process instance
-c8ctl create pi --id=myProcess --awaitCompletion            # Create and await completion
-c8ctl create user --username=john --name='John Doe' --email=john@example.com --password=secret  # Create a user
-```
-
----
-
-##### `delete`
-
-Delete a resource by key
-
-**Usage:** `c8ctl delete <resource> <key>`
-
-**Resources:** user, role, group, tenant, auth (authorization), mapping-rule
-
-**Positional arguments:**
-
-- **user:** `<username>` (required)
-- **role:** `<roleId>` (required)
-- **group:** `<groupId>` (required)
-- **tenant:** `<tenantId>` (required)
-- **authorization:** `<authorizationKey>` (required)
-- **mapping-rule:** `<mappingRuleId>` (required)
-
-**Examples:**
-
-```bash
-c8ctl delete user john                                      # Delete user
-```
-
----
-
-##### `cancel`
-
-Cancel a process instance
-
-**Usage:** `c8ctl cancel <resource> <key>`
-
-**Resources:** pi (process-instance)
-
-**Positional arguments:**
-
-- **process-instance:** `<key>` (required)
-
----
-
-##### `await`
-
-Create and await process instance completion (server-side waiting)
-
-**Usage:** `c8ctl await <resource>`
-
-**Resources:** pi (process-instance)
-
-**Flags:**
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--processDefinitionId` | string |  | Process definition ID (BPMN process ID) |
-| `--id` | string |  | Process definition ID (alias for --processDefinitionId) |
-| `--bpmnProcessId` | string |  | BPMN process ID (alias for --processDefinitionId) |
-| `--variables` | string |  | JSON variables |
-| `--fetchVariables` | boolean |  | Fetch result variables on completion |
-| `--requestTimeout` | string |  | Await timeout in milliseconds |
-
-**Examples:**
-
-```bash
-c8ctl await pi --id=myProcess                               # Create and wait for completion
-```
-
----
-
-##### `complete`
-
-Complete a user task or job
-
-**Usage:** `c8ctl complete <resource> <key>`
-
-**Resources:** ut (user-task), job
-
-**Positional arguments:**
-
-- **user-task:** `<key>` (required)
-- **job:** `<key>` (required)
-
-**Flags:**
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--variables` | string |  | JSON variables |
-
----
-
-##### `fail`
-
-Mark a job as failed with optional error message and retry count
-
-**Resources:** job
-
-**Positional arguments:**
-
-- **job:** `<key>` (required)
-
-**Flags:**
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--retries` | string |  | Remaining retries |
-| `--errorMessage` | string |  | Error message |
-
----
-
-##### `activate`
-
-Activate jobs of a specific type for processing
-
-**Resources:** jobs
-
-**Positional arguments:**
-
-- **jobs:** `<type>` (required)
-
-**Flags:**
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--maxJobsToActivate` | string |  | Maximum number of jobs to activate |
-| `--timeout` | string |  | Job timeout in milliseconds |
-| `--worker` | string |  | Worker name |
-
----
-
-##### `resolve`
-
-Resolve an incident (marks resolved, allows process to continue)
-
-**Resources:** inc (incident)
-
-**Positional arguments:**
-
-- **incident:** `<key>` (required)
-
----
-
-##### `publish`
-
-Publish a message for message correlation
-
-**Resources:** msg (message)
-
-**Positional arguments:**
-
-- **message:** `<name>` (required)
-
-**Flags:**
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--correlationKey` | string |  | Correlation key |
-| `--variables` | string |  | JSON variables |
-| `--timeToLive` | string |  | Time to live in milliseconds |
-
----
-
-##### `correlate`
-
-Correlate a message to a specific process instance
-
-**Resources:** msg (message)
-
-**Positional arguments:**
-
-- **message:** `<name>` (required)
-
-**Flags:**
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--correlationKey` | string | Yes | Correlation key |
-| `--variables` | string |  | JSON variables |
-| `--timeToLive` | string |  | Time to live in milliseconds |
-
----
-
-##### `set`
-
-Set variables on an element instance (process instance or flow element scope). Variables are propagated to the outermost scope by default; use --local to restrict to the specified scope.
-
-**Usage:** `c8ctl set variable <key>`
-
-**Resources:** variable
-
-**Positional arguments:**
-
-- **variable:** `<key>` (required)
-
-**Flags:**
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--variables` | string | Yes | JSON object of variables to set (required) |
-| `--local` | boolean |  | Set variables in local scope only (default: propagate to outermost scope) |
-
-**Examples:**
-
-```bash
-c8ctl set variable 2251799813685249 --variables='{"status":"approved"}'  # Set variables on a process instance
-c8ctl set variable 2251799813685249 --variables='{"x":1}' --local  # Set variables in local scope only
-```
-
----
-
-##### `deploy`
-
-Deploy files to Camunda (auto-discovers deployable files in directories)
-
-**Usage:** `c8ctl deploy [path...]`
-
-**Flags:**
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--force` | boolean |  | Deploy any file type, ignoring the default extension allow-list |
-
-**Examples:**
-
-```bash
-c8ctl deploy ./my-process.bpmn                              # Deploy a BPMN file
-```
-
----
-
-##### `run`
-
-Deploy and start a process instance from a BPMN file
-
-**Usage:** `c8ctl run <path>`
-
-**Flags:**
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--variables` | string |  | JSON variables |
-| `--force` | boolean |  | Deploy any file type, ignoring the default extension allow-list |
-
-**Examples:**
-
-```bash
-c8ctl run ./my-process.bpmn                                 # Deploy and start process
-```
-
----
-
-##### `assign`
-
-Assign a resource to a target (--to-user, --to-group, etc.)
-
-**Usage:** `c8ctl assign <resource> <id>`
-
-**Resources:** role, user, group, mapping-rule
-
-**Positional arguments:**
-
-- **role:** `<roleId>` (required)
-- **user:** `<username>` (required)
-- **group:** `<groupId>` (required)
-- **mapping-rule:** `<mappingRuleId>` (required)
-
-**Flags:**
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--to-user` | string |  | Target user ID |
-| `--to-group` | string |  | Target group ID |
-| `--to-tenant` | string |  | Target tenant ID |
-| `--to-mapping-rule` | string |  | Target mapping rule ID |
-
-**Examples:**
-
-```bash
-c8ctl assign role admin --to-user=john                      # Assign role to user
-```
-
----
-
-##### `unassign`
-
-Unassign a resource from a target (--from-user, --from-group, etc.)
-
-**Usage:** `c8ctl unassign <resource> <id>`
-
-**Resources:** role, user, group, mapping-rule
-
-**Positional arguments:**
-
-- **role:** `<roleId>` (required)
-- **user:** `<username>` (required)
-- **group:** `<groupId>` (required)
-- **mapping-rule:** `<mappingRuleId>` (required)
-
-**Flags:**
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--from-user` | string |  | Source user ID |
-| `--from-group` | string |  | Source group ID |
-| `--from-tenant` | string |  | Source tenant ID |
-| `--from-mapping-rule` | string |  | Source mapping rule ID |
-
-**Examples:**
-
-```bash
-c8ctl unassign role admin --from-user=john                  # Unassign role from user
-```
-
----
-
-##### `watch`
-
-Watch files for changes and auto-deploy
-
-**Usage:** `c8ctl watch [path...]`
-
-**Aliases:** `w`
-
-**Flags:**
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--force` | boolean |  | Continue watching after all deployment errors |
-| `--extensions` | string |  | Comma-separated list of file extensions to watch (e.g. .bpmn,.dmn,.form) |
-
-**Examples:**
-
-```bash
-c8ctl watch ./src                                           # Watch directory for changes
-```
-
----
-
-##### `open`
-
-Open Camunda web app in browser
-
-**Usage:** `c8ctl open <app>`
-
-**Resources:** operate, tasklist, modeler, optimize
-
-**Examples:**
-
-```bash
-c8ctl open operate                                          # Open Camunda Operate in browser
-c8ctl open tasklist                                         # Open Camunda Tasklist in browser
-c8ctl open operate --profile=prod                           # Open Operate using a specific profile
-```
-
----
-
-##### `add`
-
-Add a profile
-
-**Resources:** profile
-
-**Positional arguments:**
-
-- **profile:** `<name>` (required)
-
-**Flags:**
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--baseUrl` | string |  | Cluster base URL |
-| `--clientId` | string |  | OAuth client ID |
-| `--clientSecret` | string |  | OAuth client secret |
-| `--audience` | string |  | OAuth audience |
-| `--oAuthUrl` | string |  | OAuth token URL |
-| `--defaultTenantId` | string |  | Default tenant ID |
-| `--username` | string |  | Basic auth username |
-| `--password` | string |  | Basic auth password |
-| `--from-file` | string |  | Import from .env file |
-| `--from-env` | boolean |  | Import from environment variables |
-
----
-
-##### `remove`
-
-Remove a profile (alias: rm)
-
-**Usage:** `c8ctl remove profile <name>`
-
-**Aliases:** `rm`
-
-**Resources:** profile, plugin
-
-**Positional arguments:**
-
-- **profile:** `<name>` (required)
-- **plugin:** `<package>` (required)
-
-**Flags:**
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--none` | boolean |  | Clear active profile |
-
----
-
-##### `load`
-
-Load a c8ctl plugin (npm registry or URL)
-
-**Usage:** `c8ctl load plugin [name|--from url]`
-
-**Resources:** plugin
-
-**Positional arguments:**
-
-- **plugin:** `<package>` (optional)
-
-**Flags:**
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--from` | string |  | Load plugin from URL |
-
-**Examples:**
-
-```bash
-c8ctl load plugin my-plugin                                 # Load plugin from npm registry
-c8ctl load plugin --from https://github.com/org/plugin      # Load plugin from URL
-```
-
----
-
-##### `unload`
-
-Unload a c8ctl plugin (npm uninstall wrapper)
-
-**Usage:** `c8ctl unload plugin <name>`
-
-**Aliases:** `rm`
-
-**Resources:** plugin
-
-**Positional arguments:**
-
-- **plugin:** `<package>` (required)
-
-**Flags:**
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--force` | boolean |  | Force unload without confirmation |
-
----
-
-##### `upgrade`
-
-Upgrade a plugin (respects source type)
-
-**Usage:** `c8ctl upgrade plugin <name> [version]`
-
-**Resources:** plugin
-
-**Positional arguments:**
-
-- **plugin:** `<package>` (required), `<version>` (optional)
-
-**Examples:**
-
-```bash
-c8ctl upgrade plugin my-plugin                              # Upgrade plugin to latest version
-c8ctl upgrade plugin my-plugin 1.2.3                        # Upgrade plugin to a specific version (source-aware)
-```
-
----
-
-##### `downgrade`
-
-Downgrade a plugin to a specific version
-
-**Usage:** `c8ctl downgrade plugin <name> <version>`
-
-**Resources:** plugin
-
-**Positional arguments:**
-
-- **plugin:** `<package>` (required), `<version>` (required)
-
----
-
-##### `sync`
-
-Synchronize plugins from registry (rebuild/reinstall)
-
-**Resources:** plugin
-
-**Examples:**
-
-```bash
-c8ctl sync plugin                                           # Synchronize plugins
-```
-
----
-
-##### `init`
-
-Create a new plugin from TypeScript template
-
-**Resources:** plugin
-
-**Positional arguments:**
-
-- **plugin:** `<name>` (optional)
-
-**Examples:**
-
-```bash
-c8ctl init plugin my-plugin                                 # Create new plugin from template (c8ctl-plugin-my-plugin)
-```
-
----
-
-##### `use`
-
-Set active profile or tenant
-
-**Usage:** `c8ctl use profile|tenant`
-
-**Resources:** profile, tenant
-
-**Positional arguments:**
-
-- **profile:** `<name>` (optional)
-- **tenant:** `<tenantId>` (required)
-
-**Flags:**
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--none` | boolean |  | Clear active profile/tenant |
-
-**Examples:**
-
-```bash
-c8ctl use profile prod                                      # Set active profile
-```
-
----
-
-##### `output`
-
-Show or set output format
-
-**Usage:** `c8ctl output [json|text]`
-
-**Resources:** json, text
-
-**Examples:**
-
-```bash
-c8ctl output json                                           # Switch to JSON output
-```
-
----
-
-##### `completion`
-
-Generate shell completion script
-
-**Usage:** `c8ctl completion bash|zsh|fish|install`
-
-**Resources:** bash, zsh, fish, install
-
-**Resource-specific flags:**
-
-<details>
-<summary><code>install</code></summary>
-
-| Flag | Type | Required | Description |
-|------|------|----------|-------------|
-| `--shell` | string |  | Shell to install completions for (bash, zsh, fish) |
-
-</details>
-
-**Examples:**
-
-```bash
-c8ctl completion bash                                       # Generate bash completion script
-c8ctl completion install                                    # Auto-detect shell and install completions (auto-refreshes on upgrade)
-c8ctl completion install --shell zsh                        # Install completions for a specific shell
-```
-
----
-
-##### `mcp-proxy`
-
-Start a STDIO MCP proxy (bridges local MCP clients to remote Camunda 8)
-
-**Usage:** `c8ctl mcp-proxy [mcp-path]`
-
----
-
-##### `feedback`
-
-Open the feedback page to report issues or request features
-
----
-
-##### `help`
-
-Show help (run 'c8ctl help <command>' for details)
-
-**Usage:** `c8ctl help [command]`
-
-**Aliases:** `menu`
-
----
-
-##### `which`
-
-Show active profile
-
-**Resources:** profile
-
-**Examples:**
-
-```bash
-c8ctl which profile                                         # Show currently active profile
-```
-
-
-<!-- command-reference:end -->
-
 ### Default Extensions
 
 When scanning directories, `deploy`, `run`, and `watch` only include files with these extensions:
@@ -1881,6 +736,1151 @@ Modeler profiles are:
 - Automatically loaded on each command execution
 - Prefixed with `modeler:` when used in c8ctl
 - Support both cloud and self-managed clusters
+
+<!-- command-reference:start -->
+
+## Command Reference
+
+> Auto-generated from [`COMMAND_REGISTRY`](https://github.com/camunda/c8ctl/blob/main/src/command-registry.ts). Do not edit manually.
+> Run `node --experimental-strip-types scripts/sync-readme-commands.ts` to update.
+
+### Global Flags
+
+These flags are accepted by every command.
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--help` / `-h` | boolean |  | Show help |
+| `--version` / `-v` | string |  | Show CLI version, or filter by process definition version on supported commands |
+| `--profile` | string |  | Use a specific profile |
+| `--dry-run` | boolean |  | Preview the API request without executing |
+| `--verbose` | boolean |  | Show verbose output |
+| `--fields` | string |  | Comma-separated list of fields to display |
+
+### Resource Aliases
+
+| Alias | Resource |
+|-------|----------|
+| `auth` | `authorization` |
+| `inc` | `incident` |
+| `mr` | `mapping-rule` |
+| `msg` | `message` |
+| `pd` | `process-definition` |
+| `pi` | `process-instance` |
+| `ut` | `user-task` |
+| `vars` | `variable` |
+| `var` | `variable` |
+
+### Search Flags
+
+These flags are available on `list` and `search` commands.
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--sortBy` | string |  | Sort results by field |
+| `--asc` | boolean |  | Sort ascending |
+| `--desc` | boolean |  | Sort descending |
+| `--limit` | string |  | Maximum number of results |
+| `--between` | string |  | Date range filter (e.g. 7d, 30d, 2024-01-01..2024-12-31) |
+| `--dateField` | string |  | Date field for --between filter |
+
+### Commands
+
+#### `list`
+
+List resources
+
+**Resources:** pi (process-instance), pd (process-definition), ut (user-task), inc (incident), jobs, profiles (profile), plugins (plugin), users (user), roles (role), groups (group), tenants (tenant), auth (authorization), mapping-rules (mapping-rule)
+
+**Verb-level flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--all` | boolean |  | List all (disable pagination limit) |
+
+**Resource-specific flags:**
+
+<details>
+<summary><code>process-definition</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
+| `--id` | string |  | Filter by BPMN process ID (alias) |
+| `--processDefinitionId` | string |  | Filter by process definition ID |
+| `--name` | string |  | Filter by name |
+| `--key` | string |  | Filter by key |
+| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
+| `--iname` | string |  | Case-insensitive filter by name |
+
+</details>
+
+<details>
+<summary><code>process-instance</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
+| `--id` | string |  | Filter by BPMN process ID (alias) |
+| `--processDefinitionId` | string |  | Filter by process definition ID |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--state` | string |  | Filter by state (ACTIVE, COMPLETED, etc) |
+| `--key` | string |  | Filter by key |
+| `--parentProcessInstanceKey` | string |  | Filter by parent process instance key |
+| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
+
+</details>
+
+<details>
+<summary><code>user-task</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--state` | string |  | Filter by state |
+| `--assignee` | string |  | Filter by assignee |
+| `--processInstanceKey` | string |  | Filter by process instance key |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--elementId` | string |  | Filter by element ID |
+| `--iassignee` | string |  | Case-insensitive filter by assignee |
+
+</details>
+
+<details>
+<summary><code>incident</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--state` | string |  | Filter by state |
+| `--processInstanceKey` | string |  | Filter by process instance key |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
+| `--id` | string |  | Filter by BPMN process ID (alias) |
+| `--processDefinitionId` | string |  | Filter by process definition ID |
+| `--errorType` | string |  | Filter by error type |
+| `--errorMessage` | string |  | Filter by error message |
+| `--ierrorMessage` | string |  | Case-insensitive filter by error message |
+| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
+
+</details>
+
+<details>
+<summary><code>jobs</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--state` | string |  | Filter by state |
+| `--type` | string |  | Filter by job type |
+| `--processInstanceKey` | string |  | Filter by process instance key |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--itype` | string |  | Case-insensitive filter by job type |
+
+</details>
+
+<details>
+<summary><code>user</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--username` | string |  | Filter by username |
+| `--name` | string |  | Filter by name |
+| `--email` | string |  | Filter by email |
+
+</details>
+
+<details>
+<summary><code>role</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--roleId` | string |  | Filter by role ID |
+| `--name` | string |  | Filter by name |
+
+</details>
+
+<details>
+<summary><code>group</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--groupId` | string |  | Filter by group ID |
+| `--name` | string |  | Filter by name |
+
+</details>
+
+<details>
+<summary><code>tenant</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--tenantId` | string |  | Filter by tenant ID |
+| `--name` | string |  | Filter by name |
+
+</details>
+
+<details>
+<summary><code>authorization</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--ownerId` | string |  | Filter by owner ID |
+| `--ownerType` | string |  | Filter by owner type |
+| `--resourceType` | string |  | Filter by resource type |
+| `--resourceId` | string |  | Filter by resource ID |
+
+</details>
+
+<details>
+<summary><code>mapping-rule</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--mappingRuleId` | string |  | Filter by mapping rule ID |
+| `--name` | string |  | Filter by name |
+| `--claimName` | string |  | Filter by claim name |
+| `--claimValue` | string |  | Filter by claim value |
+
+</details>
+
+**Examples:**
+
+```bash
+c8ctl list pi                                               # List process instances
+c8ctl list pd                                               # List process definitions
+c8ctl list users                                            # List users
+```
+
+---
+
+#### `search`
+
+Search resources with filters (wildcards, date ranges, case-insensitive)
+
+**Resources:** pi (process-instance), pd (process-definition), ut (user-task), inc (incident), jobs, vars (variable), users (user), roles (role), groups (group), tenants (tenant), auth (authorization), mapping-rules (mapping-rule)
+
+**Resource-specific flags:**
+
+<details>
+<summary><code>process-definition</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
+| `--id` | string |  | Filter by BPMN process ID (alias) |
+| `--processDefinitionId` | string |  | Filter by process definition ID |
+| `--name` | string |  | Filter by name |
+| `--key` | string |  | Filter by key |
+| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
+| `--iname` | string |  | Case-insensitive filter by name |
+
+</details>
+
+<details>
+<summary><code>process-instance</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
+| `--id` | string |  | Filter by BPMN process ID (alias) |
+| `--processDefinitionId` | string |  | Filter by process definition ID |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--state` | string |  | Filter by state (ACTIVE, COMPLETED, etc) |
+| `--key` | string |  | Filter by key |
+| `--parentProcessInstanceKey` | string |  | Filter by parent process instance key |
+| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
+
+</details>
+
+<details>
+<summary><code>user-task</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--state` | string |  | Filter by state |
+| `--assignee` | string |  | Filter by assignee |
+| `--processInstanceKey` | string |  | Filter by process instance key |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--elementId` | string |  | Filter by element ID |
+| `--iassignee` | string |  | Case-insensitive filter by assignee |
+
+</details>
+
+<details>
+<summary><code>incident</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--state` | string |  | Filter by state |
+| `--processInstanceKey` | string |  | Filter by process instance key |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
+| `--id` | string |  | Filter by BPMN process ID (alias) |
+| `--processDefinitionId` | string |  | Filter by process definition ID |
+| `--errorType` | string |  | Filter by error type |
+| `--errorMessage` | string |  | Filter by error message |
+| `--ierrorMessage` | string |  | Case-insensitive filter by error message |
+| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
+
+</details>
+
+<details>
+<summary><code>jobs</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--state` | string |  | Filter by state |
+| `--type` | string |  | Filter by job type |
+| `--processInstanceKey` | string |  | Filter by process instance key |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--itype` | string |  | Case-insensitive filter by job type |
+
+</details>
+
+<details>
+<summary><code>variable</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--name` | string |  | Filter by variable name |
+| `--value` | string |  | Filter by value |
+| `--processInstanceKey` | string |  | Filter by process instance key |
+| `--scopeKey` | string |  | Filter by scope key |
+| `--fullValue` | boolean |  | Return full variable values (not truncated) |
+| `--iname` | string |  | Case-insensitive filter by name |
+| `--ivalue` | string |  | Case-insensitive filter by value |
+
+</details>
+
+<details>
+<summary><code>user</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--username` | string |  | Filter by username |
+| `--name` | string |  | Filter by name |
+| `--email` | string |  | Filter by email |
+
+</details>
+
+<details>
+<summary><code>role</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--roleId` | string |  | Filter by role ID |
+| `--name` | string |  | Filter by name |
+
+</details>
+
+<details>
+<summary><code>group</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--groupId` | string |  | Filter by group ID |
+| `--name` | string |  | Filter by name |
+
+</details>
+
+<details>
+<summary><code>tenant</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--tenantId` | string |  | Filter by tenant ID |
+| `--name` | string |  | Filter by name |
+
+</details>
+
+<details>
+<summary><code>authorization</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--ownerId` | string |  | Filter by owner ID |
+| `--ownerType` | string |  | Filter by owner type |
+| `--resourceType` | string |  | Filter by resource type |
+| `--resourceId` | string |  | Filter by resource ID |
+
+</details>
+
+<details>
+<summary><code>mapping-rule</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--mappingRuleId` | string |  | Filter by mapping rule ID |
+| `--name` | string |  | Filter by name |
+| `--claimName` | string |  | Filter by claim name |
+| `--claimValue` | string |  | Filter by claim value |
+
+</details>
+
+**Examples:**
+
+```bash
+c8ctl search pi --state=ACTIVE                              # Search for active process instances
+c8ctl search pd --bpmnProcessId=myProcess                   # Search process definitions by ID
+c8ctl search pd --name='*main*'                             # Search process definitions with wildcard
+c8ctl search ut --assignee=john                             # Search user tasks assigned to john
+c8ctl search inc --state=ACTIVE                             # Search for active incidents
+c8ctl search jobs --type=myJobType                          # Search jobs by type
+c8ctl search jobs --type='*service*'                        # Search jobs with type containing "service"
+c8ctl search variables --name=myVar                         # Search for variables by name
+c8ctl search variables --value=foo                          # Search for variables by value
+c8ctl search variables --processInstanceKey=123 --fullValue  # Search variables with full values
+c8ctl search pd --iname='*order*'                           # Case-insensitive search by name
+c8ctl search ut --iassignee=John                            # Case-insensitive search by assignee
+```
+
+---
+
+#### `get`
+
+Get a resource by key
+
+**Resources:** pi (process-instance), pd (process-definition), inc (incident), topology, form, user, role, group, tenant, auth (authorization), mapping-rule
+
+**Positional arguments:**
+
+- **process-definition:** `<key>` (required)
+- **process-instance:** `<key>` (required)
+- **incident:** `<key>` (required)
+- **user:** `<username>` (required)
+- **role:** `<roleId>` (required)
+- **group:** `<groupId>` (required)
+- **tenant:** `<tenantId>` (required)
+- **authorization:** `<authorizationKey>` (required)
+- **mapping-rule:** `<mappingRuleId>` (required)
+- **form:** `<key>` (required)
+
+**Resource-specific flags:**
+
+<details>
+<summary><code>process-definition</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--xml` | boolean |  | Get BPMN XML (process definitions) |
+
+</details>
+
+<details>
+<summary><code>form</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--userTask` | boolean |  | Get form for user task |
+| `--ut` | boolean |  | Alias for --userTask |
+| `--processDefinition` | boolean |  | Get form for process definition |
+| `--pd` | boolean |  | Alias for --processDefinition |
+
+</details>
+
+<details>
+<summary><code>process-instance</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--variables` | boolean |  | Include variables in output |
+
+</details>
+
+**Examples:**
+
+```bash
+c8ctl get pi 123456                                         # Get process instance by key
+c8ctl get pi 123456 --variables                             # Get process instance with variables
+c8ctl get pd 123456                                         # Get process definition by key
+c8ctl get pd 123456 --xml                                   # Get process definition XML
+c8ctl get form 123456                                       # Get form (searches both user task and process definition)
+c8ctl get form 123456 --ut                                  # Get form for user task only
+c8ctl get form 123456 --pd                                  # Get start form for process definition only
+c8ctl get user john                                         # Get user by username
+```
+
+---
+
+#### `create`
+
+Create a resource (process instance, identity)
+
+**Resources:** pi (process-instance), user, role, group, tenant, auth (authorization), mapping-rule
+
+**Verb-level flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--processDefinitionId` | string |  | Process definition ID (BPMN process ID) |
+| `--id` | string |  | Process definition ID (alias for --processDefinitionId) |
+| `--bpmnProcessId` | string |  | BPMN process ID (alias for --processDefinitionId) |
+| `--variables` | string |  | JSON variables |
+| `--awaitCompletion` | boolean |  | Wait for process to complete |
+| `--fetchVariables` | boolean |  | Fetch result variables on completion |
+| `--requestTimeout` | string |  | Await timeout in milliseconds |
+| `--username` | string |  | Username |
+| `--name` | string |  | Display name |
+| `--email` | string |  | Email address |
+| `--password` | string |  | Password |
+| `--roleId` | string |  | Role ID |
+| `--groupId` | string |  | Group ID |
+| `--tenantId` | string |  | Tenant ID |
+| `--mappingRuleId` | string |  | Mapping rule ID |
+| `--claimName` | string |  | Claim name |
+| `--claimValue` | string |  | Claim value |
+
+**Resource-specific flags:**
+
+<details>
+<summary><code>authorization</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--ownerId` | string | Yes | Authorization owner ID |
+| `--ownerType` | string | Yes | Authorization owner type |
+| `--resourceType` | string | Yes | Authorization resource type |
+| `--resourceId` | string | Yes | Authorization resource ID |
+| `--permissions` | string | Yes | Comma-separated permissions |
+
+</details>
+
+**Examples:**
+
+```bash
+c8ctl create pi --id=myProcess                              # Create a process instance
+c8ctl create pi --id=myProcess --awaitCompletion            # Create and await completion
+c8ctl create user --username=john --name='John Doe' --email=john@example.com --password=secret  # Create a user
+```
+
+---
+
+#### `delete`
+
+Delete a resource by key
+
+**Usage:** `c8ctl delete <resource> <key>`
+
+**Resources:** user, role, group, tenant, auth (authorization), mapping-rule
+
+**Positional arguments:**
+
+- **user:** `<username>` (required)
+- **role:** `<roleId>` (required)
+- **group:** `<groupId>` (required)
+- **tenant:** `<tenantId>` (required)
+- **authorization:** `<authorizationKey>` (required)
+- **mapping-rule:** `<mappingRuleId>` (required)
+
+**Examples:**
+
+```bash
+c8ctl delete user john                                      # Delete user
+```
+
+---
+
+#### `cancel`
+
+Cancel a process instance
+
+**Usage:** `c8ctl cancel <resource> <key>`
+
+**Resources:** pi (process-instance)
+
+**Positional arguments:**
+
+- **process-instance:** `<key>` (required)
+
+---
+
+#### `await`
+
+Create and await process instance completion (server-side waiting)
+
+**Usage:** `c8ctl await <resource>`
+
+**Resources:** pi (process-instance)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--processDefinitionId` | string |  | Process definition ID (BPMN process ID) |
+| `--id` | string |  | Process definition ID (alias for --processDefinitionId) |
+| `--bpmnProcessId` | string |  | BPMN process ID (alias for --processDefinitionId) |
+| `--variables` | string |  | JSON variables |
+| `--fetchVariables` | boolean |  | Fetch result variables on completion |
+| `--requestTimeout` | string |  | Await timeout in milliseconds |
+
+**Examples:**
+
+```bash
+c8ctl await pi --id=myProcess                               # Create and wait for completion
+```
+
+---
+
+#### `complete`
+
+Complete a user task or job
+
+**Usage:** `c8ctl complete <resource> <key>`
+
+**Resources:** ut (user-task), job
+
+**Positional arguments:**
+
+- **user-task:** `<key>` (required)
+- **job:** `<key>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--variables` | string |  | JSON variables |
+
+---
+
+#### `fail`
+
+Mark a job as failed with optional error message and retry count
+
+**Resources:** job
+
+**Positional arguments:**
+
+- **job:** `<key>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--retries` | string |  | Remaining retries |
+| `--errorMessage` | string |  | Error message |
+
+---
+
+#### `activate`
+
+Activate jobs of a specific type for processing
+
+**Resources:** jobs
+
+**Positional arguments:**
+
+- **jobs:** `<type>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--maxJobsToActivate` | string |  | Maximum number of jobs to activate |
+| `--timeout` | string |  | Job timeout in milliseconds |
+| `--worker` | string |  | Worker name |
+
+---
+
+#### `resolve`
+
+Resolve an incident (marks resolved, allows process to continue)
+
+**Resources:** inc (incident)
+
+**Positional arguments:**
+
+- **incident:** `<key>` (required)
+
+---
+
+#### `publish`
+
+Publish a message for message correlation
+
+**Resources:** msg (message)
+
+**Positional arguments:**
+
+- **message:** `<name>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--correlationKey` | string |  | Correlation key |
+| `--variables` | string |  | JSON variables |
+| `--timeToLive` | string |  | Time to live in milliseconds |
+
+---
+
+#### `correlate`
+
+Correlate a message to a specific process instance
+
+**Resources:** msg (message)
+
+**Positional arguments:**
+
+- **message:** `<name>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--correlationKey` | string | Yes | Correlation key |
+| `--variables` | string |  | JSON variables |
+| `--timeToLive` | string |  | Time to live in milliseconds |
+
+---
+
+#### `set`
+
+Set variables on an element instance (process instance or flow element scope). Variables are propagated to the outermost scope by default; use --local to restrict to the specified scope.
+
+**Usage:** `c8ctl set variable <key>`
+
+**Resources:** variable
+
+**Positional arguments:**
+
+- **variable:** `<key>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--variables` | string | Yes | JSON object of variables to set (required) |
+| `--local` | boolean |  | Set variables in local scope only (default: propagate to outermost scope) |
+
+**Examples:**
+
+```bash
+c8ctl set variable 2251799813685249 --variables='{"status":"approved"}'  # Set variables on a process instance
+c8ctl set variable 2251799813685249 --variables='{"x":1}' --local  # Set variables in local scope only
+```
+
+---
+
+#### `deploy`
+
+Deploy files to Camunda (auto-discovers deployable files in directories)
+
+**Usage:** `c8ctl deploy [path...]`
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--force` | boolean |  | Deploy any file type, ignoring the default extension allow-list |
+
+**Examples:**
+
+```bash
+c8ctl deploy ./my-process.bpmn                              # Deploy a BPMN file
+```
+
+---
+
+#### `run`
+
+Deploy and start a process instance from a BPMN file
+
+**Usage:** `c8ctl run <path>`
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--variables` | string |  | JSON variables |
+| `--force` | boolean |  | Deploy any file type, ignoring the default extension allow-list |
+
+**Examples:**
+
+```bash
+c8ctl run ./my-process.bpmn                                 # Deploy and start process
+```
+
+---
+
+#### `assign`
+
+Assign a resource to a target (--to-user, --to-group, etc.)
+
+**Usage:** `c8ctl assign <resource> <id>`
+
+**Resources:** role, user, group, mapping-rule
+
+**Positional arguments:**
+
+- **role:** `<roleId>` (required)
+- **user:** `<username>` (required)
+- **group:** `<groupId>` (required)
+- **mapping-rule:** `<mappingRuleId>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--to-user` | string |  | Target user ID |
+| `--to-group` | string |  | Target group ID |
+| `--to-tenant` | string |  | Target tenant ID |
+| `--to-mapping-rule` | string |  | Target mapping rule ID |
+
+**Examples:**
+
+```bash
+c8ctl assign role admin --to-user=john                      # Assign role to user
+```
+
+---
+
+#### `unassign`
+
+Unassign a resource from a target (--from-user, --from-group, etc.)
+
+**Usage:** `c8ctl unassign <resource> <id>`
+
+**Resources:** role, user, group, mapping-rule
+
+**Positional arguments:**
+
+- **role:** `<roleId>` (required)
+- **user:** `<username>` (required)
+- **group:** `<groupId>` (required)
+- **mapping-rule:** `<mappingRuleId>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--from-user` | string |  | Source user ID |
+| `--from-group` | string |  | Source group ID |
+| `--from-tenant` | string |  | Source tenant ID |
+| `--from-mapping-rule` | string |  | Source mapping rule ID |
+
+**Examples:**
+
+```bash
+c8ctl unassign role admin --from-user=john                  # Unassign role from user
+```
+
+---
+
+#### `watch`
+
+Watch files for changes and auto-deploy
+
+**Usage:** `c8ctl watch [path...]`
+
+**Aliases:** `w`
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--force` | boolean |  | Continue watching after all deployment errors |
+| `--extensions` | string |  | Comma-separated list of file extensions to watch (e.g. .bpmn,.dmn,.form) |
+
+**Examples:**
+
+```bash
+c8ctl watch ./src                                           # Watch directory for changes
+```
+
+---
+
+#### `open`
+
+Open Camunda web app in browser
+
+**Usage:** `c8ctl open <app>`
+
+**Resources:** operate, tasklist, modeler, optimize
+
+**Examples:**
+
+```bash
+c8ctl open operate                                          # Open Camunda Operate in browser
+c8ctl open tasklist                                         # Open Camunda Tasklist in browser
+c8ctl open operate --profile=prod                           # Open Operate using a specific profile
+```
+
+---
+
+#### `add`
+
+Add a profile
+
+**Resources:** profile
+
+**Positional arguments:**
+
+- **profile:** `<name>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--baseUrl` | string |  | Cluster base URL |
+| `--clientId` | string |  | OAuth client ID |
+| `--clientSecret` | string |  | OAuth client secret |
+| `--audience` | string |  | OAuth audience |
+| `--oAuthUrl` | string |  | OAuth token URL |
+| `--defaultTenantId` | string |  | Default tenant ID |
+| `--username` | string |  | Basic auth username |
+| `--password` | string |  | Basic auth password |
+| `--from-file` | string |  | Import from .env file |
+| `--from-env` | boolean |  | Import from environment variables |
+
+---
+
+#### `remove`
+
+Remove a profile (alias: rm)
+
+**Usage:** `c8ctl remove profile <name>`
+
+**Aliases:** `rm`
+
+**Resources:** profile, plugin
+
+**Positional arguments:**
+
+- **profile:** `<name>` (required)
+- **plugin:** `<package>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--none` | boolean |  | Clear active profile |
+
+---
+
+#### `load`
+
+Load a c8ctl plugin (npm registry or URL)
+
+**Usage:** `c8ctl load plugin [name|--from url]`
+
+**Resources:** plugin
+
+**Positional arguments:**
+
+- **plugin:** `<package>` (optional)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--from` | string |  | Load plugin from URL |
+
+**Examples:**
+
+```bash
+c8ctl load plugin my-plugin                                 # Load plugin from npm registry
+c8ctl load plugin --from https://github.com/org/plugin      # Load plugin from URL
+```
+
+---
+
+#### `unload`
+
+Unload a c8ctl plugin (npm uninstall wrapper)
+
+**Usage:** `c8ctl unload plugin <name>`
+
+**Aliases:** `rm`
+
+**Resources:** plugin
+
+**Positional arguments:**
+
+- **plugin:** `<package>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--force` | boolean |  | Force unload without confirmation |
+
+---
+
+#### `upgrade`
+
+Upgrade a plugin (respects source type)
+
+**Usage:** `c8ctl upgrade plugin <name> [version]`
+
+**Resources:** plugin
+
+**Positional arguments:**
+
+- **plugin:** `<package>` (required), `<version>` (optional)
+
+**Examples:**
+
+```bash
+c8ctl upgrade plugin my-plugin                              # Upgrade plugin to latest version
+c8ctl upgrade plugin my-plugin 1.2.3                        # Upgrade plugin to a specific version (source-aware)
+```
+
+---
+
+#### `downgrade`
+
+Downgrade a plugin to a specific version
+
+**Usage:** `c8ctl downgrade plugin <name> <version>`
+
+**Resources:** plugin
+
+**Positional arguments:**
+
+- **plugin:** `<package>` (required), `<version>` (required)
+
+---
+
+#### `sync`
+
+Synchronize plugins from registry (rebuild/reinstall)
+
+**Resources:** plugin
+
+**Examples:**
+
+```bash
+c8ctl sync plugin                                           # Synchronize plugins
+```
+
+---
+
+#### `init`
+
+Create a new plugin from TypeScript template
+
+**Resources:** plugin
+
+**Positional arguments:**
+
+- **plugin:** `<name>` (optional)
+
+**Examples:**
+
+```bash
+c8ctl init plugin my-plugin                                 # Create new plugin from template (c8ctl-plugin-my-plugin)
+```
+
+---
+
+#### `use`
+
+Set active profile or tenant
+
+**Usage:** `c8ctl use profile|tenant`
+
+**Resources:** profile, tenant
+
+**Positional arguments:**
+
+- **profile:** `<name>` (optional)
+- **tenant:** `<tenantId>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--none` | boolean |  | Clear active profile/tenant |
+
+**Examples:**
+
+```bash
+c8ctl use profile prod                                      # Set active profile
+```
+
+---
+
+#### `output`
+
+Show or set output format
+
+**Usage:** `c8ctl output [json|text]`
+
+**Resources:** json, text
+
+**Examples:**
+
+```bash
+c8ctl output json                                           # Switch to JSON output
+```
+
+---
+
+#### `completion`
+
+Generate shell completion script
+
+**Usage:** `c8ctl completion bash|zsh|fish|install`
+
+**Resources:** bash, zsh, fish, install
+
+**Resource-specific flags:**
+
+<details>
+<summary><code>install</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--shell` | string |  | Shell to install completions for (bash, zsh, fish) |
+
+</details>
+
+**Examples:**
+
+```bash
+c8ctl completion bash                                       # Generate bash completion script
+c8ctl completion install                                    # Auto-detect shell and install completions (auto-refreshes on upgrade)
+c8ctl completion install --shell zsh                        # Install completions for a specific shell
+```
+
+---
+
+#### `mcp-proxy`
+
+Start a STDIO MCP proxy (bridges local MCP clients to remote Camunda 8)
+
+**Usage:** `c8ctl mcp-proxy [mcp-path]`
+
+---
+
+#### `feedback`
+
+Open the feedback page to report issues or request features
+
+---
+
+#### `help`
+
+Show help (run 'c8ctl help <command>' for details)
+
+**Usage:** `c8ctl help [command]`
+
+**Aliases:** `menu`
+
+---
+
+#### `which`
+
+Show active profile
+
+**Resources:** profile
+
+**Examples:**
+
+```bash
+c8ctl which profile                                         # Show currently active profile
+```
+
+
+<!-- command-reference:end -->
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -923,7 +923,7 @@ c8ctl open operate --profile=prod                           # Open Operate using
 
 Add a profile
 
-**Resources:** profile (profile)
+**Resources:** profile
 
 **Positional arguments:**
 
@@ -952,7 +952,7 @@ Remove a profile (alias: rm)
 
 **Aliases:** `rm`
 
-**Resources:** profile (profile), plugin (plugin)
+**Resources:** profile, plugin
 
 **Positional arguments:**
 
@@ -971,7 +971,7 @@ Remove a profile (alias: rm)
 
 Load a c8ctl plugin (npm registry or URL)
 
-**Resources:** plugin (plugin)
+**Resources:** plugin
 
 **Positional arguments:**
 
@@ -998,7 +998,7 @@ Unload a c8ctl plugin (npm uninstall wrapper)
 
 **Aliases:** `rm`
 
-**Resources:** plugin (plugin)
+**Resources:** plugin
 
 **Positional arguments:**
 
@@ -1016,7 +1016,7 @@ Unload a c8ctl plugin (npm uninstall wrapper)
 
 Upgrade a plugin (respects source type)
 
-**Resources:** plugin (plugin)
+**Resources:** plugin
 
 **Positional arguments:**
 
@@ -1035,7 +1035,7 @@ c8ctl upgrade plugin my-plugin 1.2.3                        # Upgrade plugin to 
 
 Downgrade a plugin to a specific version
 
-**Resources:** plugin (plugin)
+**Resources:** plugin
 
 **Positional arguments:**
 
@@ -1047,7 +1047,7 @@ Downgrade a plugin to a specific version
 
 Synchronize plugins from registry (rebuild/reinstall)
 
-**Resources:** plugin (plugin)
+**Resources:** plugin
 
 **Examples:**
 
@@ -1061,7 +1061,7 @@ c8ctl sync plugin                                           # Synchronize plugin
 
 Create a new plugin from TypeScript template
 
-**Resources:** plugin (plugin)
+**Resources:** plugin
 
 **Positional arguments:**
 
@@ -1079,7 +1079,7 @@ c8ctl init plugin my-plugin                                 # Create new plugin 
 
 Set active profile or tenant
 
-**Resources:** profile (profile), tenant
+**Resources:** profile, tenant
 
 **Positional arguments:**
 
@@ -1104,6 +1104,8 @@ c8ctl use profile prod                                      # Set active profile
 
 Show or set output format
 
+**Resources:** json, text
+
 **Examples:**
 
 ```bash
@@ -1115,6 +1117,8 @@ c8ctl output json                                           # Switch to JSON out
 #### `completion`
 
 Generate shell completion script
+
+**Resources:** bash, zsh, fish, install
 
 **Resource-specific flags:**
 
@@ -1161,7 +1165,7 @@ Show help (run 'c8ctl help <command>' for details)
 
 Show active profile
 
-**Resources:** profile (profile)
+**Resources:** profile
 
 **Examples:**
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ c8ctl --version
 
 ### Command Reference
 
-> Auto-generated from [`COMMAND_REGISTRY`](src/command-registry.ts). Do not edit manually.
+> Auto-generated from [`COMMAND_REGISTRY`](https://github.com/camunda/c8ctl/blob/main/src/command-registry.ts). Do not edit manually.
 > Run `node --experimental-strip-types scripts/sync-readme-commands.ts` to update.
 
 #### Global Flags

--- a/README.md
+++ b/README.md
@@ -73,70 +73,1104 @@ c8ctl help plugin     # Shows plugin management help
 c8ctl --version
 ```
 
-### Basic Commands
+<!-- command-reference:start -->
+
+## Command Reference
+
+> Auto-generated from [`COMMAND_REGISTRY`](src/command-registry.ts). Do not edit manually.
+> Run `node --experimental-strip-types scripts/sync-readme-commands.ts` to update.
+
+### Global Flags
+
+These flags are accepted by every command.
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--help` / `-h` | boolean |  | Show help |
+| `--version` / `-v` | string |  | Show CLI version, or filter by process definition version on supported commands |
+| `--profile` | string |  | Use a specific profile |
+| `--dry-run` | boolean |  | Preview the API request without executing |
+| `--verbose` | boolean |  | Show verbose output |
+| `--fields` | string |  | Comma-separated list of fields to display |
+
+### Resource Aliases
+
+| Alias | Resource |
+|-------|----------|
+| `auth` | `authorization` |
+| `inc` | `incident` |
+| `mr` | `mapping-rule` |
+| `msg` | `message` |
+| `pd` | `process-definition` |
+| `pi` | `process-instance` |
+| `ut` | `user-task` |
+| `vars` | `variable` |
+| `var` | `variable` |
+
+### Search Flags
+
+These flags are available on `list` and `search` commands.
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--sortBy` | string |  | Sort results by field |
+| `--asc` | boolean |  | Sort ascending |
+| `--desc` | boolean |  | Sort descending |
+| `--limit` | string |  | Maximum number of results |
+| `--between` | string |  | Date range filter (e.g. 7d, 30d, 2024-01-01..2024-12-31) |
+| `--dateField` | string |  | Date field for --between filter |
+
+### Commands
+
+#### `list`
+
+List resources
+
+**Resources:** pi (process-instance), pd (process-definition), ut (user-task), inc (incident), jobs, profiles (profile), plugins (plugin), users (user), roles (role), groups (group), tenants (tenant), auth (authorization), mapping-rules (mapping-rule)
+
+**Verb-level flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--all` | boolean |  | List all (disable pagination limit) |
+
+**Resource-specific flags:**
+
+<details>
+<summary><code>process-definition</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
+| `--id` | string |  | Filter by BPMN process ID (alias) |
+| `--processDefinitionId` | string |  | Filter by process definition ID |
+| `--name` | string |  | Filter by name |
+| `--key` | string |  | Filter by key |
+| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
+| `--iname` | string |  | Case-insensitive filter by name |
+
+</details>
+
+<details>
+<summary><code>process-instance</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
+| `--id` | string |  | Filter by BPMN process ID (alias) |
+| `--processDefinitionId` | string |  | Filter by process definition ID |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--state` | string |  | Filter by state (ACTIVE, COMPLETED, etc) |
+| `--key` | string |  | Filter by key |
+| `--parentProcessInstanceKey` | string |  | Filter by parent process instance key |
+| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
+
+</details>
+
+<details>
+<summary><code>user-task</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--state` | string |  | Filter by state |
+| `--assignee` | string |  | Filter by assignee |
+| `--processInstanceKey` | string |  | Filter by process instance key |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--elementId` | string |  | Filter by element ID |
+| `--iassignee` | string |  | Case-insensitive filter by assignee |
+
+</details>
+
+<details>
+<summary><code>incident</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--state` | string |  | Filter by state |
+| `--processInstanceKey` | string |  | Filter by process instance key |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
+| `--id` | string |  | Filter by BPMN process ID (alias) |
+| `--processDefinitionId` | string |  | Filter by process definition ID |
+| `--errorType` | string |  | Filter by error type |
+| `--errorMessage` | string |  | Filter by error message |
+| `--ierrorMessage` | string |  | Case-insensitive filter by error message |
+| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
+
+</details>
+
+<details>
+<summary><code>jobs</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--state` | string |  | Filter by state |
+| `--type` | string |  | Filter by job type |
+| `--processInstanceKey` | string |  | Filter by process instance key |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--itype` | string |  | Case-insensitive filter by job type |
+
+</details>
+
+<details>
+<summary><code>user</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--username` | string |  | Filter by username |
+| `--name` | string |  | Filter by name |
+| `--email` | string |  | Filter by email |
+
+</details>
+
+<details>
+<summary><code>role</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--roleId` | string |  | Filter by role ID |
+| `--name` | string |  | Filter by name |
+
+</details>
+
+<details>
+<summary><code>group</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--groupId` | string |  | Filter by group ID |
+| `--name` | string |  | Filter by name |
+
+</details>
+
+<details>
+<summary><code>tenant</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--tenantId` | string |  | Filter by tenant ID |
+| `--name` | string |  | Filter by name |
+
+</details>
+
+<details>
+<summary><code>authorization</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--ownerId` | string |  | Filter by owner ID |
+| `--ownerType` | string |  | Filter by owner type |
+| `--resourceType` | string |  | Filter by resource type |
+| `--resourceId` | string |  | Filter by resource ID |
+
+</details>
+
+<details>
+<summary><code>mapping-rule</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--mappingRuleId` | string |  | Filter by mapping rule ID |
+| `--name` | string |  | Filter by name |
+| `--claimName` | string |  | Filter by claim name |
+| `--claimValue` | string |  | Filter by claim value |
+
+</details>
+
+**Examples:**
 
 ```bash
-# List and get resources (use aliases pi, pd, ut, inc for convenience)
-c8ctl list pi                          # List process instances
-c8ctl list pd                          # List process definitions
-c8ctl get pi 123456                    # Get process instance by key
-c8ctl get pi 123456 --variables        # Get process instance with variables
-c8ctl get pd 123456 --xml              # Get process definition as XML
-
-# Create process instance
-c8ctl create pi --id=myProcess
-c8ctl create process-instance --id=myProcess
-
-# Create process instance and wait for completion
-c8ctl create pi --id=myProcess --awaitCompletion
-
-# Create process instance with custom timeout (30 seconds)
-c8ctl create pi --id=myProcess --awaitCompletion --requestTimeout=30000
-
-# Await process instance completion (alias for create with --awaitCompletion)
-c8ctl await pi --id=myProcess
-c8ctl await process-instance --id=myProcess
-
-# Await with custom timeout
-c8ctl await pi --id=myProcess --requestTimeout=60000
-
-# Cancel process instance
-c8ctl cancel pi 123456
-
-# Get forms
-c8ctl get form 123456                        # Get form (searches both user task and process definition)
-c8ctl get form 123456 --ut                   # Get form for user task only
-c8ctl get form 123456 --pd                   # Get start form for process definition only
-
-# Search resources with filters
-c8ctl search pi --state=ACTIVE         # Search active process instances
-c8ctl search pi --id=myProcess --version=2  # Search process instances by ID and version
-c8ctl search pd --id=myProcess         # Search process definitions by ID
-c8ctl search pd --version=2            # Search process definitions by version
-c8ctl search pd --name='*order*'       # Wildcard search (* = any chars, ? = single char)
-c8ctl search pd --id='process-v?'      # Single-char wildcard (matches process-v1, process-v2, …)
-c8ctl search pd --iname='*ORDER*'      # Case-insensitive search (--i prefix)
-c8ctl search ut --iassignee=John       # Case-insensitive assignee search
-c8ctl search ut --assignee=john        # Search user tasks by assignee
-c8ctl search inc --state=ACTIVE        # Search active incidents
-c8ctl search jobs --type='*service*'   # Search jobs with type containing "service"
-c8ctl search variables --name=myVar    # Search variables by name
-c8ctl search variables --fullValue     # Search with full (non-truncated) values
-
-# Deploy and run
-c8ctl deploy ./my-process.bpmn         # Deploy a single file
-c8ctl deploy                           # Deploy current directory
-c8ctl run ./my-process.bpmn            # Deploy and start process
-c8ctl watch                            # Watch for changes and auto-deploy
-c8ctl watch --force                    # Keep watching after all deployment errors
-
-# Open Camunda web applications
-c8ctl open operate                     # Open Camunda Operate in browser
-c8ctl open tasklist                    # Open Camunda Tasklist in browser
-c8ctl open modeler                     # Open Camunda Web Modeler in browser
-c8ctl open optimize                    # Open Camunda Optimize in browser
-c8ctl open operate --profile=prod      # Open Operate with a specific profile
+c8ctl list pi                                               # List process instances
+c8ctl list pd                                               # List process definitions
+c8ctl list users                                            # List users
 ```
+
+---
+
+#### `search`
+
+Search resources with filters (wildcards, date ranges, case-insensitive)
+
+**Resources:** pi (process-instance), pd (process-definition), ut (user-task), inc (incident), jobs, vars (variable), users (user), roles (role), groups (group), tenants (tenant), auth (authorization), mapping-rules (mapping-rule)
+
+**Resource-specific flags:**
+
+<details>
+<summary><code>process-definition</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
+| `--id` | string |  | Filter by BPMN process ID (alias) |
+| `--processDefinitionId` | string |  | Filter by process definition ID |
+| `--name` | string |  | Filter by name |
+| `--key` | string |  | Filter by key |
+| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
+| `--iname` | string |  | Case-insensitive filter by name |
+
+</details>
+
+<details>
+<summary><code>process-instance</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
+| `--id` | string |  | Filter by BPMN process ID (alias) |
+| `--processDefinitionId` | string |  | Filter by process definition ID |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--state` | string |  | Filter by state (ACTIVE, COMPLETED, etc) |
+| `--key` | string |  | Filter by key |
+| `--parentProcessInstanceKey` | string |  | Filter by parent process instance key |
+| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
+
+</details>
+
+<details>
+<summary><code>user-task</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--state` | string |  | Filter by state |
+| `--assignee` | string |  | Filter by assignee |
+| `--processInstanceKey` | string |  | Filter by process instance key |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--elementId` | string |  | Filter by element ID |
+| `--iassignee` | string |  | Case-insensitive filter by assignee |
+
+</details>
+
+<details>
+<summary><code>incident</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--state` | string |  | Filter by state |
+| `--processInstanceKey` | string |  | Filter by process instance key |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
+| `--id` | string |  | Filter by BPMN process ID (alias) |
+| `--processDefinitionId` | string |  | Filter by process definition ID |
+| `--errorType` | string |  | Filter by error type |
+| `--errorMessage` | string |  | Filter by error message |
+| `--ierrorMessage` | string |  | Case-insensitive filter by error message |
+| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
+
+</details>
+
+<details>
+<summary><code>jobs</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--state` | string |  | Filter by state |
+| `--type` | string |  | Filter by job type |
+| `--processInstanceKey` | string |  | Filter by process instance key |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--itype` | string |  | Case-insensitive filter by job type |
+
+</details>
+
+<details>
+<summary><code>variable</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--name` | string |  | Filter by variable name |
+| `--value` | string |  | Filter by value |
+| `--processInstanceKey` | string |  | Filter by process instance key |
+| `--scopeKey` | string |  | Filter by scope key |
+| `--fullValue` | boolean |  | Return full variable values (not truncated) |
+| `--iname` | string |  | Case-insensitive filter by name |
+| `--ivalue` | string |  | Case-insensitive filter by value |
+
+</details>
+
+<details>
+<summary><code>user</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--username` | string |  | Filter by username |
+| `--name` | string |  | Filter by name |
+| `--email` | string |  | Filter by email |
+
+</details>
+
+<details>
+<summary><code>role</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--roleId` | string |  | Filter by role ID |
+| `--name` | string |  | Filter by name |
+
+</details>
+
+<details>
+<summary><code>group</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--groupId` | string |  | Filter by group ID |
+| `--name` | string |  | Filter by name |
+
+</details>
+
+<details>
+<summary><code>tenant</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--tenantId` | string |  | Filter by tenant ID |
+| `--name` | string |  | Filter by name |
+
+</details>
+
+<details>
+<summary><code>authorization</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--ownerId` | string |  | Filter by owner ID |
+| `--ownerType` | string |  | Filter by owner type |
+| `--resourceType` | string |  | Filter by resource type |
+| `--resourceId` | string |  | Filter by resource ID |
+
+</details>
+
+<details>
+<summary><code>mapping-rule</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--mappingRuleId` | string |  | Filter by mapping rule ID |
+| `--name` | string |  | Filter by name |
+| `--claimName` | string |  | Filter by claim name |
+| `--claimValue` | string |  | Filter by claim value |
+
+</details>
+
+**Examples:**
+
+```bash
+c8ctl search pi --state=ACTIVE                              # Search for active process instances
+c8ctl search pd --bpmnProcessId=myProcess                   # Search process definitions by ID
+c8ctl search pd --name='*main*'                             # Search process definitions with wildcard
+c8ctl search ut --assignee=john                             # Search user tasks assigned to john
+c8ctl search inc --state=ACTIVE                             # Search for active incidents
+c8ctl search jobs --type=myJobType                          # Search jobs by type
+c8ctl search jobs --type='*service*'                        # Search jobs with type containing "service"
+c8ctl search variables --name=myVar                         # Search for variables by name
+c8ctl search variables --value=foo                          # Search for variables by value
+c8ctl search variables --processInstanceKey=123 --fullValue  # Search variables with full values
+c8ctl search pd --iname='*order*'                           # Case-insensitive search by name
+c8ctl search ut --iassignee=John                            # Case-insensitive search by assignee
+```
+
+---
+
+#### `get`
+
+Get a resource by key
+
+**Resources:** pi (process-instance), pd (process-definition), inc (incident), topology, form, user, role, group, tenant, auth (authorization), mapping-rule
+
+**Positional arguments:**
+
+- **process-definition:** `<key>` (required)
+- **process-instance:** `<key>` (required)
+- **incident:** `<key>` (required)
+- **user:** `<username>` (required)
+- **role:** `<roleId>` (required)
+- **group:** `<groupId>` (required)
+- **tenant:** `<tenantId>` (required)
+- **authorization:** `<authorizationKey>` (required)
+- **mapping-rule:** `<mappingRuleId>` (required)
+- **form:** `<key>` (required)
+
+**Resource-specific flags:**
+
+<details>
+<summary><code>process-definition</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--xml` | boolean |  | Get BPMN XML (process definitions) |
+
+</details>
+
+<details>
+<summary><code>form</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--userTask` | boolean |  | Get form for user task |
+| `--ut` | boolean |  | Alias for --userTask |
+| `--processDefinition` | boolean |  | Get form for process definition |
+| `--pd` | boolean |  | Alias for --processDefinition |
+
+</details>
+
+<details>
+<summary><code>process-instance</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--variables` | boolean |  | Include variables in output |
+
+</details>
+
+**Examples:**
+
+```bash
+c8ctl get pi 123456                                         # Get process instance by key
+c8ctl get pi 123456 --variables                             # Get process instance with variables
+c8ctl get pd 123456                                         # Get process definition by key
+c8ctl get pd 123456 --xml                                   # Get process definition XML
+c8ctl get form 123456                                       # Get form (searches both user task and process definition)
+c8ctl get form 123456 --ut                                  # Get form for user task only
+c8ctl get form 123456 --pd                                  # Get start form for process definition only
+c8ctl get user john                                         # Get user by username
+```
+
+---
+
+#### `create`
+
+Create a resource (process instance, identity)
+
+**Resources:** pi (process-instance), user, role, group, tenant, auth (authorization), mapping-rule
+
+**Verb-level flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--processDefinitionId` | string |  | Process definition ID (BPMN process ID) |
+| `--id` | string |  | Process definition ID (alias for --processDefinitionId) |
+| `--bpmnProcessId` | string |  | BPMN process ID (alias for --processDefinitionId) |
+| `--variables` | string |  | JSON variables |
+| `--awaitCompletion` | boolean |  | Wait for process to complete |
+| `--fetchVariables` | boolean |  | Fetch result variables on completion |
+| `--requestTimeout` | string |  | Await timeout in milliseconds |
+| `--username` | string |  | Username |
+| `--name` | string |  | Display name |
+| `--email` | string |  | Email address |
+| `--password` | string |  | Password |
+| `--roleId` | string |  | Role ID |
+| `--groupId` | string |  | Group ID |
+| `--tenantId` | string |  | Tenant ID |
+| `--mappingRuleId` | string |  | Mapping rule ID |
+| `--claimName` | string |  | Claim name |
+| `--claimValue` | string |  | Claim value |
+
+**Resource-specific flags:**
+
+<details>
+<summary><code>authorization</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--ownerId` | string | Yes | Authorization owner ID |
+| `--ownerType` | string | Yes | Authorization owner type |
+| `--resourceType` | string | Yes | Authorization resource type |
+| `--resourceId` | string | Yes | Authorization resource ID |
+| `--permissions` | string | Yes | Comma-separated permissions |
+
+</details>
+
+**Examples:**
+
+```bash
+c8ctl create pi --id=myProcess                              # Create a process instance
+c8ctl create pi --id=myProcess --awaitCompletion            # Create and await completion
+c8ctl create user --username=john --name='John Doe' --email=john@example.com --password=secret  # Create a user
+```
+
+---
+
+#### `delete`
+
+Delete a resource by key
+
+**Resources:** user, role, group, tenant, auth (authorization), mapping-rule
+
+**Positional arguments:**
+
+- **user:** `<username>` (required)
+- **role:** `<roleId>` (required)
+- **group:** `<groupId>` (required)
+- **tenant:** `<tenantId>` (required)
+- **authorization:** `<authorizationKey>` (required)
+- **mapping-rule:** `<mappingRuleId>` (required)
+
+**Examples:**
+
+```bash
+c8ctl delete user john                                      # Delete user
+```
+
+---
+
+#### `cancel`
+
+Cancel a process instance
+
+**Resources:** pi (process-instance)
+
+**Positional arguments:**
+
+- **process-instance:** `<key>` (required)
+
+---
+
+#### `await`
+
+Create and await process instance completion (server-side waiting)
+
+**Resources:** pi (process-instance)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--processDefinitionId` | string |  | Process definition ID (BPMN process ID) |
+| `--id` | string |  | Process definition ID (alias for --processDefinitionId) |
+| `--bpmnProcessId` | string |  | BPMN process ID (alias for --processDefinitionId) |
+| `--variables` | string |  | JSON variables |
+| `--fetchVariables` | boolean |  | Fetch result variables on completion |
+| `--requestTimeout` | string |  | Await timeout in milliseconds |
+
+**Examples:**
+
+```bash
+c8ctl await pi --id=myProcess                               # Create and wait for completion
+```
+
+---
+
+#### `complete`
+
+Complete a user task or job
+
+**Resources:** ut (user-task), job
+
+**Positional arguments:**
+
+- **user-task:** `<key>` (required)
+- **job:** `<key>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--variables` | string |  | JSON variables |
+
+---
+
+#### `fail`
+
+Mark a job as failed with optional error message and retry count
+
+**Resources:** job
+
+**Positional arguments:**
+
+- **job:** `<key>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--retries` | string |  | Remaining retries |
+| `--errorMessage` | string |  | Error message |
+
+---
+
+#### `activate`
+
+Activate jobs of a specific type for processing
+
+**Resources:** jobs
+
+**Positional arguments:**
+
+- **jobs:** `<type>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--maxJobsToActivate` | string |  | Maximum number of jobs to activate |
+| `--timeout` | string |  | Job timeout in milliseconds |
+| `--worker` | string |  | Worker name |
+
+---
+
+#### `resolve`
+
+Resolve an incident (marks resolved, allows process to continue)
+
+**Resources:** inc (incident)
+
+**Positional arguments:**
+
+- **incident:** `<key>` (required)
+
+---
+
+#### `publish`
+
+Publish a message for message correlation
+
+**Resources:** msg (message)
+
+**Positional arguments:**
+
+- **message:** `<name>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--correlationKey` | string |  | Correlation key |
+| `--variables` | string |  | JSON variables |
+| `--timeToLive` | string |  | Time to live in milliseconds |
+
+---
+
+#### `correlate`
+
+Correlate a message to a specific process instance
+
+**Resources:** msg (message)
+
+**Positional arguments:**
+
+- **message:** `<name>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--correlationKey` | string | Yes | Correlation key |
+| `--variables` | string |  | JSON variables |
+| `--timeToLive` | string |  | Time to live in milliseconds |
+
+---
+
+#### `set`
+
+Set variables on an element instance (process instance or flow element scope). Variables are propagated to the outermost scope by default; use --local to restrict to the specified scope.
+
+**Resources:** variable
+
+**Positional arguments:**
+
+- **variable:** `<key>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--variables` | string | Yes | JSON object of variables to set (required) |
+| `--local` | boolean |  | Set variables in local scope only (default: propagate to outermost scope) |
+
+**Examples:**
+
+```bash
+c8ctl set variable 2251799813685249 --variables='{"status":"approved"}'  # Set variables on a process instance
+c8ctl set variable 2251799813685249 --variables='{"x":1}' --local  # Set variables in local scope only
+```
+
+---
+
+#### `deploy`
+
+Deploy files to Camunda (auto-discovers deployable files in directories)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--force` | boolean |  | Deploy any file type, ignoring the default extension allow-list |
+
+**Examples:**
+
+```bash
+c8ctl deploy ./my-process.bpmn                              # Deploy a BPMN file
+```
+
+---
+
+#### `run`
+
+Deploy and start a process instance from a BPMN file
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--variables` | string |  | JSON variables |
+| `--force` | boolean |  | Deploy any file type, ignoring the default extension allow-list |
+
+**Examples:**
+
+```bash
+c8ctl run ./my-process.bpmn                                 # Deploy and start process
+```
+
+---
+
+#### `assign`
+
+Assign a resource to a target (--to-user, --to-group, etc.)
+
+**Resources:** role, user, group, mapping-rule
+
+**Positional arguments:**
+
+- **role:** `<roleId>` (required)
+- **user:** `<username>` (required)
+- **group:** `<groupId>` (required)
+- **mapping-rule:** `<mappingRuleId>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--to-user` | string |  | Target user ID |
+| `--to-group` | string |  | Target group ID |
+| `--to-tenant` | string |  | Target tenant ID |
+| `--to-mapping-rule` | string |  | Target mapping rule ID |
+
+**Examples:**
+
+```bash
+c8ctl assign role admin --to-user=john                      # Assign role to user
+```
+
+---
+
+#### `unassign`
+
+Unassign a resource from a target (--from-user, --from-group, etc.)
+
+**Resources:** role, user, group, mapping-rule
+
+**Positional arguments:**
+
+- **role:** `<roleId>` (required)
+- **user:** `<username>` (required)
+- **group:** `<groupId>` (required)
+- **mapping-rule:** `<mappingRuleId>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--from-user` | string |  | Source user ID |
+| `--from-group` | string |  | Source group ID |
+| `--from-tenant` | string |  | Source tenant ID |
+| `--from-mapping-rule` | string |  | Source mapping rule ID |
+
+**Examples:**
+
+```bash
+c8ctl unassign role admin --from-user=john                  # Unassign role from user
+```
+
+---
+
+#### `watch`
+
+Watch files for changes and auto-deploy
+
+**Aliases:** `w`
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--force` | boolean |  | Continue watching after all deployment errors |
+| `--extensions` | string |  | Comma-separated list of file extensions to watch (e.g. .bpmn,.dmn,.form) |
+
+**Examples:**
+
+```bash
+c8ctl watch ./src                                           # Watch directory for changes
+```
+
+---
+
+#### `open`
+
+Open Camunda web app in browser
+
+**Resources:** operate, tasklist, modeler, optimize
+
+**Examples:**
+
+```bash
+c8ctl open operate                                          # Open Camunda Operate in browser
+c8ctl open tasklist                                         # Open Camunda Tasklist in browser
+c8ctl open operate --profile=prod                           # Open Operate using a specific profile
+```
+
+---
+
+#### `add`
+
+Add a profile
+
+**Resources:** profile (profile)
+
+**Positional arguments:**
+
+- **profile:** `<name>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--baseUrl` | string |  | Cluster base URL |
+| `--clientId` | string |  | OAuth client ID |
+| `--clientSecret` | string |  | OAuth client secret |
+| `--audience` | string |  | OAuth audience |
+| `--oAuthUrl` | string |  | OAuth token URL |
+| `--defaultTenantId` | string |  | Default tenant ID |
+| `--username` | string |  | Basic auth username |
+| `--password` | string |  | Basic auth password |
+| `--from-file` | string |  | Import from .env file |
+| `--from-env` | boolean |  | Import from environment variables |
+
+---
+
+#### `remove`
+
+Remove a profile (alias: rm)
+
+**Aliases:** `rm`
+
+**Resources:** profile (profile), plugin (plugin)
+
+**Positional arguments:**
+
+- **profile:** `<name>` (required)
+- **plugin:** `<package>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--none` | boolean |  | Clear active profile |
+
+---
+
+#### `load`
+
+Load a c8ctl plugin (npm registry or URL)
+
+**Resources:** plugin (plugin)
+
+**Positional arguments:**
+
+- **plugin:** `<package>` (optional)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--from` | string |  | Load plugin from URL |
+
+**Examples:**
+
+```bash
+c8ctl load plugin my-plugin                                 # Load plugin from npm registry
+c8ctl load plugin --from https://github.com/org/plugin      # Load plugin from URL
+```
+
+---
+
+#### `unload`
+
+Unload a c8ctl plugin (npm uninstall wrapper)
+
+**Aliases:** `rm`
+
+**Resources:** plugin (plugin)
+
+**Positional arguments:**
+
+- **plugin:** `<package>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--force` | boolean |  | Force unload without confirmation |
+
+---
+
+#### `upgrade`
+
+Upgrade a plugin (respects source type)
+
+**Resources:** plugin (plugin)
+
+**Positional arguments:**
+
+- **plugin:** `<package>` (required), `<version>` (optional)
+
+**Examples:**
+
+```bash
+c8ctl upgrade plugin my-plugin                              # Upgrade plugin to latest version
+c8ctl upgrade plugin my-plugin 1.2.3                        # Upgrade plugin to a specific version (source-aware)
+```
+
+---
+
+#### `downgrade`
+
+Downgrade a plugin to a specific version
+
+**Resources:** plugin (plugin)
+
+**Positional arguments:**
+
+- **plugin:** `<package>` (required), `<version>` (required)
+
+---
+
+#### `sync`
+
+Synchronize plugins from registry (rebuild/reinstall)
+
+**Resources:** plugin (plugin)
+
+**Examples:**
+
+```bash
+c8ctl sync plugin                                           # Synchronize plugins
+```
+
+---
+
+#### `init`
+
+Create a new plugin from TypeScript template
+
+**Resources:** plugin (plugin)
+
+**Positional arguments:**
+
+- **plugin:** `<name>` (optional)
+
+**Examples:**
+
+```bash
+c8ctl init plugin my-plugin                                 # Create new plugin from template (c8ctl-plugin-my-plugin)
+```
+
+---
+
+#### `use`
+
+Set active profile or tenant
+
+**Resources:** profile (profile), tenant
+
+**Positional arguments:**
+
+- **profile:** `<name>` (optional)
+- **tenant:** `<tenantId>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--none` | boolean |  | Clear active profile/tenant |
+
+**Examples:**
+
+```bash
+c8ctl use profile prod                                      # Set active profile
+```
+
+---
+
+#### `output`
+
+Show or set output format
+
+**Examples:**
+
+```bash
+c8ctl output json                                           # Switch to JSON output
+```
+
+---
+
+#### `completion`
+
+Generate shell completion script
+
+**Resource-specific flags:**
+
+<details>
+<summary><code>install</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--shell` | string |  | Shell to install completions for (bash, zsh, fish) |
+
+</details>
+
+**Examples:**
+
+```bash
+c8ctl completion bash                                       # Generate bash completion script
+c8ctl completion install                                    # Auto-detect shell and install completions (auto-refreshes on upgrade)
+c8ctl completion install --shell zsh                        # Install completions for a specific shell
+```
+
+---
+
+#### `mcp-proxy`
+
+Start a STDIO MCP proxy (bridges local MCP clients to remote Camunda 8)
+
+---
+
+#### `feedback`
+
+Open the feedback page to report issues or request features
+
+---
+
+#### `help`
+
+Show help (run 'c8ctl help <command>' for details)
+
+**Aliases:** `menu`
+
+---
+
+#### `which`
+
+Show active profile
+
+**Resources:** profile (profile)
+
+**Examples:**
+
+```bash
+c8ctl which profile                                         # Show currently active profile
+```
+
+
+<!-- command-reference:end -->
 
 ### Default Extensions
 
@@ -504,14 +1538,6 @@ export const commands = {
 ```
 
 When plugins are loaded, their commands automatically appear in `c8ctl help` output. See [PLUGIN-HELP.md](PLUGIN-HELP.md) for detailed documentation on plugin help integration.
-
-### Resource Aliases
-
-- `pi` = process-instance(s)
-- `pd` = process-definition(s)
-- `ut` = user-task(s)
-- `inc` = incident(s)
-- `msg` = message
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -741,8 +741,8 @@ Modeler profiles are:
 
 ## Command Reference
 
-> Auto-generated from [`COMMAND_REGISTRY`](https://github.com/camunda/c8ctl/blob/main/src/command-registry.ts). Do not edit manually.
-> Run `node --experimental-strip-types scripts/sync-readme-commands.ts` to update.
+<!-- Auto-generated from COMMAND_REGISTRY. Do not edit manually.
+     Run: node --experimental-strip-types scripts/sync-readme-commands.ts -->
 
 ### Global Flags
 

--- a/biome.json
+++ b/biome.json
@@ -1,11 +1,11 @@
 {
 	"$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
 	"files": {
-		"includes": ["src/**/*.ts", "!src/templates", "tests/**/*.ts"]
+		"includes": ["src/**/*.ts", "!src/templates", "tests/**/*.ts", "scripts/**/*.ts"]
 	},
 	"linter": {
 		"enabled": true,
-		"includes": ["src/**/*.ts", "!/src/templates/**", "tests/**/*.ts"],
+		"includes": ["src/**/*.ts", "!/src/templates/**", "tests/**/*.ts", "scripts/**/*.ts"],
 		"rules": {
 			"recommended": true,
 			"suspicious": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "scripts": {
     "prepare": "git rev-parse --is-inside-work-tree >/dev/null 2>&1 && sh -c 'hp=$(git config --local --get core.hooksPath 2>/dev/null || true); if [ -z \"$hp\" ] || [ \"$hp\" = \".githooks\" ]; then git config --local core.hooksPath .githooks; else echo \"prepare: leaving existing core.hooksPath=$hp\"; fi' || true",
-    "build": "npm run lint && npm run clean && tsc && npm run copy-plugins && npm run copy-templates",
+    "build": "npm run lint && npm run sync:readme:check && npm run clean && tsc && npm run copy-plugins && npm run copy-templates",
     "lint": "biome check src/ tests/",
     "lint:src": "biome check src/",
     "typecheck": "tsc --noEmit -p tsconfig.check.json",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
   "scripts": {
     "prepare": "git rev-parse --is-inside-work-tree >/dev/null 2>&1 && sh -c 'hp=$(git config --local --get core.hooksPath 2>/dev/null || true); if [ -z \"$hp\" ] || [ \"$hp\" = \".githooks\" ]; then git config --local core.hooksPath .githooks; else echo \"prepare: leaving existing core.hooksPath=$hp\"; fi' || true",
     "build": "npm run lint && npm run sync:readme && npm run clean && tsc && npm run copy-plugins && npm run copy-templates",
-    "lint": "biome check src/ tests/",
-    "lint:src": "biome check src/",
+    "lint": "biome check src/ tests/ scripts/",
+    "lint:src": "biome check src/ scripts/",
     "typecheck": "tsc --noEmit -p tsconfig.check.json",
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
     "copy-plugins": "node -e \"const fs=require('fs');const path=require('path');const src='default-plugins';const dest='dist/default-plugins';if(fs.existsSync(src)){fs.cpSync(src,dest,{recursive:true})}\"",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "scripts": {
     "prepare": "git rev-parse --is-inside-work-tree >/dev/null 2>&1 && sh -c 'hp=$(git config --local --get core.hooksPath 2>/dev/null || true); if [ -z \"$hp\" ] || [ \"$hp\" = \".githooks\" ]; then git config --local core.hooksPath .githooks; else echo \"prepare: leaving existing core.hooksPath=$hp\"; fi' || true",
-    "build": "npm run lint && npm run sync:readme:check && npm run clean && tsc && npm run copy-plugins && npm run copy-templates",
+    "build": "npm run lint && npm run sync:readme && npm run clean && tsc && npm run copy-plugins && npm run copy-templates",
     "lint": "biome check src/ tests/",
     "lint:src": "biome check src/",
     "typecheck": "tsc --noEmit -p tsconfig.check.json",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "test:unit": "node --experimental-strip-types --test tests/unit/*.test.ts",
     "test:integration": "node --experimental-strip-types --test tests/integration/*.test.ts",
     "dev": "node src/index.ts",
-    "cli": "node src/index.ts"
+    "cli": "node src/index.ts",
+    "sync:readme": "node --experimental-strip-types scripts/sync-readme-commands.ts",
+    "sync:readme:check": "node --experimental-strip-types scripts/sync-readme-commands.ts --check"
   },
   "keywords": [
     "camunda",

--- a/scripts/sync-readme-commands.ts
+++ b/scripts/sync-readme-commands.ts
@@ -54,7 +54,7 @@ export function uniqueAliases(): Array<{ alias: string; canonical: string }> {
 	return result.sort((a, b) => a.canonical.localeCompare(b.canonical));
 }
 
-/** Format a flag name for display: `--name` or `--name, -s` */
+/** Format a flag name for display: `--name` or `--name` / `-s` */
 export function formatFlag(name: string, def: FlagDef): string {
 	const long = `\`--${name}\``;
 	return def.short ? `${long} / \`-${def.short}\`` : long;
@@ -108,7 +108,7 @@ export function resourceDisplay(resource: string): string {
 export function generate(): string {
 	const lines: string[] = [];
 
-	lines.push("## Command Reference");
+	lines.push("### Command Reference");
 	lines.push("");
 	lines.push(
 		"> Auto-generated from [`COMMAND_REGISTRY`](src/command-registry.ts). Do not edit manually.",
@@ -119,7 +119,7 @@ export function generate(): string {
 	lines.push("");
 
 	// ── Global Flags ──
-	lines.push("### Global Flags");
+	lines.push("#### Global Flags");
 	lines.push("");
 	lines.push("These flags are accepted by every command.");
 	lines.push("");
@@ -129,7 +129,7 @@ export function generate(): string {
 	// ── Resource Aliases ──
 	const aliases = uniqueAliases();
 	if (aliases.length > 0) {
-		lines.push("### Resource Aliases");
+		lines.push("#### Resource Aliases");
 		lines.push("");
 		lines.push("| Alias | Resource |");
 		lines.push("|-------|----------|");
@@ -142,7 +142,7 @@ export function generate(): string {
 	// ── Search Flags ──
 	const searchFlagEntries = Object.entries(SEARCH_FLAGS);
 	if (searchFlagEntries.length > 0) {
-		lines.push("### Search Flags");
+		lines.push("#### Search Flags");
 		lines.push("");
 		lines.push("These flags are available on `list` and `search` commands.");
 		lines.push("");
@@ -151,13 +151,13 @@ export function generate(): string {
 	}
 
 	// ── Commands ──
-	lines.push("### Commands");
+	lines.push("#### Commands");
 	lines.push("");
 
 	const registry: Record<string, CommandDef> = COMMAND_REGISTRY;
 
 	for (const [verb, def] of Object.entries(registry)) {
-		lines.push(`#### \`${verb}\``);
+		lines.push(`##### \`${verb}\``);
 		lines.push("");
 		lines.push(verbDescription(def));
 		lines.push("");

--- a/scripts/sync-readme-commands.ts
+++ b/scripts/sync-readme-commands.ts
@@ -111,10 +111,10 @@ export function generate(): string {
 	lines.push("## Command Reference");
 	lines.push("");
 	lines.push(
-		"> Auto-generated from [`COMMAND_REGISTRY`](https://github.com/camunda/c8ctl/blob/main/src/command-registry.ts). Do not edit manually.",
+		"<!-- Auto-generated from COMMAND_REGISTRY. Do not edit manually.",
 	);
 	lines.push(
-		`> Run \`node --experimental-strip-types scripts/sync-readme-commands.ts\` to update.`,
+		"     Run: node --experimental-strip-types scripts/sync-readme-commands.ts -->",
 	);
 	lines.push("");
 

--- a/scripts/sync-readme-commands.ts
+++ b/scripts/sync-readme-commands.ts
@@ -22,13 +22,13 @@ const __dirname = dirname(__filename);
 const ROOT = resolve(__dirname, "..");
 const README_PATH = resolve(ROOT, "README.md");
 
-const START_MARKER = "<!-- command-reference:start -->";
-const END_MARKER = "<!-- command-reference:end -->";
+export const START_MARKER = "<!-- command-reference:start -->";
+export const END_MARKER = "<!-- command-reference:end -->";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 /** Build a reverse map: canonical resource → shortest alias */
-function buildAliasLookup(): Map<string, string> {
+export function buildAliasLookup(): Map<string, string> {
 	const map = new Map<string, string>();
 	for (const [alias, canonical] of Object.entries(RESOURCE_ALIASES)) {
 		const existing = map.get(canonical);
@@ -40,7 +40,7 @@ function buildAliasLookup(): Map<string, string> {
 }
 
 /** Deduplicate resource aliases: collapse entries where the alias is just the plural form of the canonical. */
-function uniqueAliases(): Array<{ alias: string; canonical: string }> {
+export function uniqueAliases(): Array<{ alias: string; canonical: string }> {
 	const seen = new Map<string, string[]>();
 	for (const [alias, canonical] of Object.entries(RESOURCE_ALIASES)) {
 		// Skip plural/singular forms that match the canonical name itself
@@ -63,13 +63,13 @@ function uniqueAliases(): Array<{ alias: string; canonical: string }> {
 }
 
 /** Format a flag name for display: `--name` or `--name, -s` */
-function formatFlag(name: string, def: FlagDef): string {
+export function formatFlag(name: string, def: FlagDef): string {
 	const long = `\`--${name}\``;
 	return def.short ? `${long} / \`-${def.short}\`` : long;
 }
 
 /** Render a flags table */
-function renderFlagsTable(flags: Record<string, FlagDef>): string[] {
+export function renderFlagsTable(flags: Record<string, FlagDef>): string[] {
 	const entries = Object.entries(flags);
 	if (entries.length === 0) return [];
 
@@ -84,7 +84,7 @@ function renderFlagsTable(flags: Record<string, FlagDef>): string[] {
 }
 
 /** Render positionals for a resource */
-function renderPositionals(positionals: readonly PositionalDef[]): string {
+export function renderPositionals(positionals: readonly PositionalDef[]): string {
 	return positionals
 		.map((p) => {
 			const req = p.required ? "required" : "optional";
@@ -99,7 +99,7 @@ function verbDescription(def: CommandDef): string {
 }
 
 /** Resolve resource short name to canonical, returning the display form */
-function resourceDisplay(resource: string): string {
+export function resourceDisplay(resource: string): string {
 	// If the resource is already canonical (contains hyphen or is a known long form), return as-is
 	const canonical = RESOURCE_ALIASES[resource];
 	return canonical ? `${resource} (${canonical})` : resource;
@@ -107,7 +107,7 @@ function resourceDisplay(resource: string): string {
 
 // ─── Generation ──────────────────────────────────────────────────────────────
 
-function generate(): string {
+export function generate(): string {
 	const lines: string[] = [];
 
 	lines.push("## Command Reference");
@@ -249,7 +249,7 @@ function generate(): string {
  * Filter out flags that are already shown in the Global Flags or Search Flags sections.
  * Returns only verb-specific flags.
  */
-function filterVerbSpecificFlags(def: CommandDef): Record<string, FlagDef> {
+export function filterVerbSpecificFlags(def: CommandDef): Record<string, FlagDef> {
 	const globalKeys = new Set(Object.keys(GLOBAL_FLAGS));
 	const searchKeys = new Set(Object.keys(SEARCH_FLAGS));
 
@@ -313,4 +313,11 @@ function main(): void {
 	console.log("README.md command reference updated.");
 }
 
-main();
+// Only run when executed directly (not when imported by tests)
+const isDirectExecution =
+	process.argv[1] &&
+	(resolve(process.argv[1]) === __filename ||
+		resolve(process.argv[1]).replace(/\.ts$/, "") === __filename.replace(/\.ts$/, ""));
+if (isDirectExecution) {
+	main();
+}

--- a/scripts/sync-readme-commands.ts
+++ b/scripts/sync-readme-commands.ts
@@ -108,7 +108,7 @@ export function resourceDisplay(resource: string): string {
 export function generate(): string {
 	const lines: string[] = [];
 
-	lines.push("### Command Reference");
+	lines.push("## Command Reference");
 	lines.push("");
 	lines.push(
 		"> Auto-generated from [`COMMAND_REGISTRY`](https://github.com/camunda/c8ctl/blob/main/src/command-registry.ts). Do not edit manually.",
@@ -119,7 +119,7 @@ export function generate(): string {
 	lines.push("");
 
 	// ── Global Flags ──
-	lines.push("#### Global Flags");
+	lines.push("### Global Flags");
 	lines.push("");
 	lines.push("These flags are accepted by every command.");
 	lines.push("");
@@ -129,7 +129,7 @@ export function generate(): string {
 	// ── Resource Aliases ──
 	const aliases = uniqueAliases();
 	if (aliases.length > 0) {
-		lines.push("#### Resource Aliases");
+		lines.push("### Resource Aliases");
 		lines.push("");
 		lines.push("| Alias | Resource |");
 		lines.push("|-------|----------|");
@@ -142,7 +142,7 @@ export function generate(): string {
 	// ── Search Flags ──
 	const searchFlagEntries = Object.entries(SEARCH_FLAGS);
 	if (searchFlagEntries.length > 0) {
-		lines.push("#### Search Flags");
+		lines.push("### Search Flags");
 		lines.push("");
 		lines.push("These flags are available on `list` and `search` commands.");
 		lines.push("");
@@ -151,13 +151,13 @@ export function generate(): string {
 	}
 
 	// ── Commands ──
-	lines.push("#### Commands");
+	lines.push("### Commands");
 	lines.push("");
 
 	const registry: Record<string, CommandDef> = COMMAND_REGISTRY;
 
 	for (const [verb, def] of Object.entries(registry)) {
-		lines.push(`##### \`${verb}\``);
+		lines.push(`#### \`${verb}\``);
 		lines.push("");
 		lines.push(verbDescription(def));
 		lines.push("");

--- a/scripts/sync-readme-commands.ts
+++ b/scripts/sync-readme-commands.ts
@@ -111,7 +111,7 @@ export function generate(): string {
 	lines.push("### Command Reference");
 	lines.push("");
 	lines.push(
-		"> Auto-generated from [`COMMAND_REGISTRY`](src/command-registry.ts). Do not edit manually.",
+		"> Auto-generated from [`COMMAND_REGISTRY`](https://github.com/camunda/c8ctl/blob/main/src/command-registry.ts). Do not edit manually.",
 	);
 	lines.push(
 		`> Run \`node --experimental-strip-types scripts/sync-readme-commands.ts\` to update.`,

--- a/scripts/sync-readme-commands.ts
+++ b/scripts/sync-readme-commands.ts
@@ -1,0 +1,316 @@
+/**
+ * Generates the Command Reference section of README.md from COMMAND_REGISTRY.
+ *
+ * Usage:
+ *   node --experimental-strip-types scripts/sync-readme-commands.ts          # update README
+ *   node --experimental-strip-types scripts/sync-readme-commands.ts --check  # CI check (exit 1 if stale)
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+	COMMAND_REGISTRY,
+	GLOBAL_FLAGS,
+	RESOURCE_ALIASES,
+	SEARCH_FLAGS,
+} from "../src/command-registry.ts";
+import type { FlagDef, CommandDef, PositionalDef } from "../src/command-registry.ts";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT = resolve(__dirname, "..");
+const README_PATH = resolve(ROOT, "README.md");
+
+const START_MARKER = "<!-- command-reference:start -->";
+const END_MARKER = "<!-- command-reference:end -->";
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Build a reverse map: canonical resource → shortest alias */
+function buildAliasLookup(): Map<string, string> {
+	const map = new Map<string, string>();
+	for (const [alias, canonical] of Object.entries(RESOURCE_ALIASES)) {
+		const existing = map.get(canonical);
+		if (!existing || alias.length < existing.length) {
+			map.set(canonical, alias);
+		}
+	}
+	return map;
+}
+
+/** Deduplicate resource aliases: collapse entries where the alias is just the plural form of the canonical. */
+function uniqueAliases(): Array<{ alias: string; canonical: string }> {
+	const seen = new Map<string, string[]>();
+	for (const [alias, canonical] of Object.entries(RESOURCE_ALIASES)) {
+		// Skip plural/singular forms that match the canonical name itself
+		if (alias === canonical) continue;
+		const list = seen.get(canonical) ?? [];
+		list.push(alias);
+		seen.set(canonical, list);
+	}
+
+	const result: Array<{ alias: string; canonical: string }> = [];
+	for (const [canonical, aliases] of seen) {
+		// Only include short aliases (not plural forms like "process-instances")
+		for (const alias of aliases) {
+			if (!alias.includes("-") && alias !== `${canonical}s`) {
+				result.push({ alias, canonical });
+			}
+		}
+	}
+	return result.sort((a, b) => a.canonical.localeCompare(b.canonical));
+}
+
+/** Format a flag name for display: `--name` or `--name, -s` */
+function formatFlag(name: string, def: FlagDef): string {
+	const long = `\`--${name}\``;
+	return def.short ? `${long} / \`-${def.short}\`` : long;
+}
+
+/** Render a flags table */
+function renderFlagsTable(flags: Record<string, FlagDef>): string[] {
+	const entries = Object.entries(flags);
+	if (entries.length === 0) return [];
+
+	const lines: string[] = [];
+	lines.push("| Flag | Type | Required | Description |");
+	lines.push("|------|------|----------|-------------|");
+	for (const [name, def] of entries) {
+		const req = def.required ? "Yes" : "";
+		lines.push(`| ${formatFlag(name, def)} | ${def.type} | ${req} | ${def.description} |`);
+	}
+	return lines;
+}
+
+/** Render positionals for a resource */
+function renderPositionals(positionals: readonly PositionalDef[]): string {
+	return positionals
+		.map((p) => {
+			const req = p.required ? "required" : "optional";
+			return `\`<${p.name}>\` (${req})`;
+		})
+		.join(", ");
+}
+
+/** Get the display description for a verb */
+function verbDescription(def: CommandDef): string {
+	return def.helpDescription ?? def.description;
+}
+
+/** Resolve resource short name to canonical, returning the display form */
+function resourceDisplay(resource: string): string {
+	// If the resource is already canonical (contains hyphen or is a known long form), return as-is
+	const canonical = RESOURCE_ALIASES[resource];
+	return canonical ? `${resource} (${canonical})` : resource;
+}
+
+// ─── Generation ──────────────────────────────────────────────────────────────
+
+function generate(): string {
+	const lines: string[] = [];
+
+	lines.push("## Command Reference");
+	lines.push("");
+	lines.push("> Auto-generated from [`COMMAND_REGISTRY`](src/command-registry.ts). Do not edit manually.");
+	lines.push(`> Run \`node --experimental-strip-types scripts/sync-readme-commands.ts\` to update.`);
+	lines.push("");
+
+	// ── Global Flags ──
+	lines.push("### Global Flags");
+	lines.push("");
+	lines.push("These flags are accepted by every command.");
+	lines.push("");
+	lines.push(...renderFlagsTable(GLOBAL_FLAGS));
+	lines.push("");
+
+	// ── Resource Aliases ──
+	const aliases = uniqueAliases();
+	if (aliases.length > 0) {
+		lines.push("### Resource Aliases");
+		lines.push("");
+		lines.push("| Alias | Resource |");
+		lines.push("|-------|----------|");
+		for (const { alias, canonical } of aliases) {
+			lines.push(`| \`${alias}\` | \`${canonical}\` |`);
+		}
+		lines.push("");
+	}
+
+	// ── Search Flags ──
+	const searchFlagEntries = Object.entries(SEARCH_FLAGS);
+	if (searchFlagEntries.length > 0) {
+		lines.push("### Search Flags");
+		lines.push("");
+		lines.push("These flags are available on `list` and `search` commands.");
+		lines.push("");
+		lines.push(...renderFlagsTable(SEARCH_FLAGS));
+		lines.push("");
+	}
+
+	// ── Commands ──
+	lines.push("### Commands");
+	lines.push("");
+
+	const registry = COMMAND_REGISTRY as unknown as Record<string, CommandDef>;
+
+	for (const [verb, def] of Object.entries(registry)) {
+		lines.push(`#### \`${verb}\``);
+		lines.push("");
+		lines.push(verbDescription(def));
+		lines.push("");
+
+		// Aliases
+		if (def.aliases && def.aliases.length > 0) {
+			lines.push(`**Aliases:** ${def.aliases.map((a) => `\`${a}\``).join(", ")}`);
+			lines.push("");
+		}
+
+		// Resources
+		if (def.requiresResource && def.resources.length > 0) {
+			const resourceList = def.resources.map((r) => resourceDisplay(r)).join(", ");
+			lines.push(`**Resources:** ${resourceList}`);
+			lines.push("");
+		}
+
+		// Positionals (per-resource)
+		if (def.resourcePositionals) {
+			const positionalEntries = Object.entries(def.resourcePositionals);
+			if (positionalEntries.length > 0) {
+				lines.push("**Positional arguments:**");
+				lines.push("");
+				for (const [resource, positionals] of positionalEntries) {
+					const pos = positionals as readonly PositionalDef[];
+					lines.push(`- **${resource}:** ${renderPositionals(pos)}`);
+				}
+				lines.push("");
+			}
+		}
+
+		// Flags — filter out search flags and global flags (shown separately)
+		const verbFlags = filterVerbSpecificFlags(def);
+
+		if (def.resourceFlags && Object.keys(def.resourceFlags).length > 0) {
+			// Show per-resource flag breakdown
+			if (Object.keys(verbFlags).length > 0) {
+				lines.push("**Verb-level flags:**");
+				lines.push("");
+				lines.push(...renderFlagsTable(verbFlags));
+				lines.push("");
+			}
+
+			lines.push("**Resource-specific flags:**");
+			lines.push("");
+			for (const [resource, rFlags] of Object.entries(def.resourceFlags)) {
+				const typedFlags = rFlags as Record<string, FlagDef>;
+				if (Object.keys(typedFlags).length === 0) continue;
+				lines.push(`<details>`);
+				lines.push(`<summary><code>${resource}</code></summary>`);
+				lines.push("");
+				lines.push(...renderFlagsTable(typedFlags));
+				lines.push("");
+				lines.push(`</details>`);
+				lines.push("");
+			}
+		} else if (Object.keys(verbFlags).length > 0) {
+			lines.push("**Flags:**");
+			lines.push("");
+			lines.push(...renderFlagsTable(verbFlags));
+			lines.push("");
+		}
+
+		// Examples
+		if (def.helpExamples && def.helpExamples.length > 0) {
+			lines.push("**Examples:**");
+			lines.push("");
+			lines.push("```bash");
+			for (const ex of def.helpExamples) {
+				const padding = 60 - ex.command.length;
+				const pad = padding > 2 ? " ".repeat(padding) : "  ";
+				lines.push(`${ex.command}${pad}# ${ex.description}`);
+			}
+			lines.push("```");
+			lines.push("");
+		}
+
+		lines.push("---");
+		lines.push("");
+	}
+
+	// Remove trailing ---
+	if (lines[lines.length - 1] === "" && lines[lines.length - 2] === "---") {
+		lines.splice(lines.length - 2, 2);
+	}
+
+	return lines.join("\n");
+}
+
+/**
+ * Filter out flags that are already shown in the Global Flags or Search Flags sections.
+ * Returns only verb-specific flags.
+ */
+function filterVerbSpecificFlags(def: CommandDef): Record<string, FlagDef> {
+	const globalKeys = new Set(Object.keys(GLOBAL_FLAGS));
+	const searchKeys = new Set(Object.keys(SEARCH_FLAGS));
+
+	// Collect all resource-specific flag keys
+	const resourceFlagKeys = new Set<string>();
+	if (def.resourceFlags) {
+		for (const rFlags of Object.values(def.resourceFlags)) {
+			for (const key of Object.keys(rFlags as Record<string, FlagDef>)) {
+				resourceFlagKeys.add(key);
+			}
+		}
+	}
+
+	const result: Record<string, FlagDef> = {};
+	for (const [name, flagDef] of Object.entries(def.flags)) {
+		// Skip if it's a global flag, search flag, or already shown per-resource
+		if (globalKeys.has(name)) continue;
+		if (searchKeys.has(name)) continue;
+		if (resourceFlagKeys.has(name)) continue;
+		result[name] = flagDef;
+	}
+	return result;
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+function main(): void {
+	const checkMode = process.argv.includes("--check");
+	const readme = readFileSync(README_PATH, "utf-8");
+
+	const startIdx = readme.indexOf(START_MARKER);
+	const endIdx = readme.indexOf(END_MARKER);
+
+	if (startIdx === -1 || endIdx === -1) {
+		console.error(
+			`ERROR: README.md is missing ${START_MARKER} and/or ${END_MARKER} markers.`,
+		);
+		process.exit(1);
+	}
+
+	const generated = generate();
+	const before = readme.slice(0, startIdx + START_MARKER.length);
+	const after = readme.slice(endIdx);
+	const updated = `${before}\n\n${generated}\n\n${after}`;
+
+	if (checkMode) {
+		if (updated !== readme) {
+			console.error(
+				"README.md command reference is out of sync with COMMAND_REGISTRY.",
+			);
+			console.error(
+				"Run: node --experimental-strip-types scripts/sync-readme-commands.ts",
+			);
+			process.exit(1);
+		}
+		console.log("README.md command reference is up to date.");
+		return;
+	}
+
+	writeFileSync(README_PATH, updated, "utf-8");
+	console.log("README.md command reference updated.");
+}
+
+main();

--- a/scripts/sync-readme-commands.ts
+++ b/scripts/sync-readme-commands.ts
@@ -27,18 +27,6 @@ export const END_MARKER = "<!-- command-reference:end -->";
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-/** Build a reverse map: canonical resource → shortest alias */
-export function buildAliasLookup(): Map<string, string> {
-	const map = new Map<string, string>();
-	for (const [alias, canonical] of Object.entries(RESOURCE_ALIASES)) {
-		const existing = map.get(canonical);
-		if (!existing || alias.length < existing.length) {
-			map.set(canonical, alias);
-		}
-	}
-	return map;
-}
-
 /** Deduplicate resource aliases: collapse entries where the alias is just the plural form of the canonical. */
 export function uniqueAliases(): Array<{ alias: string; canonical: string }> {
 	const seen = new Map<string, string[]>();
@@ -100,9 +88,9 @@ function verbDescription(def: CommandDef): string {
 
 /** Resolve resource short name to canonical, returning the display form */
 export function resourceDisplay(resource: string): string {
-	// If the resource is already canonical (contains hyphen or is a known long form), return as-is
+	// Only show the canonical form when it differs from the requested resource.
 	const canonical = RESOURCE_ALIASES[resource];
-	return canonical ? `${resource} (${canonical})` : resource;
+	return canonical && canonical !== resource ? `${resource} (${canonical})` : resource;
 }
 
 // ─── Generation ──────────────────────────────────────────────────────────────
@@ -167,7 +155,7 @@ export function generate(): string {
 		}
 
 		// Resources
-		if (def.requiresResource && def.resources.length > 0) {
+		if (def.resources.length > 0) {
 			const resourceList = def.resources.map((r) => resourceDisplay(r)).join(", ");
 			lines.push(`**Resources:** ${resourceList}`);
 			lines.push("");
@@ -286,6 +274,13 @@ function main(): void {
 	if (startIdx === -1 || endIdx === -1) {
 		console.error(
 			`ERROR: README.md is missing ${START_MARKER} and/or ${END_MARKER} markers.`,
+		);
+		process.exit(1);
+	}
+
+	if (startIdx >= endIdx) {
+		console.error(
+			`ERROR: ${START_MARKER} must appear before ${END_MARKER} in README.md.`,
 		);
 		process.exit(1);
 	}

--- a/scripts/sync-readme-commands.ts
+++ b/scripts/sync-readme-commands.ts
@@ -192,9 +192,7 @@ export function generate(): string {
 				lines.push("**Positional arguments:**");
 				lines.push("");
 				for (const [resource, positionals] of positionalEntries) {
-					// biome-ignore lint/plugin: Object.entries loses readonly tuple type from CommandDef.resourcePositionals
-					const pos = positionals as readonly PositionalDef[];
-					lines.push(`- **${resource}:** ${renderPositionals(pos)}`);
+					lines.push(`- **${resource}:** ${renderPositionals(positionals)}`);
 				}
 				lines.push("");
 			}
@@ -215,13 +213,11 @@ export function generate(): string {
 			lines.push("**Resource-specific flags:**");
 			lines.push("");
 			for (const [resource, rFlags] of Object.entries(def.resourceFlags)) {
-				// biome-ignore lint/plugin: Object.entries loses Record<string, FlagDef> type from CommandDef.resourceFlags
-				const typedFlags = rFlags as Record<string, FlagDef>;
-				if (Object.keys(typedFlags).length === 0) continue;
+				if (Object.keys(rFlags).length === 0) continue;
 				lines.push(`<details>`);
 				lines.push(`<summary><code>${resource}</code></summary>`);
 				lines.push("");
-				lines.push(...renderFlagsTable(typedFlags));
+				lines.push(...renderFlagsTable(rFlags));
 				lines.push("");
 				lines.push(`</details>`);
 				lines.push("");
@@ -273,8 +269,7 @@ export function filterVerbSpecificFlags(
 	const resourceFlagKeys = new Set<string>();
 	if (def.resourceFlags) {
 		for (const rFlags of Object.values(def.resourceFlags)) {
-			// biome-ignore lint/plugin: Object.values loses Record<string, FlagDef> type from CommandDef.resourceFlags
-			for (const key of Object.keys(rFlags as Record<string, FlagDef>)) {
+			for (const key of Object.keys(rFlags)) {
 				resourceFlagKeys.add(key);
 			}
 		}

--- a/scripts/sync-readme-commands.ts
+++ b/scripts/sync-readme-commands.ts
@@ -7,15 +7,19 @@
  */
 
 import { readFileSync, writeFileSync } from "node:fs";
-import { resolve, dirname } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import type {
+	CommandDef,
+	FlagDef,
+	PositionalDef,
+} from "../src/command-registry.ts";
 import {
 	COMMAND_REGISTRY,
 	GLOBAL_FLAGS,
 	RESOURCE_ALIASES,
 	SEARCH_FLAGS,
 } from "../src/command-registry.ts";
-import type { FlagDef, CommandDef, PositionalDef } from "../src/command-registry.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -66,13 +70,17 @@ export function renderFlagsTable(flags: Record<string, FlagDef>): string[] {
 	lines.push("|------|------|----------|-------------|");
 	for (const [name, def] of entries) {
 		const req = def.required ? "Yes" : "";
-		lines.push(`| ${formatFlag(name, def)} | ${def.type} | ${req} | ${def.description} |`);
+		lines.push(
+			`| ${formatFlag(name, def)} | ${def.type} | ${req} | ${def.description} |`,
+		);
 	}
 	return lines;
 }
 
 /** Render positionals for a resource */
-export function renderPositionals(positionals: readonly PositionalDef[]): string {
+export function renderPositionals(
+	positionals: readonly PositionalDef[],
+): string {
 	return positionals
 		.map((p) => {
 			const req = p.required ? "required" : "optional";
@@ -90,7 +98,9 @@ function verbDescription(def: CommandDef): string {
 export function resourceDisplay(resource: string): string {
 	// Only show the canonical form when it differs from the requested resource.
 	const canonical = RESOURCE_ALIASES[resource];
-	return canonical && canonical !== resource ? `${resource} (${canonical})` : resource;
+	return canonical && canonical !== resource
+		? `${resource} (${canonical})`
+		: resource;
 }
 
 // ─── Generation ──────────────────────────────────────────────────────────────
@@ -100,8 +110,12 @@ export function generate(): string {
 
 	lines.push("## Command Reference");
 	lines.push("");
-	lines.push("> Auto-generated from [`COMMAND_REGISTRY`](src/command-registry.ts). Do not edit manually.");
-	lines.push(`> Run \`node --experimental-strip-types scripts/sync-readme-commands.ts\` to update.`);
+	lines.push(
+		"> Auto-generated from [`COMMAND_REGISTRY`](src/command-registry.ts). Do not edit manually.",
+	);
+	lines.push(
+		`> Run \`node --experimental-strip-types scripts/sync-readme-commands.ts\` to update.`,
+	);
 	lines.push("");
 
 	// ── Global Flags ──
@@ -140,7 +154,7 @@ export function generate(): string {
 	lines.push("### Commands");
 	lines.push("");
 
-	const registry = COMMAND_REGISTRY as unknown as Record<string, CommandDef>;
+	const registry: Record<string, CommandDef> = COMMAND_REGISTRY;
 
 	for (const [verb, def] of Object.entries(registry)) {
 		lines.push(`#### \`${verb}\``);
@@ -148,15 +162,25 @@ export function generate(): string {
 		lines.push(verbDescription(def));
 		lines.push("");
 
+		// Usage (from helpResource)
+		if (def.helpResource) {
+			lines.push(`**Usage:** \`c8ctl ${verb} ${def.helpResource}\``);
+			lines.push("");
+		}
+
 		// Aliases
 		if (def.aliases && def.aliases.length > 0) {
-			lines.push(`**Aliases:** ${def.aliases.map((a) => `\`${a}\``).join(", ")}`);
+			lines.push(
+				`**Aliases:** ${def.aliases.map((a) => `\`${a}\``).join(", ")}`,
+			);
 			lines.push("");
 		}
 
 		// Resources
 		if (def.resources.length > 0) {
-			const resourceList = def.resources.map((r) => resourceDisplay(r)).join(", ");
+			const resourceList = def.resources
+				.map((r) => resourceDisplay(r))
+				.join(", ");
 			lines.push(`**Resources:** ${resourceList}`);
 			lines.push("");
 		}
@@ -168,6 +192,7 @@ export function generate(): string {
 				lines.push("**Positional arguments:**");
 				lines.push("");
 				for (const [resource, positionals] of positionalEntries) {
+					// biome-ignore lint/plugin: Object.entries loses readonly tuple type from CommandDef.resourcePositionals
 					const pos = positionals as readonly PositionalDef[];
 					lines.push(`- **${resource}:** ${renderPositionals(pos)}`);
 				}
@@ -190,6 +215,7 @@ export function generate(): string {
 			lines.push("**Resource-specific flags:**");
 			lines.push("");
 			for (const [resource, rFlags] of Object.entries(def.resourceFlags)) {
+				// biome-ignore lint/plugin: Object.entries loses Record<string, FlagDef> type from CommandDef.resourceFlags
 				const typedFlags = rFlags as Record<string, FlagDef>;
 				if (Object.keys(typedFlags).length === 0) continue;
 				lines.push(`<details>`);
@@ -237,7 +263,9 @@ export function generate(): string {
  * Filter out flags that are already shown in the Global Flags or Search Flags sections.
  * Returns only verb-specific flags.
  */
-export function filterVerbSpecificFlags(def: CommandDef): Record<string, FlagDef> {
+export function filterVerbSpecificFlags(
+	def: CommandDef,
+): Record<string, FlagDef> {
 	const globalKeys = new Set(Object.keys(GLOBAL_FLAGS));
 	const searchKeys = new Set(Object.keys(SEARCH_FLAGS));
 
@@ -245,6 +273,7 @@ export function filterVerbSpecificFlags(def: CommandDef): Record<string, FlagDef
 	const resourceFlagKeys = new Set<string>();
 	if (def.resourceFlags) {
 		for (const rFlags of Object.values(def.resourceFlags)) {
+			// biome-ignore lint/plugin: Object.values loses Record<string, FlagDef> type from CommandDef.resourceFlags
 			for (const key of Object.keys(rFlags as Record<string, FlagDef>)) {
 				resourceFlagKeys.add(key);
 			}
@@ -312,7 +341,8 @@ function main(): void {
 const isDirectExecution =
 	process.argv[1] &&
 	(resolve(process.argv[1]) === __filename ||
-		resolve(process.argv[1]).replace(/\.ts$/, "") === __filename.replace(/\.ts$/, ""));
+		resolve(process.argv[1]).replace(/\.ts$/, "") ===
+			__filename.replace(/\.ts$/, ""));
 if (isDirectExecution) {
 	main();
 }

--- a/tests/unit/sync-readme-commands.test.ts
+++ b/tests/unit/sync-readme-commands.test.ts
@@ -47,7 +47,7 @@ describe("generate() output structure", () => {
 	const output = generate();
 
 	test("starts with Command Reference heading", () => {
-		assert.ok(output.startsWith("## Command Reference"));
+		assert.ok(output.startsWith("### Command Reference"));
 	});
 
 	test("contains auto-generated notice", () => {
@@ -56,19 +56,19 @@ describe("generate() output structure", () => {
 	});
 
 	test("contains Global Flags section", () => {
-		assert.ok(output.includes("### Global Flags"));
+		assert.ok(output.includes("#### Global Flags"));
 	});
 
 	test("contains Resource Aliases section", () => {
-		assert.ok(output.includes("### Resource Aliases"));
+		assert.ok(output.includes("#### Resource Aliases"));
 	});
 
 	test("contains Search Flags section", () => {
-		assert.ok(output.includes("### Search Flags"));
+		assert.ok(output.includes("#### Search Flags"));
 	});
 
 	test("contains Commands section", () => {
-		assert.ok(output.includes("### Commands"));
+		assert.ok(output.includes("#### Commands"));
 	});
 
 	test("renders Resources for verbs that support optional resources", () => {
@@ -85,7 +85,7 @@ describe("generate() output structure", () => {
 		const expectedResources = def.resources.map(resourceDisplay).join(", ");
 
 		assert.ok(
-			output.includes(`#### \`${verb}\``),
+			output.includes(`##### \`${verb}\``),
 			`Missing heading for verb "${verb}"`,
 		);
 		assert.ok(
@@ -103,7 +103,7 @@ describe("generate() includes all registry verbs", () => {
 	for (const verb of Object.keys(REGISTRY)) {
 		test(`verb "${verb}" appears as a heading`, () => {
 			assert.ok(
-				output.includes(`#### \`${verb}\``),
+				output.includes(`##### \`${verb}\``),
 				`Missing heading for verb "${verb}"`,
 			);
 		});
@@ -500,7 +500,7 @@ describe("README.md sync check", () => {
 
 describe("generate() completeness guard", () => {
 	const output = generate();
-	const verbHeadings = [...output.matchAll(/^#### `(\S+)`$/gm)].map(
+	const verbHeadings = [...output.matchAll(/^##### `(\S+)`$/gm)].map(
 		(m) => m[1],
 	);
 

--- a/tests/unit/sync-readme-commands.test.ts
+++ b/tests/unit/sync-readme-commands.test.ts
@@ -50,9 +50,9 @@ describe("generate() output structure", () => {
 		assert.ok(output.startsWith("## Command Reference"));
 	});
 
-	test("contains auto-generated notice", () => {
-		assert.ok(output.includes("Auto-generated from"));
-		assert.ok(output.includes("COMMAND_REGISTRY"));
+	test("contains auto-generated notice as HTML comment", () => {
+		assert.ok(output.includes("<!-- Auto-generated from COMMAND_REGISTRY"));
+		assert.ok(output.includes("-->"));
 	});
 
 	test("contains Global Flags section", () => {

--- a/tests/unit/sync-readme-commands.test.ts
+++ b/tests/unit/sync-readme-commands.test.ts
@@ -22,11 +22,7 @@ import {
 	START_MARKER,
 	uniqueAliases,
 } from "../../scripts/sync-readme-commands.ts";
-import type {
-	CommandDef,
-	FlagDef,
-	PositionalDef,
-} from "../../src/command-registry.ts";
+import type { CommandDef } from "../../src/command-registry.ts";
 import {
 	COMMAND_REGISTRY,
 	GLOBAL_FLAGS,
@@ -37,6 +33,17 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const ROOT = resolve(__dirname, "../..");
 const README_PATH = resolve(ROOT, "README.md");
+
+/** Extract the generated output section for a specific verb heading */
+function verbSection(output: string, verb: string): string {
+	const heading = `#### \`${verb}\``;
+	const start = output.indexOf(heading);
+	if (start === -1) return "";
+	const nextHeading = output.indexOf("\n#### ", start + heading.length);
+	return nextHeading === -1
+		? output.slice(start)
+		: output.slice(start, nextHeading);
+}
 
 /** Widened registry for iteration */
 const REGISTRY: Readonly<Record<string, CommandDef>> = COMMAND_REGISTRY;
@@ -217,19 +224,16 @@ describe("generate() includes positional arguments", () => {
 
 	for (const [verb, def] of Object.entries(REGISTRY)) {
 		if (!def.resourcePositionals) continue;
-		for (const [resource, positionals] of Object.entries(
-			def.resourcePositionals,
-		)) {
-			// biome-ignore lint/plugin: positionals are readonly PositionalDef[] from the registry but typed as unknown via Object.entries
-			const pos = positionals as readonly PositionalDef[];
-			for (const p of pos) {
-				test(`verb "${verb}" resource "${resource}" shows positional "<${p.name}>"`, () => {
-					assert.ok(
-						output.includes(`<${p.name}>`),
-						`Missing positional "<${p.name}>" for ${verb}/${resource}`,
-					);
-				});
-			}
+		for (const resource of Object.keys(def.resourcePositionals)) {
+			const pos = def.resourcePositionals[resource];
+			const expectedLine = `- **${resource}:** ${renderPositionals(pos)}`;
+			test(`verb "${verb}" resource "${resource}" shows its positional arguments line`, () => {
+				const section = verbSection(output, verb);
+				assert.ok(
+					section.includes(expectedLine),
+					`Missing positional arguments line "${expectedLine}" for ${verb}/${resource}`,
+				);
+			});
 		}
 	}
 });
@@ -241,13 +245,13 @@ describe("generate() includes resource-specific flags", () => {
 
 	for (const [verb, def] of Object.entries(REGISTRY)) {
 		if (!def.resourceFlags) continue;
-		for (const [resource, rFlags] of Object.entries(def.resourceFlags)) {
-			// biome-ignore lint/plugin: rFlags are Record<string, FlagDef> from the registry but typed as unknown via Object.entries
-			const flags = rFlags as Record<string, FlagDef>;
+		for (const resource of Object.keys(def.resourceFlags)) {
+			const flags = def.resourceFlags[resource];
 			if (Object.keys(flags).length === 0) continue;
 			test(`verb "${verb}" shows resource "${resource}" flags section`, () => {
+				const section = verbSection(output, verb);
 				assert.ok(
-					output.includes(`<code>${resource}</code>`),
+					section.includes(`<code>${resource}</code>`),
 					`Missing resource flag section for "${resource}" in verb "${verb}"`,
 				);
 			});

--- a/tests/unit/sync-readme-commands.test.ts
+++ b/tests/unit/sync-readme-commands.test.ts
@@ -7,32 +7,31 @@
 
 import assert from "node:assert";
 import { readFileSync } from "node:fs";
-import { resolve, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
 import { describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
 
 import {
-	COMMAND_REGISTRY,
-	GLOBAL_FLAGS,
-	RESOURCE_ALIASES,
-	SEARCH_FLAGS,
-} from "../../src/command-registry.ts";
+	END_MARKER,
+	filterVerbSpecificFlags,
+	formatFlag,
+	generate,
+	renderFlagsTable,
+	renderPositionals,
+	resourceDisplay,
+	START_MARKER,
+	uniqueAliases,
+} from "../../scripts/sync-readme-commands.ts";
 import type {
 	CommandDef,
 	FlagDef,
 	PositionalDef,
 } from "../../src/command-registry.ts";
 import {
-	generate,
-	formatFlag,
-	renderFlagsTable,
-	renderPositionals,
-	resourceDisplay,
-	uniqueAliases,
-	filterVerbSpecificFlags,
-	START_MARKER,
-	END_MARKER,
-} from "../../scripts/sync-readme-commands.ts";
+	COMMAND_REGISTRY,
+	GLOBAL_FLAGS,
+	SEARCH_FLAGS,
+} from "../../src/command-registry.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -198,6 +197,7 @@ describe("generate() includes positional arguments", () => {
 		for (const [resource, positionals] of Object.entries(
 			def.resourcePositionals,
 		)) {
+			// biome-ignore lint/plugin: positionals are readonly PositionalDef[] from the registry but typed as unknown via Object.entries
 			const pos = positionals as readonly PositionalDef[];
 			for (const p of pos) {
 				test(`verb "${verb}" resource "${resource}" shows positional "<${p.name}>"`, () => {
@@ -219,6 +219,7 @@ describe("generate() includes resource-specific flags", () => {
 	for (const [verb, def] of Object.entries(REGISTRY)) {
 		if (!def.resourceFlags) continue;
 		for (const [resource, rFlags] of Object.entries(def.resourceFlags)) {
+			// biome-ignore lint/plugin: rFlags are Record<string, FlagDef> from the registry but typed as unknown via Object.entries
 			const flags = rFlags as Record<string, FlagDef>;
 			if (Object.keys(flags).length === 0) continue;
 			test(`verb "${verb}" shows resource "${resource}" flags section`, () => {
@@ -251,10 +252,7 @@ describe("filterVerbSpecificFlags()", () => {
 
 		const result = filterVerbSpecificFlags(mockDef);
 		assert.ok(!("help" in result), "help should be excluded (global flag)");
-		assert.ok(
-			"customFlag" in result,
-			"customFlag should be included",
-		);
+		assert.ok("customFlag" in result, "customFlag should be included");
 	});
 
 	test("excludes search flags", () => {
@@ -351,10 +349,7 @@ describe("renderFlagsTable()", () => {
 			verbose: { type: "boolean", description: "Verbose mode" },
 		});
 		assert.strictEqual(result[0], "| Flag | Type | Required | Description |");
-		assert.strictEqual(
-			result[1],
-			"|------|------|----------|-------------|",
-		);
+		assert.strictEqual(result[1], "|------|------|----------|-------------|");
 		assert.ok(result[2]?.includes("Yes"));
 		assert.ok(result[2]?.includes("The name"));
 		assert.ok(result[3]?.includes("Verbose mode"));
@@ -366,9 +361,7 @@ describe("renderFlagsTable()", () => {
 
 describe("renderPositionals()", () => {
 	test("renders required positional", () => {
-		const result = renderPositionals([
-			{ name: "key", required: true },
-		]);
+		const result = renderPositionals([{ name: "key", required: true }]);
 		assert.strictEqual(result, "`<key>` (required)");
 	});
 
@@ -455,10 +448,7 @@ describe("README.md markers", () => {
 	test("start marker appears before end marker", () => {
 		const startIdx = readme.indexOf(START_MARKER);
 		const endIdx = readme.indexOf(END_MARKER);
-		assert.ok(
-			startIdx < endIdx,
-			"Start marker must appear before end marker",
-		);
+		assert.ok(startIdx < endIdx, "Start marker must appear before end marker");
 	});
 });
 

--- a/tests/unit/sync-readme-commands.test.ts
+++ b/tests/unit/sync-readme-commands.test.ts
@@ -47,7 +47,7 @@ describe("generate() output structure", () => {
 	const output = generate();
 
 	test("starts with Command Reference heading", () => {
-		assert.ok(output.startsWith("### Command Reference"));
+		assert.ok(output.startsWith("## Command Reference"));
 	});
 
 	test("contains auto-generated notice", () => {
@@ -56,19 +56,19 @@ describe("generate() output structure", () => {
 	});
 
 	test("contains Global Flags section", () => {
-		assert.ok(output.includes("#### Global Flags"));
+		assert.ok(output.includes("### Global Flags"));
 	});
 
 	test("contains Resource Aliases section", () => {
-		assert.ok(output.includes("#### Resource Aliases"));
+		assert.ok(output.includes("### Resource Aliases"));
 	});
 
 	test("contains Search Flags section", () => {
-		assert.ok(output.includes("#### Search Flags"));
+		assert.ok(output.includes("### Search Flags"));
 	});
 
 	test("contains Commands section", () => {
-		assert.ok(output.includes("#### Commands"));
+		assert.ok(output.includes("### Commands"));
 	});
 
 	test("renders Resources for verbs that support optional resources", () => {
@@ -85,7 +85,7 @@ describe("generate() output structure", () => {
 		const expectedResources = def.resources.map(resourceDisplay).join(", ");
 
 		assert.ok(
-			output.includes(`##### \`${verb}\``),
+			output.includes(`#### \`${verb}\``),
 			`Missing heading for verb "${verb}"`,
 		);
 		assert.ok(
@@ -103,7 +103,7 @@ describe("generate() includes all registry verbs", () => {
 	for (const verb of Object.keys(REGISTRY)) {
 		test(`verb "${verb}" appears as a heading`, () => {
 			assert.ok(
-				output.includes(`##### \`${verb}\``),
+				output.includes(`#### \`${verb}\``),
 				`Missing heading for verb "${verb}"`,
 			);
 		});
@@ -500,7 +500,7 @@ describe("README.md sync check", () => {
 
 describe("generate() completeness guard", () => {
 	const output = generate();
-	const verbHeadings = [...output.matchAll(/^##### `(\S+)`$/gm)].map(
+	const verbHeadings = [...output.matchAll(/^#### `(\S+)`$/gm)].map(
 		(m) => m[1],
 	);
 

--- a/tests/unit/sync-readme-commands.test.ts
+++ b/tests/unit/sync-readme-commands.test.ts
@@ -70,6 +70,29 @@ describe("generate() output structure", () => {
 	test("contains Commands section", () => {
 		assert.ok(output.includes("### Commands"));
 	});
+
+	test("renders Resources for verbs that support optional resources", () => {
+		const optionalResourceVerb = Object.entries(REGISTRY).find(
+			([, def]) => def.requiresResource === false && def.resources.length > 0,
+		);
+
+		assert.ok(
+			optionalResourceVerb,
+			"Expected at least one verb with optional resources in COMMAND_REGISTRY",
+		);
+
+		const [verb, def] = optionalResourceVerb;
+		const expectedResources = def.resources.map(resourceDisplay).join(", ");
+
+		assert.ok(
+			output.includes(`#### \`${verb}\``),
+			`Missing heading for verb "${verb}"`,
+		);
+		assert.ok(
+			output.includes(`**Resources:** ${expectedResources}`),
+			`Missing Resources line for optional-resource verb "${verb}"`,
+		);
+	});
 });
 
 // ─── Every verb in the registry appears in generated output ──────────────────

--- a/tests/unit/sync-readme-commands.test.ts
+++ b/tests/unit/sync-readme-commands.test.ts
@@ -1,0 +1,521 @@
+/**
+ * Tests for scripts/sync-readme-commands.ts
+ *
+ * Verifies that the README command reference generator correctly
+ * derives documentation from COMMAND_REGISTRY.
+ */
+
+import assert from "node:assert";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, test } from "node:test";
+
+import {
+	COMMAND_REGISTRY,
+	GLOBAL_FLAGS,
+	RESOURCE_ALIASES,
+	SEARCH_FLAGS,
+} from "../../src/command-registry.ts";
+import type {
+	CommandDef,
+	FlagDef,
+	PositionalDef,
+} from "../../src/command-registry.ts";
+import {
+	generate,
+	formatFlag,
+	renderFlagsTable,
+	renderPositionals,
+	resourceDisplay,
+	uniqueAliases,
+	filterVerbSpecificFlags,
+	START_MARKER,
+	END_MARKER,
+} from "../../scripts/sync-readme-commands.ts";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const ROOT = resolve(__dirname, "../..");
+const README_PATH = resolve(ROOT, "README.md");
+
+/** Widened registry for iteration */
+const REGISTRY: Readonly<Record<string, CommandDef>> = COMMAND_REGISTRY;
+
+// ─── generate() structural tests ─────────────────────────────────────────────
+
+describe("generate() output structure", () => {
+	const output = generate();
+
+	test("starts with Command Reference heading", () => {
+		assert.ok(output.startsWith("## Command Reference"));
+	});
+
+	test("contains auto-generated notice", () => {
+		assert.ok(output.includes("Auto-generated from"));
+		assert.ok(output.includes("COMMAND_REGISTRY"));
+	});
+
+	test("contains Global Flags section", () => {
+		assert.ok(output.includes("### Global Flags"));
+	});
+
+	test("contains Resource Aliases section", () => {
+		assert.ok(output.includes("### Resource Aliases"));
+	});
+
+	test("contains Search Flags section", () => {
+		assert.ok(output.includes("### Search Flags"));
+	});
+
+	test("contains Commands section", () => {
+		assert.ok(output.includes("### Commands"));
+	});
+});
+
+// ─── Every verb in the registry appears in generated output ──────────────────
+
+describe("generate() includes all registry verbs", () => {
+	const output = generate();
+
+	for (const verb of Object.keys(REGISTRY)) {
+		test(`verb "${verb}" appears as a heading`, () => {
+			assert.ok(
+				output.includes(`#### \`${verb}\``),
+				`Missing heading for verb "${verb}"`,
+			);
+		});
+	}
+});
+
+// ─── Every verb description appears ─────────────────────────────────────────
+
+describe("generate() includes verb descriptions", () => {
+	const output = generate();
+
+	for (const [verb, def] of Object.entries(REGISTRY)) {
+		test(`verb "${verb}" shows its description`, () => {
+			const expected = def.helpDescription ?? def.description;
+			assert.ok(
+				output.includes(expected),
+				`Missing description for "${verb}": expected "${expected}"`,
+			);
+		});
+	}
+});
+
+// ─── Global flags all appear ─────────────────────────────────────────────────
+
+describe("generate() includes all global flags", () => {
+	const output = generate();
+
+	for (const flagName of Object.keys(GLOBAL_FLAGS)) {
+		test(`global flag "--${flagName}" appears`, () => {
+			assert.ok(
+				output.includes(`\`--${flagName}\``),
+				`Missing global flag "--${flagName}"`,
+			);
+		});
+	}
+});
+
+// ─── Search flags all appear ─────────────────────────────────────────────────
+
+describe("generate() includes all search flags", () => {
+	const output = generate();
+
+	for (const flagName of Object.keys(SEARCH_FLAGS)) {
+		test(`search flag "--${flagName}" appears`, () => {
+			assert.ok(
+				output.includes(`\`--${flagName}\``),
+				`Missing search flag "--${flagName}"`,
+			);
+		});
+	}
+});
+
+// ─── Resource aliases appear ─────────────────────────────────────────────────
+
+describe("generate() includes resource aliases", () => {
+	const output = generate();
+	const aliases = uniqueAliases();
+
+	for (const { alias, canonical } of aliases) {
+		test(`alias "${alias}" → "${canonical}" appears`, () => {
+			assert.ok(
+				output.includes(`\`${alias}\``) && output.includes(`\`${canonical}\``),
+				`Missing alias mapping "${alias}" → "${canonical}"`,
+			);
+		});
+	}
+});
+
+// ─── Verbs with aliases show them ────────────────────────────────────────────
+
+describe("generate() shows verb aliases", () => {
+	const output = generate();
+
+	for (const [verb, def] of Object.entries(REGISTRY)) {
+		if (def.aliases && def.aliases.length > 0) {
+			test(`verb "${verb}" lists aliases: ${def.aliases.join(", ")}`, () => {
+				for (const alias of def.aliases ?? []) {
+					assert.ok(
+						output.includes(`\`${alias}\``),
+						`Missing alias "${alias}" for verb "${verb}"`,
+					);
+				}
+			});
+		}
+	}
+});
+
+// ─── Verbs with examples show them ───────────────────────────────────────────
+
+describe("generate() includes help examples", () => {
+	const output = generate();
+
+	for (const [verb, def] of Object.entries(REGISTRY)) {
+		if (def.helpExamples && def.helpExamples.length > 0) {
+			test(`verb "${verb}" includes example commands`, () => {
+				for (const ex of def.helpExamples ?? []) {
+					assert.ok(
+						output.includes(ex.command),
+						`Missing example command "${ex.command}" for verb "${verb}"`,
+					);
+				}
+			});
+		}
+	}
+});
+
+// ─── Verbs with positionals show them ────────────────────────────────────────
+
+describe("generate() includes positional arguments", () => {
+	const output = generate();
+
+	for (const [verb, def] of Object.entries(REGISTRY)) {
+		if (!def.resourcePositionals) continue;
+		for (const [resource, positionals] of Object.entries(
+			def.resourcePositionals,
+		)) {
+			const pos = positionals as readonly PositionalDef[];
+			for (const p of pos) {
+				test(`verb "${verb}" resource "${resource}" shows positional "<${p.name}>"`, () => {
+					assert.ok(
+						output.includes(`<${p.name}>`),
+						`Missing positional "<${p.name}>" for ${verb}/${resource}`,
+					);
+				});
+			}
+		}
+	}
+});
+
+// ─── Verbs with resource-specific flags show them ────────────────────────────
+
+describe("generate() includes resource-specific flags", () => {
+	const output = generate();
+
+	for (const [verb, def] of Object.entries(REGISTRY)) {
+		if (!def.resourceFlags) continue;
+		for (const [resource, rFlags] of Object.entries(def.resourceFlags)) {
+			const flags = rFlags as Record<string, FlagDef>;
+			if (Object.keys(flags).length === 0) continue;
+			test(`verb "${verb}" shows resource "${resource}" flags section`, () => {
+				assert.ok(
+					output.includes(`<code>${resource}</code>`),
+					`Missing resource flag section for "${resource}" in verb "${verb}"`,
+				);
+			});
+		}
+	}
+});
+
+// ─── filterVerbSpecificFlags ─────────────────────────────────────────────────
+
+describe("filterVerbSpecificFlags()", () => {
+	test("excludes global flags", () => {
+		const mockDef = {
+			description: "test",
+			mutating: false,
+			requiresResource: false,
+			resources: [],
+			flags: {
+				help: { type: "boolean" as const, description: "Show help" },
+				customFlag: {
+					type: "string" as const,
+					description: "Custom",
+				},
+			},
+		} satisfies CommandDef;
+
+		const result = filterVerbSpecificFlags(mockDef);
+		assert.ok(!("help" in result), "help should be excluded (global flag)");
+		assert.ok(
+			"customFlag" in result,
+			"customFlag should be included",
+		);
+	});
+
+	test("excludes search flags", () => {
+		const mockDef = {
+			description: "test",
+			mutating: false,
+			requiresResource: false,
+			resources: [],
+			flags: {
+				sortBy: {
+					type: "string" as const,
+					description: "Sort results",
+				},
+				myFlag: { type: "string" as const, description: "Mine" },
+			},
+		} satisfies CommandDef;
+
+		const result = filterVerbSpecificFlags(mockDef);
+		assert.ok(!("sortBy" in result), "sortBy should be excluded (search flag)");
+		assert.ok("myFlag" in result, "myFlag should be included");
+	});
+
+	test("excludes flags already shown in resourceFlags", () => {
+		const mockDef = {
+			description: "test",
+			mutating: false,
+			requiresResource: true,
+			resources: ["thing"],
+			flags: {
+				sharedFlag: {
+					type: "string" as const,
+					description: "Shared",
+				},
+				verbOnly: {
+					type: "string" as const,
+					description: "Verb only",
+				},
+			},
+			resourceFlags: {
+				thing: {
+					sharedFlag: {
+						type: "string" as const,
+						description: "Shared",
+					},
+				},
+			},
+		} satisfies CommandDef;
+
+		const result = filterVerbSpecificFlags(mockDef);
+		assert.ok(
+			!("sharedFlag" in result),
+			"sharedFlag should be excluded (shown per-resource)",
+		);
+		assert.ok("verbOnly" in result, "verbOnly should be included");
+	});
+});
+
+// ─── formatFlag() ────────────────────────────────────────────────────────────
+
+describe("formatFlag()", () => {
+	test("renders flag without short alias", () => {
+		const result = formatFlag("verbose", {
+			type: "boolean",
+			description: "Verbose output",
+		});
+		assert.strictEqual(result, "`--verbose`");
+	});
+
+	test("renders flag with short alias", () => {
+		const result = formatFlag("help", {
+			type: "boolean",
+			description: "Show help",
+			short: "h",
+		});
+		assert.strictEqual(result, "`--help` / `-h`");
+	});
+});
+
+// ─── renderFlagsTable() ─────────────────────────────────────────────────────
+
+describe("renderFlagsTable()", () => {
+	test("returns empty array for empty flags", () => {
+		const result = renderFlagsTable({});
+		assert.deepStrictEqual(result, []);
+	});
+
+	test("renders table header and rows", () => {
+		const result = renderFlagsTable({
+			name: {
+				type: "string",
+				description: "The name",
+				required: true,
+			},
+			verbose: { type: "boolean", description: "Verbose mode" },
+		});
+		assert.strictEqual(result[0], "| Flag | Type | Required | Description |");
+		assert.strictEqual(
+			result[1],
+			"|------|------|----------|-------------|",
+		);
+		assert.ok(result[2]?.includes("Yes"));
+		assert.ok(result[2]?.includes("The name"));
+		assert.ok(result[3]?.includes("Verbose mode"));
+		assert.ok(!result[3]?.includes("Yes"));
+	});
+});
+
+// ─── renderPositionals() ────────────────────────────────────────────────────
+
+describe("renderPositionals()", () => {
+	test("renders required positional", () => {
+		const result = renderPositionals([
+			{ name: "key", required: true },
+		]);
+		assert.strictEqual(result, "`<key>` (required)");
+	});
+
+	test("renders optional positional", () => {
+		const result = renderPositionals([{ name: "version" }]);
+		assert.strictEqual(result, "`<version>` (optional)");
+	});
+
+	test("renders multiple positionals comma-separated", () => {
+		const result = renderPositionals([
+			{ name: "package", required: true },
+			{ name: "version" },
+		]);
+		assert.strictEqual(
+			result,
+			"`<package>` (required), `<version>` (optional)",
+		);
+	});
+});
+
+// ─── resourceDisplay() ──────────────────────────────────────────────────────
+
+describe("resourceDisplay()", () => {
+	test("shows alias with canonical in parens for known aliases", () => {
+		const result = resourceDisplay("pi");
+		assert.strictEqual(result, "pi (process-instance)");
+	});
+
+	test("returns resource as-is when no alias exists", () => {
+		const result = resourceDisplay("topology");
+		assert.strictEqual(result, "topology");
+	});
+});
+
+// ─── uniqueAliases() ────────────────────────────────────────────────────────
+
+describe("uniqueAliases()", () => {
+	test("returns sorted array", () => {
+		const result = uniqueAliases();
+		const canonicals = result.map((r) => r.canonical);
+		const sorted = [...canonicals].sort();
+		assert.deepStrictEqual(canonicals, sorted);
+	});
+
+	test("does not include long hyphenated aliases", () => {
+		const result = uniqueAliases();
+		for (const { alias } of result) {
+			assert.ok(
+				!alias.includes("-"),
+				`Alias "${alias}" should not include hyphens (long form)`,
+			);
+		}
+	});
+
+	test("includes expected short aliases", () => {
+		const result = uniqueAliases();
+		const aliasNames = result.map((r) => r.alias);
+		assert.ok(aliasNames.includes("pi"), "Should include pi alias");
+		assert.ok(aliasNames.includes("pd"), "Should include pd alias");
+		assert.ok(aliasNames.includes("ut"), "Should include ut alias");
+		assert.ok(aliasNames.includes("inc"), "Should include inc alias");
+	});
+});
+
+// ─── README markers exist ───────────────────────────────────────────────────
+
+describe("README.md markers", () => {
+	const readme = readFileSync(README_PATH, "utf-8");
+
+	test("contains start marker", () => {
+		assert.ok(
+			readme.includes(START_MARKER),
+			`README.md is missing ${START_MARKER}`,
+		);
+	});
+
+	test("contains end marker", () => {
+		assert.ok(
+			readme.includes(END_MARKER),
+			`README.md is missing ${END_MARKER}`,
+		);
+	});
+
+	test("start marker appears before end marker", () => {
+		const startIdx = readme.indexOf(START_MARKER);
+		const endIdx = readme.indexOf(END_MARKER);
+		assert.ok(
+			startIdx < endIdx,
+			"Start marker must appear before end marker",
+		);
+	});
+});
+
+// ─── README is in sync (same assertion as --check mode) ──────────────────────
+
+describe("README.md sync check", () => {
+	test("generated content matches what is in README", () => {
+		const readme = readFileSync(README_PATH, "utf-8");
+		const startIdx = readme.indexOf(START_MARKER);
+		const endIdx = readme.indexOf(END_MARKER);
+
+		const generated = generate();
+		const before = readme.slice(0, startIdx + START_MARKER.length);
+		const after = readme.slice(endIdx);
+		const expected = `${before}\n\n${generated}\n\n${after}`;
+
+		assert.strictEqual(
+			readme,
+			expected,
+			"README.md command reference is out of sync. Run: npm run sync:readme",
+		);
+	});
+});
+
+// ─── No verb in the registry is missing from the generated output ────────────
+
+describe("generate() completeness guard", () => {
+	const output = generate();
+	const verbHeadings = [...output.matchAll(/^#### `(\S+)`$/gm)].map(
+		(m) => m[1],
+	);
+
+	test("number of verb headings matches registry size", () => {
+		const registrySize = Object.keys(REGISTRY).length;
+		assert.strictEqual(
+			verbHeadings.length,
+			registrySize,
+			`Generated ${verbHeadings.length} verb headings but registry has ${registrySize} verbs`,
+		);
+	});
+
+	test("every registry verb has a matching heading", () => {
+		for (const verb of Object.keys(REGISTRY)) {
+			assert.ok(
+				verbHeadings.includes(verb),
+				`Verb "${verb}" is in the registry but missing from generated output`,
+			);
+		}
+	});
+
+	test("no extra headings beyond registry verbs", () => {
+		const registryVerbs = new Set(Object.keys(REGISTRY));
+		for (const heading of verbHeadings) {
+			assert.ok(
+				heading !== undefined && registryVerbs.has(heading),
+				`Generated heading "${heading}" does not correspond to any registry verb`,
+			);
+		}
+	});
+});

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -5,6 +5,6 @@
     "outDir": "./dist",
     "noEmit": true
   },
-  "include": ["src/**/*", "tests/**/*"],
+  "include": ["src/**/*", "tests/**/*", "scripts/**/*"],
   "exclude": ["node_modules", "dist", "src/templates"]
 }


### PR DESCRIPTION
## Summary

Addresses the first half of #237 — deriving the README command reference from `COMMAND_REGISTRY` so it can never drift from the implementation.

## Changes

### New: `scripts/sync-readme-commands.ts`

A script that reads `COMMAND_REGISTRY` and generates a complete Command Reference section in the README, including:

- **Global Flags** — table of flags accepted by every command
- **Resource Aliases** — short aliases (`pi`, `pd`, `ut`, etc.) mapped to canonical names
- **Search Flags** — shared flags for `list`/`search` commands
- **Per-verb documentation** — for each verb in the registry:
  - Description, aliases, supported resources
  - Positional arguments with required/optional status
  - Verb-level flags (filtered to exclude global/search flags shown elsewhere)
  - Per-resource flags in collapsible `<details>` sections
  - Examples from `helpExamples`

Supports `--check` mode for CI (exits 1 if README is out of sync).

### New: `tests/unit/sync-readme-commands.test.ts`

217 tests across 19 suites covering:

- **Structural tests** — generated output has all required sections (Global Flags, Resource Aliases, Search Flags, Commands)
- **Completeness guards** — every registry verb, description, alias, example, positional, and resource-specific flag appears in the output; verb heading count matches registry size exactly
- **Helper unit tests** — `formatFlag`, `renderFlagsTable`, `renderPositionals`, `resourceDisplay`, `uniqueAliases`, `filterVerbSpecificFlags`
- **Sync check** — README markers exist, are in correct order, and content matches what `generate()` produces

### Modified: `README.md`

- Replaced hand-maintained "Basic Commands" and "Resource Aliases" sections with `<!-- command-reference:start/end -->` markers
- Generated content injected between markers

### Modified: `package.json`

- Added `sync:readme` and `sync:readme:check` npm scripts

## Acceptance criteria addressed

- [x] README command reference is generated from `COMMAND_REGISTRY` — not hand-maintained
- [x] A script keeps README in sync with `--check` mode for CI
- [x] Adding a new command via `defineCommand()` + registry entry automatically updates README on next sync
- [x] Flag descriptions, types, short aliases, and required/optional status included
- [x] Positional arguments and their required/optional status included
- [x] Resource aliases documented
- [x] No duplicate command metadata outside `COMMAND_REGISTRY`

## Usage

```bash
# Update README from registry
npm run sync:readme

# CI gate (fails if out of sync)
npm run sync:readme:check
```

## Still TODO (second half of #237)

- [ ] Integration with Camunda Docs (consuming README as canonical CLI reference)