### PR TITLE
feat(help): scope top-level Flags section to global flags only (#321)

### DIFF
--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -43,10 +43,6 @@ export interface FlagDef {
 	 */
 	// biome-ignore lint/suspicious/noExplicitAny: validators return branded types that vary per flag
 	validate?: (value: string) => any;
-	/** When true, this flag appears in the top-level `c8ctl help` Flags section. */
-	showInTopLevelHelp?: boolean;
-	/** Context hint shown in the top-level help (e.g. "use with 'get pd'"). */
-	helpHint?: string;
 	/** Rich description for agent-facing help (AI/programmatic consumers). Shown in Agent Flags section. */
 	agentDescription?: string;
 	/** Scope hint for agent-facing help (e.g. "all commands", "all list/search/get commands"). */
@@ -435,8 +431,6 @@ export const GET_PD_FLAGS = {
 	xml: {
 		type: "boolean",
 		description: "Get BPMN XML (process definitions)",
-		showInTopLevelHelp: true,
-		helpHint: "use with 'get pd'",
 	},
 } as const satisfies Record<string, FlagDef>;
 
@@ -444,8 +438,6 @@ const GET_FORM_FLAGS = {
 	userTask: {
 		type: "boolean",
 		description: "Get form for user task",
-		showInTopLevelHelp: true,
-		helpHint: "use with 'get form'",
 	},
 	ut: {
 		type: "boolean",
@@ -454,8 +446,6 @@ const GET_FORM_FLAGS = {
 	processDefinition: {
 		type: "boolean",
 		description: "Get form for process definition",
-		showInTopLevelHelp: true,
-		helpHint: "use with 'get form'",
 	},
 	pd: {
 		type: "boolean",
@@ -467,8 +457,6 @@ const GET_PI_FLAGS = {
 	variables: {
 		type: "boolean",
 		description: "Include variables in output",
-		showInTopLevelHelp: true,
-		helpHint: "use with 'get pi'",
 	},
 } as const satisfies Record<string, FlagDef>;
 
@@ -821,8 +809,6 @@ export const COMMAND_REGISTRY = {
 			id: {
 				type: "string",
 				description: "Process definition ID (alias for --processDefinitionId)",
-				showInTopLevelHelp: true,
-				helpHint: "alias for --bpmnProcessId",
 			},
 			bpmnProcessId: {
 				type: "string",
@@ -832,19 +818,14 @@ export const COMMAND_REGISTRY = {
 			awaitCompletion: {
 				type: "boolean",
 				description: "Wait for process to complete",
-				showInTopLevelHelp: true,
-				helpHint: "use with 'create pi'",
 			},
 			fetchVariables: {
 				type: "boolean",
 				description: "Fetch result variables on completion",
-				showInTopLevelHelp: true,
 			},
 			requestTimeout: {
 				type: "string",
 				description: "Await timeout in milliseconds",
-				showInTopLevelHelp: true,
-				helpHint: "use with --awaitCompletion",
 			},
 			// Identity user
 			username: {
@@ -1171,15 +1152,11 @@ export const COMMAND_REGISTRY = {
 				type: "string",
 				description: "JSON object of variables to set (required)",
 				required: true,
-				showInTopLevelHelp: true,
-				helpHint: "use with 'set variable'",
 			},
 			local: {
 				type: "boolean",
 				description:
 					"Set variables in local scope only (default: propagate to outermost scope)",
-				showInTopLevelHelp: true,
-				helpHint: "use with 'set variable'",
 			},
 		},
 		resourcePositionals: {
@@ -1412,8 +1389,6 @@ export const COMMAND_REGISTRY = {
 			from: {
 				type: "string",
 				description: "Load plugin from URL",
-				showInTopLevelHelp: true,
-				helpHint: "use with 'load plugin'",
 			},
 		},
 		resourcePositionals: {

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -672,12 +672,9 @@ function showGenericVerbHelp(verb: string): void {
 				}
 			}
 
-			// SEARCH_FLAGS for list/search commands
-			if (verb === "list" || verb === "search") {
-				for (const [name, flagDef] of flagEntries(SEARCH_FLAGS)) {
-					lines.push(formatFlag(name, flagDef, FLAG_COL));
-				}
-			}
+			// SEARCH_FLAGS are NOT emitted per resource — they are a coherent
+			// shared shape across all list/search resources and are rendered
+			// once, below, under a dedicated "Search flags" section.
 
 			// --profile always applicable
 			lines.push(
@@ -703,7 +700,18 @@ function showGenericVerbHelp(verb: string): void {
 		}
 	}
 
-	// Verb-level flags (excluding search flags already shown per-resource)
+	// Consolidated Search flags section for list/search verbs.
+	// SEARCH_FLAGS describe a coherent shared shape that applies to every
+	// list/search resource — render once here instead of repeating per resource.
+	if (verb === "list" || verb === "search") {
+		lines.push("");
+		lines.push("Search flags (apply to all resources above):");
+		for (const [name, flagDef] of flagEntries(SEARCH_FLAGS)) {
+			lines.push(formatFlag(name, flagDef, FLAG_COL));
+		}
+	}
+
+	// Verb-level flags (excluding search flags already shown in their dedicated section)
 	const verbFlags = Object.entries(def.flags).filter(
 		([name]) => !(name in SEARCH_FLAGS),
 	);

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -713,9 +713,20 @@ function showGenericVerbHelp(verb: string): void {
 		}
 	}
 
-	// Verb-level flags (excluding search flags already shown in their dedicated section)
+	// Verb-level flags: exclude SEARCH_FLAGS (rendered above in their dedicated
+	// section) and any flag names already rendered under a per-resource block
+	// via def.resourceFlags. Without this filter, verbs like list/search would
+	// repeat every per-resource flag here, making the section extremely noisy.
+	const excludedVerbFlagNames = new Set(Object.keys(SEARCH_FLAGS));
+	if (def.resourceFlags) {
+		for (const resourceFlags of Object.values(def.resourceFlags)) {
+			for (const name of Object.keys(resourceFlags)) {
+				excludedVerbFlagNames.add(name);
+			}
+		}
+	}
 	const verbFlags = Object.entries(def.flags).filter(
-		([name]) => !(name in SEARCH_FLAGS),
+		([name]) => !excludedVerbFlagNames.has(name),
 	);
 	if (verbFlags.length > 0) {
 		lines.push("");

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -134,7 +134,8 @@ function buildHelpJson(
 		}
 	}
 
-	// Derive global flags from GLOBAL_FLAGS + SEARCH_FLAGS
+	// Derive global flags from GLOBAL_FLAGS only.
+	// Per #321, SEARCH_FLAGS belong in `searchFlags`, not `globalFlags`.
 	const globalFlags: HelpFlag[] = [];
 	for (const [name, def] of flagEntries(GLOBAL_FLAGS)) {
 		globalFlags.push({
@@ -144,17 +145,18 @@ function buildHelpJson(
 			...(def.short ? { short: `-${def.short}` } : {}),
 		});
 	}
+
+	// Derive search flags from SEARCH_FLAGS plus list/search resourceFlags
+	const searchFlags: HelpFlag[] = [];
+	const seenSearchFlags = new Set<string>();
 	for (const [name, def] of Object.entries(SEARCH_FLAGS)) {
-		globalFlags.push({
+		seenSearchFlags.add(name);
+		searchFlags.push({
 			flag: `--${name}`,
 			type: def.type,
 			description: def.description,
 		});
 	}
-
-	// Derive search flags from list/search resourceFlags
-	const searchFlags: HelpFlag[] = [];
-	const seenSearchFlags = new Set<string>();
 	for (const verb of ["list", "search"] as const) {
 		const cmdDef = lookupVerb(verb);
 		if (cmdDef?.resourceFlags) {
@@ -297,43 +299,15 @@ function generateCommandLines(): string {
  * Uses the curated descriptions from the registry.
  */
 function generateFlagsSection(): string {
+	// Per #321, the top-level Flags section lists ONLY truly global flags.
+	// Command-specific flags belong in `c8ctl help <verb>`.
 	const lines: string[] = [];
 	const FLAG_COL = 36;
-
-	// Global flags first
 	for (const [name, def] of flagEntries(GLOBAL_FLAGS)) {
 		const flag = def.short ? `--${name}, -${def.short}` : `--${name}`;
 		const typeHint = def.type === "string" ? ` <${name}>` : "";
 		lines.push(`  ${(flag + typeHint).padEnd(FLAG_COL)}${def.description}`);
 	}
-
-	// Collect notable verb-specific flags marked with showInTopLevelHelp
-	const seen = new Set<string>(Object.keys(GLOBAL_FLAGS));
-
-	function addFlag(name: string, flagDef: FlagDef): void {
-		if (!flagDef.showInTopLevelHelp || seen.has(name)) return;
-		seen.add(name);
-		const flag = flagDef.short ? `--${name}, --${flagDef.short}` : `--${name}`;
-		const typeHint = flagDef.type === "string" ? ` <${name}>` : "";
-		const hint = flagDef.helpHint ? ` (${flagDef.helpHint})` : "";
-		lines.push(
-			`  ${(flag + typeHint).padEnd(FLAG_COL)}${flagDef.description}${hint}`,
-		);
-	}
-
-	for (const [, cmd] of registryEntries()) {
-		for (const [name, flagDef] of flagEntries(cmd.flags)) {
-			addFlag(name, flagDef);
-		}
-		if (cmd.resourceFlags) {
-			for (const resourceFlags of Object.values(cmd.resourceFlags)) {
-				for (const [name, flagDef] of flagEntries(resourceFlags)) {
-					addFlag(name, flagDef);
-				}
-			}
-		}
-	}
-
 	return lines.join("\n");
 }
 

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -295,8 +295,10 @@ function generateCommandLines(): string {
 }
 
 /**
- * Generate the Flags section from GLOBAL_FLAGS and select verb-specific flags.
- * Uses the curated descriptions from the registry.
+ * Generate the top-level Flags section.
+ *
+ * Per #321, this lists ONLY truly global flags (the keys in GLOBAL_FLAGS).
+ * Command-specific flags are surfaced via `c8ctl help <verb>` instead.
  */
 function generateFlagsSection(): string {
 	// Per #321, the top-level Flags section lists ONLY truly global flags.

--- a/tests/unit/help.test.ts
+++ b/tests/unit/help.test.ts
@@ -75,18 +75,19 @@ describe("Help Module", () => {
 		assert.ok(output.includes("inc"));
 		assert.ok(output.includes("msg"));
 
-		// Check for flags
+		// Check for global flags only (per #321 — command-specific flags belong
+		// in `c8ctl help <verb>`, not the top-level Flags section).
 		assert.ok(output.includes("--profile"));
-		assert.ok(output.includes("--variables"));
-		assert.ok(output.includes("--awaitCompletion"));
-		assert.ok(output.includes("--fetchVariables"));
-		assert.ok(output.includes("--requestTimeout"));
+		assert.ok(output.includes("--version"));
+		assert.ok(output.includes("--help"));
+		assert.ok(output.includes("--dry-run"));
+		assert.ok(output.includes("--verbose"));
+		assert.ok(output.includes("--fields"));
+		// Search flags still render in their dedicated Search Flags section.
 		assert.ok(output.includes("--sortBy"));
 		assert.ok(output.includes("--asc"));
 		assert.ok(output.includes("--desc"));
 		assert.ok(output.includes("--limit"));
-		assert.ok(output.includes("--version"));
-		assert.ok(output.includes("--help"));
 
 		// Check for case-insensitive search flags
 		assert.ok(output.includes("--iname"));
@@ -1160,4 +1161,152 @@ describe("Help Module", () => {
 		assert.ok(deleteCmd, "commands should include delete");
 		assert.strictEqual(deleteCmd.mutating, true, "delete should be mutating");
 	});
+});
+
+// ─── #321: top-level Flags scoped to GLOBAL_FLAGS only ──────────────────────
+//
+// Class-scoped regression guard for camunda/c8ctl#321. The top-level
+// `c8ctl --help` Flags section must list only truly global flags. Every
+// command-specific flag must continue to be reachable via `c8ctl help <verb>`.
+// Tests in this block were written red-first against the pre-fix code path;
+// they pin the contract so the same category of leak cannot recur.
+
+describe("Top-level help is scoped to global flags (#321)", () => {
+	let consoleLogSpy: string[];
+	let originalLog: typeof console.log;
+	let originalOutputMode: typeof c8ctl.outputMode;
+
+	beforeEach(() => {
+		consoleLogSpy = [];
+		originalLog = console.log;
+		originalOutputMode = c8ctl.outputMode;
+		c8ctl.outputMode = "text";
+		console.log = (...args: unknown[]) => {
+			consoleLogSpy.push(args.join(" "));
+		};
+	});
+
+	afterEach(() => {
+		console.log = originalLog;
+		c8ctl.outputMode = originalOutputMode;
+	});
+
+	/** Extract the `Flags:` section (between the `Flags:` heading and the next blank-line-then-heading). */
+	function extractFlagsSection(output: string): string {
+		const lines = output.split("\n");
+		const start = lines.findIndex((l) => l.trim() === "Flags:");
+		assert.ok(start >= 0, "expected a Flags: section in help output");
+		const tail = lines.slice(start + 1);
+		// Section ends at the first blank line followed by another heading
+		// (e.g. "Search Flags:"), or at end of output.
+		let end = tail.length;
+		for (let i = 0; i < tail.length - 1; i++) {
+			if (tail[i].trim() === "" && /^[A-Z][^\n]*:$/.test(tail[i + 1])) {
+				end = i;
+				break;
+			}
+		}
+		return tail.slice(0, end).join("\n");
+	}
+
+	test("Flags section contains only the six global flags", () => {
+		showHelp();
+		const flagsSection = extractFlagsSection(consoleLogSpy.join("\n"));
+
+		// Must include every GLOBAL_FLAGS key.
+		for (const flag of [
+			"--help",
+			"--version",
+			"--profile",
+			"--dry-run",
+			"--verbose",
+			"--fields",
+		]) {
+			assert.ok(
+				flagsSection.includes(flag),
+				`top-level Flags section should include ${flag}`,
+			);
+		}
+
+		// Must NOT include any command-specific flag previously surfaced via
+		// FlagDef.showInTopLevelHelp. Class-scoped guard: any new opt-in would
+		// be caught by the `(use with '` substring check below; this list pins
+		// today's known leaks.
+		for (const flag of [
+			"--xml",
+			"--userTask",
+			"--processDefinition",
+			"--awaitCompletion",
+			"--fetchVariables",
+			"--requestTimeout",
+			"--from ",
+			"--local ",
+		]) {
+			assert.ok(
+				!flagsSection.includes(flag),
+				`top-level Flags section should NOT include command-specific ${flag.trim()}`,
+			);
+		}
+	});
+
+	test("top-level help output contains no '(use with' context hints", () => {
+		showHelp();
+		const output = consoleLogSpy.join("\n");
+		assert.ok(
+			!output.includes("(use with '"),
+			"per #321, the '(use with ...)' parenthetical workaround must not appear in top-level help",
+		);
+	});
+
+	test("JSON help payload globalFlags contains only GLOBAL_FLAGS keys", () => {
+		c8ctl.outputMode = "json";
+		// Re-spy after mode flip — the runtime helper uses logger.json which
+		// also writes via console.log in this test harness.
+		showHelp();
+		const raw = consoleLogSpy.join("\n");
+		const parsed: { globalFlags: Array<{ flag: string }> } = JSON.parse(raw);
+		const flagNames = parsed.globalFlags.map((f) => f.flag).sort();
+		assert.deepStrictEqual(
+			flagNames,
+			[
+				"--dry-run",
+				"--fields",
+				"--help",
+				"--profile",
+				"--verbose",
+				"--version",
+			],
+			"JSON globalFlags must equal the GLOBAL_FLAGS keys (no command-specific leak)",
+		);
+	});
+
+	// Class-scoped guard: every flag previously opted in via showInTopLevelHelp
+	// must remain reachable through `c8ctl help <verb>`. Iterating the list
+	// proves the per-resource help surface covers the whole class, not just
+	// one instance — so a future addition to that list is automatically tested
+	// once it's also added here.
+	const perVerbFlagCoverage: Array<[verb: string, flag: string]> = [
+		["get", "--xml"],
+		["get", "--userTask"],
+		["get", "--processDefinition"],
+		["get", "--variables"],
+		["create", "--id"],
+		["create", "--awaitCompletion"],
+		["create", "--fetchVariables"],
+		["create", "--requestTimeout"],
+		["set", "--variables"],
+		["set", "--local"],
+		["load", "--from"],
+	];
+
+	for (const [verb, flag] of perVerbFlagCoverage) {
+		test(`c8ctl help ${verb} surfaces ${flag} (was previously top-level)`, async () => {
+			await showCommandHelp(verb);
+			const output = consoleLogSpy.join("\n");
+			assert.ok(
+				output.includes(flag),
+				`'c8ctl help ${verb}' must surface ${flag}; otherwise removing it from top-level help loses discoverability`,
+			);
+		});
+	}
 });

--- a/tests/unit/help.test.ts
+++ b/tests/unit/help.test.ts
@@ -1245,7 +1245,7 @@ describe("Top-level help is scoped to global flags (#321)", () => {
 		);
 	});
 
-	test("JSON help payload globalFlags contains only GLOBAL_FLAGS keys", () => {
+	test("JSON help payload globalFlags contains exactly the GLOBAL_FLAGS keys", () => {
 		c8ctl.outputMode = "json";
 		// Re-spy after mode flip — the runtime helper uses logger.json which
 		// also writes via console.log in this test harness.
@@ -1253,16 +1253,12 @@ describe("Top-level help is scoped to global flags (#321)", () => {
 		const raw = consoleLogSpy.join("\n");
 		const parsed: { globalFlags: Array<{ flag: string }> } = JSON.parse(raw);
 		const flagNames = parsed.globalFlags.map((f) => f.flag).sort();
+		const expected = Object.keys(GLOBAL_FLAGS)
+			.map((name) => `--${name}`)
+			.sort();
 		assert.deepStrictEqual(
 			flagNames,
-			[
-				"--dry-run",
-				"--fields",
-				"--help",
-				"--profile",
-				"--verbose",
-				"--version",
-			],
+			expected,
 			"JSON globalFlags must equal the GLOBAL_FLAGS keys (no command-specific leak)",
 		);
 	});
@@ -1290,8 +1286,15 @@ describe("Top-level help is scoped to global flags (#321)", () => {
 		test(`c8ctl help ${verb} surfaces ${flag} (was previously top-level)`, async () => {
 			await showCommandHelp(verb);
 			const output = consoleLogSpy.join("\n");
+			// Match the flag as a declaration at the start of a line so short
+			// flag names (e.g. --id) are not satisfied by longer flags that
+			// happen to contain them as a substring (e.g. --iid, --identityType).
+			const flagDecl = new RegExp(
+				`^\\s*${flag.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")}\\b`,
+				"m",
+			);
 			assert.ok(
-				output.includes(flag),
+				flagDecl.test(output),
 				`'c8ctl help ${verb}' must surface ${flag}; otherwise removing it from top-level help loses discoverability`,
 			);
 		});
@@ -1305,10 +1308,15 @@ describe("Top-level help is scoped to global flags (#321)", () => {
 describe("Search flags are consolidated into a single section per verb (#322 follow-up)", () => {
 	let consoleLogSpy: string[];
 	let originalLog: typeof console.log;
+	let originalOutputMode: typeof c8ctl.outputMode;
 
 	beforeEach(() => {
 		consoleLogSpy = [];
 		originalLog = console.log;
+		originalOutputMode = c8ctl.outputMode;
+		// Force text mode — other suites may flip outputMode to 'json' and the
+		// runtime mutation would otherwise leak into this suite (order-dependent).
+		c8ctl.outputMode = "text";
 		console.log = (...args: unknown[]) => {
 			consoleLogSpy.push(
 				args
@@ -1320,6 +1328,7 @@ describe("Search flags are consolidated into a single section per verb (#322 fol
 
 	afterEach(() => {
 		console.log = originalLog;
+		c8ctl.outputMode = originalOutputMode;
 	});
 
 	const sharedSearchFlags = [
@@ -1338,9 +1347,11 @@ describe("Search flags are consolidated into a single section per verb (#322 fol
 				const output = consoleLogSpy.join("\n");
 				// Match the flag only when it appears as a flag declaration
 				// (start of a line, after indent) — not when it is referenced
-				// inside another flag's description text.
+				// inside another flag's description text. Escape regex metachars
+				// (including backslash) defensively, even though SEARCH_FLAGS
+				// names contain none today.
 				const flagLine = new RegExp(
-					`^\\s*${flag.replace(/-/g, "\\-")}\\b`,
+					`^\\s*${flag.replace(/[.*+?^${}()|[\\]\\\\]/g, "\\\\$&")}\\b`,
 					"gm",
 				);
 				const occurrences = (output.match(flagLine) ?? []).length;

--- a/tests/unit/help.test.ts
+++ b/tests/unit/help.test.ts
@@ -4,6 +4,7 @@
 
 import assert from "node:assert";
 import { afterEach, beforeEach, describe, test } from "node:test";
+import { GLOBAL_FLAGS } from "../../src/command-registry.ts";
 import {
 	getVersion,
 	showCommandHelp,
@@ -1209,44 +1210,30 @@ describe("Top-level help is scoped to global flags (#321)", () => {
 		return tail.slice(0, end).join("\n");
 	}
 
-	test("Flags section contains only the six global flags", () => {
+	test("Flags section contains exactly the GLOBAL_FLAGS keys", () => {
 		showHelp();
 		const flagsSection = extractFlagsSection(consoleLogSpy.join("\n"));
 
-		// Must include every GLOBAL_FLAGS key.
-		for (const flag of [
-			"--help",
-			"--version",
-			"--profile",
-			"--dry-run",
-			"--verbose",
-			"--fields",
-		]) {
-			assert.ok(
-				flagsSection.includes(flag),
-				`top-level Flags section should include ${flag}`,
-			);
-		}
-
-		// Must NOT include any command-specific flag previously surfaced via
-		// FlagDef.showInTopLevelHelp. Class-scoped guard: any new opt-in would
-		// be caught by the `(use with '` substring check below; this list pins
-		// today's known leaks.
-		for (const flag of [
-			"--xml",
-			"--userTask",
-			"--processDefinition",
-			"--awaitCompletion",
-			"--fetchVariables",
-			"--requestTimeout",
-			"--from ",
-			"--local ",
-		]) {
-			assert.ok(
-				!flagsSection.includes(flag),
-				`top-level Flags section should NOT include command-specific ${flag.trim()}`,
-			);
-		}
+		// Strongest possible guard: extract every `--<name>` token that
+		// appears as a flag declaration in the section, then compare it
+		// against the registry. Any command-specific flag that leaks in
+		// (e.g. --xml, --id, --variables, --awaitCompletion, --from, --local)
+		// will fail this assertion regardless of which one it is.
+		const flagDeclarations = (
+			flagsSection.match(/^\s*(--[a-zA-Z][\w-]*)/gm) ?? []
+		)
+			.map((m) => m.trim())
+			.sort();
+		const expected = Object.keys(GLOBAL_FLAGS)
+			.map((name) => `--${name}`)
+			.sort();
+		assert.deepStrictEqual(
+			flagDeclarations,
+			expected,
+			"top-level Flags section must contain exactly the GLOBAL_FLAGS keys — " +
+				"any command-specific flag leaking in (e.g. --id, --variables, --xml, " +
+				"--awaitCompletion, --from, --local) is a regression of #321",
+		);
 	});
 
 	test("top-level help output contains no '(use with' context hints", () => {

--- a/tests/unit/help.test.ts
+++ b/tests/unit/help.test.ts
@@ -1310,3 +1310,68 @@ describe("Top-level help is scoped to global flags (#321)", () => {
 		});
 	}
 });
+
+// Reviewer follow-up on PR #322: SEARCH_FLAGS were duplicated under every
+// resource block in `c8ctl help list` / `c8ctl help search`. They are a
+// coherent shared shape across all list/search resources, so they belong in
+// a single dedicated section per verb — not repeated 13× per resource.
+describe("Search flags are consolidated into a single section per verb (#322 follow-up)", () => {
+	let consoleLogSpy: string[];
+	let originalLog: typeof console.log;
+
+	beforeEach(() => {
+		consoleLogSpy = [];
+		originalLog = console.log;
+		console.log = (...args: unknown[]) => {
+			consoleLogSpy.push(
+				args
+					.map((a) => (typeof a === "string" ? a : JSON.stringify(a)))
+					.join(" "),
+			);
+		};
+	});
+
+	afterEach(() => {
+		console.log = originalLog;
+	});
+
+	const sharedSearchFlags = [
+		"--sortBy",
+		"--asc",
+		"--desc",
+		"--limit",
+		"--between",
+		"--dateField",
+	];
+
+	for (const verb of ["list", "search"] as const) {
+		for (const flag of sharedSearchFlags) {
+			test(`c8ctl help ${verb} emits ${flag} exactly once`, async () => {
+				await showCommandHelp(verb);
+				const output = consoleLogSpy.join("\n");
+				// Match the flag only when it appears as a flag declaration
+				// (start of a line, after indent) — not when it is referenced
+				// inside another flag's description text.
+				const flagLine = new RegExp(
+					`^\\s*${flag.replace(/-/g, "\\-")}\\b`,
+					"gm",
+				);
+				const occurrences = (output.match(flagLine) ?? []).length;
+				assert.strictEqual(
+					occurrences,
+					1,
+					`'c8ctl help ${verb}' must emit ${flag} once (consolidated section), got ${occurrences} occurrences`,
+				);
+			});
+		}
+
+		test(`c8ctl help ${verb} groups search flags under a dedicated header`, async () => {
+			await showCommandHelp(verb);
+			const output = consoleLogSpy.join("\n");
+			assert.ok(
+				/Search flags/i.test(output),
+				`'c8ctl help ${verb}' must include a 'Search flags' section header`,
+			);
+		});
+	}
+});

--- a/tests/unit/help.test.ts
+++ b/tests/unit/help.test.ts
@@ -1247,8 +1247,8 @@ describe("Top-level help is scoped to global flags (#321)", () => {
 
 	test("JSON help payload globalFlags contains exactly the GLOBAL_FLAGS keys", () => {
 		c8ctl.outputMode = "json";
-		// Re-spy after mode flip — the runtime helper uses logger.json which
-		// also writes via console.log in this test harness.
+		// The existing console.log spy from beforeEach continues to capture
+		// logger.json output in this test harness after the mode switch.
 		showHelp();
 		const raw = consoleLogSpy.join("\n");
 		const parsed: { globalFlags: Array<{ flag: string }> } = JSON.parse(raw);


### PR DESCRIPTION
Closes #321.

The top-level `c8ctl --help` **Flags:** section previously mixed truly global flags with eleven command-specific flags opted in via `FlagDef.showInTopLevelHelp`, each carrying a `(use with 'verb resource')` parenthetical. The result was hard to scan and misleading — a flag listed at the root looked like it applied to every command.

## Behaviour change

**Before**

```
Flags:
  --help, -h                          Show help
  --version, -v <version>             Show CLI version, ...
  --profile <profile>                 Use a specific profile
  --dry-run                           Preview the API request without executing
  --verbose                           Show verbose output
  --fields <fields>                   Comma-separated list of fields to display
  --xml                               Get BPMN XML (process definitions) (use with 'get pd')
  --userTask                          Get form for user task (use with 'get form')
  --processDefinition                 Get form for process definition (use with 'get form')
  --variables                         Include variables in output (use with 'get pi')
  --id <id>                           Process definition ID (alias for --bpmnProcessId)
  --awaitCompletion                   Wait for process to complete (use with 'create pi')
  --fetchVariables                    Fetch result variables on completion
  --requestTimeout <requestTimeout>   Await timeout in milliseconds (use with --awaitCompletion)
  --local                             Set variables in local scope only ... (use with 'set variable')
  --from <from>                       Load plugin from URL (use with 'load plugin')
```

**After**

```
Flags:
  --help, -h                          Show help
  --version, -v <version>             Show CLI version, ...
  --profile <profile>                 Use a specific profile
  --dry-run                           Preview the API request without executing
  --verbose                           Show verbose output
  --fields <fields>                   Comma-separated list of fields to display
```

## Code

- `generateFlagsSection()` now iterates `GLOBAL_FLAGS` only — the registry scan and the `seen` set are gone.
- `buildHelpJson()` no longer lumps `SEARCH_FLAGS` into `globalFlags`; they are emitted under `searchFlags` where they belong.
- The eleven `showInTopLevelHelp: true` opt-ins are removed from `command-registry.ts`.
- `FlagDef.showInTopLevelHelp` and `FlagDef.helpHint` fields are removed.

Per-verb help (`c8ctl help <verb>`) was already structured to surface every removed flag under the correct resource block — no coverage lost.

## Tests (red-first per AGENTS.md)

In `tests/unit/help.test.ts`, new `Top-level help is scoped to global flags (#321)` describe block:

1. Top-level **Flags:** section contains every `GLOBAL_FLAGS` key and **none** of the command-specific flags previously opted in.
2. The `(use with '` substring does not appear anywhere in top-level help output.
3. JSON help payload `globalFlags` equals exactly the `GLOBAL_FLAGS` keys (no `SEARCH_FLAGS` leak).
4. **Class-scoped guard**: for each of the eleven previously opted-in flags, `c8ctl help <verb>` continues to surface it under the correct verb. This pins the contract so we never lose discoverability when removing future entries from the top-level surface.

Existing `showHelp outputs full help text` test updated to assert only the six global flags are in the Flags section (the search-flag assertions still hold for the Search Flags section).

## Pipeline

| Check | Result |
| --- | --- |
| `npm run build` | ✅ |
| `npm run typecheck` | ✅ |
| `npx biome check src tests` | ✅ |
| `npm test` | ✅ 1360/1361 pass, 1 skip (was 1346 → +14 new tests, 0 regressions) |


## Follow-up changes in this PR (in response to review)

Two additional user-visible improvements to `c8ctl help list` / `c8ctl help search` were added as part of addressing review comments. They build on the same theme — making help output reflect the actual scope of each flag — but worth calling out:

1. **Search flags consolidated into a single section per verb** (commit `7176634`).
   `--sortBy`, `--asc`, `--desc`, `--limit`, `--between`, `--dateField` were previously emitted under every resource block (13× per verb). They now appear once under a dedicated `Search flags (apply to all resources above):` section.
2. **Verb-level Flags section no longer duplicates resource-specific filter flags** (commit `d27dfe3`).
   Before: `c8ctl help list` ended with a 30+-line `Flags:` section repeating every per-resource filter (`--bpmnProcessId`, `--state`, `--assignee`, `--type`, …) that was already shown above. After: the trailing `Flags:` section contains only truly verb-scoped flags (e.g. `--all` for `list`).

Both behaviours are guarded by class-scoped tests in `tests/unit/help.test.ts`.
