### PR TITLE
fix(watch): emit readiness banner only after fs.watch + SIGINT handler are registered

### DIFF
--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -56,15 +56,6 @@ export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
 	const ignoreBaseDir = resolve(process.cwd());
 	const ig = loadIgnoreRules(ignoreBaseDir);
 
-	logger.info(`👁️  Watching for changes in: ${resolvedPaths.join(", ")}`);
-	logger.info(`📋 Monitoring extensions: ${watchedExtensions.join(", ")}`);
-	if (flags.force) {
-		logger.info(
-			"🔒 Force mode: will continue watching after deployment errors",
-		);
-	}
-	logger.info("Press Ctrl+C to stop watching\n");
-
 	// Keep track of recently deployed files to avoid duplicate deploys
 	const recentlyDeployed = new Map<string, number>();
 	// Debounce timers per file to let writes settle before deploying
@@ -193,6 +184,21 @@ export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
 			inflightDeploys.clear();
 			resolveSignal();
 		});
+
+		// Emit the readiness banner ONLY AFTER both the fs watchers and the
+		// SIGINT handler are registered. Tests poll the "Watching for
+		// changes" line as a readiness signal before dropping a file or
+		// sending SIGINT; emitting it earlier (before fs.watch() returns)
+		// races the inotify subscription on slow CI runners and the file
+		// event is silently lost.
+		logger.info(`👁️  Watching for changes in: ${resolvedPaths.join(", ")}`);
+		logger.info(`📋 Monitoring extensions: ${watchedExtensions.join(", ")}`);
+		if (flags.force) {
+			logger.info(
+				"🔒 Force mode: will continue watching after deployment errors",
+			);
+		}
+		logger.info("Press Ctrl+C to stop watching\n");
 	});
 
 	return { kind: "never" };

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -189,8 +189,10 @@ export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
 		// SIGINT handler are registered. Tests poll the "Watching for
 		// changes" line as a readiness signal before dropping a file or
 		// sending SIGINT; emitting it earlier (before fs.watch() returns)
-		// races the inotify subscription on slow CI runners and the file
-		// event is silently lost.
+		// races the file-system watcher registration on slow CI runners
+		// (fs.watch backends differ per platform — inotify on Linux,
+		// FSEvents on macOS, ReadDirectoryChangesW on Windows) and the
+		// file event is silently lost.
 		logger.info(`👁️  Watching for changes in: ${resolvedPaths.join(", ")}`);
 		logger.info(`📋 Monitoring extensions: ${watchedExtensions.join(", ")}`);
 		if (flags.force) {


### PR DESCRIPTION
## Why

CI failure on `tests/integration/watch-cancellation.test.ts`:

```
✖ SIGINT mid-deploy aborts the HTTP request and exits 0 within the shutdown budget
   Error: mock server did not receive POST /deployments within startup budget
```

Output captured at the failure showed the watcher had printed its three startup lines, but no deploy was ever attempted — so the test timed out waiting for `POST /deployments`.

## Root cause — category-1 test defect

Per [AGENTS.md → "There are no flaky tests"](../blob/main/AGENTS.md): an intermittent failure is either a test defect (race / readiness mis-signal) or a product defect.

This is a **handler-registration race** — the same shape called out in the testing-principles section about SIGINT readiness. The `👁️ Watching for changes` log line was emitted **before** `fs.watch()` was called, but the test polls for that line as its readiness signal and then immediately drops a BPMN into the watch directory.

On a slow shared runner, the file copy can race ahead of the inotify subscription:

1. `logger.info("Watching for changes")` ← test sees this, polling resolves
2. test calls `copyFileSync(VALID_BPMN, droppedFile)` — file event fires in the kernel
3. `const watchers = resolvedPaths.map(p => fs.watch(p, …))` ← inotify handler attached **here**, too late

The file event has nowhere to land, the debounced deploy never schedules, the mock server never gets `POST /deployments`, and the test fails 5s later.

## Fix

Hoist the four banner lines ("Watching for changes", "Monitoring extensions", optional force-mode, "Press Ctrl+C") into the `await new Promise(...)` body, **after**:

1. `const watchers = resolvedPaths.map(...)` returns (fs.watch handlers attached)
2. `process.once('SIGINT', ...)` runs (signal handler installed)

By the time any test (or human) sees "Watching for changes", both the file-event handler and the SIGINT handler are guaranteed to be registered. The banner is now a truthful readiness signal.

User-visible behaviour change: the banner appears a few microseconds later. Imperceptible on interactive runs.

## Regression guard

`tests/integration/watch-cancellation.test.ts` is the class-scoped guard: it polls for the readiness line and immediately drops a file, so any future regression of the same shape (ready-line emitted before fs.watch attaches) makes it fail. Verified locally:

- `watch-cancellation.test.ts` — ✔ 495ms (well under the 5s startup budget and 3s shutdown budget)
- `watch.test.ts` — ✔ all 4 tests pass
- full unit suite — ✔ 1235/1235 pass

No production behaviour change beyond the banner timing.