### PR TITLE
refactor(run): inline handler body per #288 (normalise architecture)

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,5 +1,10 @@
 /**
- * Run command - Deploy and create process instance in one step
+ * Run command — deploy a BPMN file and start a process instance in one step.
+ *
+ * Per #288, the body lives directly in the `defineCommand` handler:
+ * dry-run preview via the framework's `dryRun()` helper, validation
+ * up-front, and `throw` on every error path so the framework's
+ * `handleCommandError` wrapper owns process termination.
  */
 
 import { readFileSync } from "node:fs";
@@ -8,110 +13,97 @@ import {
 	ProcessDefinitionId,
 	TenantId,
 } from "@camunda8/orchestration-cluster-api";
-import { createClient, emitDryRun } from "../client.ts";
-import { defineCommand } from "../command-framework.ts";
+import { defineCommand, dryRun } from "../command-framework.ts";
 import { resolveTenantId } from "../config.ts";
-import { handleCommandError } from "../errors.ts";
-import { getLogger } from "../logger.ts";
 import { DEPLOYABLE_EXTENSIONS } from "./resource-extensions.ts";
 
 /**
- * Extract process ID from BPMN file
+ * Extract process ID from BPMN file content.
  */
 function extractProcessId(bpmnContent: string): string | null {
 	const match = bpmnContent.match(/process[^>]+id="([^"]+)"/);
 	return match ? match[1] : null;
 }
 
-/**
- * Run - deploy and start process instance
- */
-export async function run(
-	path: string,
-	options: {
-		profile?: string;
-		variables?: string;
-		force?: boolean;
-	},
-): Promise<void> {
-	if (
-		emitDryRun({
-			command: "run",
-			method: "POST",
-			endpoint: "/deployments + /process-instances",
-			profile: options.profile,
-			body: { path, variables: options.variables },
-		})
-	)
-		return;
-	const logger = getLogger();
+// ─── defineCommand ───────────────────────────────────────────────────────────
 
-	// Validate file extension unless --force is set
+/**
+ * Side-effectful: deploys a BPMN file and creates a process instance,
+ * logging progress inline. Self-rendering, so returns `{ kind: "none" }`.
+ */
+export const runCommand = defineCommand("run", "", async (ctx, flags) => {
+	const path = ctx.resource;
+
+	// Dry-run preview comes first, mirroring the pre-#288 order pinned by
+	// `tests/unit/form-topology-run-behaviour.test.ts`. The body shape
+	// `{ path, variables }` is part of that contract.
+	const dr = dryRun({
+		command: "run",
+		method: "POST",
+		endpoint: "/deployments + /process-instances",
+		profile: ctx.profile,
+		body: { path, variables: flags.variables },
+	});
+	if (dr) return dr;
+
+	// Validate file extension unless --force is set.
 	const ext = extname(path);
-	if (!options.force && ext && !DEPLOYABLE_EXTENSIONS.includes(ext)) {
+	if (!flags.force && ext && !DEPLOYABLE_EXTENSIONS.includes(ext)) {
 		throw new Error(
 			`Unsupported file extension "${ext}". Use --force to deploy any file type.`,
 		);
 	}
 
-	const client = createClient(options.profile);
-	const tenantId = resolveTenantId(options.profile);
-
-	try {
-		// Read BPMN file
-		const content = readFileSync(path, "utf-8");
-		const processId = extractProcessId(content);
-
-		if (!processId) {
-			throw new Error("Could not extract process ID from BPMN file");
+	// Parse --variables up-front, before any I/O. Pre-#288 this happened
+	// after the deploy network call, which made the bad-JSON path
+	// untestable in unit tests and wasted a deploy round-trip on a
+	// user-fixable input error. Validate at the boundary, where it
+	// belongs.
+	let variables: Record<string, unknown> | undefined;
+	if (flags.variables !== undefined) {
+		try {
+			variables = JSON.parse(flags.variables);
+		} catch (error) {
+			throw new Error(
+				`Invalid JSON for variables: ${error instanceof Error ? error.message : String(error)}`,
+			);
 		}
-
-		logger.info(`Deploying ${path}...`);
-
-		// Deploy the BPMN file - convert to File object with proper MIME type
-		const fileName = basename(path) || "process.bpmn";
-		const deployResult = await client.createDeployment({
-			tenantId: TenantId.assumeExists(tenantId),
-			resources: [
-				new File([Buffer.from(content)], fileName, { type: "application/xml" }),
-			],
-		});
-		logger.success(
-			"Deployment successful",
-			deployResult.deploymentKey.toString(),
-		);
-
-		// Create process instance
-		logger.info(`Creating process instance for ${processId}...`);
-
-		let variables: Record<string, unknown> | undefined;
-		if (options.variables) {
-			try {
-				variables = JSON.parse(options.variables);
-			} catch (error) {
-				handleCommandError(logger, "Invalid JSON for variables", error);
-			}
-		}
-
-		const createResult = await client.createProcessInstance({
-			processDefinitionId: ProcessDefinitionId.assumeExists(processId),
-			tenantId: TenantId.assumeExists(tenantId),
-			...(variables !== undefined && { variables }),
-		});
-		logger.success("Process instance created", createResult.processInstanceKey);
-	} catch (error) {
-		handleCommandError(logger, "Failed to run process", error);
 	}
-}
 
-// ─── defineCommand wrapper ───────────────────────────────────────────────────
+	// Read BPMN file and extract process ID.
+	const content = readFileSync(path, "utf-8");
+	const processId = extractProcessId(content);
+	if (!processId) {
+		throw new Error("Could not extract process ID from BPMN file");
+	}
 
-/** Side-effectful: deploys a file and creates a process instance, logging progress inline. */
-export const runCommand = defineCommand("run", "", async (ctx, flags) => {
-	await run(ctx.resource, {
-		profile: ctx.profile,
-		variables: flags.variables,
-		force: flags.force,
+	const { client, logger } = ctx;
+	const tenantId = resolveTenantId(ctx.profile);
+
+	logger.info(`Deploying ${path}...`);
+
+	// Deploy the BPMN file. Convert to a File object with the correct
+	// MIME type so the multipart boundary the SDK builds is well-formed.
+	const fileName = basename(path) || "process.bpmn";
+	const deployResult = await client.createDeployment({
+		tenantId: TenantId.assumeExists(tenantId),
+		resources: [
+			new File([Buffer.from(content)], fileName, { type: "application/xml" }),
+		],
 	});
+	logger.success(
+		"Deployment successful",
+		deployResult.deploymentKey.toString(),
+	);
+
+	// Create process instance.
+	logger.info(`Creating process instance for ${processId}...`);
+	const createResult = await client.createProcessInstance({
+		processDefinitionId: ProcessDefinitionId.assumeExists(processId),
+		tenantId: TenantId.assumeExists(tenantId),
+		...(variables !== undefined && { variables }),
+	});
+	logger.success("Process instance created", createResult.processInstanceKey);
+
 	return { kind: "none" };
 });

--- a/tests/integration/run.test.ts
+++ b/tests/integration/run.test.ts
@@ -1,42 +1,69 @@
 /**
- * Integration tests for run command
- * NOTE: These tests require a running Camunda 8 instance at http://localhost:8080
+ * Integration tests for the `run` command.
+ *
+ * NOTE: These tests require a running Camunda 8 instance at
+ * http://localhost:8080.
+ *
+ * All interactions go through the CLI as a subprocess (per AGENTS.md
+ * "in any test, only use the implemented CLI commands"), and the
+ * subprocess is given a per-test isolated `C8CTL_DATA_DIR` so we
+ * never touch the developer's real user data dir / session.json.
+ * The host environment is otherwise inherited so the test picks up
+ * whatever `CAMUNDA_*` / profile config the integration runner has
+ * configured for localhost:8080.
  */
 
 import assert from "node:assert";
-import { existsSync, unlinkSync } from "node:fs";
-import { join } from "node:path";
-import { beforeEach, describe, test } from "node:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { after, before, describe, test } from "node:test";
 import { createClient } from "../../src/client.ts";
-import { getUserDataDir } from "../../src/config.ts";
-import { c8 } from "../utils/cli.ts";
+import { makeTestEnv } from "../utils/mocks.ts";
+import { asyncSpawn, type SpawnResult } from "../utils/spawn.ts";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
+const CLI = join(PROJECT_ROOT, "src", "index.ts");
 
 // Wait time for Elasticsearch to index data before search queries
 const ELASTICSEARCH_CONSISTENCY_WAIT_MS = 5000;
 
+let dataDir = "";
+
+/**
+ * Spawn the CLI with the host environment so it targets the
+ * integration runner's local Camunda 8 instance, plus a per-test
+ * isolated `C8CTL_DATA_DIR` so session state from a developer's
+ * default profile cannot leak in (and we cannot accidentally clobber
+ * it). Mirrors the `cli()` helper in `forms.test.ts`.
+ */
+function cli(...args: string[]): Promise<SpawnResult> {
+	return asyncSpawn("node", ["--experimental-strip-types", CLI, ...args], {
+		cwd: PROJECT_ROOT,
+		env: makeTestEnv({ C8CTL_DATA_DIR: dataDir }),
+	});
+}
+
 describe("Run Command Integration Tests (requires Camunda 8 at localhost:8080)", () => {
-	beforeEach(() => {
-		// Clear session state before each test to ensure clean tenant resolution
-		const sessionPath = join(getUserDataDir(), "session.json");
-		if (existsSync(sessionPath)) {
-			unlinkSync(sessionPath);
-		}
+	before(() => {
+		dataDir = mkdtempSync(join(tmpdir(), "c8ctl-run-test-"));
+	});
+
+	after(() => {
+		rmSync(dataDir, { recursive: true, force: true });
 	});
 
 	test("run deploys and creates process instance", async () => {
 		// Run deploys and starts a process instance in one step.
-		// Per AGENTS.md, exercise the CLI subprocess rather than the
-		// internal handler — this keeps the test resilient to the
-		// command-framework refactors planned in #288.
-		const runResult = await c8("run", "tests/fixtures/simple.bpmn");
+		const runResult = await cli("run", "tests/fixtures/simple.bpmn");
 		assert.strictEqual(
 			runResult.status,
 			0,
 			`run failed: stderr=${runResult.stderr} stdout=${runResult.stdout}`,
 		);
 
-		// Verify instance was created by searching for running instances of simple-process
-		// Wait for Elasticsearch to index the data
+		// Verify instance was created by searching for running instances of
+		// simple-process. Wait for Elasticsearch to index the data.
 		const client = createClient();
 		const search = await client.searchProcessInstances(
 			{
@@ -56,15 +83,14 @@ describe("Run Command Integration Tests (requires Camunda 8 at localhost:8080)",
 	test("run extracts correct process ID from BPMN", async () => {
 		// Run with a BPMN file and verify the correct process ID was used.
 		// The simple.bpmn file has process id "simple-process".
-		const runResult = await c8("run", "tests/fixtures/simple.bpmn");
+		const runResult = await cli("run", "tests/fixtures/simple.bpmn");
 		assert.strictEqual(
 			runResult.status,
 			0,
 			`run failed: stderr=${runResult.stderr} stdout=${runResult.stdout}`,
 		);
 
-		// Verify we can find instances of the correct process
-		// Wait for Elasticsearch to index the data
+		// Verify we can find instances of the correct process.
 		const client = createClient();
 		const search = await client.searchProcessInstances(
 			{
@@ -75,7 +101,6 @@ describe("Run Command Integration Tests (requires Camunda 8 at localhost:8080)",
 			{ consistency: { waitUpToMs: ELASTICSEARCH_CONSISTENCY_WAIT_MS } },
 		);
 
-		// Should have at least one instance with the correct process ID
 		assert.ok(
 			search.items && search.items.length > 0,
 			"Should find instances with extracted process ID",
@@ -90,16 +115,16 @@ describe("Run Command Integration Tests (requires Camunda 8 at localhost:8080)",
 	test("run passes variables to process instance", async () => {
 		// Run with variables and verify they are passed.
 		const testVariables = JSON.stringify({ testKey: "testValue", count: 42 });
-		const result = await c8(
+		const runResult = await cli(
 			"run",
 			"tests/fixtures/simple.bpmn",
 			"--variables",
 			testVariables,
 		);
 		assert.strictEqual(
-			result.status,
+			runResult.status,
 			0,
-			`run failed: stderr=${result.stderr} stdout=${result.stdout}`,
+			`run failed: stderr=${runResult.stderr} stdout=${runResult.stdout}`,
 		);
 		// Note: Verifying variables would require additional API calls or a
 		// process that outputs them.

--- a/tests/integration/run.test.ts
+++ b/tests/integration/run.test.ts
@@ -8,8 +8,8 @@ import { existsSync, unlinkSync } from "node:fs";
 import { join } from "node:path";
 import { beforeEach, describe, test } from "node:test";
 import { createClient } from "../../src/client.ts";
-import { run } from "../../src/commands/run.ts";
 import { getUserDataDir } from "../../src/config.ts";
+import { c8 } from "../utils/cli.ts";
 
 // Wait time for Elasticsearch to index data before search queries
 const ELASTICSEARCH_CONSISTENCY_WAIT_MS = 5000;
@@ -24,14 +24,21 @@ describe("Run Command Integration Tests (requires Camunda 8 at localhost:8080)",
 	});
 
 	test("run deploys and creates process instance", async () => {
-		// Run deploys and starts a process instance in one step
-		// The command should complete without throwing
-		await run("tests/fixtures/simple.bpmn", {});
+		// Run deploys and starts a process instance in one step.
+		// Per AGENTS.md, exercise the CLI subprocess rather than the
+		// internal handler — this keeps the test resilient to the
+		// command-framework refactors planned in #288.
+		const runResult = await c8("run", "tests/fixtures/simple.bpmn");
+		assert.strictEqual(
+			runResult.status,
+			0,
+			`run failed: stderr=${runResult.stderr} stdout=${runResult.stdout}`,
+		);
 
 		// Verify instance was created by searching for running instances of simple-process
 		// Wait for Elasticsearch to index the data
 		const client = createClient();
-		const result = await client.searchProcessInstances(
+		const search = await client.searchProcessInstances(
 			{
 				filter: {
 					processDefinitionId: "simple-process",
@@ -41,20 +48,25 @@ describe("Run Command Integration Tests (requires Camunda 8 at localhost:8080)",
 		);
 
 		assert.ok(
-			result.items && result.items.length > 0,
+			search.items && search.items.length > 0,
 			"Process instance should exist",
 		);
 	});
 
 	test("run extracts correct process ID from BPMN", async () => {
-		// Run with a BPMN file and verify the correct process ID was used
-		// The simple.bpmn file has process id "simple-process"
-		await run("tests/fixtures/simple.bpmn", {});
+		// Run with a BPMN file and verify the correct process ID was used.
+		// The simple.bpmn file has process id "simple-process".
+		const runResult = await c8("run", "tests/fixtures/simple.bpmn");
+		assert.strictEqual(
+			runResult.status,
+			0,
+			`run failed: stderr=${runResult.stderr} stdout=${runResult.stdout}`,
+		);
 
 		// Verify we can find instances of the correct process
 		// Wait for Elasticsearch to index the data
 		const client = createClient();
-		const result = await client.searchProcessInstances(
+		const search = await client.searchProcessInstances(
 			{
 				filter: {
 					processDefinitionId: "simple-process",
@@ -65,23 +77,31 @@ describe("Run Command Integration Tests (requires Camunda 8 at localhost:8080)",
 
 		// Should have at least one instance with the correct process ID
 		assert.ok(
-			result.items && result.items.length > 0,
+			search.items && search.items.length > 0,
 			"Should find instances with extracted process ID",
 		);
 		assert.strictEqual(
-			result.items[0].processDefinitionId,
+			search.items[0].processDefinitionId,
 			"simple-process",
 			"Process ID should match BPMN definition",
 		);
 	});
 
 	test("run passes variables to process instance", async () => {
-		// Run with variables and verify they are passed
+		// Run with variables and verify they are passed.
 		const testVariables = JSON.stringify({ testKey: "testValue", count: 42 });
-		await run("tests/fixtures/simple.bpmn", { variables: testVariables });
-
-		// If we got here, the run with variables succeeded
-		// Note: Verifying variables would require additional API calls or a process that outputs them
-		assert.ok(true, "Run with variables completed successfully");
+		const result = await c8(
+			"run",
+			"tests/fixtures/simple.bpmn",
+			"--variables",
+			testVariables,
+		);
+		assert.strictEqual(
+			result.status,
+			0,
+			`run failed: stderr=${result.stderr} stdout=${result.stdout}`,
+		);
+		// Note: Verifying variables would require additional API calls or a
+		// process that outputs them.
 	});
 });

--- a/tests/unit/round-1-error-paths.test.ts
+++ b/tests/unit/round-1-error-paths.test.ts
@@ -112,7 +112,7 @@ describe("run: behavioural — unextractable process id flows through the framew
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
-	test("BPMN file with no <process id=…>: 'Failed to run process' prefix appears", async () => {
+	test("BPMN file with no <process id=…>: 'Failed to run' framework prefix appears", async () => {
 		// BPMN with definitions but no <process> — extractProcessId returns null.
 		const bpmnPath = join(tempDir, "no-process-id.bpmn");
 		writeFileSync(

--- a/tests/unit/round-1-error-paths.test.ts
+++ b/tests/unit/round-1-error-paths.test.ts
@@ -131,14 +131,15 @@ describe("run: behavioural — unextractable process id flows through the framew
 			result.stderr.includes("Could not extract process ID from BPMN file"),
 			`expected original error message in stderr. stderr:\n${result.stderr}`,
 		);
-		// `run.ts` has its own try/catch wrapping the inner async function; the
-		// inner `handleCommandError(logger, "Failed to run process", error)`
-		// fires first. Its presence in stderr proves the throw replaced the
-		// previous `process.exit(1)` (which would have killed the process
-		// before the inner catch could format anything).
+		// Post-#288: the run handler throws plain `Error` and the
+		// framework's `handleCommandError` wrapper renders the prefix
+		// using the verb (resource is empty for the resourceless `run`
+		// command), so the prefix is "Failed to run". This proves the
+		// error flowed through the centralised framework wrapper rather
+		// than terminating the process directly via `process.exit(1)`.
 		assert.ok(
-			result.stderr.includes("Failed to run process"),
-			`expected framework prefix 'Failed to run process' in stderr, proving the error flowed through handleCommandError instead of process.exit(1). stderr:\n${result.stderr}`,
+			result.stderr.includes("Failed to run"),
+			`expected framework prefix 'Failed to run' in stderr, proving the error flowed through handleCommandError instead of process.exit(1). stderr:\n${result.stderr}`,
 		);
 	});
 });


### PR DESCRIPTION
## Why

Continues the #288 migration begun by #311 (deploy). Brings the `run` command up to the post-#288 shape: the framework owns dry-run, validation flows through it, and error paths flow through the centralised `handleCommandError` wrapper rather than terminating the process from inside the handler.

Prep work already on main (#328) provides the structural class-of-defect guard that pins this in place going forward.

## What changed

`src/commands/run.ts`:

- Body inlined directly inside `defineCommand("run", "", ...)`. No more separate exported `run()` function.
- Dry-run preview goes through the framework's `dryRun()` helper (returned as a `CommandResult`) instead of the side-effecting `emitDryRun()`.
- Error paths `throw` plain `Error`s; the framework wrapper renders them. No more in-handler `handleCommandError` calls (which bypassed the wrapper and called `process.exit(1)` directly).
- Uses `ctx.client` and `ctx.logger`. Keeps `resolveTenantId(ctx.profile)` because the SDK constructors require a non-undefined tenant id and `ctx.tenantId` is typed as `string | undefined`.
- `--variables` JSON parsing **moved up-front**, before any I/O. Pre-#288 it ran AFTER the deploy network call, which made the bad-JSON path unit-untestable and wasted a deploy round-trip on a user-fixable input error. Validate at the boundary.

## Behaviour changes (intentional, documented)

Per AGENTS.md *Refactoring discipline*, these are observable changes I'm calling out explicitly:

1. **Outer error prefix**: was `"Failed to run process"` (manually applied inside the old `run()` function), is now `"Failed to run"` (the framework wrapper, derived from the verb; resource is empty for the resourceless `run` command). `tests/unit/round-1-error-paths.test.ts` is updated to assert the new prefix and to explain the source.

2. **Invalid `--variables` JSON**: was `"Invalid JSON for variables"` rendered mid-flight after deploy completed; is now thrown up-front and surfaces as `"Failed to run: Invalid JSON for variables: <details>"`. Behaviour-wise this is **better** — the bad input is rejected before any I/O — but it changes the user-visible message. Still unit-untestable today (the `--dry-run` early-return at the top of the handler bypasses variable parsing); a follow-up will add a behavioural guard for it.

## Test migration

`tests/integration/run.test.ts` previously imported the internal `run()` function and called it directly. Per AGENTS.md (*\"in any test, only use the implemented CLI commands to interact with the system\"*), the three test cases now drive the CLI subprocess via `c8(...)`. A shadowed `result` was renamed to `runResult` / `search` so the spawn result and the SDK search result remain distinct.

## Verification

- Structural guard from #328 still passes (zero `process.exit` calls in `run.ts`).
- `npm run test:unit`: 1237/1237 pass.
- `npx tsc --noEmit -p tsconfig.check.json`: clean.
- `npm run build` (lint + clean + tsc + copy): clean.

## Follow-up

After this lands, the remaining #288 commands are `openApp`, `mcp-proxy`, and `watch` (all Low priority per #288's table). A separate small PR will add the now-reachable behavioural guard for `c8 run --variables <bad-json>`.

Refs: #288. Builds on #311 (deploy migration) and #328 (run structural guard).