### PR TITLE
feat(lint): add Biome plugin forbidding process.exit under src/commands/** (#289)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -22,5 +22,11 @@
 			"vue": "none"
 		}
 	},
-	"plugins": ["./plugins/no-unsafe-type-assertion.grit"]
+	"plugins": ["./plugins/no-unsafe-type-assertion.grit"],
+	"overrides": [
+		{
+			"includes": ["src/commands/**/*.ts"],
+			"plugins": ["./plugins/no-process-exit-in-commands.grit"]
+		}
+	]
 }

--- a/plugins/no-process-exit-in-commands.grit
+++ b/plugins/no-process-exit-in-commands.grit
@@ -1,0 +1,27 @@
+engine biome(1.0)
+language js(typescript)
+
+// Forbids `process.exit(...)` calls under `src/commands/**`.
+// Enforcement target for issue #289 (follow-up to #288 — normalise
+// command handler architecture). All failure paths in command handlers
+// must throw typed errors; the framework's `handleCommandError`
+// pipeline owns process termination so:
+//
+//   - `--verbose` can rethrow to surface a stack trace,
+//   - failures format consistently (`Failed to <verb> <resource>: ...`),
+//   - `finally` blocks (test cleanup, logger flushes) run.
+//
+// The architectural CI guard at `tests/unit/no-process-exit-in-handlers.test.ts`
+// performs the same check via AST scan in CI; this Biome plugin adds
+// **editor-time** feedback so violations surface in the IDE before the
+// commit. `process.exit` remains legal in `src/index.ts` and
+// `src/errors.ts` — those files are outside the plugin's scope (Biome
+// `overrides.includes`).
+
+`process.exit($_)` as $exit where {
+    register_diagnostic(
+        span = $exit,
+        message = "Command handlers must not call `process.exit(...)` (#288 / #289). Throw a typed `Error` instead — the framework's `handleCommandError` pipeline will format and terminate. See AGENTS.md and `tests/unit/no-process-exit-in-handlers.test.ts`.",
+        severity = "error"
+    )
+}


### PR DESCRIPTION
Closes #289 (follow-up to #288).

## What

A new GritQL plugin at [plugins/no-process-exit-in-commands.grit](plugins/no-process-exit-in-commands.grit) that rejects any `process.exit($_)` call. Wired through [biome.json](biome.json)'s `overrides` block so it activates **only** under `src/commands/**/*.ts`.

## Why now

#288's command-handler migrations are complete. The existing CI-only AST guard at [tests/unit/no-process-exit-in-handlers.test.ts](tests/unit/no-process-exit-in-handlers.test.ts) (shipped in #306) catches regressions in CI. This plugin adds the missing **editor-time** feedback so violations surface in the IDE before commit.

## Scope discipline

| File set | Plugin active? |
|---|---|
| `src/commands/**` | ✅ yes — error on `process.exit` |
| `src/index.ts` | ❌ no — owns the legitimate top-level boundary |
| `src/errors.ts` | ❌ no — owns the framework error pipeline boundary |
| `src/templates/**` | ❌ excluded via existing `files` config |
| `tests/**` | ❌ not in scope |

## Note on issue option 1 vs 2

The issue listed two enforcement options:

1. Biome built-in `noProcessExit` rule
2. GritQL plugin

Biome 2.4 does not expose a `noProcessExit` rule (verified via `biome explain noProcessExit` → `Unrecognized option`), so option 2 was chosen. The plugin pattern mirrors the existing [plugins/no-unsafe-type-assertion.grit](plugins/no-unsafe-type-assertion.grit).

## Verification

- **Positive smoke test**: dropped a temporary `src/commands/_temp_violation.ts` with `process.exit(1)` → `npx biome check` reported 1 error pointing at the call expression.
- **Negative test**: `npx biome check src/index.ts src/errors.ts` clean (those files have legitimate `process.exit` calls and are outside the plugin's scope).
- `npx biome check`: clean across the whole repo (1 info diagnostic, no errors).
- `npm run test:unit`: 1241/1241 pass.

Refs: #288, #306.