### PR TITLE
feat: show resource aliases in command reference and escape angle brackets for MDX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Cocktail (c8ctl) - Camunda 8 CLI
+# Cocktail (c8ctl) - Camunda 8 CLI
 
 c8ctl (_pronounced: "cocktail"_) — a minimal-dependency CLI for Camunda 8 operations built on top of [`@camunda8/orchestration-cluster-api`](https://www.npmjs.com/package/@camunda8/orchestration-cluster-api).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Cocktail (c8ctl) - Camunda 8 CLI
+﻿# Cocktail (c8ctl) - Camunda 8 CLI
 
 c8ctl (_pronounced: "cocktail"_) — a minimal-dependency CLI for Camunda 8 operations built on top of [`@camunda8/orchestration-cluster-api`](https://www.npmjs.com/package/@camunda8/orchestration-cluster-api).
 
@@ -801,7 +801,7 @@ List resources
 **Resource-specific flags:**
 
 <details>
-<summary><code>process-definition</code></summary>
+<summary><code>process-definition</code> (<code>pd</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -816,7 +816,7 @@ List resources
 </details>
 
 <details>
-<summary><code>process-instance</code></summary>
+<summary><code>process-instance</code> (<code>pi</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -832,7 +832,7 @@ List resources
 </details>
 
 <details>
-<summary><code>user-task</code></summary>
+<summary><code>user-task</code> (<code>ut</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -846,7 +846,7 @@ List resources
 </details>
 
 <details>
-<summary><code>incident</code></summary>
+<summary><code>incident</code> (<code>inc</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -918,7 +918,7 @@ List resources
 </details>
 
 <details>
-<summary><code>authorization</code></summary>
+<summary><code>authorization</code> (<code>auth</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -930,7 +930,7 @@ List resources
 </details>
 
 <details>
-<summary><code>mapping-rule</code></summary>
+<summary><code>mapping-rule</code> (<code>mr</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -960,7 +960,7 @@ Search resources with filters (wildcards, date ranges, case-insensitive)
 **Resource-specific flags:**
 
 <details>
-<summary><code>process-definition</code></summary>
+<summary><code>process-definition</code> (<code>pd</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -975,7 +975,7 @@ Search resources with filters (wildcards, date ranges, case-insensitive)
 </details>
 
 <details>
-<summary><code>process-instance</code></summary>
+<summary><code>process-instance</code> (<code>pi</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -991,7 +991,7 @@ Search resources with filters (wildcards, date ranges, case-insensitive)
 </details>
 
 <details>
-<summary><code>user-task</code></summary>
+<summary><code>user-task</code> (<code>ut</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -1005,7 +1005,7 @@ Search resources with filters (wildcards, date ranges, case-insensitive)
 </details>
 
 <details>
-<summary><code>incident</code></summary>
+<summary><code>incident</code> (<code>inc</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -1036,7 +1036,7 @@ Search resources with filters (wildcards, date ranges, case-insensitive)
 </details>
 
 <details>
-<summary><code>variable</code></summary>
+<summary><code>variable</code> (<code>var</code>, <code>vars</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -1092,7 +1092,7 @@ Search resources with filters (wildcards, date ranges, case-insensitive)
 </details>
 
 <details>
-<summary><code>authorization</code></summary>
+<summary><code>authorization</code> (<code>auth</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -1104,7 +1104,7 @@ Search resources with filters (wildcards, date ranges, case-insensitive)
 </details>
 
 <details>
-<summary><code>mapping-rule</code></summary>
+<summary><code>mapping-rule</code> (<code>mr</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -1156,7 +1156,7 @@ Get a resource by key
 **Resource-specific flags:**
 
 <details>
-<summary><code>process-definition</code></summary>
+<summary><code>process-definition</code> (<code>pd</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -1177,7 +1177,7 @@ Get a resource by key
 </details>
 
 <details>
-<summary><code>process-instance</code></summary>
+<summary><code>process-instance</code> (<code>pi</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -1231,7 +1231,7 @@ Create a resource (process instance, identity)
 **Resource-specific flags:**
 
 <details>
-<summary><code>authorization</code></summary>
+<summary><code>authorization</code> (<code>auth</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -1859,7 +1859,7 @@ Open the feedback page to report issues or request features
 
 #### `help`
 
-Show help (run 'c8ctl help <command>' for details)
+Show help (run 'c8ctl help \<command>' for details)
 
 **Usage:** `c8ctl help [command]`
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -69,7 +69,7 @@ List resources
 **Resource-specific flags:**
 
 <details>
-<summary><code>process-definition</code></summary>
+<summary><code>process-definition</code> (<code>pd</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -84,7 +84,7 @@ List resources
 </details>
 
 <details>
-<summary><code>process-instance</code></summary>
+<summary><code>process-instance</code> (<code>pi</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -100,7 +100,7 @@ List resources
 </details>
 
 <details>
-<summary><code>user-task</code></summary>
+<summary><code>user-task</code> (<code>ut</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -114,7 +114,7 @@ List resources
 </details>
 
 <details>
-<summary><code>incident</code></summary>
+<summary><code>incident</code> (<code>inc</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -186,7 +186,7 @@ List resources
 </details>
 
 <details>
-<summary><code>authorization</code></summary>
+<summary><code>authorization</code> (<code>auth</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -198,7 +198,7 @@ List resources
 </details>
 
 <details>
-<summary><code>mapping-rule</code></summary>
+<summary><code>mapping-rule</code> (<code>mr</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -228,7 +228,7 @@ Search resources with filters (wildcards, date ranges, case-insensitive)
 **Resource-specific flags:**
 
 <details>
-<summary><code>process-definition</code></summary>
+<summary><code>process-definition</code> (<code>pd</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -243,7 +243,7 @@ Search resources with filters (wildcards, date ranges, case-insensitive)
 </details>
 
 <details>
-<summary><code>process-instance</code></summary>
+<summary><code>process-instance</code> (<code>pi</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -259,7 +259,7 @@ Search resources with filters (wildcards, date ranges, case-insensitive)
 </details>
 
 <details>
-<summary><code>user-task</code></summary>
+<summary><code>user-task</code> (<code>ut</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -273,7 +273,7 @@ Search resources with filters (wildcards, date ranges, case-insensitive)
 </details>
 
 <details>
-<summary><code>incident</code></summary>
+<summary><code>incident</code> (<code>inc</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -304,7 +304,7 @@ Search resources with filters (wildcards, date ranges, case-insensitive)
 </details>
 
 <details>
-<summary><code>variable</code></summary>
+<summary><code>variable</code> (<code>var</code>, <code>vars</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -360,7 +360,7 @@ Search resources with filters (wildcards, date ranges, case-insensitive)
 </details>
 
 <details>
-<summary><code>authorization</code></summary>
+<summary><code>authorization</code> (<code>auth</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -372,7 +372,7 @@ Search resources with filters (wildcards, date ranges, case-insensitive)
 </details>
 
 <details>
-<summary><code>mapping-rule</code></summary>
+<summary><code>mapping-rule</code> (<code>mr</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -424,7 +424,7 @@ Get a resource by key
 **Resource-specific flags:**
 
 <details>
-<summary><code>process-definition</code></summary>
+<summary><code>process-definition</code> (<code>pd</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -445,7 +445,7 @@ Get a resource by key
 </details>
 
 <details>
-<summary><code>process-instance</code></summary>
+<summary><code>process-instance</code> (<code>pi</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -499,7 +499,7 @@ Create a resource (process instance, identity)
 **Resource-specific flags:**
 
 <details>
-<summary><code>authorization</code></summary>
+<summary><code>authorization</code> (<code>auth</code>)</summary>
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
@@ -1127,7 +1127,7 @@ Open the feedback page to report issues or request features
 
 ### `help`
 
-Show help (run 'c8ctl help <command>' for details)
+Show help (run 'c8ctl help \<command>' for details)
 
 **Usage:** `c8ctl help [command]`
 

--- a/scripts/sync-readme-commands.ts
+++ b/scripts/sync-readme-commands.ts
@@ -57,6 +57,17 @@ export function uniqueAliases(): Array<{ alias: string; canonical: string }> {
 	return result.sort((a, b) => a.canonical.localeCompare(b.canonical));
 }
 
+/** Get all short aliases for a canonical resource name. */
+function aliasesForResource(canonical: string): string[] {
+	const aliases: string[] = [];
+	for (const [alias, target] of Object.entries(RESOURCE_ALIASES)) {
+		if (target === canonical && alias !== canonical && alias !== `${canonical}s`) {
+			aliases.push(alias);
+		}
+	}
+	return aliases.sort();
+}
+
 /** Format a flag name for display: `--name` or `--name` / `-s` */
 export function formatFlag(name: string, def: FlagDef): string {
 	const long = `\`--${name}\``;
@@ -92,9 +103,12 @@ export function renderPositionals(
 		.join(", ");
 }
 
-/** Get the display description for a verb */
+/** Get the display description for a verb (escapes bare angle brackets for MDX compatibility) */
 function verbDescription(def: CommandDef): string {
-	return def.helpDescription ?? def.description;
+	const desc = def.helpDescription ?? def.description;
+	// Escape < that are NOT inside backtick spans (MDX treats them as JSX tags).
+	// Replace < only when not preceded by a backtick context.
+	return desc.replace(/`[^`]*`|(<)/g, (match, lt) => (lt ? "\\<" : match));
 }
 
 /** Resolve resource short name to canonical, returning the display form */
@@ -223,8 +237,15 @@ export function generateCommandContent(
 			lines.push("");
 			for (const [resource, rFlags] of Object.entries(def.resourceFlags)) {
 				if (Object.keys(rFlags).length === 0) continue;
+				const aliases = aliasesForResource(resource);
+				const aliasSuffix =
+					aliases.length > 0
+						? ` (${aliases.map((a) => `<code>${a}</code>`).join(", ")})`
+						: "";
 				lines.push(`<details>`);
-				lines.push(`<summary><code>${resource}</code></summary>`);
+				lines.push(
+					`<summary><code>${resource}</code>${aliasSuffix}</summary>`,
+				);
 				lines.push("");
 				lines.push(...renderFlagsTable(rFlags));
 				lines.push("");

--- a/scripts/sync-readme-commands.ts
+++ b/scripts/sync-readme-commands.ts
@@ -61,7 +61,11 @@ export function uniqueAliases(): Array<{ alias: string; canonical: string }> {
 function aliasesForResource(canonical: string): string[] {
 	const aliases: string[] = [];
 	for (const [alias, target] of Object.entries(RESOURCE_ALIASES)) {
-		if (target === canonical && alias !== canonical && alias !== `${canonical}s`) {
+		if (
+			target === canonical &&
+			alias !== canonical &&
+			alias !== `${canonical}s`
+		) {
 			aliases.push(alias);
 		}
 	}
@@ -243,9 +247,7 @@ export function generateCommandContent(
 						? ` (${aliases.map((a) => `<code>${a}</code>`).join(", ")})`
 						: "";
 				lines.push(`<details>`);
-				lines.push(
-					`<summary><code>${resource}</code>${aliasSuffix}</summary>`,
-				);
+				lines.push(`<summary><code>${resource}</code>${aliasSuffix}</summary>`);
 				lines.push("");
 				lines.push(...renderFlagsTable(rFlags));
 				lines.push("");

--- a/tests/unit/sync-readme-commands.test.ts
+++ b/tests/unit/sync-readme-commands.test.ts
@@ -163,8 +163,13 @@ describe("verbDescription escapes bare angle brackets for MDX", () => {
 	test("angle brackets inside backtick spans are not escaped", () => {
 		// Usage lines like `c8ctl delete <resource> <key>` should keep < unescaped
 		assert.ok(
-			output.includes("`c8ctl help"),
-			"Expected backtick-wrapped usage line for help",
+			output.includes("`c8ctl delete <resource> <key>`"),
+			"Expected unescaped <resource> <key> inside backtick usage span",
+		);
+		// The escaped form should NOT appear inside backtick spans
+		assert.ok(
+			!output.includes("`c8ctl delete \\<resource>"),
+			"Escaped \\<resource> should not appear inside backtick spans",
 		);
 	});
 });

--- a/tests/unit/sync-readme-commands.test.ts
+++ b/tests/unit/sync-readme-commands.test.ts
@@ -128,7 +128,11 @@ describe("generate() includes verb descriptions", () => {
 
 	for (const [verb, def] of Object.entries(REGISTRY)) {
 		test(`verb "${verb}" shows its description`, () => {
-			const expected = def.helpDescription ?? def.description;
+			const raw = def.helpDescription ?? def.description;
+			// verbDescription() escapes bare angle brackets for MDX compatibility
+			const expected = raw.replace(/`[^`]*`|(<)/g, (m, lt) =>
+				lt ? "\\<" : m,
+			);
 			assert.ok(
 				output.includes(expected),
 				`Missing description for "${verb}": expected "${expected}"`,

--- a/tests/unit/sync-readme-commands.test.ts
+++ b/tests/unit/sync-readme-commands.test.ts
@@ -129,14 +129,44 @@ describe("generate() includes verb descriptions", () => {
 	for (const [verb, def] of Object.entries(REGISTRY)) {
 		test(`verb "${verb}" shows its description`, () => {
 			const raw = def.helpDescription ?? def.description;
-			// verbDescription() escapes bare angle brackets for MDX compatibility
-			const expected = raw.replace(/`[^`]*`|(<)/g, (m, lt) => (lt ? "\\<" : m));
 			assert.ok(
-				output.includes(expected),
-				`Missing description for "${verb}": expected "${expected}"`,
+				output.includes(raw) ||
+					// If the raw description has bare <, it will be escaped
+					(raw.includes("<") && output.includes(raw.replaceAll("<", "\\<"))),
+				`Missing description for "${verb}": expected "${raw}"`,
 			);
 		});
 	}
+});
+
+// ─── MDX angle bracket escaping ──────────────────────────────────────────────
+
+describe("verbDescription escapes bare angle brackets for MDX", () => {
+	const output = generate();
+
+	test("help verb description escapes bare <command> to \\<command>", () => {
+		assert.ok(
+			output.includes("\\<command>"),
+			"Expected escaped \\<command> in help description",
+		);
+		// The unescaped form (without preceding backslash) should NOT appear
+		// outside backtick spans
+		const helpSection = verbSection(output, "help");
+		const withoutCodeSpans = helpSection.replace(/`[^`]*`/g, "");
+		const hasBareAngleBracket = /(?<!\\)<command>/.test(withoutCodeSpans);
+		assert.ok(
+			!hasBareAngleBracket,
+			"Bare <command> should not appear outside backtick spans",
+		);
+	});
+
+	test("angle brackets inside backtick spans are not escaped", () => {
+		// Usage lines like `c8ctl delete <resource> <key>` should keep < unescaped
+		assert.ok(
+			output.includes("`c8ctl help"),
+			"Expected backtick-wrapped usage line for help",
+		);
+	});
 });
 
 // ─── Global flags all appear ─────────────────────────────────────────────────
@@ -263,6 +293,42 @@ describe("generate() includes resource-specific flags", () => {
 			});
 		}
 	}
+});
+
+// ─── Resource alias display in resource-specific flag summaries ──────────────
+
+describe("resource-specific flag summaries include aliases", () => {
+	const output = generate();
+
+	test('process-instance summary shows alias "pi"', () => {
+		assert.ok(
+			output.includes("<code>process-instance</code> (<code>pi</code>)"),
+			'Expected process-instance summary to include alias "pi"',
+		);
+	});
+
+	test('variable summary shows aliases "var" and "vars"', () => {
+		assert.ok(
+			output.includes(
+				"<code>variable</code> (<code>var</code>, <code>vars</code>)",
+			),
+			'Expected variable summary to include aliases "var" and "vars"',
+		);
+	});
+
+	test("resources with no short aliases have no parenthetical", () => {
+		// "jobs" is a canonical resource with no short aliases
+		const jobsSummary = output.includes("<code>jobs</code> (");
+		assert.ok(
+			!jobsSummary,
+			'"jobs" should have no alias parenthetical in its summary',
+		);
+		// But the resource itself should still appear
+		assert.ok(
+			output.includes("<code>jobs</code>"),
+			'"jobs" should still appear as a resource',
+		);
+	});
 });
 
 // ─── filterVerbSpecificFlags ─────────────────────────────────────────────────

--- a/tests/unit/sync-readme-commands.test.ts
+++ b/tests/unit/sync-readme-commands.test.ts
@@ -130,9 +130,7 @@ describe("generate() includes verb descriptions", () => {
 		test(`verb "${verb}" shows its description`, () => {
 			const raw = def.helpDescription ?? def.description;
 			// verbDescription() escapes bare angle brackets for MDX compatibility
-			const expected = raw.replace(/`[^`]*`|(<)/g, (m, lt) =>
-				lt ? "\\<" : m,
-			);
+			const expected = raw.replace(/`[^`]*`|(<)/g, (m, lt) => (lt ? "\\<" : m));
 			assert.ok(
 				output.includes(expected),
 				`Missing description for "${verb}": expected "${expected}"`,


### PR DESCRIPTION
## Description

Two improvements to the generated command reference:

1. **Resource aliases in resource-specific flags** — The `<details>` summary for each resource now shows valid short aliases in parentheses. For example:
   - `process-definition` (`pd`)
   - `process-instance` (`pi`)
   - `user-task` (`ut`)
   - `variable` (`var`, `vars`)
   - Resources with no aliases show no parenthetical

2. **MDX angle bracket escaping** — Bare `<` characters in verb descriptions (e.g. `<command>` in the help description) are now escaped as `\<` to prevent Docusaurus MDX from interpreting them as JSX tags. Angle brackets inside backtick spans are left alone.

### Related

- Follows up on #340 (docs generation)
- Part of #237 (integrate with Camunda docs)

## PR Checklist

- [x] Tests pass (230/230)
- [x] README and docs regenerated