### PR TITLE
feat: generate standalone Docusaurus command reference page

### DIFF
--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1,0 +1,1149 @@
+---
+id: command-reference
+title: "Command reference"
+sidebar_label: "Command reference"
+description: "Complete reference of all c8ctl CLI commands, flags, resources, and aliases — auto-generated from the command registry."
+---
+
+<!-- Auto-generated from COMMAND_REGISTRY. Do not edit manually.
+     Run: node --experimental-strip-types scripts/sync-readme-commands.ts --docs -->
+
+:::warning Alpha feature
+`c8ctl` is in alpha and is not intended for production use. Commands and flags may change without notice between releases. See [Getting started](getting-started.md) for details.
+:::
+
+## Global Flags
+
+These flags are accepted by every command.
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--help` / `-h` | boolean |  | Show help |
+| `--version` / `-v` | string |  | Show CLI version, or filter by process definition version on supported commands |
+| `--profile` | string |  | Use a specific profile |
+| `--dry-run` | boolean |  | Preview the API request without executing |
+| `--verbose` | boolean |  | Show verbose output |
+| `--fields` | string |  | Comma-separated list of fields to display |
+
+## Resource Aliases
+
+| Alias | Resource |
+|-------|----------|
+| `auth` | `authorization` |
+| `inc` | `incident` |
+| `mr` | `mapping-rule` |
+| `msg` | `message` |
+| `pd` | `process-definition` |
+| `pi` | `process-instance` |
+| `ut` | `user-task` |
+| `vars` | `variable` |
+| `var` | `variable` |
+
+## Search Flags
+
+These flags are available on `list` and `search` commands.
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--sortBy` | string |  | Sort results by field |
+| `--asc` | boolean |  | Sort ascending |
+| `--desc` | boolean |  | Sort descending |
+| `--limit` | string |  | Maximum number of results |
+| `--between` | string |  | Date range filter (e.g. 7d, 30d, 2024-01-01..2024-12-31) |
+| `--dateField` | string |  | Date field for --between filter |
+
+## Commands
+
+### `list`
+
+List resources
+
+**Resources:** pi (process-instance), pd (process-definition), ut (user-task), inc (incident), jobs, profiles (profile), plugins (plugin), users (user), roles (role), groups (group), tenants (tenant), auth (authorization), mapping-rules (mapping-rule)
+
+**Verb-level flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--all` | boolean |  | List all (disable pagination limit) |
+
+**Resource-specific flags:**
+
+<details>
+<summary><code>process-definition</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
+| `--id` | string |  | Filter by BPMN process ID (alias) |
+| `--processDefinitionId` | string |  | Filter by process definition ID |
+| `--name` | string |  | Filter by name |
+| `--key` | string |  | Filter by key |
+| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
+| `--iname` | string |  | Case-insensitive filter by name |
+
+</details>
+
+<details>
+<summary><code>process-instance</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
+| `--id` | string |  | Filter by BPMN process ID (alias) |
+| `--processDefinitionId` | string |  | Filter by process definition ID |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--state` | string |  | Filter by state (ACTIVE, COMPLETED, etc) |
+| `--key` | string |  | Filter by key |
+| `--parentProcessInstanceKey` | string |  | Filter by parent process instance key |
+| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
+
+</details>
+
+<details>
+<summary><code>user-task</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--state` | string |  | Filter by state |
+| `--assignee` | string |  | Filter by assignee |
+| `--processInstanceKey` | string |  | Filter by process instance key |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--elementId` | string |  | Filter by element ID |
+| `--iassignee` | string |  | Case-insensitive filter by assignee |
+
+</details>
+
+<details>
+<summary><code>incident</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--state` | string |  | Filter by state |
+| `--processInstanceKey` | string |  | Filter by process instance key |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
+| `--id` | string |  | Filter by BPMN process ID (alias) |
+| `--processDefinitionId` | string |  | Filter by process definition ID |
+| `--errorType` | string |  | Filter by error type |
+| `--errorMessage` | string |  | Filter by error message |
+| `--ierrorMessage` | string |  | Case-insensitive filter by error message |
+| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
+
+</details>
+
+<details>
+<summary><code>jobs</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--state` | string |  | Filter by state |
+| `--type` | string |  | Filter by job type |
+| `--processInstanceKey` | string |  | Filter by process instance key |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--itype` | string |  | Case-insensitive filter by job type |
+
+</details>
+
+<details>
+<summary><code>user</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--username` | string |  | Filter by username |
+| `--name` | string |  | Filter by name |
+| `--email` | string |  | Filter by email |
+
+</details>
+
+<details>
+<summary><code>role</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--roleId` | string |  | Filter by role ID |
+| `--name` | string |  | Filter by name |
+
+</details>
+
+<details>
+<summary><code>group</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--groupId` | string |  | Filter by group ID |
+| `--name` | string |  | Filter by name |
+
+</details>
+
+<details>
+<summary><code>tenant</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--tenantId` | string |  | Filter by tenant ID |
+| `--name` | string |  | Filter by name |
+
+</details>
+
+<details>
+<summary><code>authorization</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--ownerId` | string |  | Filter by owner ID |
+| `--ownerType` | string |  | Filter by owner type |
+| `--resourceType` | string |  | Filter by resource type |
+| `--resourceId` | string |  | Filter by resource ID |
+
+</details>
+
+<details>
+<summary><code>mapping-rule</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--mappingRuleId` | string |  | Filter by mapping rule ID |
+| `--name` | string |  | Filter by name |
+| `--claimName` | string |  | Filter by claim name |
+| `--claimValue` | string |  | Filter by claim value |
+
+</details>
+
+**Examples:**
+
+```bash
+c8ctl list pi                                               # List process instances
+c8ctl list pd                                               # List process definitions
+c8ctl list users                                            # List users
+```
+
+---
+
+### `search`
+
+Search resources with filters (wildcards, date ranges, case-insensitive)
+
+**Resources:** pi (process-instance), pd (process-definition), ut (user-task), inc (incident), jobs, vars (variable), users (user), roles (role), groups (group), tenants (tenant), auth (authorization), mapping-rules (mapping-rule)
+
+**Resource-specific flags:**
+
+<details>
+<summary><code>process-definition</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
+| `--id` | string |  | Filter by BPMN process ID (alias) |
+| `--processDefinitionId` | string |  | Filter by process definition ID |
+| `--name` | string |  | Filter by name |
+| `--key` | string |  | Filter by key |
+| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
+| `--iname` | string |  | Case-insensitive filter by name |
+
+</details>
+
+<details>
+<summary><code>process-instance</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
+| `--id` | string |  | Filter by BPMN process ID (alias) |
+| `--processDefinitionId` | string |  | Filter by process definition ID |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--state` | string |  | Filter by state (ACTIVE, COMPLETED, etc) |
+| `--key` | string |  | Filter by key |
+| `--parentProcessInstanceKey` | string |  | Filter by parent process instance key |
+| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
+
+</details>
+
+<details>
+<summary><code>user-task</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--state` | string |  | Filter by state |
+| `--assignee` | string |  | Filter by assignee |
+| `--processInstanceKey` | string |  | Filter by process instance key |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--elementId` | string |  | Filter by element ID |
+| `--iassignee` | string |  | Case-insensitive filter by assignee |
+
+</details>
+
+<details>
+<summary><code>incident</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--state` | string |  | Filter by state |
+| `--processInstanceKey` | string |  | Filter by process instance key |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--bpmnProcessId` | string |  | Filter by BPMN process ID |
+| `--id` | string |  | Filter by BPMN process ID (alias) |
+| `--processDefinitionId` | string |  | Filter by process definition ID |
+| `--errorType` | string |  | Filter by error type |
+| `--errorMessage` | string |  | Filter by error message |
+| `--ierrorMessage` | string |  | Case-insensitive filter by error message |
+| `--iid` | string |  | Case-insensitive filter by BPMN process ID |
+
+</details>
+
+<details>
+<summary><code>jobs</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--state` | string |  | Filter by state |
+| `--type` | string |  | Filter by job type |
+| `--processInstanceKey` | string |  | Filter by process instance key |
+| `--processDefinitionKey` | string |  | Filter by process definition key |
+| `--itype` | string |  | Case-insensitive filter by job type |
+
+</details>
+
+<details>
+<summary><code>variable</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--name` | string |  | Filter by variable name |
+| `--value` | string |  | Filter by value |
+| `--processInstanceKey` | string |  | Filter by process instance key |
+| `--scopeKey` | string |  | Filter by scope key |
+| `--fullValue` | boolean |  | Return full variable values (not truncated) |
+| `--iname` | string |  | Case-insensitive filter by name |
+| `--ivalue` | string |  | Case-insensitive filter by value |
+
+</details>
+
+<details>
+<summary><code>user</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--username` | string |  | Filter by username |
+| `--name` | string |  | Filter by name |
+| `--email` | string |  | Filter by email |
+
+</details>
+
+<details>
+<summary><code>role</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--roleId` | string |  | Filter by role ID |
+| `--name` | string |  | Filter by name |
+
+</details>
+
+<details>
+<summary><code>group</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--groupId` | string |  | Filter by group ID |
+| `--name` | string |  | Filter by name |
+
+</details>
+
+<details>
+<summary><code>tenant</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--tenantId` | string |  | Filter by tenant ID |
+| `--name` | string |  | Filter by name |
+
+</details>
+
+<details>
+<summary><code>authorization</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--ownerId` | string |  | Filter by owner ID |
+| `--ownerType` | string |  | Filter by owner type |
+| `--resourceType` | string |  | Filter by resource type |
+| `--resourceId` | string |  | Filter by resource ID |
+
+</details>
+
+<details>
+<summary><code>mapping-rule</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--mappingRuleId` | string |  | Filter by mapping rule ID |
+| `--name` | string |  | Filter by name |
+| `--claimName` | string |  | Filter by claim name |
+| `--claimValue` | string |  | Filter by claim value |
+
+</details>
+
+**Examples:**
+
+```bash
+c8ctl search pi --state=ACTIVE                              # Search for active process instances
+c8ctl search pd --bpmnProcessId=myProcess                   # Search process definitions by ID
+c8ctl search pd --name='*main*'                             # Search process definitions with wildcard
+c8ctl search ut --assignee=john                             # Search user tasks assigned to john
+c8ctl search inc --state=ACTIVE                             # Search for active incidents
+c8ctl search jobs --type=myJobType                          # Search jobs by type
+c8ctl search jobs --type='*service*'                        # Search jobs with type containing "service"
+c8ctl search variables --name=myVar                         # Search for variables by name
+c8ctl search variables --value=foo                          # Search for variables by value
+c8ctl search variables --processInstanceKey=123 --fullValue  # Search variables with full values
+c8ctl search pd --iname='*order*'                           # Case-insensitive search by name
+c8ctl search ut --iassignee=John                            # Case-insensitive search by assignee
+```
+
+---
+
+### `get`
+
+Get a resource by key
+
+**Resources:** pi (process-instance), pd (process-definition), inc (incident), topology, form, user, role, group, tenant, auth (authorization), mapping-rule
+
+**Positional arguments:**
+
+- **process-definition:** `<key>` (required)
+- **process-instance:** `<key>` (required)
+- **incident:** `<key>` (required)
+- **user:** `<username>` (required)
+- **role:** `<roleId>` (required)
+- **group:** `<groupId>` (required)
+- **tenant:** `<tenantId>` (required)
+- **authorization:** `<authorizationKey>` (required)
+- **mapping-rule:** `<mappingRuleId>` (required)
+- **form:** `<key>` (required)
+
+**Resource-specific flags:**
+
+<details>
+<summary><code>process-definition</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--xml` | boolean |  | Get BPMN XML (process definitions) |
+
+</details>
+
+<details>
+<summary><code>form</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--userTask` | boolean |  | Get form for user task |
+| `--ut` | boolean |  | Alias for --userTask |
+| `--processDefinition` | boolean |  | Get form for process definition |
+| `--pd` | boolean |  | Alias for --processDefinition |
+
+</details>
+
+<details>
+<summary><code>process-instance</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--variables` | boolean |  | Include variables in output |
+
+</details>
+
+**Examples:**
+
+```bash
+c8ctl get pi 123456                                         # Get process instance by key
+c8ctl get pi 123456 --variables                             # Get process instance with variables
+c8ctl get pd 123456                                         # Get process definition by key
+c8ctl get pd 123456 --xml                                   # Get process definition XML
+c8ctl get form 123456                                       # Get form (searches both user task and process definition)
+c8ctl get form 123456 --ut                                  # Get form for user task only
+c8ctl get form 123456 --pd                                  # Get start form for process definition only
+c8ctl get user john                                         # Get user by username
+```
+
+---
+
+### `create`
+
+Create a resource (process instance, identity)
+
+**Resources:** pi (process-instance), user, role, group, tenant, auth (authorization), mapping-rule
+
+**Verb-level flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--processDefinitionId` | string |  | Process definition ID (BPMN process ID) |
+| `--id` | string |  | Process definition ID (alias for --processDefinitionId) |
+| `--bpmnProcessId` | string |  | BPMN process ID (alias for --processDefinitionId) |
+| `--variables` | string |  | JSON variables |
+| `--awaitCompletion` | boolean |  | Wait for process to complete |
+| `--fetchVariables` | boolean |  | Fetch result variables on completion |
+| `--requestTimeout` | string |  | Await timeout in milliseconds |
+| `--username` | string |  | Username |
+| `--name` | string |  | Display name |
+| `--email` | string |  | Email address |
+| `--password` | string |  | Password |
+| `--roleId` | string |  | Role ID |
+| `--groupId` | string |  | Group ID |
+| `--tenantId` | string |  | Tenant ID |
+| `--mappingRuleId` | string |  | Mapping rule ID |
+| `--claimName` | string |  | Claim name |
+| `--claimValue` | string |  | Claim value |
+
+**Resource-specific flags:**
+
+<details>
+<summary><code>authorization</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--ownerId` | string | Yes | Authorization owner ID |
+| `--ownerType` | string | Yes | Authorization owner type |
+| `--resourceType` | string | Yes | Authorization resource type |
+| `--resourceId` | string | Yes | Authorization resource ID |
+| `--permissions` | string | Yes | Comma-separated permissions |
+
+</details>
+
+**Examples:**
+
+```bash
+c8ctl create pi --id=myProcess                              # Create a process instance
+c8ctl create pi --id=myProcess --awaitCompletion            # Create and await completion
+c8ctl create user --username=john --name='John Doe' --email=john@example.com --password=secret  # Create a user
+```
+
+---
+
+### `delete`
+
+Delete a resource by key
+
+**Usage:** `c8ctl delete <resource> <key>`
+
+**Resources:** user, role, group, tenant, auth (authorization), mapping-rule
+
+**Positional arguments:**
+
+- **user:** `<username>` (required)
+- **role:** `<roleId>` (required)
+- **group:** `<groupId>` (required)
+- **tenant:** `<tenantId>` (required)
+- **authorization:** `<authorizationKey>` (required)
+- **mapping-rule:** `<mappingRuleId>` (required)
+
+**Examples:**
+
+```bash
+c8ctl delete user john                                      # Delete user
+```
+
+---
+
+### `cancel`
+
+Cancel a process instance
+
+**Usage:** `c8ctl cancel <resource> <key>`
+
+**Resources:** pi (process-instance)
+
+**Positional arguments:**
+
+- **process-instance:** `<key>` (required)
+
+---
+
+### `await`
+
+Create and await process instance completion (server-side waiting)
+
+**Usage:** `c8ctl await <resource>`
+
+**Resources:** pi (process-instance)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--processDefinitionId` | string |  | Process definition ID (BPMN process ID) |
+| `--id` | string |  | Process definition ID (alias for --processDefinitionId) |
+| `--bpmnProcessId` | string |  | BPMN process ID (alias for --processDefinitionId) |
+| `--variables` | string |  | JSON variables |
+| `--fetchVariables` | boolean |  | Fetch result variables on completion |
+| `--requestTimeout` | string |  | Await timeout in milliseconds |
+
+**Examples:**
+
+```bash
+c8ctl await pi --id=myProcess                               # Create and wait for completion
+```
+
+---
+
+### `complete`
+
+Complete a user task or job
+
+**Usage:** `c8ctl complete <resource> <key>`
+
+**Resources:** ut (user-task), job
+
+**Positional arguments:**
+
+- **user-task:** `<key>` (required)
+- **job:** `<key>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--variables` | string |  | JSON variables |
+
+---
+
+### `fail`
+
+Mark a job as failed with optional error message and retry count
+
+**Resources:** job
+
+**Positional arguments:**
+
+- **job:** `<key>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--retries` | string |  | Remaining retries |
+| `--errorMessage` | string |  | Error message |
+
+---
+
+### `activate`
+
+Activate jobs of a specific type for processing
+
+**Resources:** jobs
+
+**Positional arguments:**
+
+- **jobs:** `<type>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--maxJobsToActivate` | string |  | Maximum number of jobs to activate |
+| `--timeout` | string |  | Job timeout in milliseconds |
+| `--worker` | string |  | Worker name |
+
+---
+
+### `resolve`
+
+Resolve an incident (marks resolved, allows process to continue)
+
+**Resources:** inc (incident)
+
+**Positional arguments:**
+
+- **incident:** `<key>` (required)
+
+---
+
+### `publish`
+
+Publish a message for message correlation
+
+**Resources:** msg (message)
+
+**Positional arguments:**
+
+- **message:** `<name>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--correlationKey` | string |  | Correlation key |
+| `--variables` | string |  | JSON variables |
+| `--timeToLive` | string |  | Time to live in milliseconds |
+
+---
+
+### `correlate`
+
+Correlate a message to a specific process instance
+
+**Resources:** msg (message)
+
+**Positional arguments:**
+
+- **message:** `<name>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--correlationKey` | string | Yes | Correlation key |
+| `--variables` | string |  | JSON variables |
+| `--timeToLive` | string |  | Time to live in milliseconds |
+
+---
+
+### `set`
+
+Set variables on an element instance (process instance or flow element scope). Variables are propagated to the outermost scope by default; use --local to restrict to the specified scope.
+
+**Usage:** `c8ctl set variable <key>`
+
+**Resources:** variable
+
+**Positional arguments:**
+
+- **variable:** `<key>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--variables` | string | Yes | JSON object of variables to set (required) |
+| `--local` | boolean |  | Set variables in local scope only (default: propagate to outermost scope) |
+
+**Examples:**
+
+```bash
+c8ctl set variable 2251799813685249 --variables='{"status":"approved"}'  # Set variables on a process instance
+c8ctl set variable 2251799813685249 --variables='{"x":1}' --local  # Set variables in local scope only
+```
+
+---
+
+### `deploy`
+
+Deploy files to Camunda (auto-discovers deployable files in directories)
+
+**Usage:** `c8ctl deploy [path...]`
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--force` | boolean |  | Deploy any file type, ignoring the default extension allow-list |
+
+**Examples:**
+
+```bash
+c8ctl deploy ./my-process.bpmn                              # Deploy a BPMN file
+```
+
+---
+
+### `run`
+
+Deploy and start a process instance from a BPMN file
+
+**Usage:** `c8ctl run <path>`
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--variables` | string |  | JSON variables |
+| `--force` | boolean |  | Deploy any file type, ignoring the default extension allow-list |
+
+**Examples:**
+
+```bash
+c8ctl run ./my-process.bpmn                                 # Deploy and start process
+```
+
+---
+
+### `assign`
+
+Assign a resource to a target (--to-user, --to-group, etc.)
+
+**Usage:** `c8ctl assign <resource> <id>`
+
+**Resources:** role, user, group, mapping-rule
+
+**Positional arguments:**
+
+- **role:** `<roleId>` (required)
+- **user:** `<username>` (required)
+- **group:** `<groupId>` (required)
+- **mapping-rule:** `<mappingRuleId>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--to-user` | string |  | Target user ID |
+| `--to-group` | string |  | Target group ID |
+| `--to-tenant` | string |  | Target tenant ID |
+| `--to-mapping-rule` | string |  | Target mapping rule ID |
+
+**Examples:**
+
+```bash
+c8ctl assign role admin --to-user=john                      # Assign role to user
+```
+
+---
+
+### `unassign`
+
+Unassign a resource from a target (--from-user, --from-group, etc.)
+
+**Usage:** `c8ctl unassign <resource> <id>`
+
+**Resources:** role, user, group, mapping-rule
+
+**Positional arguments:**
+
+- **role:** `<roleId>` (required)
+- **user:** `<username>` (required)
+- **group:** `<groupId>` (required)
+- **mapping-rule:** `<mappingRuleId>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--from-user` | string |  | Source user ID |
+| `--from-group` | string |  | Source group ID |
+| `--from-tenant` | string |  | Source tenant ID |
+| `--from-mapping-rule` | string |  | Source mapping rule ID |
+
+**Examples:**
+
+```bash
+c8ctl unassign role admin --from-user=john                  # Unassign role from user
+```
+
+---
+
+### `watch`
+
+Watch files for changes and auto-deploy
+
+**Usage:** `c8ctl watch [path...]`
+
+**Aliases:** `w`
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--force` | boolean |  | Continue watching after all deployment errors |
+| `--extensions` | string |  | Comma-separated list of file extensions to watch (e.g. .bpmn,.dmn,.form) |
+
+**Examples:**
+
+```bash
+c8ctl watch ./src                                           # Watch directory for changes
+```
+
+---
+
+### `open`
+
+Open Camunda web app in browser
+
+**Usage:** `c8ctl open <app>`
+
+**Resources:** operate, tasklist, modeler, optimize
+
+**Examples:**
+
+```bash
+c8ctl open operate                                          # Open Camunda Operate in browser
+c8ctl open tasklist                                         # Open Camunda Tasklist in browser
+c8ctl open operate --profile=prod                           # Open Operate using a specific profile
+```
+
+---
+
+### `add`
+
+Add a profile
+
+**Resources:** profile
+
+**Positional arguments:**
+
+- **profile:** `<name>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--baseUrl` | string |  | Cluster base URL |
+| `--clientId` | string |  | OAuth client ID |
+| `--clientSecret` | string |  | OAuth client secret |
+| `--audience` | string |  | OAuth audience |
+| `--oAuthUrl` | string |  | OAuth token URL |
+| `--defaultTenantId` | string |  | Default tenant ID |
+| `--username` | string |  | Basic auth username |
+| `--password` | string |  | Basic auth password |
+| `--from-file` | string |  | Import from .env file |
+| `--from-env` | boolean |  | Import from environment variables |
+
+---
+
+### `remove`
+
+Remove a profile (alias: rm)
+
+**Usage:** `c8ctl remove profile <name>`
+
+**Aliases:** `rm`
+
+**Resources:** profile, plugin
+
+**Positional arguments:**
+
+- **profile:** `<name>` (required)
+- **plugin:** `<package>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--none` | boolean |  | Clear active profile |
+
+---
+
+### `load`
+
+Load a c8ctl plugin (npm registry or URL)
+
+**Usage:** `c8ctl load plugin [name|--from url]`
+
+**Resources:** plugin
+
+**Positional arguments:**
+
+- **plugin:** `<package>` (optional)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--from` | string |  | Load plugin from URL |
+
+**Examples:**
+
+```bash
+c8ctl load plugin my-plugin                                 # Load plugin from npm registry
+c8ctl load plugin --from https://github.com/org/plugin      # Load plugin from URL
+```
+
+---
+
+### `unload`
+
+Unload a c8ctl plugin (npm uninstall wrapper)
+
+**Usage:** `c8ctl unload plugin <name>`
+
+**Aliases:** `rm`
+
+**Resources:** plugin
+
+**Positional arguments:**
+
+- **plugin:** `<package>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--force` | boolean |  | Force unload without confirmation |
+
+---
+
+### `upgrade`
+
+Upgrade a plugin (respects source type)
+
+**Usage:** `c8ctl upgrade plugin <name> [version]`
+
+**Resources:** plugin
+
+**Positional arguments:**
+
+- **plugin:** `<package>` (required), `<version>` (optional)
+
+**Examples:**
+
+```bash
+c8ctl upgrade plugin my-plugin                              # Upgrade plugin to latest version
+c8ctl upgrade plugin my-plugin 1.2.3                        # Upgrade plugin to a specific version (source-aware)
+```
+
+---
+
+### `downgrade`
+
+Downgrade a plugin to a specific version
+
+**Usage:** `c8ctl downgrade plugin <name> <version>`
+
+**Resources:** plugin
+
+**Positional arguments:**
+
+- **plugin:** `<package>` (required), `<version>` (required)
+
+---
+
+### `sync`
+
+Synchronize plugins from registry (rebuild/reinstall)
+
+**Resources:** plugin
+
+**Examples:**
+
+```bash
+c8ctl sync plugin                                           # Synchronize plugins
+```
+
+---
+
+### `init`
+
+Create a new plugin from TypeScript template
+
+**Resources:** plugin
+
+**Positional arguments:**
+
+- **plugin:** `<name>` (optional)
+
+**Examples:**
+
+```bash
+c8ctl init plugin my-plugin                                 # Create new plugin from template (c8ctl-plugin-my-plugin)
+```
+
+---
+
+### `use`
+
+Set active profile or tenant
+
+**Usage:** `c8ctl use profile|tenant`
+
+**Resources:** profile, tenant
+
+**Positional arguments:**
+
+- **profile:** `<name>` (optional)
+- **tenant:** `<tenantId>` (required)
+
+**Flags:**
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--none` | boolean |  | Clear active profile/tenant |
+
+**Examples:**
+
+```bash
+c8ctl use profile prod                                      # Set active profile
+```
+
+---
+
+### `output`
+
+Show or set output format
+
+**Usage:** `c8ctl output [json|text]`
+
+**Resources:** json, text
+
+**Examples:**
+
+```bash
+c8ctl output json                                           # Switch to JSON output
+```
+
+---
+
+### `completion`
+
+Generate shell completion script
+
+**Usage:** `c8ctl completion bash|zsh|fish|install`
+
+**Resources:** bash, zsh, fish, install
+
+**Resource-specific flags:**
+
+<details>
+<summary><code>install</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--shell` | string |  | Shell to install completions for (bash, zsh, fish) |
+
+</details>
+
+**Examples:**
+
+```bash
+c8ctl completion bash                                       # Generate bash completion script
+c8ctl completion install                                    # Auto-detect shell and install completions (auto-refreshes on upgrade)
+c8ctl completion install --shell zsh                        # Install completions for a specific shell
+```
+
+---
+
+### `mcp-proxy`
+
+Start a STDIO MCP proxy (bridges local MCP clients to remote Camunda 8)
+
+**Usage:** `c8ctl mcp-proxy [mcp-path]`
+
+---
+
+### `feedback`
+
+Open the feedback page to report issues or request features
+
+---
+
+### `help`
+
+Show help (run 'c8ctl help <command>' for details)
+
+**Usage:** `c8ctl help [command]`
+
+**Aliases:** `menu`
+
+---
+
+### `which`
+
+Show active profile
+
+**Resources:** profile
+
+**Examples:**
+
+```bash
+c8ctl which profile                                         # Show currently active profile
+```
+

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "scripts": {
     "prepare": "git rev-parse --is-inside-work-tree >/dev/null 2>&1 && sh -c 'hp=$(git config --local --get core.hooksPath 2>/dev/null || true); if [ -z \"$hp\" ] || [ \"$hp\" = \".githooks\" ]; then git config --local core.hooksPath .githooks; else echo \"prepare: leaving existing core.hooksPath=$hp\"; fi' || true",
-    "build": "npm run lint && npm run sync:readme && npm run clean && tsc && npm run copy-plugins && npm run copy-templates",
+    "build": "npm run lint && npm run sync:readme && npm run sync:docs && npm run clean && tsc && npm run copy-plugins && npm run copy-templates",
     "lint": "biome check src/ tests/ scripts/",
     "lint:src": "biome check src/ scripts/",
     "typecheck": "tsc --noEmit -p tsconfig.check.json",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,9 @@
     "dev": "node src/index.ts",
     "cli": "node src/index.ts",
     "sync:readme": "node --experimental-strip-types scripts/sync-readme-commands.ts",
-    "sync:readme:check": "node --experimental-strip-types scripts/sync-readme-commands.ts --check"
+    "sync:readme:check": "node --experimental-strip-types scripts/sync-readme-commands.ts --check",
+    "sync:docs": "node --experimental-strip-types scripts/sync-readme-commands.ts --docs",
+    "sync:docs:check": "node --experimental-strip-types scripts/sync-readme-commands.ts --docs --check"
   },
   "keywords": [
     "camunda",

--- a/scripts/sync-readme-commands.ts
+++ b/scripts/sync-readme-commands.ts
@@ -114,7 +114,16 @@ export function resourceDisplay(resource: string): string {
  *   - headingBase=3 → ### Global Flags, #### verb (README, nested under ## Command Reference)
  *   - headingBase=2 → ## Global Flags, ### verb (standalone docs page, title is h1)
  */
-export function generateCommandContent(headingBase: number): string[] {
+export type CommandContentHeadingBase = 2 | 3;
+
+export function generateCommandContent(
+	headingBase: CommandContentHeadingBase,
+): string[] {
+	if (headingBase !== 2 && headingBase !== 3) {
+		throw new RangeError(
+			`Unsupported headingBase: ${headingBase}. Expected 2 or 3.`,
+		);
+	}
 	const h = (level: number) => "#".repeat(headingBase + level);
 	const lines: string[] = [];
 

--- a/scripts/sync-readme-commands.ts
+++ b/scripts/sync-readme-commands.ts
@@ -1,9 +1,11 @@
 /**
- * Generates the Command Reference section of README.md from COMMAND_REGISTRY.
+ * Generates the Command Reference section of README.md from COMMAND_REGISTRY,
+ * and optionally a standalone Docusaurus-compatible markdown page.
  *
  * Usage:
  *   node --experimental-strip-types scripts/sync-readme-commands.ts          # update README
  *   node --experimental-strip-types scripts/sync-readme-commands.ts --check  # CI check (exit 1 if stale)
+ *   node --experimental-strip-types scripts/sync-readme-commands.ts --docs   # generate docs/command-reference.md
  */
 
 import { readFileSync, writeFileSync } from "node:fs";
@@ -25,6 +27,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const ROOT = resolve(__dirname, "..");
 const README_PATH = resolve(ROOT, "README.md");
+const DOCS_PATH = resolve(ROOT, "docs", "command-reference.md");
 
 export const START_MARKER = "<!-- command-reference:start -->";
 export const END_MARKER = "<!-- command-reference:end -->";
@@ -105,21 +108,18 @@ export function resourceDisplay(resource: string): string {
 
 // ─── Generation ──────────────────────────────────────────────────────────────
 
-export function generate(): string {
+/**
+ * Generate the shared command reference body (sections + verb entries).
+ * The `headingBase` parameter sets the markdown heading level for top sections:
+ *   - headingBase=3 → ### Global Flags, #### verb (README, nested under ## Command Reference)
+ *   - headingBase=2 → ## Global Flags, ### verb (standalone docs page, title is h1)
+ */
+export function generateCommandContent(headingBase: number): string[] {
+	const h = (level: number) => "#".repeat(headingBase + level);
 	const lines: string[] = [];
 
-	lines.push("## Command Reference");
-	lines.push("");
-	lines.push(
-		"<!-- Auto-generated from COMMAND_REGISTRY. Do not edit manually.",
-	);
-	lines.push(
-		"     Run: node --experimental-strip-types scripts/sync-readme-commands.ts -->",
-	);
-	lines.push("");
-
 	// ── Global Flags ──
-	lines.push("### Global Flags");
+	lines.push(`${h(0)} Global Flags`);
 	lines.push("");
 	lines.push("These flags are accepted by every command.");
 	lines.push("");
@@ -129,7 +129,7 @@ export function generate(): string {
 	// ── Resource Aliases ──
 	const aliases = uniqueAliases();
 	if (aliases.length > 0) {
-		lines.push("### Resource Aliases");
+		lines.push(`${h(0)} Resource Aliases`);
 		lines.push("");
 		lines.push("| Alias | Resource |");
 		lines.push("|-------|----------|");
@@ -142,7 +142,7 @@ export function generate(): string {
 	// ── Search Flags ──
 	const searchFlagEntries = Object.entries(SEARCH_FLAGS);
 	if (searchFlagEntries.length > 0) {
-		lines.push("### Search Flags");
+		lines.push(`${h(0)} Search Flags`);
 		lines.push("");
 		lines.push("These flags are available on `list` and `search` commands.");
 		lines.push("");
@@ -151,13 +151,13 @@ export function generate(): string {
 	}
 
 	// ── Commands ──
-	lines.push("### Commands");
+	lines.push(`${h(0)} Commands`);
 	lines.push("");
 
 	const registry: Record<string, CommandDef> = COMMAND_REGISTRY;
 
 	for (const [verb, def] of Object.entries(registry)) {
-		lines.push(`#### \`${verb}\``);
+		lines.push(`${h(1)} \`${verb}\``);
 		lines.push("");
 		lines.push(verbDescription(def));
 		lines.push("");
@@ -252,7 +252,57 @@ export function generate(): string {
 		lines.splice(lines.length - 2, 2);
 	}
 
+	return lines;
+}
+
+/** Generate the README command reference section (nested under ## Command Reference). */
+export function generate(): string {
+	const lines: string[] = [];
+
+	lines.push("## Command Reference");
+	lines.push("");
+	lines.push(
+		"<!-- Auto-generated from COMMAND_REGISTRY. Do not edit manually.",
+	);
+	lines.push(
+		"     Run: node --experimental-strip-types scripts/sync-readme-commands.ts -->",
+	);
+	lines.push("");
+
+	lines.push(...generateCommandContent(3));
+
 	return lines.join("\n");
+}
+
+export const DOCS_FRONTMATTER = [
+	"---",
+	"id: command-reference",
+	'title: "Command reference"',
+	'sidebar_label: "Command reference"',
+	'description: "Complete reference of all c8ctl CLI commands, flags, resources, and aliases — auto-generated from the command registry."',
+	"---",
+].join("\n");
+
+export const DOCS_PREAMBLE = [
+	"<!-- Auto-generated from COMMAND_REGISTRY. Do not edit manually.",
+	"     Run: node --experimental-strip-types scripts/sync-readme-commands.ts --docs -->",
+	"",
+	":::warning Alpha feature",
+	"`c8ctl` is in alpha and is not intended for production use. Commands and flags may change without notice between releases. See [Getting started](getting-started.md) for details.",
+	":::",
+].join("\n");
+
+/** Generate a standalone Docusaurus-compatible command reference page. */
+export function generateDocs(): string {
+	const lines: string[] = [];
+
+	lines.push(DOCS_FRONTMATTER);
+	lines.push("");
+	lines.push(DOCS_PREAMBLE);
+	lines.push("");
+	lines.push(...generateCommandContent(2));
+
+	return `${lines.join("\n")}\n`;
 }
 
 /**
@@ -290,6 +340,34 @@ export function filterVerbSpecificFlags(
 
 function main(): void {
 	const checkMode = process.argv.includes("--check");
+	const docsMode = process.argv.includes("--docs");
+
+	if (docsMode) {
+		const generated = generateDocs();
+		if (checkMode) {
+			let existing = "";
+			try {
+				existing = readFileSync(DOCS_PATH, "utf-8");
+			} catch {
+				// File doesn't exist yet — always out of sync
+			}
+			if (generated !== existing) {
+				console.error(
+					"docs/command-reference.md is out of sync with COMMAND_REGISTRY.",
+				);
+				console.error(
+					"Run: node --experimental-strip-types scripts/sync-readme-commands.ts --docs",
+				);
+				process.exit(1);
+			}
+			console.log("docs/command-reference.md is up to date.");
+			return;
+		}
+		writeFileSync(DOCS_PATH, generated, "utf-8");
+		console.log("docs/command-reference.md updated.");
+		return;
+	}
+
 	const readme = readFileSync(README_PATH, "utf-8");
 
 	const startIdx = readme.indexOf(START_MARKER);

--- a/tests/unit/sync-readme-commands.test.ts
+++ b/tests/unit/sync-readme-commands.test.ts
@@ -12,10 +12,14 @@ import { describe, test } from "node:test";
 import { fileURLToPath } from "node:url";
 
 import {
+	DOCS_FRONTMATTER,
+	DOCS_PREAMBLE,
 	END_MARKER,
 	filterVerbSpecificFlags,
 	formatFlag,
 	generate,
+	generateCommandContent,
+	generateDocs,
 	renderFlagsTable,
 	renderPositionals,
 	resourceDisplay,
@@ -534,5 +538,108 @@ describe("generate() completeness guard", () => {
 				`Generated heading "${heading}" does not correspond to any registry verb`,
 			);
 		}
+	});
+});
+
+// ─── generateCommandContent() ────────────────────────────────────────────────
+
+describe("generateCommandContent() heading levels", () => {
+	test("headingBase=3 produces ### top sections and #### verbs", () => {
+		const content = generateCommandContent(3).join("\n");
+		assert.ok(content.includes("### Global Flags"));
+		assert.ok(content.includes("### Commands"));
+		for (const verb of Object.keys(REGISTRY)) {
+			assert.ok(
+				content.includes(`#### \`${verb}\``),
+				`Missing #### heading for verb "${verb}" at headingBase=3`,
+			);
+		}
+	});
+
+	test("headingBase=2 produces ## top sections and ### verbs", () => {
+		const content = generateCommandContent(2).join("\n");
+		assert.ok(content.includes("## Global Flags"));
+		assert.ok(content.includes("## Commands"));
+		for (const verb of Object.keys(REGISTRY)) {
+			assert.ok(
+				content.includes(`### \`${verb}\``),
+				`Missing ### heading for verb "${verb}" at headingBase=2`,
+			);
+		}
+	});
+
+	test("content is identical regardless of heading level", () => {
+		const base2 = generateCommandContent(2).join("\n");
+		const base3 = generateCommandContent(3).join("\n");
+		// Strip heading markers and compare — content should be the same
+		const stripHeadings = (s: string) => s.replace(/^#{2,5}\s/gm, "");
+		assert.strictEqual(stripHeadings(base2), stripHeadings(base3));
+	});
+});
+
+// ─── generateDocs() output structure ─────────────────────────────────────────
+
+describe("generateDocs() output structure", () => {
+	const output = generateDocs();
+
+	test("starts with YAML frontmatter", () => {
+		assert.ok(output.startsWith("---\n"));
+		assert.ok(output.includes("id: command-reference"));
+		assert.ok(output.includes('title: "Command reference"'));
+		assert.ok(output.includes('sidebar_label: "Command reference"'));
+		assert.ok(output.includes("description:"));
+	});
+
+	test("contains DOCS_FRONTMATTER verbatim", () => {
+		assert.ok(output.includes(DOCS_FRONTMATTER));
+	});
+
+	test("contains DOCS_PREAMBLE verbatim", () => {
+		assert.ok(output.includes(DOCS_PREAMBLE));
+	});
+
+	test("includes alpha warning admonition", () => {
+		assert.ok(output.includes(":::warning Alpha feature"));
+		assert.ok(output.includes(":::"));
+	});
+
+	test("uses ## for top-level sections (not ###)", () => {
+		assert.ok(output.includes("## Global Flags"));
+		assert.ok(output.includes("## Commands"));
+		// Must NOT have ### Global Flags (that's the README level)
+		assert.ok(!output.includes("### Global Flags"));
+	});
+
+	test("uses ### for verb headings (not ####)", () => {
+		const firstVerb = Object.keys(REGISTRY)[0];
+		assert.ok(firstVerb);
+		assert.ok(output.includes(`### \`${firstVerb}\``));
+		assert.ok(!output.includes(`#### \`${firstVerb}\``));
+	});
+
+	test("does not contain the README-level ## Command Reference heading", () => {
+		assert.ok(!output.includes("## Command Reference"));
+	});
+
+	test("ends with a trailing newline", () => {
+		assert.ok(output.endsWith("\n"));
+	});
+
+	test("includes all registry verbs", () => {
+		for (const verb of Object.keys(REGISTRY)) {
+			assert.ok(
+				output.includes(`### \`${verb}\``),
+				`Missing verb "${verb}" in docs output`,
+			);
+		}
+	});
+
+	test("does not contain README markers", () => {
+		assert.ok(!output.includes(START_MARKER));
+		assert.ok(!output.includes(END_MARKER));
+	});
+
+	test("links to getting-started.md in alpha warning", () => {
+		assert.ok(output.includes("[Getting started](getting-started.md)"));
 	});
 });


### PR DESCRIPTION
## Description

Extends the sync script to generate a standalone `docs/command-reference.md` suitable for direct consumption by the Camunda docs site via a sync workflow.

Part 2 of #237 — integrating the generated command reference with Camunda Docs.

## What changed

### `scripts/sync-readme-commands.ts`
- Extracted shared content generation into `generateCommandContent(headingBase)` — takes a heading level parameter so both README and docs outputs share the same rendering logic
- Added `generateDocs()` that wraps the content with Docusaurus frontmatter, alpha warning admonition, and `##` heading levels (page title is h1)
- Added `--docs` flag to generate `docs/command-reference.md`
- Combined with `--check` for CI: `--docs --check`

### `docs/command-reference.md` (new, auto-generated)
- Docusaurus-compatible frontmatter (`id`, `title`, `sidebar_label`, `description`)
- `:::warning Alpha feature` admonition matching existing c8ctl docs pages
- `##` top sections / `###` verb headings (shifted one level from README since page title serves as h1)
- Ready for `camunda-docs` to consume via sync workflow

### `package.json`
- Added `sync:docs` and `sync:docs:check` npm scripts

### Tests
- 14 new tests covering:
  - `generateCommandContent()` heading level parameterization
  - `generateDocs()` output structure (frontmatter, preamble, heading levels, no README markers, trailing newline)
  - Content equivalence between heading levels

## Camunda Docs integration (follow-up PR)

A companion PR on `camunda/camunda-docs` will:
1. Add a `sync-c8ctl-docs.yaml` workflow (modeled on existing SDK sync workflows)
2. Add `command-reference` to `docs/apis-tools/c8ctl/sidebar-schema.js`

## When should this change go live?

There is **no urgency** — this can be merged at any time.

## PR Checklist

- [x] Tests pass (230 total, 14 new)
- [x] Lint clean
- [x] README sync unaffected (refactor is behavior-preserving)</details>
