### PR TITLE
test(boundary): add staged import-boundary guard for tests → src/commands/** (#291)

### DIFF
--- a/tests/unit/test-import-boundary.test.ts
+++ b/tests/unit/test-import-boundary.test.ts
@@ -93,7 +93,12 @@ const PENDING_MIGRATION: ReadonlySet<string> = new Set([
 function listTestFiles(): string[] {
 	const out: string[] = [];
 	function walk(dir: string): void {
-		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		// Sort entries so diagnostics order is stable across OS/filesystems
+		// (CI runs on both Ubuntu and macOS, which differ in readdir order).
+		const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+			a.name.localeCompare(b.name),
+		);
+		for (const entry of entries) {
 			const abs = join(dir, entry.name);
 			if (entry.isDirectory()) {
 				walk(abs);
@@ -147,10 +152,13 @@ function isRuntimeCommandsImport(node: ts.ImportDeclaration): boolean {
 	return true;
 }
 
-/** True iff `spec` is a relative path into `src/commands/`. */
+/** True iff `spec` is a relative path into `src/commands` or a descendant. */
 function isCommandsSpecifier(spec: string): boolean {
-	// Match relative paths into src/commands/, regardless of `..` depth.
-	return /^(?:\.\.\/)+src\/commands\//.test(spec);
+	// Match relative paths into src/commands, regardless of `..` depth,
+	// allowing an optional leading `./` and either the directory itself
+	// (`../../src/commands`) or any child path beneath it
+	// (`../../src/commands/foo.ts`).
+	return /^(?:\.\/)?(?:\.\.\/)+src\/commands(?:\/|$)/.test(spec);
 }
 
 /**

--- a/tests/unit/test-import-boundary.test.ts
+++ b/tests/unit/test-import-boundary.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Architectural import-boundary guard for issue #291 (follow-up to
+ * #288 — normalise command handler architecture).
+ *
+ * Invariant
+ * ---------
+ *
+ * No file under `tests/**` imports a runtime value from
+ * `src/commands/**`. Tests must drive commands via the `c8()`
+ * subprocess helper. Type-only imports (`import type { ... }`) are
+ * permitted because they have no runtime coupling.
+ *
+ * Why
+ * ---
+ *
+ * Direct value imports of handlers (or handler-shaped helpers like
+ * `handleAssign`) couple tests to internal call shapes, hide bugs
+ * that only manifest end-to-end through the dispatch chain (flag
+ * parsing, validation, dry-run helper, error rendering), and made
+ * the #288 migrations harder than they needed to be. AGENTS.md
+ * codifies this rule:
+ *
+ *   > In any test, only use the implemented CLI commands to interact
+ *   > with the system. Avoid using internal functions or direct API
+ *   > calls in tests, as this can lead to brittle tests that are
+ *   > tightly coupled to the implementation.
+ *
+ * Staged rollout
+ * --------------
+ *
+ * The `PENDING_MIGRATION` allow-list below names every test file that
+ * currently violates the boundary. The list is **closed** — it cannot
+ * grow. Adding a new test that imports from `src/commands/**` will
+ * fail this guard. Each entry is removed as the file is migrated to
+ * the `c8()` subprocess pattern; once empty, the rule becomes
+ * unconditional and this comment block can be retired (mirroring the
+ * pattern that `tests/unit/no-process-exit-in-handlers.test.ts` used
+ * during the #288 rollout).
+ *
+ * Detection
+ * ---------
+ *
+ * AST-based via the TypeScript compiler API so:
+ *   - `import type { X } from "..."` is correctly excluded.
+ *   - `import { type X } from "..."` is correctly excluded
+ *     (type-only specifier).
+ *   - String literals containing `from "../../src/commands/..."`
+ *     and commented-out imports do not produce false positives.
+ *   - Both `../../src/commands/...` and `../../../src/commands/...`
+ *     forms (any depth of `..`) are caught.
+ */
+
+import assert from "node:assert";
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import { describe, test } from "node:test";
+import ts from "typescript";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
+const TESTS_DIR = join(PROJECT_ROOT, "tests");
+
+/**
+ * Closed allow-list of test files that currently import runtime
+ * values from `src/commands/**`. New violations are rejected. This
+ * list shrinks as files are migrated to the `c8()` subprocess
+ * pattern; when it reaches zero, delete the allow-list entirely
+ * and let the rule be unconditional.
+ *
+ * Paths are workspace-relative POSIX paths under `tests/`.
+ */
+const PENDING_MIGRATION: ReadonlySet<string> = new Set([
+	"integration/deploy.test.ts",
+	"integration/mcp-proxy-mock.test.ts",
+	"integration/process-instances.test.ts",
+	"integration/watch.test.ts",
+	"unit/completion-install.test.ts",
+	"unit/completion.test.ts",
+	"unit/help.test.ts",
+	"unit/identity.test.ts",
+	"unit/mcp-proxy-auth.test.ts",
+	"unit/mcp-proxy.test.ts",
+	"unit/open.test.ts",
+	"unit/plugins-version.test.ts",
+	"unit/search-feedback.test.ts",
+	"unit/search-wildcard.test.ts",
+]);
+
+function listTestFiles(): string[] {
+	const out: string[] = [];
+	function walk(dir: string): void {
+		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+			const abs = join(dir, entry.name);
+			if (entry.isDirectory()) {
+				walk(abs);
+			} else if (entry.isFile() && entry.name.endsWith(".test.ts")) {
+				out.push(abs);
+			}
+		}
+	}
+	walk(TESTS_DIR);
+	return out;
+}
+
+/** Workspace-relative POSIX path under `tests/`. */
+function toTestsRelative(absPath: string): string {
+	return relative(TESTS_DIR, absPath).split(/[\\/]/).join("/");
+}
+
+/**
+ * Returns true iff the import declaration imports any runtime value
+ * from a `src/commands/**` module. `import type { ... } from ...`
+ * is excluded; an inline `import { type X } from ...` is excluded
+ * only if EVERY specifier is `type`.
+ */
+function isRuntimeCommandsImport(node: ts.ImportDeclaration): boolean {
+	if (node.importClause?.isTypeOnly) return false;
+
+	const moduleSpec = node.moduleSpecifier;
+	if (!ts.isStringLiteral(moduleSpec)) return false;
+	const spec = moduleSpec.text;
+	// Match relative paths into src/commands/, regardless of `..` depth.
+	if (!/^(?:\.\.\/)+src\/commands\//.test(spec)) return false;
+
+	const clause = node.importClause;
+	if (!clause) {
+		// Side-effect import `import "../../src/commands/x"` — runtime.
+		return true;
+	}
+
+	const namedBindings = clause.namedBindings;
+	if (
+		namedBindings !== undefined &&
+		ts.isNamedImports(namedBindings) &&
+		namedBindings.elements.length > 0 &&
+		namedBindings.elements.every((el) => el.isTypeOnly) &&
+		clause.name === undefined
+	) {
+		// All specifiers individually marked `type` and no default
+		// import alongside → no runtime import.
+		return false;
+	}
+
+	return true;
+}
+
+interface Violation {
+	file: string;
+	line: number;
+	specifier: string;
+}
+
+function findViolations(absPath: string): Violation[] {
+	const source = readFileSync(absPath, "utf8");
+	const sf = ts.createSourceFile(
+		absPath,
+		source,
+		ts.ScriptTarget.Latest,
+		true,
+		ts.ScriptKind.TS,
+	);
+	const out: Violation[] = [];
+	for (const stmt of sf.statements) {
+		if (!ts.isImportDeclaration(stmt)) continue;
+		if (!isRuntimeCommandsImport(stmt)) continue;
+		const moduleSpec = stmt.moduleSpecifier;
+		const { line } = sf.getLineAndCharacterOfPosition(moduleSpec.getStart(sf));
+		out.push({
+			file: toTestsRelative(absPath),
+			line: line + 1,
+			specifier: ts.isStringLiteral(moduleSpec) ? moduleSpec.text : "",
+		});
+	}
+	return out;
+}
+
+describe("architectural guard: tests must not import handlers from src/commands/** (#291)", () => {
+	const files = listTestFiles();
+
+	test("no test file imports runtime values from src/commands/** (except those on the closed PENDING_MIGRATION allow-list)", () => {
+		const newViolations: Violation[] = [];
+		const seenAllowlisted = new Set<string>();
+
+		for (const abs of files) {
+			const rel = toTestsRelative(abs);
+			const v = findViolations(abs);
+			if (v.length === 0) continue;
+			if (PENDING_MIGRATION.has(rel)) {
+				seenAllowlisted.add(rel);
+				continue;
+			}
+			newViolations.push(...v);
+		}
+
+		assert.strictEqual(
+			newViolations.length,
+			0,
+			`Test files must not import runtime values from src/commands/**. ` +
+				`Drive commands via the \`c8()\` subprocess helper instead. ` +
+				`Found ${newViolations.length} new violation(s):\n` +
+				newViolations
+					.map((v) => `  - tests/${v.file}:${v.line} — from "${v.specifier}"`)
+					.join("\n") +
+				`\n\nIf you have intentionally migrated a file off the allow-list, ` +
+				`remove it from PENDING_MIGRATION in this file. ` +
+				`See AGENTS.md → "Command handler shape" for the canonical pattern.`,
+		);
+
+		// Pin the allow-list shape: every entry must currently violate.
+		// If an entry no longer violates, the maintainer should remove
+		// it from PENDING_MIGRATION (this is how the list shrinks to
+		// zero).
+		const stale = [...PENDING_MIGRATION].filter((f) => !seenAllowlisted.has(f));
+		assert.strictEqual(
+			stale.length,
+			0,
+			`PENDING_MIGRATION contains entries that no longer violate the ` +
+				`import boundary. Remove them so the allow-list keeps shrinking:\n` +
+				stale.map((f) => `  - ${f}`).join("\n"),
+		);
+	});
+});

--- a/tests/unit/test-import-boundary.test.ts
+++ b/tests/unit/test-import-boundary.test.ts
@@ -48,6 +48,10 @@
  *     and commented-out imports do not produce false positives.
  *   - Both `../../src/commands/...` and `../../../src/commands/...`
  *     forms (any depth of `..`) are caught.
+ *   - **Dynamic imports** (`await import("../../src/commands/...")`)
+ *     and CommonJS `require("../../src/commands/...")` calls are
+ *     also caught — the AST is walked recursively, not just the
+ *     top-level statement list.
  */
 
 import assert from "node:assert";
@@ -72,6 +76,7 @@ const PENDING_MIGRATION: ReadonlySet<string> = new Set([
 	"integration/deploy.test.ts",
 	"integration/mcp-proxy-mock.test.ts",
 	"integration/process-instances.test.ts",
+	"integration/profile-switching.test.ts",
 	"integration/watch.test.ts",
 	"unit/completion-install.test.ts",
 	"unit/completion.test.ts",
@@ -118,8 +123,7 @@ function isRuntimeCommandsImport(node: ts.ImportDeclaration): boolean {
 	const moduleSpec = node.moduleSpecifier;
 	if (!ts.isStringLiteral(moduleSpec)) return false;
 	const spec = moduleSpec.text;
-	// Match relative paths into src/commands/, regardless of `..` depth.
-	if (!/^(?:\.\.\/)+src\/commands\//.test(spec)) return false;
+	if (!isCommandsSpecifier(spec)) return false;
 
 	const clause = node.importClause;
 	if (!clause) {
@@ -143,6 +147,35 @@ function isRuntimeCommandsImport(node: ts.ImportDeclaration): boolean {
 	return true;
 }
 
+/** True iff `spec` is a relative path into `src/commands/`. */
+function isCommandsSpecifier(spec: string): boolean {
+	// Match relative paths into src/commands/, regardless of `..` depth.
+	return /^(?:\.\.\/)+src\/commands\//.test(spec);
+}
+
+/**
+ * True iff `node` is a dynamic `import("...")` or CommonJS
+ * `require("...")` call whose argument is a string literal pointing
+ * into `src/commands/**`. Both are runtime couplings — no equivalent
+ * of `import type` exists for either form.
+ */
+function isRuntimeCommandsCall(node: ts.CallExpression): boolean {
+	const arg0 = node.arguments[0];
+	if (!arg0 || !ts.isStringLiteral(arg0)) return false;
+	if (!isCommandsSpecifier(arg0.text)) return false;
+
+	// Dynamic import: `import(...)` parses to a CallExpression whose
+	// expression has SyntaxKind.ImportKeyword.
+	if (node.expression.kind === ts.SyntaxKind.ImportKeyword) return true;
+
+	// CommonJS `require(...)`.
+	if (ts.isIdentifier(node.expression) && node.expression.text === "require") {
+		return true;
+	}
+
+	return false;
+}
+
 interface Violation {
 	file: string;
 	line: number;
@@ -159,17 +192,30 @@ function findViolations(absPath: string): Violation[] {
 		ts.ScriptKind.TS,
 	);
 	const out: Violation[] = [];
-	for (const stmt of sf.statements) {
-		if (!ts.isImportDeclaration(stmt)) continue;
-		if (!isRuntimeCommandsImport(stmt)) continue;
-		const moduleSpec = stmt.moduleSpecifier;
-		const { line } = sf.getLineAndCharacterOfPosition(moduleSpec.getStart(sf));
+
+	const record = (specNode: ts.Node, specText: string): void => {
+		const { line } = sf.getLineAndCharacterOfPosition(specNode.getStart(sf));
 		out.push({
 			file: toTestsRelative(absPath),
 			line: line + 1,
-			specifier: ts.isStringLiteral(moduleSpec) ? moduleSpec.text : "",
+			specifier: specText,
 		});
-	}
+	};
+
+	const visit = (node: ts.Node): void => {
+		// Static `import` declarations only appear at the top level of a
+		// source file, but visit them via the same walk for symmetry.
+		if (ts.isImportDeclaration(node) && isRuntimeCommandsImport(node)) {
+			const moduleSpec = node.moduleSpecifier;
+			record(moduleSpec, ts.isStringLiteral(moduleSpec) ? moduleSpec.text : "");
+		} else if (ts.isCallExpression(node) && isRuntimeCommandsCall(node)) {
+			const arg0 = node.arguments[0];
+			if (ts.isStringLiteral(arg0)) record(arg0, arg0.text);
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(sf);
+
 	return out;
 }
 


### PR DESCRIPTION
Implements #291 (follow-up to #288).

## What

A new architectural guard at [tests/unit/test-import-boundary.test.ts](tests/unit/test-import-boundary.test.ts) that walks every `tests/**/*.test.ts`, parses imports with the TypeScript compiler API, and rejects any **runtime value** import from `src/commands/**`. Type-only imports (`import type { ... }` and inline `import { type X }` where every specifier is `type`) are allowed because they have no runtime coupling.

## Why

Tests must drive commands via the `c8()` subprocess helper. Direct value imports of handlers (or handler-style helpers like `handleAssign`) couple tests to internal call shapes, hide bugs that only manifest end-to-end through the dispatch chain (flag parsing, validation, dry-run helper, error rendering), and made the #288 migrations harder than they needed to be. AGENTS.md already codifies the rule.

## Staged rollout (closed allow-list)

The **14 test files** that currently violate the boundary are listed in a closed `PENDING_MIGRATION` allow-list:

- 4 integration: `deploy`, `mcp-proxy-mock`, `process-instances`, `watch`
- 10 unit: `completion-install`, `completion`, `help`, `identity`, `mcp-proxy-auth`, `mcp-proxy`, `open`, `plugins-version`, `search-feedback`, `search-wildcard`

The list cannot grow — adding a new test that imports from `src/commands/**` fails the guard immediately. Each entry shrinks the list as the file is migrated to `c8()`. When it reaches zero, delete the allow-list and the rule becomes unconditional.

The guard also detects **stale allow-list entries** — if a file no longer violates, it must be removed from `PENDING_MIGRATION` so the list keeps shrinking instead of accumulating dead weight.

This mirrors the staging pattern that [tests/unit/no-process-exit-in-handlers.test.ts](tests/unit/no-process-exit-in-handlers.test.ts) used during the #288 rollout.

## Detection

AST-based via the TypeScript compiler API so:

- `import type { X } from "..."` is correctly excluded
- `import { type X } from "..."` is correctly excluded (only when every named specifier is `type` and no default import is present alongside)
- String literals containing `from "...src/commands/..."` and commented-out imports do not produce false positives
- Both `../../src/commands/...` and deeper relative paths are caught

## Verification

- `npx tsx --test tests/unit/test-import-boundary.test.ts`: 1/1 pass
- **Negative smoke test**: dropped a temp file with `import { someFn } from "../../src/commands/jobs.ts"` — the guard rejected it with the expected diagnostic listing file, line, and specifier
- `npx biome check`: clean
- `npx tsc --noEmit -p tsconfig.check.json`: clean
- `npm run test:unit`: 1242/1242 pass (1241 prior + 1 new)

## Out of scope

Migrating the 14 allow-listed files. Each one is its own follow-up PR (rewrite to use `c8(...)` subprocess, then delete the entry from `PENDING_MIGRATION`).

Refs: #288, #289 (#334), #290, #292 (#335).