### PR TITLE
test(run): add pre-#288 structural class-of-defect guard for run.ts (redo)

### DIFF
--- a/tests/unit/run-error-paths.test.ts
+++ b/tests/unit/run-error-paths.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Class-of-defect regression guard for `c8 run` error paths.
+ *
+ * This file is the green/green prep work for issue #288: before the
+ * refactor that inlines `run()`'s body into the `defineCommand`
+ * handler, lock in the structural invariant the refactor must
+ * preserve.
+ *
+ * Existing prep coverage (already on main):
+ *
+ *   - `tests/unit/round-1-error-paths.test.ts` covers the
+ *     "BPMN file with no <process id>" path and asserts the
+ *     "Failed to run process" framework prefix appears (proving the
+ *     throw replaced what used to be `process.exit(1)`).
+ *   - `tests/unit/form-topology-run-behaviour.test.ts` covers the
+ *     dry-run JSON shape (POST, both endpoints, path/variables in
+ *     body), missing-path usage error, unsupported-extension
+ *     rejection, and `--force` bypass.
+ *
+ * Gap this file fills:
+ *
+ *   STRUCTURAL guard — AST scan over `src/commands/run.ts` for
+ *   zero `process.exit(...)` calls. Mirrors the structural part of
+ *   `tests/unit/deploy-error-paths.test.ts`. Any future regression
+ *   that adds a `process.exit(...)` call into `run.ts` fails here
+ *   immediately, without needing to construct a CLI scenario for
+ *   the new code path. AST-based (not regex) so string literals
+ *   containing `process.exit(` and stripped-comment edge cases
+ *   cannot produce false positives or false negatives.
+ *
+ * Note on `--variables` invalid-JSON path: a behavioural guard for
+ * this path was attempted but cannot be unit-tested against the
+ * current shape of `run.ts` — the legacy code parses `--variables`
+ * AFTER the deploy network call, so the bad-JSON path is unreachable
+ * without a live Camunda server. The `--dry-run` early-return at
+ * the top of `run()` also bypasses variable parsing. This is itself
+ * a class of defect #288's refactor should address (validate up
+ * front, before any I/O); pinning a behavioural guard for that path
+ * belongs in the post-refactor PR alongside the move that makes it
+ * reachable.
+ */
+
+import assert from "node:assert";
+import { join, resolve } from "node:path";
+import { describe, test } from "node:test";
+import { findProcessExitCalls } from "../utils/no-process-exit.ts";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
+const RUN_TS = join(PROJECT_ROOT, "src", "commands", "run.ts");
+
+describe("run: structural guard — no process.exit in run.ts", () => {
+	test("src/commands/run.ts contains no `process.exit(...)` calls", () => {
+		const calls = findProcessExitCalls(RUN_TS);
+		assert.strictEqual(
+			calls.length,
+			0,
+			`Expected zero \`process.exit(...)\` calls in run.ts, found ${calls.length}:\n` +
+				calls
+					.map((c) => `  - line ${c.line}:${c.column} — ${c.text}`)
+					.join("\n") +
+				`\n\nEvery error path must throw so the framework's handleCommandError pipeline owns process termination.`,
+		);
+	});
+});


### PR DESCRIPTION
## Why

Green/green prep for #288 ("Normalise command handler architecture"). Per AGENTS.md *Coverage analysis before a behaviour-preserving refactor*, the guard for the `run` command must land on a separate PR off `main` and pass against the **pre-refactor** code, so there is a recorded moment at which it guarded the old shape.

## History

PR #313 was meant to deliver this plus a behavioural file, but its merge only carried a +11/-2 update to `form-topology-run-behaviour.test.ts` — the dedicated files described in its body never landed (branch was significantly behind main; merge resolution dropped them). This PR redoes the missing part not covered elsewhere.

## What's in this PR

- \`tests/unit/run-error-paths.test.ts\` — AST-based structural guard asserting zero \`process.exit(...)\` calls in \`src/commands/run.ts\`. Mirrors the structural part of \`deploy-error-paths.test.ts\`. Catches the class of defect, not just one instance.

## Already covered on main, not duplicated here

- Unextractable process ID → 'Failed to run process' framework prefix → \`round-1-error-paths.test.ts\`
- Dry-run JSON shape, missing-path usage, unsupported-extension rejection, \`--force\` bypass → \`form-topology-run-behaviour.test.ts\`

## NOT covered, intentionally deferred

A behavioural guard for \`--variables <bad-json>\` was attempted but is unreachable in the legacy code without a live Camunda server: \`run.ts\` parses \`--variables\` AFTER the deploy network call, and \`--dry-run\` early-returns at the top of \`run()\`. That's itself a class of defect #288's refactor should fix (validate up-front before any I/O); the behavioural guard for that path belongs in the post-refactor PR alongside the move that makes it reachable.

## Verification

- Structural guard: green against pre-refactor \`run.ts\`.
- \`npm run test:unit\`: 1237/1237 pass.
- \`npm run typecheck\`: clean.
- \`npx biome check\`: clean.

## Follow-up

After this lands, the actual #288 \`run\` migration PR will inline \`run()\`'s body into the \`defineCommand\` handler, with the structural guard in this PR providing the regression net.

Refs: #288. Supersedes the missed prep portion of #313.