### PR TITLE
fix(tests): bind mock servers to kernel-assigned ports (closes #316)

### DIFF
--- a/tests/integration/mcp-proxy-mock.test.ts
+++ b/tests/integration/mcp-proxy-mock.test.ts
@@ -16,15 +16,29 @@ import { makeMockClient, makeMockLogger } from "../utils/mocks.ts";
 
 describe("MCP Proxy Mock Server Integration Tests", () => {
 	let mockServer: Server;
-	let mockServerPort: number;
 	let mockServerUrl: string;
 	let mockLogger: Logger;
 
-	beforeEach(async () => {
-		// Find an available port and start mock server
-		mockServerPort = 9876 + Math.floor(Math.random() * 1000);
-		mockServerUrl = `http://localhost:${mockServerPort}`;
+	/**
+	 * Bind `mockServer` to a kernel-assigned port on 127.0.0.1 and set
+	 * `mockServerUrl` to the resulting URL. See issue #316: hardcoded
+	 * numeric ports and `Math.random()`-derived port ranges are vulnerable
+	 * to undici's "bad port" rejection list (e.g. port 10080) and to
+	 * EADDRINUSE collisions when integration suites run in parallel.
+	 * Binding to port 0 lets the kernel pick a guaranteed-free, valid port.
+	 */
+	async function bindMockServer(): Promise<void> {
+		await new Promise<void>((resolve) => {
+			mockServer.listen(0, "127.0.0.1", () => resolve());
+		});
+		const addr = mockServer.address();
+		if (!addr || typeof addr === "string") {
+			throw new Error("mock server did not bind to an inet address");
+		}
+		mockServerUrl = `http://127.0.0.1:${addr.port}`;
+	}
 
+	beforeEach(async () => {
 		mockLogger = makeMockLogger();
 	});
 
@@ -45,9 +59,7 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 			res.end(JSON.stringify({ success: true }));
 		});
 
-		await new Promise<void>((resolve) => {
-			mockServer.listen(mockServerPort, () => resolve());
-		});
+		await bindMockServer();
 
 		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({ Authorization: "Bearer test-token-123" }),
@@ -67,9 +79,7 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 			res.end("Not Found");
 		});
 
-		await new Promise<void>((resolve) => {
-			mockServer.listen(mockServerPort, () => resolve());
-		});
+		await bindMockServer();
 
 		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),
@@ -88,9 +98,7 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 			res.end("Internal Server Error");
 		});
 
-		await new Promise<void>((resolve) => {
-			mockServer.listen(mockServerPort, () => resolve());
-		});
+		await bindMockServer();
 
 		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),
@@ -121,9 +129,7 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 			}
 		});
 
-		await new Promise<void>((resolve) => {
-			mockServer.listen(mockServerPort, () => resolve());
-		});
+		await bindMockServer();
 
 		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({
@@ -143,13 +149,30 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 	});
 
 	test("handles connection refused error", async () => {
-		// Don't start server - connection will be refused
-		const unreachablePort = 9999;
+		// Bind a transient server to a kernel-assigned port, capture the
+		// port, then immediately close it. The captured port is now both
+		// (a) guaranteed to have been a valid port the kernel was willing
+		// to hand out (so it can't be on undici's "bad ports" list) and
+		// (b) almost certainly free again — so a connect attempt will be
+		// refused with ECONNREFUSED rather than succeeding against a
+		// stranger's process. See issue #316: hardcoded test ports
+		// (here, the previous `9999`) are vulnerable to undici's bad-port
+		// list and to colliding with whatever else happens to be bound.
+		const probe = createServer();
+		await new Promise<void>((resolve) => {
+			probe.listen(0, "127.0.0.1", () => resolve());
+		});
+		const probeAddr = probe.address();
+		if (!probeAddr || typeof probeAddr === "string") {
+			throw new Error("probe server did not bind to an inet address");
+		}
+		const unreachablePort = probeAddr.port;
+		await new Promise<void>((resolve) => probe.close(() => resolve()));
 
 		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),
 			getConfig: () => ({
-				restAddress: `http://localhost:${unreachablePort}`,
+				restAddress: `http://127.0.0.1:${unreachablePort}`,
 			}),
 		});
 
@@ -158,14 +181,14 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 		await assert.rejects(
 			async () =>
 				await customFetch(
-					`http://localhost:${unreachablePort}/mcp/cluster`,
+					`http://127.0.0.1:${unreachablePort}/mcp/cluster`,
 					{},
 				),
 			(error: Error) => {
 				assert.match(error.message, /Connection refused/);
 				assert.match(
 					error.message,
-					new RegExp(`http://localhost:${unreachablePort}`),
+					new RegExp(`http://127.0.0.1:${unreachablePort}`),
 				);
 				return true;
 			},
@@ -182,9 +205,7 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 			},
 		);
 
-		await new Promise<void>((resolve) => {
-			mockServer.listen(mockServerPort, () => resolve());
-		});
+		await bindMockServer();
 
 		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),
@@ -210,9 +231,7 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 			res.end(JSON.stringify({ success: true }));
 		});
 
-		await new Promise<void>((resolve) => {
-			mockServer.listen(mockServerPort, () => resolve());
-		});
+		await bindMockServer();
 
 		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),
@@ -239,9 +258,7 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 			res.end();
 		});
 
-		await new Promise<void>((resolve) => {
-			mockServer.listen(mockServerPort, () => resolve());
-		});
+		await bindMockServer();
 
 		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),
@@ -275,9 +292,7 @@ describe("MCP Proxy Mock Server Integration Tests", () => {
 			});
 		});
 
-		await new Promise<void>((resolve) => {
-			mockServer.listen(mockServerPort, () => resolve());
-		});
+		await bindMockServer();
 
 		const mockCamundaClient = makeMockClient({
 			getAuthHeaders: async () => ({}),

--- a/tests/unit/no-hardcoded-listen-ports.test.ts
+++ b/tests/unit/no-hardcoded-listen-ports.test.ts
@@ -31,10 +31,25 @@ import { findHardcodedListenPorts } from "../utils/no-hardcoded-listen-ports.ts"
 const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
 const INTEGRATION_DIR = join(PROJECT_ROOT, "tests", "integration");
 
-function listIntegrationTestFiles(): string[] {
-	return readdirSync(INTEGRATION_DIR)
-		.filter((name) => name.endsWith(".test.ts"))
-		.map((name) => join(INTEGRATION_DIR, name));
+function listIntegrationTestFiles(dir: string = INTEGRATION_DIR): string[] {
+	// Recursive `.ts` scan rather than `readdirSync` + `*.test.ts`. The
+	// guard's intent is to cover every TS file under tests/integration —
+	// not just the top-level `*.test.ts` files. A hardcoded port in a
+	// helper module like `tests/integration/helpers/mock-server.ts`
+	// would be the same defect class, and a flat top-level scan would
+	// silently let it through.
+	const files: string[] = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const absPath = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			files.push(...listIntegrationTestFiles(absPath));
+			continue;
+		}
+		if (entry.isFile() && entry.name.endsWith(".ts")) {
+			files.push(absPath);
+		}
+	}
+	return files;
 }
 
 function toRelative(absPath: string): string {

--- a/tests/unit/no-hardcoded-listen-ports.test.ts
+++ b/tests/unit/no-hardcoded-listen-ports.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Architectural class-of-defect guard for issue #316.
+ *
+ * Integration tests under `tests/integration/**.ts` must not bind their
+ * mock HTTP servers to a hardcoded numeric port (e.g.
+ * `server.listen(8080, ...)`) or to a port derived from `Math.random()`
+ * (e.g. `9876 + Math.floor(Math.random() * 1000)`). Both shapes are
+ * vulnerable to:
+ *
+ *   - undici's "bad port" rejection (Chromium's restricted-ports list,
+ *     e.g. 10080 = Sun RPC), which causes `fetch()` to throw
+ *     `Error: bad port` before any network I/O — observed on PR #313 CI.
+ *   - EADDRINUSE collisions across parallel test runs.
+ *
+ * The fix is to use `listen(0, ...)` (kernel-assigned port) and read
+ * the actual port back from `server.address()`. The kernel never
+ * returns a bad port and never collides.
+ *
+ * AST-based (not regex) so that string literals containing `.listen(8080`,
+ * comments mentioning the pattern, and commented-out code cannot
+ * produce false positives or false negatives. See
+ * `tests/utils/no-hardcoded-listen-ports.ts`.
+ */
+
+import assert from "node:assert";
+import { readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, test } from "node:test";
+import { findHardcodedListenPorts } from "../utils/no-hardcoded-listen-ports.ts";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
+const INTEGRATION_DIR = join(PROJECT_ROOT, "tests", "integration");
+
+function listIntegrationTestFiles(): string[] {
+	return readdirSync(INTEGRATION_DIR)
+		.filter((name) => name.endsWith(".test.ts"))
+		.map((name) => join(INTEGRATION_DIR, name));
+}
+
+function toRelative(absPath: string): string {
+	const rel = absPath.slice(PROJECT_ROOT.length + 1);
+	return rel.split(/[\\/]/).join("/");
+}
+
+describe("architectural guard: integration mocks must bind to port 0 (#316)", () => {
+	const files = listIntegrationTestFiles();
+
+	test("no integration test calls .listen(<hardcoded-or-random-port>, ...)", () => {
+		const violations: {
+			file: string;
+			line: number;
+			text: string;
+			reason: string;
+		}[] = [];
+		for (const abs of files) {
+			for (const call of findHardcodedListenPorts(abs)) {
+				violations.push({
+					file: toRelative(abs),
+					line: call.line,
+					text: call.text,
+					reason: call.reason,
+				});
+			}
+		}
+		assert.strictEqual(
+			violations.length,
+			0,
+			`Integration tests must bind mock servers to port 0 (kernel-assigned). ` +
+				`Hardcoded numeric ports and Math.random()-derived ports trigger ` +
+				`undici "bad port" rejections (e.g. 10080 = Sun RPC) and EADDRINUSE ` +
+				`collisions across parallel runs. Found ${violations.length}:\n` +
+				violations
+					.map((v) => `  - ${v.file}:${v.line} [${v.reason}] — ${v.text}`)
+					.join("\n") +
+				`\n\nFix: replace \`server.listen(<port>, cb)\` with ` +
+				`\`server.listen(0, "127.0.0.1", cb)\` and read the actual port ` +
+				`back from \`server.address()\`. See ` +
+				`\`tests/integration/watch-cancellation.test.ts\` for the pattern.`,
+		);
+	});
+});

--- a/tests/utils/no-hardcoded-listen-ports.ts
+++ b/tests/utils/no-hardcoded-listen-ports.ts
@@ -1,0 +1,172 @@
+/**
+ * AST-based scanner that finds every `<server>.listen(<port>, ...)` call
+ * in a TypeScript test file where `<port>` is a hardcoded numeric literal
+ * other than `0`, OR is derived from a numeric literal via `Math.random()`
+ * (e.g. `9876 + Math.floor(Math.random() * 1000)`).
+ *
+ * Why this guard exists (issue #316): integration tests that bind their
+ * mock servers to either a hardcoded numeric port or a random number drawn
+ * from a numeric range are vulnerable to two latent failure modes that
+ * have already cost us at least one CI failure:
+ *
+ *   1. Bad-port lottery — undici (Node's native fetch) rejects requests
+ *      to ports on Chromium's "bad ports" list with `Error: bad port`
+ *      before any network I/O happens. Port 10080 (Sun RPC) lives inside
+ *      the historical 9876 + 1000 range used by `mcp-proxy-mock.test.ts`
+ *      and triggered an intermittent CI failure on PR #313.
+ *   2. EADDRINUSE collisions — two integration suites running in parallel
+ *      may draw the same port. The legacy random-port code path had no
+ *      `error` listener on `listen()`, so a collision silently hung the
+ *      test instead of failing fast.
+ *
+ * The deterministic fix is `server.listen(0, ...)` plus reading the
+ * kernel-assigned port back from `server.address()`. The kernel never
+ * returns a "bad port" and never collides.
+ *
+ * AST (not regex) so that string literals containing `.listen(8080`,
+ * comments mentioning the pattern, and commented-out code cannot
+ * produce false positives or false negatives.
+ *
+ * Allowlist: `listen(0, ...)` is fine. `listen(somePortVariable, ...)`
+ * is fine — the assumption is that the variable was assigned from
+ * `address().port` after a kernel-assigned bind, and a reviewer caught
+ * that. The check is deliberately scoped to the most common copy-paste
+ * footgun: a numeric literal sitting inline at the call site, or a
+ * `Math.random()`-derived range.
+ */
+
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+
+export interface BadListenCall {
+	/** 1-based line number of the call. */
+	line: number;
+	/** 1-based column number of the call. */
+	column: number;
+	/** The full call text, e.g. `server.listen(8080, cb)`. */
+	text: string;
+	/** Why it was flagged. */
+	reason:
+		| "numeric-literal-port"
+		| "math-random-derived-port"
+		| "variable-derived-from-math-random";
+}
+
+/**
+ * Parse a TypeScript file and return every offending `.listen(...)`
+ * call site found in it.
+ */
+export function findHardcodedListenPorts(filePath: string): BadListenCall[] {
+	const source = readFileSync(filePath, "utf8");
+	const sf = ts.createSourceFile(
+		filePath,
+		source,
+		ts.ScriptTarget.Latest,
+		/* setParentNodes */ true,
+		ts.ScriptKind.TS,
+	);
+
+	// First pass: identify any local variable whose initializer or
+	// assignment uses Math.random(). These are "tainted" — using them as a
+	// port argument is the same defect class as inlining the expression.
+	const taintedNames = collectMathRandomTaintedIdentifiers(sf);
+
+	const hits: BadListenCall[] = [];
+
+	const visit = (node: ts.Node): void => {
+		if (
+			ts.isCallExpression(node) &&
+			ts.isPropertyAccessExpression(node.expression) &&
+			node.expression.name.text === "listen" &&
+			node.arguments.length >= 1
+		) {
+			const portArg = node.arguments[0];
+			const reason = classifyPortArg(portArg, taintedNames);
+			if (reason) {
+				const { line, character } = sf.getLineAndCharacterOfPosition(
+					node.getStart(sf),
+				);
+				hits.push({
+					line: line + 1,
+					column: character + 1,
+					text: node.getText(sf),
+					reason,
+				});
+			}
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(sf);
+
+	return hits;
+}
+
+function classifyPortArg(
+	arg: ts.Expression,
+	tainted: ReadonlySet<string>,
+): BadListenCall["reason"] | null {
+	// `listen(0, ...)` — the kernel-assigned-port idiom we want.
+	if (ts.isNumericLiteral(arg) && arg.text === "0") {
+		return null;
+	}
+	// `listen(<numeric-literal>, ...)` where literal !== 0.
+	if (ts.isNumericLiteral(arg)) {
+		return "numeric-literal-port";
+	}
+	// Inline expression containing Math.random() — the original
+	// `9876 + Math.floor(Math.random() * 1000)` shape.
+	if (containsMathRandom(arg)) {
+		return "math-random-derived-port";
+	}
+	// Identifier that was tainted by a Math.random() initializer.
+	if (ts.isIdentifier(arg) && tainted.has(arg.text)) {
+		return "variable-derived-from-math-random";
+	}
+	return null;
+}
+
+function containsMathRandom(node: ts.Node): boolean {
+	let found = false;
+	const walk = (n: ts.Node): void => {
+		if (found) return;
+		if (
+			ts.isCallExpression(n) &&
+			ts.isPropertyAccessExpression(n.expression) &&
+			ts.isIdentifier(n.expression.expression) &&
+			n.expression.expression.text === "Math" &&
+			n.expression.name.text === "random"
+		) {
+			found = true;
+			return;
+		}
+		ts.forEachChild(n, walk);
+	};
+	walk(node);
+	return found;
+}
+
+function collectMathRandomTaintedIdentifiers(
+	sf: ts.SourceFile,
+): ReadonlySet<string> {
+	const tainted = new Set<string>();
+	const visit = (node: ts.Node): void => {
+		// `const port = 9876 + Math.random() * 1000;`
+		if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name)) {
+			if (node.initializer && containsMathRandom(node.initializer)) {
+				tainted.add(node.name.text);
+			}
+		}
+		// `port = 9876 + Math.random() * 1000;`
+		if (
+			ts.isBinaryExpression(node) &&
+			node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+			ts.isIdentifier(node.left) &&
+			containsMathRandom(node.right)
+		) {
+			tainted.add(node.left.text);
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(sf);
+	return tainted;
+}


### PR DESCRIPTION
Closes #316.

## Why

`tests/integration/mcp-proxy-mock.test.ts` picked its mock server port from the range `[9876, 10875]` using `Math.random()`. That range includes port **10080 (Sun RPC)** which is on undici's restricted-ports list — when the random draw landed on 10080, every `fetch()` in the file rejected with `Error: bad port` before any network I/O.

Per-run probability ~0.7%. Observed on PR #313 CI run [24705728123](https://github.com/camunda/c8ctl/actions/runs/24705728123) (Node 24 Integration). Per [AGENTS.md → "There are no flaky tests"](../blob/main/AGENTS.md), this is a category-1 test defect: the test was relying on luck.

## Fix

Bind to port 0 and read the kernel-assigned port back from `server.address()` — the kernel never returns a bad port and never collides. Mirrors the pattern already in `tests/integration/watch-cancellation.test.ts`.

- New `bindMockServer()` helper inside the suite — each test creates its server with its handler, then `await bindMockServer()` does the bind-to-0 + address-readback.
- The "connection refused" test was using a hardcoded `unreachablePort = 9999` (same defect class, lower probability). Now it binds a probe server to port 0, captures the port, then immediately closes it — guaranteeing the port was both valid (kernel handed it out) and almost certainly free.

## Class-of-defect regression guard

Added `tests/unit/no-hardcoded-listen-ports.test.ts` — an AST-based scan over `tests/integration/**.ts` (modelled on `tests/unit/no-process-exit-in-handlers.test.ts`) that fails the build if any `.listen(<numeric-literal-other-than-0>, …)` or `.listen(<Math.random()-derived-value>, …)` call appears.

The guard was written **first** and verified to fail against the unmodified `mcp-proxy-mock.test.ts` (flagged 8 violations). It now passes after the refactor — proving both that it can detect the defect class AND that the fix removed every instance.

## Verification

- Guard test (red → green): ✔ — failed with 8 violations before the fix, passes now.
- `mcp-proxy-mock.test.ts` — all 9 tests pass locally.
- Full unit suite — 1236/1236 pass.
- `npm run typecheck` — clean.
- `npx biome check` — clean.

## Scope

Test-only change. No production code touched.