### PR TITLE
test(run): add behavioural guard for --variables invalid JSON

### DIFF
--- a/tests/unit/run-error-paths.test.ts
+++ b/tests/unit/run-error-paths.test.ts
@@ -1,52 +1,57 @@
 /**
- * Class-of-defect regression guard for `c8 run` error paths.
+ * Class-of-defect regression guards for `c8 run` error paths.
  *
- * This file is the green/green prep work for issue #288: before the
- * refactor that inlines `run()`'s body into the `defineCommand`
- * handler, lock in the structural invariant the refactor must
- * preserve.
- *
- * Existing prep coverage (already on main):
+ * Existing coverage on main (don't duplicate here):
  *
  *   - `tests/unit/round-1-error-paths.test.ts` covers the
  *     "BPMN file with no <process id>" path and asserts the
- *     "Failed to run process" framework prefix appears (proving the
- *     throw replaced what used to be `process.exit(1)`).
+ *     "Failed to run" framework prefix appears (proving the throw
+ *     flowed through the framework wrapper rather than terminating
+ *     the process directly via `process.exit(1)`).
  *   - `tests/unit/form-topology-run-behaviour.test.ts` covers the
  *     dry-run JSON shape (POST, both endpoints, path/variables in
  *     body), missing-path usage error, unsupported-extension
  *     rejection, and `--force` bypass.
  *
- * Gap this file fills:
+ * Guards in this file:
  *
- *   STRUCTURAL guard — AST scan over `src/commands/run.ts` for
- *   zero `process.exit(...)` calls. Mirrors the structural part of
- *   `tests/unit/deploy-error-paths.test.ts`. Any future regression
- *   that adds a `process.exit(...)` call into `run.ts` fails here
- *   immediately, without needing to construct a CLI scenario for
- *   the new code path. AST-based (not regex) so string literals
- *   containing `process.exit(` and stripped-comment edge cases
- *   cannot produce false positives or false negatives.
+ *   1. STRUCTURAL — AST scan over `src/commands/run.ts` for zero
+ *      `process.exit(...)` calls. Mirrors the structural part of
+ *      `tests/unit/deploy-error-paths.test.ts`. Any future
+ *      regression that adds a `process.exit(...)` call into
+ *      `run.ts` fails here immediately. AST-based (not regex) so
+ *      string literals containing `process.exit(` and
+ *      stripped-comment edge cases cannot produce false positives
+ *      or false negatives.
  *
- * Note on `--variables` invalid-JSON path: a behavioural guard for
- * this path was attempted but cannot be unit-tested against the
- * current shape of `run.ts` — the legacy code parses `--variables`
- * AFTER the deploy network call, so the bad-JSON path is unreachable
- * without a live Camunda server. The `--dry-run` early-return at
- * the top of `run()` also bypasses variable parsing. This is itself
- * a class of defect #288's refactor should address (validate up
- * front, before any I/O); pinning a behavioural guard for that path
- * belongs in the post-refactor PR alongside the move that makes it
- * reachable.
+ *   2. BEHAVIOURAL — `c8 run <bpmn> --variables <bad-json>`. After
+ *      #329 inlined the handler body, `--variables` JSON parsing
+ *      runs up-front (before any I/O), which made this path
+ *      reachable in unit tests for the first time. Pinning the
+ *      observable contract — exit 1 + the "Invalid JSON for
+ *      variables" message in stderr — means a future change to the
+ *      validation order or wrapper text cannot silently regress the
+ *      user-fixable error case.
  */
 
 import assert from "node:assert";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { describe, test } from "node:test";
+import { afterEach, beforeEach, describe, test } from "node:test";
+import { c8 } from "../utils/cli.ts";
 import { findProcessExitCalls } from "../utils/no-process-exit.ts";
 
 const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
 const RUN_TS = join(PROJECT_ROOT, "src", "commands", "run.ts");
+
+const MINIMAL_BPMN = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="test-process" isExecutable="true">
+    <bpmn:startEvent id="start"/>
+  </bpmn:process>
+</bpmn:definitions>`;
 
 describe("run: structural guard — no process.exit in run.ts", () => {
 	test("src/commands/run.ts contains no `process.exit(...)` calls", () => {
@@ -59,6 +64,45 @@ describe("run: structural guard — no process.exit in run.ts", () => {
 					.map((c) => `  - line ${c.line}:${c.column} — ${c.text}`)
 					.join("\n") +
 				`\n\nEvery error path must throw so the framework's handleCommandError pipeline owns process termination.`,
+		);
+	});
+});
+
+describe("run: behavioural — invalid --variables JSON is rejected up-front", () => {
+	let tempDir: string;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "c8ctl-run-bad-variables-"));
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test("c8 run <bpmn> --variables <bad-json>: exit 1 + 'Invalid JSON for variables' in stderr", async () => {
+		// Use a real BPMN file so argument validation passes. The
+		// `--variables` value is intentionally malformed JSON. Post-#329
+		// the handler parses `--variables` BEFORE any network I/O, so
+		// this path is reachable from a unit test without a live Camunda
+		// server. The observable contract pinned here:
+		//   - exit code 1
+		//   - stderr contains "Invalid JSON for variables"
+		// (The framework prepends its own "Failed to run: " prefix; we
+		// don't assert on the prefix here because that's separately
+		// pinned by `round-1-error-paths.test.ts`.)
+		const bpmnPath = join(tempDir, "process.bpmn");
+		writeFileSync(bpmnPath, MINIMAL_BPMN);
+
+		const result = await c8("run", bpmnPath, "--variables", "{not-json");
+
+		assert.strictEqual(
+			result.status,
+			1,
+			`expected exit 1, got ${result.status}. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("Invalid JSON for variables"),
+			`expected 'Invalid JSON for variables' in stderr. stderr:\n${result.stderr}`,
 		);
 	});
 });


### PR DESCRIPTION
## Why

Follow-up to #329 (the `run` command #288 migration). #329 moved `--variables` JSON parsing up-front, before any I/O — that made the bad-JSON path reachable in unit tests for the first time. Prior to #329, the parsing happened after the deploy network call, so exercising it required a live Camunda server. The PR body of #329 noted this guard would land separately; this is that PR.

## What's in this PR

A new behavioural test in [tests/unit/run-error-paths.test.ts](tests/unit/run-error-paths.test.ts) pinning the observable contract for the now-reachable path:

```
c8 run <bpmn> --variables {not-json
  → exit code 1
  → stderr contains 'Invalid JSON for variables'
```

The structural AST guard already in the file (from #328) is unchanged; the file docstring is updated to drop the obsolete "can't be unit-tested today" note and to document both guards.

## Why this guards a class of defect, not just an instance

Three independent ways this contract could regress in future:

1. The order of validation in the handler could be moved back to "after I/O" (re-introducing the original wasted-round-trip defect).
2. The framework could swallow the inner error message and only render the wrapper prefix.
3. The exit code could drift away from 1.

The test fails for any of those, and any future ergonomic helper that accepts a `--variables`-shaped flag can use this as the reference assertion.

## Verification

- `npx tsx --test tests/unit/run-error-paths.test.ts`: 2/2 pass
- `npm run test:unit`: 1238/1238 pass (1237 prior + 1 new)
- biome: clean

Refs: #288, follows up #329.