### PR TITLE
fix(ci): re-enable --experimental-test-isolation=none for integration tests (closes #312)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,7 +160,7 @@ Never skip the lint and type-check steps before pushing.
 
 This is **not** a performance choice — it is a correctness choice. Do not remove the flag from `test:integration` without reading [#312](https://github.com/camunda/c8ctl/issues/312) and [#182](https://github.com/camunda/c8ctl/issues/182) first.
 
-Background: per-file isolation spawns one subprocess per test file and structure-clones results back to the parent. This trips [nodejs/node#56802](https://github.com/nodejs/node/issues/56802) intermittently, surfacing as `Error: Unable to deserialize cloned data due to invalid or unsupported version.` The defect is in the IPC channel itself, so reducing parallelism (`--concurrency=1`, serialising files) does not fix it — only removing the IPC channel does.
+Background: per-file isolation spawns one subprocess per test file and structure-clones results back to the parent. This trips [nodejs/node#56802](https://github.com/nodejs/node/issues/56802) intermittently, surfacing as `Error: Unable to deserialize cloned data due to invalid or unsupported version.` The defect is in the IPC channel itself, so reducing parallelism (`--test-concurrency=1`, serialising files) does not fix it — only removing the IPC channel does.
 
 The flag was originally added in [#189](https://github.com/camunda/c8ctl/pull/189), removed in `2bae796` (PR #282) on the assumption that Node 24.12.0 had fixed the underlying bug, and reinstated for the integration suite after the failure recurred. The Node bug is still open — verify with the upstream issue before removing the flag again.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,18 @@ Never skip the lint and type-check steps before pushing.
 - `npm run test:unit` — fast unit tests (no live Camunda required)
 - `.githooks/pre-commit` — on commit, runs biome on staged files and typechecks a temporary tsconfig scoped to the staged set (transitive imports are still resolved). Skips biome or tsc individually if not installed locally.
 
+#### Test process isolation — `--experimental-test-isolation=none` for integration tests
+
+`tests/unit/*.test.ts` runs with the default per-file process isolation of `node:test`. `tests/integration/*.test.ts` runs with `--experimental-test-isolation=none` (single process for all integration files).
+
+This is **not** a performance choice — it is a correctness choice. Do not remove the flag from `test:integration` without reading [#312](https://github.com/camunda/c8ctl/issues/312) and [#182](https://github.com/camunda/c8ctl/issues/182) first.
+
+Background: per-file isolation spawns one subprocess per test file and structure-clones results back to the parent. This trips [nodejs/node#56802](https://github.com/nodejs/node/issues/56802) intermittently, surfacing as `Error: Unable to deserialize cloned data due to invalid or unsupported version.` The defect is in the IPC channel itself, so reducing parallelism (`--concurrency=1`, serialising files) does not fix it — only removing the IPC channel does.
+
+The flag was originally added in [#189](https://github.com/camunda/c8ctl/pull/189), removed in `2bae796` (PR #282) on the assumption that Node 24.12.0 had fixed the underlying bug, and reinstated for the integration suite after the failure recurred. The Node bug is still open — verify with the upstream issue before removing the flag again.
+
+The flag is **not** applied to `test:unit` because the unit suite has 66 files and isolation gives a 22s vs 10m+ wall-clock win. The IPC bug fires there too in principle, but the unit suite has been observed to be stable in practice and the perf delta is too large to give up. If `test:unit` ever starts hitting the same error, apply the same flag to it as well.
+
 ### Implementation details
 
 - always make sure that CLI commands, resources and options are reflected in

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
     "copy-plugins": "node -e \"const fs=require('fs');const path=require('path');const src='default-plugins';const dest='dist/default-plugins';if(fs.existsSync(src)){fs.cpSync(src,dest,{recursive:true})}\"",
     "copy-templates": "node -e \"const fs=require('fs');const src='src/templates';const dest='dist/templates';if(fs.existsSync(src)){fs.cpSync(src,dest,{recursive:true})}\"",
     "prepublishOnly": "npm run build",
-    "test": "node --experimental-strip-types --test tests/unit/*.test.ts tests/integration/*.test.ts",
+    "test": "npm run test:unit && npm run test:integration",
     "test:unit": "node --experimental-strip-types --test tests/unit/*.test.ts",
-    "test:integration": "node --experimental-strip-types --test tests/integration/*.test.ts",
+    "test:integration": "node --experimental-strip-types --experimental-test-isolation=none --test tests/integration/*.test.ts",
     "dev": "node src/index.ts",
     "cli": "node src/index.ts"
   },


### PR DESCRIPTION
Closes #312.

## Why

The integration suite intermittently fails CI with:

```
Error: Unable to deserialize cloned data due to invalid or unsupported version.
```

Root cause is [nodejs/node#56802](https://github.com/nodejs/node/issues/56802) — `node:test` runs each `*.test.ts` file in its own subprocess and structure-clones the result back to the parent runner. Occasionally the parent rejects the buffer header it receives and the test result is lost. **The defect lives in the IPC channel itself**, so reducing parallelism (`--concurrency=1`, serialising files) does NOT fix it — only removing the IPC channel does.

## History

| When | What | Why |
|---|---|---|
| Sep 2025 | PR #189 / `e1f479e` | Added `--experimental-test-isolation=none` | Fix #182 (same defect) |
| Apr 2026 | PR #282 / `2bae796` | **Removed** the flag | Assumed Node 24.12.0 fixed the bug + wanted the 22s vs 10m+ unit-suite perf win |
| Apr 2026 | #312 filed | Same failure recurred | Assumption was wrong — upstream bug is still open |
| Today | PR #326 CI | Hit the same failure on `tests/integration/run.test.ts` | Triggered this PR |

## Fix

Re-apply `--experimental-test-isolation=none` to `test:integration` **only**:

```diff
-    "test": "node --experimental-strip-types --test tests/unit/*.test.ts tests/integration/*.test.ts",
+    "test": "npm run test:unit && npm run test:integration",
     "test:unit": "node --experimental-strip-types --test tests/unit/*.test.ts",
-    "test:integration": "node --experimental-strip-types --test tests/integration/*.test.ts",
+    "test:integration": "node --experimental-strip-types --experimental-test-isolation=none --test tests/integration/*.test.ts",
```

Asymmetric on purpose:

- **`test:unit` (66 files)** keeps default per-file isolation — the perf delta (22s vs 10m+) is too large to give up while the suite has been stable in practice.
- **`test:integration` (21 files)** uses isolation=none — wall-clock is dominated by Camunda-server I/O, not the IPC channel, so removing the IPC channel costs nothing measurable but eliminates exposure to the upstream Node bug entirely.

Also splits the combined `test` script into `test:unit && test:integration` so each gets the right flag.

## Why not serialise tests in CI?

- **Doesn't address the root cause.** The IPC defect fires per-channel, not per-parallelism. `--concurrency=1` would still spawn one subprocess per file and structure-clone results back. The defect window stays open.
- **Wall-clock is already hostile.** Integration suite is ~3 minutes per matrix cell parallel; serialised it would balloon × 4 matrix cells, for no correctness gain.
- **`--experimental-test-isolation=none` is strictly stronger** — zero subprocesses → zero IPC → zero exposure to the bug.

## Documentation

[AGENTS.md](../blob/fix/integration-test-isolation-none/AGENTS.md) gets a new "Test process isolation" section under "Build pipeline" → "Local checks" that explains:

- Why the flag is on integration but not unit
- That this is a correctness choice, not a performance choice
- The full history (#182 → #189 → #282 → #312)
- A directive to verify nodejs/node#56802 is actually closed before reverting again
- Guidance to apply the same flag to `test:unit` if it ever starts hitting the same error

This aims to prevent the next reviewer from re-reverting it without checking the upstream Node bug status.

## Verification

- `npm run test:unit` — 1235/1235 pass locally.
- Integration suite needs CI to verify (no local Camunda) — will see in this PR's checks.

## Scope

CI/build config + docs. No production code or test code touched.