### PR TITLE
refactor(registry): structural flag-bucket disjointness invariant (#256)

### DIFF
--- a/src/command-framework.ts
+++ b/src/command-framework.ts
@@ -361,11 +361,17 @@ export function defineCommand<V extends keyof Registry, R extends string>(
 			);
 			if (result) renderResult(result, ctx);
 		} catch (error) {
-			handleCommandError(
-				ctx.logger,
-				`Failed to ${verb} ${resource.replace(/-/g, " ")}`,
-				error,
-			);
+			// Use ctx.resource (the runtime resource) for the error prefix so
+			// verbs like `completion` — which register against one resource
+			// ("install") for typing convenience but dispatch against many
+			// (bash/zsh/fish/install) — report the actual user-facing
+			// resource. Falls back to the registration resource when the
+			// runtime resource is empty (e.g. resourceless verbs).
+			const errorResource = (ctx.resource || resource).replace(/-/g, " ");
+			const errorPrefix = errorResource
+				? `Failed to ${verb} ${errorResource}`
+				: `Failed to ${verb}`;
+			handleCommandError(ctx.logger, errorPrefix, error);
 		}
 	};
 	const handler_ = { verb, resource, execute };

--- a/src/command-framework.ts
+++ b/src/command-framework.ts
@@ -361,13 +361,24 @@ export function defineCommand<V extends keyof Registry, R extends string>(
 			);
 			if (result) renderResult(result, ctx);
 		} catch (error) {
-			// Use ctx.resource (the runtime resource) for the error prefix so
-			// verbs like `completion` — which register against one resource
-			// ("install") for typing convenience but dispatch against many
-			// (bash/zsh/fish/install) — report the actual user-facing
-			// resource. Falls back to the registration resource when the
-			// runtime resource is empty (e.g. resourceless verbs).
-			const errorResource = (ctx.resource || resource).replace(/-/g, " ");
+			// Build the framework error prefix.
+			//
+			// `ctx.resource` is meaningful only for verbs that declare
+			// enumerated resources in the registry (e.g. `list process-instance`,
+			// `completion bash|zsh|fish|install`). For verbs WITHOUT enumerated
+			// resources (deploy/run/watch/…), `ctx.resource` holds the FIRST
+			// POSITIONAL argument (e.g. a `.bpmn` file path) per `src/index.ts`,
+			// not a resource identifier. Using it in the prefix would leak user
+			// input — `Failed to deploy /tmp/foo.bpmn` instead of `Failed to deploy`.
+			//
+			// Rule:
+			//   - enumerated-resource verb → use `ctx.resource` (the actual
+			//     user-facing resource, which may differ from the registration
+			//     resource for verbs like `completion` that register against
+			//     "install" for typing convenience but dispatch many resources).
+			//   - resourceless verb → omit the resource segment entirely.
+			const enumerated = (entry.resources?.length ?? 0) > 0;
+			const errorResource = enumerated ? ctx.resource.replace(/-/g, " ") : "";
 			const errorPrefix = errorResource
 				? `Failed to ${verb} ${errorResource}`
 				: `Failed to ${verb}`;

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -71,20 +71,44 @@ export interface CommandDef {
 	/** Valid resource names (canonical short forms used in help). */
 	resources: string[];
 	/**
-	 * Flags shared across every resource for this verb (in addition to
-	 * global flags). Per-resource flags must live exclusively in
+	 * Verb-level flag schema. Per-resource flags must live exclusively in
 	 * `resourceFlags` — they are *not* duplicated here. Mixing a flag into
 	 * both buckets defeats unknown-flag detection (#256), and the
 	 * structural disjointness invariant in
 	 * `tests/unit/command-registry.test.ts` will fail.
+	 *
+	 * **Effective-resolution semantics** (see `ResolvedFlags` in
+	 * `src/command-framework.ts` and `validateFlags` in `src/index.ts`):
+	 * the handler's typed `flags` parameter and `validateFlags`'s
+	 * required-field/validator checks resolve to
+	 * `resourceFlags[resource] ?? flags`. So for a verb that declares
+	 * **both** `flags` and `resourceFlags[r]`, the verb-level `flags` are
+	 * **not** seen by the handler or by `validateFlags` when dispatching to
+	 * resource `r` — only `resourceFlags[r]` is. Verb-level `flags` are
+	 * still treated as valid by `detectUnknownFlags` (so `parseArgs` won't
+	 * warn on them) and by `deriveParseArgsOptions` (so they parse), but
+	 * they will not flow into the handler's typed parameter for any
+	 * resource that has its own bucket.
+	 *
+	 * Practical guidance: if a flag must be visible to the handler for a
+	 * given resource, declare it in that resource's `resourceFlags` bucket
+	 * (typically by spreading a shared constant such as `SEARCH_FLAGS`
+	 * into each per-resource bucket). Reserve verb-level `flags` for verbs
+	 * with no `resourceFlags` at all, or for flags that are deliberately
+	 * parse-only on resources with their own bucket.
 	 */
 	flags: Record<string, FlagDef>;
 	/**
 	 * Per-resource flag scoping. Keys are canonical resource names.
 	 * Flags declared here must not also appear in `flags` (see above).
-	 * `parseArgs` still sees these via `deriveParseArgsOptions`, but the
+	 *
+	 * When a resource has an entry here, the framework resolves the
+	 * effective flag schema as `resourceFlags[resource]` and **ignores**
+	 * the verb-level `flags` for handler typing and `validateFlags`.
+	 * `parseArgs` still sees both via `deriveParseArgsOptions`, and the
 	 * scoping lets `warnUnknownFlags` warn when a flag is passed against a
-	 * resource that does not declare it.
+	 * resource that does not declare it. See the doc on `flags` above for
+	 * the full effective-resolution semantics.
 	 */
 	resourceFlags?: Record<string, Record<string, FlagDef>>;
 	/** Per-resource positional argument schemas. Keys are canonical resource names. */

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -85,10 +85,11 @@ export interface CommandDef {
 	 * **both** `flags` and `resourceFlags[r]`, the verb-level `flags` are
 	 * **not** seen by the handler or by `validateFlags` when dispatching to
 	 * resource `r` — only `resourceFlags[r]` is. Verb-level `flags` are
-	 * still treated as valid by `detectUnknownFlags` (so `parseArgs` won't
-	 * warn on them) and by `deriveParseArgsOptions` (so they parse), but
-	 * they will not flow into the handler's typed parameter for any
-	 * resource that has its own bucket.
+	 * still treated as valid by `detectUnknownFlags`, so
+	 * `detectUnknownFlags`/`warnUnknownFlags` will not emit an
+	 * unknown-flag warning for them, and `deriveParseArgsOptions` still
+	 * includes them so they parse, but they will not flow into the
+	 * handler's typed parameter for any resource that has its own bucket.
 	 *
 	 * Practical guidance: if a flag must be visible to the handler for a
 	 * given resource, declare it in that resource's `resourceFlags` bucket
@@ -105,10 +106,10 @@ export interface CommandDef {
 	 * When a resource has an entry here, the framework resolves the
 	 * effective flag schema as `resourceFlags[resource]` and **ignores**
 	 * the verb-level `flags` for handler typing and `validateFlags`.
-	 * `parseArgs` still sees both via `deriveParseArgsOptions`, and the
-	 * scoping lets `warnUnknownFlags` warn when a flag is passed against a
-	 * resource that does not declare it. See the doc on `flags` above for
-	 * the full effective-resolution semantics.
+	 * `deriveParseArgsOptions` still includes both buckets so they parse,
+	 * and the scoping lets `warnUnknownFlags` warn when a flag is passed
+	 * against a resource that does not declare it. See the doc on `flags`
+	 * above for the full effective-resolution semantics.
 	 */
 	resourceFlags?: Record<string, Record<string, FlagDef>>;
 	/** Per-resource positional argument schemas. Keys are canonical resource names. */

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -70,9 +70,22 @@ export interface CommandDef {
 	requiresResource: boolean;
 	/** Valid resource names (canonical short forms used in help). */
 	resources: string[];
-	/** Flags specific to this verb (beyond global flags). Superset of all resource-specific flags. */
+	/**
+	 * Flags shared across every resource for this verb (in addition to
+	 * global flags). Per-resource flags must live exclusively in
+	 * `resourceFlags` — they are *not* duplicated here. Mixing a flag into
+	 * both buckets defeats unknown-flag detection (#256), and the
+	 * structural disjointness invariant in
+	 * `tests/unit/command-registry.test.ts` will fail.
+	 */
 	flags: Record<string, FlagDef>;
-	/** Per-resource flag scoping. Keys are canonical resource names. */
+	/**
+	 * Per-resource flag scoping. Keys are canonical resource names.
+	 * Flags declared here must not also appear in `flags` (see above).
+	 * `parseArgs` still sees these via `deriveParseArgsOptions`, but the
+	 * scoping lets `warnUnknownFlags` warn when a flag is passed against a
+	 * resource that does not declare it.
+	 */
 	resourceFlags?: Record<string, Record<string, FlagDef>>;
 	/** Per-resource positional argument schemas. Keys are canonical resource names. */
 	resourcePositionals?: Record<string, readonly PositionalDef[]>;

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -560,9 +560,10 @@ export const COMMAND_REGISTRY = {
 		],
 		// Verb-level `flags` holds only genuinely shared flags. Per-resource
 		// flags live exclusively in `resourceFlags` so unknown-flag detection
-		// can reject `--processDefinitionId` against a non-PD resource (#256).
-		// `parseArgs` still accepts every per-resource flag — see
-		// `deriveParseArgsOptions` which iterates `resourceFlags` too.
+		// warns when (e.g.) `--processDefinitionId` is passed against a
+		// non-PD resource (#256). The flag is still parsed by `parseArgs`
+		// (see `deriveParseArgsOptions`, which iterates `resourceFlags` too)
+		// and the value is ignored — the warning is the user-facing signal.
 		flags: {
 			all: {
 				type: "boolean",
@@ -659,9 +660,10 @@ export const COMMAND_REGISTRY = {
 		],
 		// Verb-level `flags` holds only genuinely shared flags. Per-resource
 		// flags live exclusively in `resourceFlags` so unknown-flag detection
-		// can reject `--processDefinitionId` against a non-PD resource (#256).
-		// `parseArgs` still accepts every per-resource flag — see
-		// `deriveParseArgsOptions` which iterates `resourceFlags` too.
+		// warns when (e.g.) `--processDefinitionId` is passed against a
+		// non-PD resource (#256). The flag is still parsed by `parseArgs`
+		// (see `deriveParseArgsOptions`, which iterates `resourceFlags` too)
+		// and the value is ignored — the warning is the user-facing signal.
 		flags: {
 			...SEARCH_FLAGS,
 		},
@@ -735,9 +737,10 @@ export const COMMAND_REGISTRY = {
 		],
 		// Verb-level `flags` holds only genuinely shared flags. Per-resource
 		// flags live exclusively in `resourceFlags` so unknown-flag detection
-		// can reject `--xml` against a non-PD resource (#256). `parseArgs`
-		// still accepts every per-resource flag — see `deriveParseArgsOptions`
-		// which iterates `resourceFlags` too.
+		// warns when (e.g.) `--xml` is passed against a non-PD resource
+		// (#256). The flag is still parsed by `parseArgs` (see
+		// `deriveParseArgsOptions`, which iterates `resourceFlags` too) and
+		// the value is ignored — the warning is the user-facing signal.
 		flags: {},
 		resourceFlags: {
 			"process-definition": GET_PD_FLAGS,
@@ -1546,10 +1549,12 @@ export const COMMAND_REGISTRY = {
 		],
 		resources: ["bash", "zsh", "fish", "install"],
 		// `--shell` only applies to `completion install` — declared once in
-		// `resourceFlags.install` so it's rejected with a useful warning when
-		// passed to other resources (e.g. `completion zsh --shell bash`). This
-		// is the original #256 defect class. `parseArgs` still accepts the
-		// flag globally via `deriveParseArgsOptions` iterating `resourceFlags`.
+		// `resourceFlags.install` so it triggers an unknown-flag warning when
+		// passed to other resources (e.g. `completion zsh --shell bash`).
+		// This is the original #256 defect class. `parseArgs` still accepts
+		// the flag globally via `deriveParseArgsOptions` iterating
+		// `resourceFlags`, and the value is ignored on non-install branches
+		// of `completionCommand` — the warning is the user-facing signal.
 		flags: {},
 		resourceFlags: {
 			install: {

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -558,23 +558,17 @@ export const COMMAND_REGISTRY = {
 			"auth",
 			"mapping-rules",
 		],
+		// Verb-level `flags` holds only genuinely shared flags. Per-resource
+		// flags live exclusively in `resourceFlags` so unknown-flag detection
+		// can reject `--processDefinitionId` against a non-PD resource (#256).
+		// `parseArgs` still accepts every per-resource flag — see
+		// `deriveParseArgsOptions` which iterates `resourceFlags` too.
 		flags: {
 			all: {
 				type: "boolean",
 				description: "List all (disable pagination limit)",
 			},
 			...SEARCH_FLAGS,
-			...PI_SEARCH_FLAGS,
-			...PD_SEARCH_FLAGS,
-			...UT_SEARCH_FLAGS,
-			...INC_SEARCH_FLAGS,
-			...JOB_SEARCH_FLAGS,
-			...USER_SEARCH_FLAGS,
-			...ROLE_SEARCH_FLAGS,
-			...GROUP_SEARCH_FLAGS,
-			...TENANT_SEARCH_FLAGS,
-			...AUTH_SEARCH_FLAGS,
-			...MR_SEARCH_FLAGS,
 		},
 		resourceFlags: {
 			"process-definition": PD_SEARCH_FLAGS,
@@ -663,20 +657,13 @@ export const COMMAND_REGISTRY = {
 			"auth",
 			"mapping-rules",
 		],
+		// Verb-level `flags` holds only genuinely shared flags. Per-resource
+		// flags live exclusively in `resourceFlags` so unknown-flag detection
+		// can reject `--processDefinitionId` against a non-PD resource (#256).
+		// `parseArgs` still accepts every per-resource flag — see
+		// `deriveParseArgsOptions` which iterates `resourceFlags` too.
 		flags: {
 			...SEARCH_FLAGS,
-			...PI_SEARCH_FLAGS,
-			...PD_SEARCH_FLAGS,
-			...UT_SEARCH_FLAGS,
-			...INC_SEARCH_FLAGS,
-			...JOB_SEARCH_FLAGS,
-			...VAR_SEARCH_FLAGS,
-			...USER_SEARCH_FLAGS,
-			...ROLE_SEARCH_FLAGS,
-			...GROUP_SEARCH_FLAGS,
-			...TENANT_SEARCH_FLAGS,
-			...AUTH_SEARCH_FLAGS,
-			...MR_SEARCH_FLAGS,
 		},
 		resourceFlags: {
 			"process-definition": PD_SEARCH_FLAGS,
@@ -746,7 +733,12 @@ export const COMMAND_REGISTRY = {
 			"auth",
 			"mapping-rule",
 		],
-		flags: { ...GET_PD_FLAGS, ...GET_FORM_FLAGS, ...GET_PI_FLAGS },
+		// Verb-level `flags` holds only genuinely shared flags. Per-resource
+		// flags live exclusively in `resourceFlags` so unknown-flag detection
+		// can reject `--xml` against a non-PD resource (#256). `parseArgs`
+		// still accepts every per-resource flag — see `deriveParseArgsOptions`
+		// which iterates `resourceFlags` too.
+		flags: {},
 		resourceFlags: {
 			"process-definition": GET_PD_FLAGS,
 			form: GET_FORM_FLAGS,
@@ -1553,12 +1545,12 @@ export const COMMAND_REGISTRY = {
 			},
 		],
 		resources: ["bash", "zsh", "fish", "install"],
-		flags: {
-			shell: {
-				type: "string" as const,
-				description: "Shell to install completions for (bash, zsh, fish)",
-			},
-		},
+		// `--shell` only applies to `completion install` — declared once in
+		// `resourceFlags.install` so it's rejected with a useful warning when
+		// passed to other resources (e.g. `completion zsh --shell bash`). This
+		// is the original #256 defect class. `parseArgs` still accepts the
+		// flag globally via `deriveParseArgsOptions` iterating `resourceFlags`.
+		flags: {},
 		resourceFlags: {
 			install: {
 				shell: {

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -20,6 +20,13 @@ import { installCompletion, showCompletion } from "../completion.ts";
  * invocation to `completion:` because `requiresResource` is false. This
  * single handler branches on the incoming resource.
  *
+ * Registered against `"install"` (not `""`) so the typed `flags`
+ * parameter includes `shell` — the only resource-scoped flag, declared
+ * in `resourceFlags.install` per the verb/resource flag-bucket
+ * disjointness invariant (#256). The dispatch key is still `completion:`
+ * because dispatch is derived from `requiresResource`, not from the
+ * registration resource.
+ *
  * All validation errors are raised via `throw` so the framework wrapper
  * routes them through `handleCommandError`. The architectural guard in
  * `tests/unit/no-process-exit-in-handlers.test.ts` forbids `process.exit`
@@ -27,7 +34,7 @@ import { installCompletion, showCompletion } from "../completion.ts";
  */
 export const completionCommand = defineCommand(
 	"completion",
-	"",
+	"install",
 	async (ctx, flags) => {
 		const resource = ctx.resource;
 		if (resource === "install") {
@@ -35,7 +42,9 @@ export const completionCommand = defineCommand(
 			installCompletion(typeof shellFlag === "string" ? shellFlag : undefined);
 			return undefined;
 		}
-		// Empty resource → show usage error consistent with prior behaviour.
+		// Non-install resource → render the requested shell's completion script.
+		// `--shell` is unknown-flag-rejected for non-install resources by
+		// `detectUnknownFlags`, so it is never set on this branch.
 		showCompletion(resource || undefined);
 		return undefined;
 	},

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -25,7 +25,9 @@ import { installCompletion, showCompletion } from "../completion.ts";
  * in `resourceFlags.install` per the verb/resource flag-bucket
  * disjointness invariant (#256). The dispatch key is still `completion:`
  * because dispatch is derived from `requiresResource`, not from the
- * registration resource.
+ * registration resource. The framework uses `ctx.resource` for error
+ * messages so failures on non-install branches are not mislabelled
+ * "Failed to completion install".
  *
  * All validation errors are raised via `throw` so the framework wrapper
  * routes them through `handleCommandError`. The architectural guard in
@@ -43,8 +45,13 @@ export const completionCommand = defineCommand(
 			return undefined;
 		}
 		// Non-install resource → render the requested shell's completion script.
-		// `--shell` is unknown-flag-rejected for non-install resources by
-		// `detectUnknownFlags`, so it is never set on this branch.
+		// Note: `flags.shell` may still be populated here because dispatch is
+		// `completion:` regardless of resource and the install schema is in
+		// effect — `parseArgs` will accept `--shell` and `deserializeFlags`
+		// will populate it. `detectUnknownFlags` (src/command-validation.ts)
+		// emits a warning that `--shell` is not valid for non-install
+		// resources, but the value is not stripped. This branch deliberately
+		// ignores `flags.shell`; the warning is the user-facing signal.
 		showCompletion(resource || undefined);
 		return undefined;
 	},

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -44,7 +44,12 @@ export const completionCommand = defineCommand(
 			installCompletion(typeof shellFlag === "string" ? shellFlag : undefined);
 			return undefined;
 		}
-		// Non-install resource → render the requested shell's completion script.
+		// Non-install resource → render the requested shell's completion
+		// script when `resource` is one of bash/zsh/fish. When `resource`
+		// is empty (`c8ctl completion` with no positional), `showCompletion`
+		// throws a usage error listing the supported shells; the framework
+		// wrapper routes that through `handleCommandError`.
+		//
 		// Note: `flags.shell` may still be populated here because dispatch is
 		// `completion:` regardless of resource and the install schema is in
 		// effect — `parseArgs` will accept `--shell` and `deserializeFlags`

--- a/tests/unit/command-registry.test.ts
+++ b/tests/unit/command-registry.test.ts
@@ -517,3 +517,54 @@ describe("mutating flag correctness", () => {
 		}
 	});
 });
+
+// ─── Verb-level vs resource-level flag bucket disjointness (#256) ───────────
+//
+// Class-scoped guard: for any verb that declares `resourceFlags`, no flag
+// name may appear in BOTH the verb-level `flags` bucket and any
+// `resourceFlags[*]` bucket.
+//
+// Why
+// ---
+// `detectUnknownFlags` (src/command-validation.ts) treats a verb-level flag
+// that ALSO appears in any `resourceFlags` entry as resource-specific —
+// the verb-level declaration is silently dead metadata. This is the exact
+// shape that produced the `--shell` defect class in #255 / #256: a flag
+// looked verb-wide in the registry but was actually only honoured for one
+// resource. Forbidding the duplication structurally makes the misleading
+// shape unrepresentable, so the next contributor can't reintroduce the
+// same defect by copying the existing `completion` pattern.
+//
+// Rule
+// ----
+// If a flag is shared across all resources of a verb, declare it once in
+// verb-level `flags` and leave it out of every `resourceFlags` bucket.
+// If a flag is resource-specific, declare it only in the relevant
+// `resourceFlags[resource]` bucket.
+describe("verb-level flags must not duplicate resourceFlags entries (#256)", () => {
+	test("no flag name appears in both verb-level flags and any resourceFlags bucket", () => {
+		const violations: string[] = [];
+		for (const [verb, def] of Object.entries(REGISTRY)) {
+			if (!def.resourceFlags) continue;
+			const verbFlagNames = new Set(Object.keys(def.flags ?? {}));
+			if (verbFlagNames.size === 0) continue;
+			for (const [resource, resFlags] of Object.entries(def.resourceFlags)) {
+				for (const flagName of Object.keys(resFlags)) {
+					if (verbFlagNames.has(flagName)) {
+						violations.push(
+							`${verb}: --${flagName} declared in both verb-level flags ` +
+								`AND resourceFlags.${resource}. Pick one bucket: ` +
+								`shared verb flags go in 'flags' only; resource-specific ` +
+								`flags go in 'resourceFlags' only.`,
+						);
+					}
+				}
+			}
+		}
+		assert.deepStrictEqual(
+			violations,
+			[],
+			`Found verb/resource flag duplication:\n  - ${violations.join("\n  - ")}`,
+		);
+	});
+});

--- a/tests/unit/command-validation.test.ts
+++ b/tests/unit/command-validation.test.ts
@@ -366,24 +366,21 @@ describe("validateFlags behaviour", () => {
 	beforeEach(setup);
 	afterEach(teardown);
 
+	// processDefinitionKey lives in `search.resourceFlags["process-instance"]`,
+	// not at the verb level (#256 — per-resource flags must not be duplicated
+	// in the verb-level `flags` bucket).
+	const piFlags = COMMAND_REGISTRY.search.resourceFlags?.["process-instance"];
+	assert.ok(piFlags, "search.resourceFlags['process-instance'] must exist");
+
 	test("exits on invalid flag value", () => {
-		const searchDef = COMMAND_REGISTRY.search;
 		assert.throws(
-			() =>
-				validateFlags(
-					{ processDefinitionKey: "not-a-number" },
-					searchDef.flags,
-				),
+			() => validateFlags({ processDefinitionKey: "not-a-number" }, piFlags),
 			/process\.exit\(1\)/,
 		);
 	});
 
 	test("passes valid values through", () => {
-		const searchDef = COMMAND_REGISTRY.search;
-		const result = validateFlags(
-			{ processDefinitionKey: "12345" },
-			searchDef.flags,
-		);
+		const result = validateFlags({ processDefinitionKey: "12345" }, piFlags);
 		assert.ok(result.has("processDefinitionKey"));
 		assert.strictEqual(String(result.get("processDefinitionKey")), "12345");
 	});
@@ -398,18 +395,13 @@ describe("validateFlags behaviour", () => {
 	});
 
 	test("skips flags not present in values", () => {
-		const searchDef = COMMAND_REGISTRY.search;
-		const result = validateFlags({}, searchDef.flags);
+		const result = validateFlags({}, piFlags);
 		assert.strictEqual(result.size, 0);
 	});
 
 	test("skips boolean flag values", () => {
-		const searchDef = COMMAND_REGISTRY.search;
 		// processDefinitionKey as boolean should be skipped (not validated)
-		const result = validateFlags(
-			{ processDefinitionKey: true },
-			searchDef.flags,
-		);
+		const result = validateFlags({ processDefinitionKey: true }, piFlags);
 		assert.strictEqual(result.size, 0);
 	});
 });

--- a/tests/unit/command-validation.test.ts
+++ b/tests/unit/command-validation.test.ts
@@ -251,7 +251,7 @@ describe("requireOneOf", () => {
 
 // ─── validateFlags ───────────────────────────────────────────────────────────
 
-import type { CommandDef } from "../../src/command-registry.ts";
+import type { CommandDef, FlagDef } from "../../src/command-registry.ts";
 import {
 	COMMAND_REGISTRY,
 	GLOBAL_FLAGS,
@@ -293,17 +293,38 @@ function isBrandedInContext(
 }
 
 describe("validateFlags structural invariants", () => {
+	// Iterate both verb-level `flags` and every `resourceFlags[*]` bucket so
+	// these guards remain effective after the #256 refactor moved per-resource
+	// flags out of verb-level `flags`. Without iterating `resourceFlags`, the
+	// branded-type and validator checks would silently skip flags like
+	// `processDefinitionKey` (now in `search.resourceFlags["process-instance"]`)
+	// and miss the same defect class they were written to catch.
+	function* allFlagEntries(
+		def: CommandDef,
+	): IterableIterator<[string, string, FlagDef]> {
+		for (const [name, flagDef] of Object.entries(def.flags)) {
+			yield ["flags", name, flagDef];
+		}
+		if (def.resourceFlags) {
+			for (const [resource, rFlags] of Object.entries(def.resourceFlags)) {
+				for (const [name, flagDef] of Object.entries(rFlags)) {
+					yield [`resourceFlags.${resource}`, name, flagDef];
+				}
+			}
+		}
+	}
+
 	test("every branded-type flag in the registry has a validate function", () => {
 		const missing: string[] = [];
 
 		for (const [verb, def] of Object.entries(REGISTRY)) {
-			for (const [flagName, flagDef] of Object.entries(def.flags)) {
+			for (const [bucket, flagName, flagDef] of allFlagEntries(def)) {
 				if (
 					BRANDED_FLAG_NAMES.has(flagName) &&
 					isBrandedInContext(flagName, def) &&
 					!flagDef.validate
 				) {
-					missing.push(`${verb}.flags.${flagName}`);
+					missing.push(`${verb}.${bucket}.${flagName}`);
 				}
 			}
 		}
@@ -317,14 +338,14 @@ describe("validateFlags structural invariants", () => {
 
 	test("validate functions throw on invalid input for key-type flags", () => {
 		for (const [verb, def] of Object.entries(REGISTRY)) {
-			for (const [flagName, flagDef] of Object.entries(def.flags)) {
+			for (const [bucket, flagName, flagDef] of allFlagEntries(def)) {
 				if (!flagDef.validate) continue;
 
 				// Key-type fields (numeric pattern) reject non-numeric strings
 				if (flagName.endsWith("Key")) {
 					assert.throws(
 						() => flagDef.validate?.("not-a-number"),
-						`${verb}.flags.${flagName}.validate should throw on invalid input`,
+						`${verb}.${bucket}.${flagName}.validate should throw on invalid input`,
 					);
 				}
 			}
@@ -333,7 +354,7 @@ describe("validateFlags structural invariants", () => {
 
 	test("validate functions return the input for valid values", () => {
 		for (const [verb, def] of Object.entries(REGISTRY)) {
-			for (const [flagName, flagDef] of Object.entries(def.flags)) {
+			for (const [bucket, flagName, flagDef] of allFlagEntries(def)) {
 				if (!flagDef.validate) continue;
 
 				// Key-type fields accept numeric strings
@@ -342,7 +363,7 @@ describe("validateFlags structural invariants", () => {
 					assert.strictEqual(
 						String(result),
 						"12345",
-						`${verb}.flags.${flagName}.validate("12345") should return "12345"`,
+						`${verb}.${bucket}.${flagName}.validate("12345") should return "12345"`,
 					);
 				}
 
@@ -354,7 +375,7 @@ describe("validateFlags structural invariants", () => {
 					assert.strictEqual(
 						String(result),
 						"test-value",
-						`${verb}.flags.${flagName}.validate("test-value") should return "test-value"`,
+						`${verb}.${bucket}.${flagName}.validate("test-value") should return "test-value"`,
 					);
 				}
 			}

--- a/tests/unit/deploy-error-paths.test.ts
+++ b/tests/unit/deploy-error-paths.test.ts
@@ -135,4 +135,48 @@ describe("deploy: behavioural — error paths flow through the framework", () =>
 			`SilentError must suppress the framework's '${FRAMEWORK_PREFIX}' summary on top of the pre-rendered rich error. stderr:\n${result.stderr}`,
 		);
 	});
+
+	// Class-of-defect regression for PR #343 review comment:
+	// For verbs without enumerated resources (deploy/run/watch/…), `ctx.resource`
+	// in `defineCommand` holds the FIRST POSITIONAL argument (e.g. a file path),
+	// not a resource identifier. Using it in the framework error prefix produces
+	// misleading messages like "Failed to deploy /tmp/xyz/empty" that leak user
+	// input into the diagnostic prefix. The framework prefix message for
+	// resourceless verbs must be exactly "Failed to deploy" — no trailing
+	// positional. (Note: the framework also runs `replace(/-/g, " ")` on the
+	// resource segment, so a literal substring search for the leaked path can
+	// false-negative; this test parses the JSON error record and asserts the
+	// `message` field equals "Failed to deploy" exactly.)
+	test("resourceless verbs: framework prefix must not leak the first positional", async () => {
+		const emptyDir = join(tempDir, "leak-check");
+		mkdirSync(emptyDir, { recursive: true });
+
+		const result = await c8("deploy", emptyDir);
+
+		assert.strictEqual(result.status, 1);
+		// In JSON output mode (test default), each logger.error call emits
+		// a single-line JSON object on stderr. Find the error record.
+		const errorLine = result.stderr
+			.split("\n")
+			.map((l) => l.trim())
+			.find((l) => l.startsWith("{") && l.includes('"status":"error"'));
+		assert.ok(
+			errorLine,
+			`expected a JSON error record on stderr. stderr:\n${result.stderr}`,
+		);
+		const errorRecord: unknown = JSON.parse(errorLine);
+		assert.ok(
+			typeof errorRecord === "object" &&
+				errorRecord !== null &&
+				"message" in errorRecord &&
+				typeof errorRecord.message === "string",
+			`expected JSON error record with a string 'message' field. Got: ${errorLine}`,
+		);
+		assert.strictEqual(
+			errorRecord.message,
+			"Failed to deploy",
+			`framework prefix must be exactly 'Failed to deploy' for the resourceless deploy verb — ` +
+				`first-positional path arguments must NOT be appended. Got: ${JSON.stringify(errorRecord.message)}`,
+		);
+	});
 });


### PR DESCRIPTION
Closes #256.

## What

Adds a class-scoped structural guard that forbids declaring the same flag name in both verb-level `flags` and any `resourceFlags[*]` bucket, and removes the existing duplications that the new guard catches.

## Why

`detectUnknownFlags` (`src/command-validation.ts`) treats verb-level flags that *also* appear in any `resourceFlags` entry as resource-specific — the verb-level entry is silently dead metadata. This is the exact misleading shape that produced the original `--shell` defect (#255 / #256): a flag looked verb-wide in the registry but was only honoured for one resource.

The new guard makes the misleading shape unrepresentable. The next contributor cannot reintroduce the same defect class by copying the previous `completion` pattern.

## Red → green

Two-commit sequence:

1. **`test(registry): add structural guard …`** — adds the failing guard. Run alone, it fails for `completion`, `list`, `search`, and `get` — proving the guard can detect the defect class.
2. **`refactor(registry): remove dead per-resource flag duplicates …`** — drops the duplicates from the four verbs and updates `validateFlags behaviour` tests to read `processDefinitionKey` from `search.resourceFlags["process-instance"]` (where it now lives).

## Behaviour changes

- `parseArgs` still accepts every per-resource flag globally — `deriveParseArgsOptions` already iterates `resourceFlags` (no change).
- `detectUnknownFlags` now correctly **rejects** misuse it previously silently accepted via the dead duplicate. For example:
  - `c8ctl get user --xml` → unknown-flag warning (was: silently parsed and ignored)
  - `c8ctl list users --processDefinitionId=foo` → unknown-flag warning
  - `c8ctl completion zsh --shell bash` → unchanged (already warned via runtime check; now structurally enforced)
- `help` and shell-completion output are unaffected. `help.ts` already filtered duplicates explicitly (the cleanup turns that filter into a no-op); `completion.ts` iterates both buckets via `Set`/`Map`.

## Implementation note: `completion`

`completionCommand` is now registered against `"install"` instead of `""` so the typed `flags` parameter still includes `shell`. The dispatch key remains `completion:` because dispatch derives from `requiresResource`, not from the registration resource. Documented inline.

## Test counts

- Unit tests: 1447 → 1448 (+1 structural guard).
- All other suites unchanged. `npm run build` and `npm test` pass locally.

## Refs

- #256 — parent issue
- #255 — original `--shell` defect that motivated #256
- #289 — sibling structural lint (no `process.exit` under `src/commands/**`)
- #290 — sibling structural test (every `COMMAND_DISPATCH` entry from `defineCommand`)
- #291 — sibling boundary test (no test imports from `src/commands/**`)