### PR TITLE
fix: forward all args to plugins (closed)

### DIFF
--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -68,7 +68,7 @@ Commands:
   add       profile <name>   Add a profile
   remove    profile <name>   Remove a profile (alias: rm)
   load      plugin <name>    Load a c8ctl plugin from npm registry
-  load      plugin <url>     Load a c8ctl plugin from URL (https://, git://, file://)
+  load      plugin --from <url>  Load a c8ctl plugin from URL (https://, git://, file://)
   unload    plugin <name>    Unload a c8ctl plugin (npm uninstall wrapper)
   upgrade   plugin <name> [version]  Upgrade a plugin (respects source type)
   downgrade plugin <name> <version>  Downgrade a plugin to a specific version
@@ -82,7 +82,7 @@ Commands:
 
 Flags:
   --profile <name>      Use specific profile for this command
-  --from <url>          Load plugin from URL, alternative to passing URL as positional arg (use with 'load plugin')
+  --from <url>          Load plugin from URL (use with 'load plugin')
   --xml                 Get process definition as XML (use with 'get pd')
   --variables           Get process instance with variables (use with 'get pi')
   --userTask, --ut      Get form for a user task (optional, use with 'get form')
@@ -172,7 +172,7 @@ Examples:
   c8ctl output json                  Switch to JSON output
   c8ctl init plugin my-plugin        Create new plugin from template
   c8ctl load plugin my-plugin        Load plugin from npm registry
-  c8ctl load plugin https://github.com/org/plugin  Load plugin from URL
+  c8ctl load plugin --from https://github.com/org/plugin  Load plugin from URL
   c8ctl upgrade plugin my-plugin     Upgrade plugin to latest version
   c8ctl upgrade plugin my-plugin 1.2.3  Upgrade plugin to a specific version (source-aware)
   c8ctl sync plugin                  Synchronize plugins
@@ -979,8 +979,8 @@ Plugin commands:
   load plugin <name>
     Load a plugin from npm registry.
 
-  load plugin <url>
-    Load a plugin from URL source (https://, http://, git://, git+https://, git+ssh://, file://, github:, gitlab:, bitbucket:). The --from flag is also accepted for backwards compatibility.
+  load plugin --from <url>
+    Load a plugin from URL source (file://, https://, git://, github:).
 
   unload plugin <name>
     Unload and unregister a plugin.
@@ -1009,8 +1009,8 @@ Plugin commands:
 
 Examples:
   c8ctl load plugin my-plugin
-  c8ctl load plugin https://github.com/org/plugin
-  c8ctl load plugin file:///path/to/plugin
+  c8ctl load plugin --from https://github.com/org/plugin
+  c8ctl load plugin --from file:///path/to/plugin
   c8ctl list plugins
   c8ctl upgrade plugin my-plugin
   c8ctl upgrade plugin my-plugin 1.2.3

--- a/src/commands/help.ts
+++ b/src/commands/help.ts
@@ -68,7 +68,7 @@ Commands:
   add       profile <name>   Add a profile
   remove    profile <name>   Remove a profile (alias: rm)
   load      plugin <name>    Load a c8ctl plugin from npm registry
-  load      plugin --from    Load a c8ctl plugin from URL (file://, https://, git://)
+  load      plugin <url>     Load a c8ctl plugin from URL (https://, git://, file://)
   unload    plugin <name>    Unload a c8ctl plugin (npm uninstall wrapper)
   upgrade   plugin <name> [version]  Upgrade a plugin (respects source type)
   downgrade plugin <name> <version>  Downgrade a plugin to a specific version
@@ -82,7 +82,7 @@ Commands:
 
 Flags:
   --profile <name>      Use specific profile for this command
-  --from <url>          Load plugin from URL (use with 'load plugin')
+  --from <url>          Load plugin from URL, alternative to passing URL as positional arg (use with 'load plugin')
   --xml                 Get process definition as XML (use with 'get pd')
   --variables           Get process instance with variables (use with 'get pi')
   --userTask, --ut      Get form for a user task (optional, use with 'get form')
@@ -172,7 +172,7 @@ Examples:
   c8ctl output json                  Switch to JSON output
   c8ctl init plugin my-plugin        Create new plugin from template
   c8ctl load plugin my-plugin        Load plugin from npm registry
-  c8ctl load plugin --from file:///path/to/plugin  Load plugin from file URL
+  c8ctl load plugin https://github.com/org/plugin  Load plugin from URL
   c8ctl upgrade plugin my-plugin     Upgrade plugin to latest version
   c8ctl upgrade plugin my-plugin 1.2.3  Upgrade plugin to a specific version (source-aware)
   c8ctl sync plugin                  Synchronize plugins
@@ -976,8 +976,8 @@ Plugin commands:
   load plugin <name>
     Load a plugin from npm registry.
 
-  load plugin --from <url>
-    Load a plugin from URL source (file://, https://, git://, github:).
+  load plugin <url>
+    Load a plugin from URL source (https://, http://, git://, git+https://, git+ssh://, file://, github:, gitlab:, bitbucket:). The --from flag is also accepted for backwards compatibility.
 
   unload plugin <name>
     Unload and unregister a plugin.
@@ -1006,7 +1006,8 @@ Plugin commands:
 
 Examples:
   c8ctl load plugin my-plugin
-  c8ctl load plugin --from file:///path/to/plugin
+  c8ctl load plugin https://github.com/org/plugin
+  c8ctl load plugin file:///path/to/plugin
   c8ctl list plugins
   c8ctl upgrade plugin my-plugin
   c8ctl upgrade plugin my-plugin 1.2.3

--- a/src/commands/plugins.ts
+++ b/src/commands/plugins.ts
@@ -23,7 +23,7 @@ type NpmListOutput = { dependencies?: Record<string, unknown> };
 type ExecFileErrorWithStdout = Error & { status?: number; stdout?: Buffer | string };
 
 function isAcceptedUrl(input: string): boolean {
-  return /^(https?\/\/|git(\+https|\+ssh)?\/\/|file\/\/?):/i.test(input);
+  return /^(https?:\/\/|git(\+https|\+ssh)?:\/\/|file:\/\/?)/i.test(input);
 }
 
 function getTemplate(templateFileName: string): string {

--- a/src/commands/plugins.ts
+++ b/src/commands/plugins.ts
@@ -23,7 +23,7 @@ type NpmListOutput = { dependencies?: Record<string, unknown> };
 type ExecFileErrorWithStdout = Error & { status?: number; stdout?: Buffer | string };
 
 function isAcceptedUrl(input: string): boolean {
-  return /^(https?|git(\+https|\+ssh)?|file):\/\//i.test(input);
+  return /^(https?\/\/|git(\+https|\+ssh)?\/\/|file\/\/?):/i.test(input);
 }
 
 function getTemplate(templateFileName: string): string {

--- a/src/commands/plugins.ts
+++ b/src/commands/plugins.ts
@@ -22,6 +22,10 @@ const __dirname = dirname(__filename);
 type NpmListOutput = { dependencies?: Record<string, unknown> };
 type ExecFileErrorWithStdout = Error & { status?: number; stdout?: Buffer | string };
 
+function isAcceptedUrl(input: string): boolean {
+  return /^(https?|git(\+https|\+ssh)?|file):\/\//i.test(input);
+}
+
 function getTemplate(templateFileName: string): string {
   const templatePath = join(__dirname, '..', 'templates', templateFileName);
   return readFileSync(templatePath, 'utf-8');
@@ -40,17 +44,27 @@ function renderTemplate(templateFileName: string, replacements: Record<string, s
  * Supports either package name or --from flag with URL
  * Installs to global plugins directory
  */
-export async function loadPlugin(packageNameOrFrom?: string, fromUrl?: string): Promise<void> {
+export async function loadPlugin(packageName?: string, fromUrl?: string): Promise<void> {
   const logger = getLogger();
   
-  // Validate exclusive usage
-  if (packageNameOrFrom && fromUrl) {
-    logger.error('Cannot specify both package name and --from flag. Use either "c8ctl load plugin <name>" or "c8ctl load plugin --from <url>"');
+  // Validate input
+  if (fromUrl && packageName) {
+    logger.error('Cannot specify both a positional argument and --from flag. Use either "c8 load plugin <name>" or "c8 load plugin --from <url>"');
     process.exit(1);
   }
   
-  if (!packageNameOrFrom && !fromUrl) {
-    logger.error('Package name or --from URL required. Usage: c8ctl load plugin <package-name> OR c8ctl load plugin --from <url>');
+  if (!packageName && !fromUrl) {
+    logger.error('Package name or URL required. Usage: c8 load plugin <name> or c8 load plugin --from <url>');
+    process.exit(1);
+  }
+  
+  if (fromUrl && !isAcceptedUrl(fromUrl)) {
+    logger.error('Invalid URL format. Accepted URL formats include file://, https://, git:// (see help for more)');
+    process.exit(1);
+  }
+  
+  if (packageName && isAcceptedUrl(packageName)) {
+    logger.error('Package name cannot be a URL. If you want to load from a URL, use the --from flag. Usage: c8 load plugin --from <url>');
     process.exit(1);
   }
   
@@ -83,13 +97,13 @@ export async function loadPlugin(packageNameOrFrom?: string, fromUrl?: string): 
       logger.success('Plugin loaded successfully from URL', fromUrl);
     } else {
       // Install from npm registry by package name
-      logger.info(`Loading plugin: ${packageNameOrFrom}...`);
-      execSync(`npm install ${packageNameOrFrom} --prefix "${pluginsDir}"`, { stdio: 'inherit' });
+      logger.info(`Loading plugin: ${packageName}...`);
+      execSync(`npm install ${packageName} --prefix "${pluginsDir}"`, { stdio: 'inherit' });
       
-      pluginName = packageNameOrFrom!;
-      pluginSource = packageNameOrFrom!;
+      pluginName = packageName!;
+      pluginSource = packageName!;
       
-      logger.success('Plugin loaded successfully', packageNameOrFrom);
+      logger.success('Plugin loaded successfully', packageName);
     }
     
     // Add to plugin registry

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,8 +73,9 @@ function normalizeResource(resource: string): string {
  */
 function parseCliArgs() {
   try {
-    const { values, positionals } = parseArgs({
+    const { values, positionals, tokens } = parseArgs({
       args: process.argv.slice(2),
+      tokens: true,
       options: {
         help: { type: 'boolean', short: 'h' },
         version: { type: 'string', short: 'v' },
@@ -134,7 +135,7 @@ function parseCliArgs() {
       strict: false,
     });
 
-    return { values, positionals };
+    return { values, positionals, tokens };
   } catch (error: any) {
     console.error(`Error parsing arguments: ${error.message}`);
     process.exit(1);
@@ -166,7 +167,7 @@ async function main() {
   // Load session state from disk at startup
   loadSessionState();
   
-  const { values, positionals } = parseCliArgs();
+  const { values, positionals, tokens } = parseCliArgs()!;
 
   // Initialize logger with current output mode from c8ctl runtime
   const logger = getLogger(c8ctl.outputMode);
@@ -784,7 +785,12 @@ async function main() {
   }
 
   // Try to execute plugin command (before verb-only check)
-  if (await executePluginCommand(verb, resource ? [resource, ...args] : args)) {
+  // Use raw argv slice so flags (e.g. --from) are forwarded to the plugin, not just positionals.
+  const verbToken = (tokens as Array<{ kind: string; index: number }>).find(t => t.kind === 'positional');
+  const pluginArgs = verbToken !== undefined
+    ? process.argv.slice(2 + verbToken.index + 1)
+    : (resource ? [resource, ...args] : args);
+  if (await executePluginCommand(verb, pluginArgs)) {
     return;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,6 +67,11 @@ function normalizeResource(resource: string): string {
   return aliases[resource] || resource;
 }
 
+function isUrl(input: string): boolean {
+  return /^(https?|git(\+https|\+ssh)?|file):\/\//i.test(input) ||
+    /^(github|gitlab|bitbucket):/i.test(input);
+}
+
 /**
  * Parse command line arguments
  */
@@ -300,20 +305,23 @@ async function main() {
   }
 
   if (verb === 'load' && normalizedResource === 'plugin') {
-    const fromUrl = values.from as string | undefined;
-    const packageName = args[0];
-    
-    // Ensure exclusive usage
-    if (packageName && fromUrl) {
-      logger.error('Cannot specify both package name and --from flag. Use either "c8 load plugin <name>" or "c8 load plugin --from <url>"');
+    const fromFlag = values.from as string | undefined;
+    const arg = args[0];
+
+    if (fromFlag && arg) {
+      logger.error('Cannot specify both a positional argument and --from flag. Use either "c8 load plugin <name-or-url>" or "c8 load plugin --from <url>"');
       process.exit(1);
     }
-    
-    if (!packageName && !fromUrl) {
-      logger.error('Package name or --from URL required. Usage: c8 load plugin <package-name> OR c8 load plugin --from <url>');
+
+    if (!arg && !fromFlag) {
+      logger.error('Package name or URL required. Usage: c8 load plugin <package-name-or-url>');
       process.exit(1);
     }
-    
+
+    // Auto-detect URLs passed as positional argument (--from is optional for URLs)
+    const fromUrl = fromFlag ?? (arg && isUrl(arg) ? arg : undefined);
+    const packageName = fromUrl ? undefined : arg;
+
     await loadPlugin(packageName, fromUrl);
     return;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,11 +67,6 @@ function normalizeResource(resource: string): string {
   return aliases[resource] || resource;
 }
 
-function isUrl(input: string): boolean {
-  return /^(https?|git(\+https|\+ssh)?|file):\/\//i.test(input) ||
-    /^(github|gitlab|bitbucket):/i.test(input);
-}
-
 /**
  * Parse command line arguments
  */
@@ -305,23 +300,8 @@ async function main() {
   }
 
   if (verb === 'load' && normalizedResource === 'plugin') {
-    const fromFlag = values.from as string | undefined;
-    const arg = args[0];
-
-    if (fromFlag && arg) {
-      logger.error('Cannot specify both a positional argument and --from flag. Use either "c8 load plugin <name-or-url>" or "c8 load plugin --from <url>"');
-      process.exit(1);
-    }
-
-    if (!arg && !fromFlag) {
-      logger.error('Package name or URL required. Usage: c8 load plugin <package-name-or-url>');
-      process.exit(1);
-    }
-
-    // Auto-detect URLs passed as positional argument (--from is optional for URLs)
-    const fromUrl = fromFlag ?? (arg && isUrl(arg) ? arg : undefined);
-    const packageName = fromUrl ? undefined : arg;
-
+    const fromUrl = values.from as string | undefined;
+    const packageName = args[0];
     await loadPlugin(packageName, fromUrl);
     return;
   }

--- a/tests/unit/help.test.ts
+++ b/tests/unit/help.test.ts
@@ -477,7 +477,7 @@ describe('Help Module', () => {
     const output = consoleLogSpy.join('\n');
     assert.ok(output.includes('c8ctl plugin'));
     assert.ok(output.includes('load plugin <name>'));
-    assert.ok(output.includes('load plugin --from <url>'));
+    assert.ok(output.includes('load plugin <url>'));
     assert.ok(output.includes('list plugins'));
     assert.ok(output.includes('upgrade plugin <name> [version]'));
     assert.ok(output.includes('downgrade plugin <name> <version>'));

--- a/tests/unit/help.test.ts
+++ b/tests/unit/help.test.ts
@@ -477,7 +477,7 @@ describe('Help Module', () => {
     const output = consoleLogSpy.join('\n');
     assert.ok(output.includes('c8ctl plugin'));
     assert.ok(output.includes('load plugin <name>'));
-    assert.ok(output.includes('load plugin <url>'));
+    assert.ok(output.includes('load plugin --from <url>'));
     assert.ok(output.includes('list plugins'));
     assert.ok(output.includes('upgrade plugin <name> [version]'));
     assert.ok(output.includes('downgrade plugin <name> <version>'));


### PR DESCRIPTION
## Why

While developing the solutions plugin, I noticed that commands like

```
c8 solutions get bb --from URL
```

would only forward

```
[ 'get', 'bb']
```

to the plugin.

## What
All arguments are now forwarded to the plugins.

## Fixes
This may also resolve #283, and potentially other problems in untested plugin commands like in https://github.com/camunda/c8ctl-plugin-dev.