### PR TITLE
test(mcp-proxy): add structural class-of-defect guard for mcp-proxy.ts (#288)

### DIFF
--- a/tests/unit/mcp-proxy-error-paths.test.ts
+++ b/tests/unit/mcp-proxy-error-paths.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Class-of-defect regression guard for `c8 mcp-proxy` error paths.
+ *
+ * Status of `mcp-proxy` for issue #288:
+ *
+ *   `src/commands/mcp-proxy.ts` is **already #288-compliant at the
+ *   file level**: the handler body lives directly inside
+ *   `defineCommand("mcp-proxy", "", ...)`, uses `ctx.profile` and
+ *   `ctx.resource`/`ctx.positionals` from the framework context,
+ *   returns `{ kind: "never" }` for the long-running case, and does
+ *   not call `process.exit(...)`.
+ *
+ *   The migration that #288 prescribes for `mcp-proxy` is therefore
+ *   the no-op shape it already has. This file pins that shape so it
+ *   cannot drift back.
+ *
+ * Intentional protocol-driven deviation from the standard #288 shape:
+ *
+ *   The `mcp-proxy` handler catches its own startup/shutdown errors
+ *   and sets `process.exitCode = 1` rather than `throw`-ing into the
+ *   framework's `handleCommandError` wrapper. This is REQUIRED by the
+ *   MCP STDIO protocol contract:
+ *
+ *     - MCP clients read framed JSON-RPC messages from the proxy's
+ *       stdout. Any non-protocol bytes on stdout corrupt the stream
+ *       and break the client.
+ *     - The framework's default error handler renders user-facing
+ *       hints to stdout via the active logger. For `mcp-proxy` that
+ *       would write into the protocol channel.
+ *     - The handler installs a stderr-only `Logger`, surfaces the
+ *       failure on stderr, and signals failure via `process.exitCode`
+ *       so the event loop drains naturally without re-entering the
+ *       framework's stdout-emitting error path.
+ *
+ *   The structural guard below uses the AST-based scanner that
+ *   intentionally does NOT flag `process.exitCode = N`
+ *   (see `tests/utils/no-process-exit.ts`'s file docstring), so this
+ *   protocol-driven idiom is permitted while still rejecting any
+ *   future regression that adds a real `process.exit(...)` call.
+ *
+ * Existing behavioural coverage on main (don't duplicate here):
+ *
+ *   - `tests/integration/mcp-proxy-mock.test.ts` covers the
+ *     `createCamundaFetch` request path against a mock server: auth
+ *     headers, 404 / 500 / connection-refused / timeout / slow-server
+ *     handling, the 401 + token-refresh retry, custom request
+ *     headers, and POST-with-body.
+ *   - `tests/unit/mcp-proxy.test.ts` covers `normalizeRemoteMcpUrl`.
+ *   - `tests/unit/mcp-proxy-auth.test.ts` covers the auth-header
+ *     attachment behaviour of `createCamundaFetch`.
+ *
+ * Guard in this file:
+ *
+ *   STRUCTURAL — AST scan over `src/commands/mcp-proxy.ts` for zero
+ *   `process.exit(...)` call expressions. Mirrors the structural part
+ *   of `tests/unit/deploy-error-paths.test.ts`,
+ *   `tests/unit/run-error-paths.test.ts`, and
+ *   `tests/unit/open-error-paths.test.ts`. AST-based (not regex) so
+ *   string literals containing `process.exit(` and stripped-comment
+ *   edge cases cannot produce false positives or false negatives.
+ *   `process.exitCode = N` is correctly distinguished and permitted.
+ */
+
+import assert from "node:assert";
+import { join, resolve } from "node:path";
+import { describe, test } from "node:test";
+import { findProcessExitCalls } from "../utils/no-process-exit.ts";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
+const MCP_PROXY_TS = join(PROJECT_ROOT, "src", "commands", "mcp-proxy.ts");
+
+describe("mcp-proxy: structural guard — no process.exit in mcp-proxy.ts", () => {
+	test("src/commands/mcp-proxy.ts contains no `process.exit(...)` calls", () => {
+		const calls = findProcessExitCalls(MCP_PROXY_TS);
+		assert.strictEqual(
+			calls.length,
+			0,
+			`Expected zero \`process.exit(...)\` calls in mcp-proxy.ts, found ${calls.length}:\n` +
+				calls
+					.map((c) => `  - line ${c.line}:${c.column} — ${c.text}`)
+					.join("\n") +
+				`\n\nThe MCP STDIO protocol forbids non-protocol bytes on stdout. Use\n` +
+				`\`process.exitCode = 1\` + a stderr log line so the event loop drains\n` +
+				`naturally, instead of re-entering the framework's stdout-emitting\n` +
+				`error path. \`process.exitCode = N\` is permitted by this guard.`,
+		);
+	});
+});


### PR DESCRIPTION
## Why

Continues the #288 migration. After `deploy` (#311), `run` (#329), and `open` (#331), `mcp-proxy` is the next command on #288's table.

## Investigation findings

`src/commands/mcp-proxy.ts` is **already #288-compliant at the file level**:

- Body lives directly inside `defineCommand(\"mcp-proxy\", \"\", ...)`
- Uses `ctx.profile` and `ctx.resource` / `ctx.positionals`
- Returns `{ kind: \"never\" }` for the long-running case
- Zero `process.exit(...)` calls

Existing behavioural coverage is strong:

- [tests/integration/mcp-proxy-mock.test.ts](tests/integration/mcp-proxy-mock.test.ts) — 9 cases covering `createCamundaFetch`: auth headers, 404/500/connection-refused/timeout/slow-server, the 401+token-refresh retry, custom request headers, POST-with-body
- [tests/unit/mcp-proxy.test.ts](tests/unit/mcp-proxy.test.ts) — `normalizeRemoteMcpUrl`
- [tests/unit/mcp-proxy-auth.test.ts](tests/unit/mcp-proxy-auth.test.ts) — auth-header attachment

The migration #288 prescribes for `mcp-proxy` is therefore the no-op shape it already has.

## Intentional protocol-driven deviation, documented

The handler catches its own startup/shutdown errors and sets `process.exitCode = 1` rather than `throw`-ing into the framework's `handleCommandError` wrapper. This is **required** by the MCP STDIO protocol contract:

- MCP clients read framed JSON-RPC messages from stdout. Any non-protocol bytes on stdout corrupt the stream.
- The framework's default error handler renders user-facing hints to stdout via the active logger — for `mcp-proxy` that would write into the protocol channel.
- The handler installs a stderr-only `Logger`, surfaces the failure on stderr, and signals failure via `process.exitCode` so the event loop drains naturally without re-entering the framework's stdout-emitting error path.

The AST scanner in [tests/utils/no-process-exit.ts](tests/utils/no-process-exit.ts) intentionally does NOT flag `process.exitCode = N` (see its file docstring) — this protocol-driven idiom is permitted while still rejecting any future regression that adds a real `process.exit(...)` call. The guard's failure message explains the protocol constraint and the permitted alternative.

## What's in this PR

A new structural guard at [tests/unit/mcp-proxy-error-paths.test.ts](tests/unit/mcp-proxy-error-paths.test.ts) — AST scan over `src/commands/mcp-proxy.ts` for zero `process.exit(...)` call expressions. Mirrors the structural part of the existing per-command guards.

## Verification

- `npx tsx --test tests/unit/mcp-proxy-error-paths.test.ts`: 1/1 pass
- `npm run test:unit`: 1240/1240 pass (1239 prior + 1 new)
- biome: clean

Refs: #288. Follows up #311 (deploy), #329 (run), #331 (open).