### PR TITLE
feat: add --json global flag and C8CTL_OUTPUT_MODE env for per-invocation output

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,6 +756,7 @@ These flags are accepted by every command.
 | `--dry-run` | boolean |  | Preview the API request without executing |
 | `--verbose` | boolean |  | Show verbose output |
 | `--fields` | string |  | Comma-separated list of fields to display |
+| `--json` | boolean |  | Force JSON output for this invocation (does not persist; overrides session state and C8CTL_OUTPUT_MODE) |
 
 ### Resource Aliases
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,27 @@ c8ctl output json
 c8ctl output text
 ```
 
+#### Per-invocation output override
+
+The persisted output mode (set by `c8ctl output json|text`) can be overridden for a single invocation without mutating `session.json`. This is useful for scripts, agent integrations, and one-off JSON capture without flipping global state.
+
+Precedence (highest first):
+
+1. `--json` global flag — force JSON for this invocation only.
+2. `C8CTL_OUTPUT_MODE` env var — accepts `json` or `text`. Other values (including unset or typos) fall through to the persisted mode without erroring.
+3. Persisted `session.json` `outputMode`.
+
+```bash
+# Force JSON for one command — session.json is not touched
+c8ctl --json list profile
+
+# Same effect via env var (handy for scoped shells / CI steps)
+C8CTL_OUTPUT_MODE=json c8ctl list profile
+
+# --json wins over the env var
+C8CTL_OUTPUT_MODE=text c8ctl --json list profile  # → JSON
+```
+
 ### Debug Mode
 
 Enable debug logging to see detailed information about plugin loading and other internal operations:
@@ -705,6 +726,9 @@ c8ctl <command>
 - `CAMUNDA_TOKEN_AUDIENCE`: OAuth token audience
 - `CAMUNDA_OAUTH_URL`: OAuth token endpoint
 - `CAMUNDA_DEFAULT_TENANT_ID`: Default tenant ID
+- `C8CTL_OUTPUT_MODE`: Per-invocation output mode override (`json` or `text`); does not persist. Lower precedence than `--json`. See [Per-invocation output override](#per-invocation-output-override).
+- `C8CTL_DATA_DIR`: Override the OS-default data directory for plugins and session state.
+- `C8CTL_DEBUG` / `DEBUG`: Enable debug logging to stderr.
 
 ## Configuration Files
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -24,6 +24,7 @@ These flags are accepted by every command.
 | `--dry-run` | boolean |  | Preview the API request without executing |
 | `--verbose` | boolean |  | Show verbose output |
 | `--fields` | string |  | Comma-separated list of fields to display |
+| `--json` | boolean |  | Force JSON output for this invocation (does not persist; overrides session state and C8CTL_OUTPUT_MODE) |
 
 ## Resource Aliases
 

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -205,6 +205,14 @@ export const GLOBAL_FLAGS = {
 			"Comma-separated list of output fields to include.\nReduces context window size when parsing output.\nExample: c8ctl list pi --fields Key,State,processDefinitionId\nCase-insensitive.",
 		agentAppliesTo: "all list/search/get commands",
 	},
+	json: {
+		type: "boolean",
+		description:
+			"Force JSON output for this invocation (does not persist; overrides session state and C8CTL_OUTPUT_MODE)",
+		agentDescription:
+			"Per-invocation JSON output. Equivalent to setting outputMode=json for one command without mutating session.json.\nPrecedence: --json > C8CTL_OUTPUT_MODE > persisted session state.",
+		agentAppliesTo: "all commands",
+	},
 } as const satisfies Record<string, FlagDef>;
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -99,6 +99,19 @@ export interface SessionState {
 	outputMode: OutputMode;
 }
 
+/**
+ * The output mode persisted on disk in `session.json`.
+ *
+ * Tracked separately from `c8ctl.outputMode` (which reflects the *effective*
+ * mode for this invocation) so that per-invocation overrides like `--json`
+ * or `C8CTL_OUTPUT_MODE` do not leak into `saveSessionState()` when other
+ * commands (e.g. `use profile`, `set-tenant`) write the file. See #356.
+ *
+ * Initialised by `loadSessionState()`; updated by `setOutputMode()` (the
+ * persistent setter behind `c8ctl output json|text`).
+ */
+let persistedOutputMode: OutputMode = "text";
+
 export interface ClusterConfig {
 	baseUrl: string;
 	clientId?: string;
@@ -634,6 +647,7 @@ export function loadSessionState(): SessionState {
 		c8ctl.activeTenant =
 			typeof state.activeTenant === "string" ? state.activeTenant : undefined;
 		c8ctl.outputMode = state.outputMode === "json" ? "json" : "text";
+		persistedOutputMode = c8ctl.outputMode;
 
 		return {
 			activeProfile: c8ctl.activeProfile,
@@ -653,16 +667,20 @@ export function loadSessionState(): SessionState {
  * Save session state from c8ctl runtime object to disk
  */
 export function saveSessionState(state?: SessionState): void {
+	// Use persistedOutputMode (the on-disk value) by default, NOT
+	// c8ctl.outputMode — the latter may carry a per-invocation override
+	// from --json or C8CTL_OUTPUT_MODE that must not leak to disk (#356).
 	const stateToSave: SessionState = {
 		activeProfile: state?.activeProfile ?? c8ctl.activeProfile,
 		activeTenant: state?.activeTenant ?? c8ctl.activeTenant,
-		outputMode: state?.outputMode ?? c8ctl.outputMode,
+		outputMode: state?.outputMode ?? persistedOutputMode,
 	};
 
 	if (state) {
 		c8ctl.activeProfile = state.activeProfile;
 		c8ctl.activeTenant = state.activeTenant;
 		c8ctl.outputMode = state.outputMode;
+		persistedOutputMode = state.outputMode;
 	}
 
 	const path = getSessionStatePath();
@@ -698,6 +716,7 @@ export function setActiveTenant(tenantId: string): void {
  */
 export function setOutputMode(mode: OutputMode): void {
 	c8ctl.outputMode = mode;
+	persistedOutputMode = mode;
 	saveSessionState();
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -105,7 +105,7 @@ export interface SessionState {
  * Tracked separately from `c8ctl.outputMode` (which reflects the *effective*
  * mode for this invocation) so that per-invocation overrides like `--json`
  * or `C8CTL_OUTPUT_MODE` do not leak into `saveSessionState()` when other
- * commands (e.g. `use profile`, `set-tenant`) write the file. See #356.
+ * commands (e.g. `use profile`, `use tenant`) write the file. See #356.
  *
  * Initialised by `loadSessionState()`; updated by `setOutputMode()` (the
  * persistent setter behind `c8ctl output json|text`).

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,6 +171,21 @@ async function main() {
 
 	const { values, positionals } = parseCliArgs();
 
+	// Apply per-invocation output mode override (#356).
+	// Precedence: --json flag > C8CTL_OUTPUT_MODE env var > persisted session.
+	// Setting `c8ctl.outputMode` directly is in-memory only; saveSessionState
+	// uses the separately-tracked persistedOutputMode from config.ts so this
+	// override never leaks back to disk.
+	if (values.json === true) {
+		c8ctl.outputMode = "json";
+	} else if (process.env.C8CTL_OUTPUT_MODE === "json") {
+		c8ctl.outputMode = "json";
+	} else if (process.env.C8CTL_OUTPUT_MODE === "text") {
+		c8ctl.outputMode = "text";
+	}
+	// Any other C8CTL_OUTPUT_MODE value (including unset, empty, or
+	// "yaml"/typo) falls through to the persisted mode loaded above.
+
 	// Initialize logger with current output mode from c8ctl runtime
 	const logger = getLogger(c8ctl.outputMode);
 

--- a/tests/unit/output-mode-per-invocation.test.ts
+++ b/tests/unit/output-mode-per-invocation.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Per-invocation output mode override tests (#356).
+ *
+ * Covers the `--json` global flag and the `C8CTL_OUTPUT_MODE` env var.
+ * Both are per-invocation overrides and MUST NOT mutate the persisted
+ * `session.json` outputMode — that file is owned by the `c8 output` command.
+ *
+ * Precedence (highest first):
+ *   1. `--json` flag
+ *   2. `C8CTL_OUTPUT_MODE` env var
+ *   3. persisted session state
+ */
+
+import assert from "node:assert";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, test } from "node:test";
+import { makeTestEnv } from "../utils/mocks.ts";
+import { asyncSpawn } from "../utils/spawn.ts";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
+const CLI = join(PROJECT_ROOT, "src", "index.ts");
+
+let dataDir = "";
+
+function cli(
+	args: string[],
+	extraEnv: Record<string, string> = {},
+): Promise<ReturnType<typeof asyncSpawn> extends Promise<infer R> ? R : never> {
+	return asyncSpawn("node", ["--experimental-strip-types", CLI, ...args], {
+		cwd: PROJECT_ROOT,
+		env: makeTestEnv({ C8CTL_DATA_DIR: dataDir, ...extraEnv }),
+	});
+}
+
+function writeSession(outputMode: "text" | "json"): void {
+	writeFileSync(join(dataDir, "session.json"), JSON.stringify({ outputMode }));
+}
+
+function readSession(): Record<string, unknown> {
+	const raw = readFileSync(join(dataDir, "session.json"), "utf-8");
+	return JSON.parse(raw);
+}
+
+describe("Per-invocation output mode (#356)", () => {
+	beforeEach(() => {
+		dataDir = mkdtempSync(join(tmpdir(), "c8ctl-per-inv-output-"));
+	});
+	afterEach(() => {
+		rmSync(dataDir, { recursive: true, force: true });
+	});
+
+	describe("--json global flag", () => {
+		test("forces JSON output for the invocation when session is text", async () => {
+			writeSession("text");
+			// `list profile` prints a human-readable table in text mode and
+			// JSON in json mode — the contrast is unambiguous.
+			const result = await cli(["--json", "list", "profile"]);
+			assert.strictEqual(
+				result.status,
+				0,
+				`exit ${result.status}; stderr=${result.stderr}`,
+			);
+			assert.doesNotThrow(
+				() => JSON.parse(result.stdout),
+				`stdout must be valid JSON under --json, got: ${result.stdout}`,
+			);
+		});
+
+		test("does NOT mutate persisted session.json", async () => {
+			writeSession("text");
+			const before = readSession();
+			await cli(["--json", "list", "profile"]);
+			const after = readSession();
+			assert.deepStrictEqual(
+				after,
+				before,
+				"session.json must be unchanged after --json invocation",
+			);
+		});
+	});
+
+	describe("C8CTL_OUTPUT_MODE env var", () => {
+		test("forces JSON output when set to 'json'", async () => {
+			writeSession("text");
+			const result = await cli(["list", "profile"], {
+				C8CTL_OUTPUT_MODE: "json",
+			});
+			assert.strictEqual(
+				result.status,
+				0,
+				`exit ${result.status}; stderr=${result.stderr}`,
+			);
+			assert.doesNotThrow(
+				() => JSON.parse(result.stdout),
+				`stdout must be valid JSON under env override, got: ${result.stdout}`,
+			);
+		});
+
+		test("does NOT mutate persisted session.json", async () => {
+			writeSession("text");
+			const before = readSession();
+			await cli(["list", "profile"], { C8CTL_OUTPUT_MODE: "json" });
+			const after = readSession();
+			assert.deepStrictEqual(after, before);
+		});
+
+		test("invalid value falls back to persisted mode (no error)", async () => {
+			writeSession("text");
+			const result = await cli(["list", "profile"], {
+				C8CTL_OUTPUT_MODE: "yaml",
+			});
+			assert.strictEqual(
+				result.status,
+				0,
+				`exit ${result.status}; stderr=${result.stderr}`,
+			);
+			assert.throws(
+				() => JSON.parse(result.stdout),
+				`invalid env var should fall back to text (table); got JSON: ${result.stdout}`,
+			);
+		});
+	});
+
+	describe("Precedence", () => {
+		test("--json flag overrides C8CTL_OUTPUT_MODE=text", async () => {
+			writeSession("text");
+			const result = await cli(["--json", "list", "profile"], {
+				C8CTL_OUTPUT_MODE: "text",
+			});
+			assert.doesNotThrow(
+				() => JSON.parse(result.stdout),
+				`--json must beat env=text, got: ${result.stdout}`,
+			);
+		});
+
+		test("C8CTL_OUTPUT_MODE=json overrides persisted text", async () => {
+			writeSession("text");
+			const result = await cli(["list", "profile"], {
+				C8CTL_OUTPUT_MODE: "json",
+			});
+			assert.doesNotThrow(
+				() => JSON.parse(result.stdout),
+				`env=json must beat persisted=text, got: ${result.stdout}`,
+			);
+		});
+	});
+
+	describe("Persistent setter still works", () => {
+		test("`c8 output json` persists JSON to session.json (regression guard)", async () => {
+			writeSession("text");
+			await cli(["output", "json"]);
+			const after = readSession();
+			assert.strictEqual(after.outputMode, "json");
+		});
+
+		test("`c8 --json use profile foo` does not pollute persisted outputMode", async () => {
+			writeSession("text");
+			// Use a profile-mutating command WITH --json — the per-invocation
+			// override must not leak into the saved session.
+			const result = await cli(["--json", "use", "profile", "local"]);
+			// Either succeeds (profile exists) or fails — we only care about
+			// the persisted state.
+			assert.ok(
+				result.status === 0 || result.status === 1,
+				`unexpected exit ${result.status}`,
+			);
+			const after = readSession();
+			assert.strictEqual(
+				after.outputMode,
+				"text",
+				`persisted outputMode must remain 'text'; got ${JSON.stringify(after)}`,
+			);
+		});
+	});
+});


### PR DESCRIPTION
Closes #356.

Adds a per-invocation output-mode override that does **not** mutate the persisted session state.

## Precedence

`--json` flag → `C8CTL_OUTPUT_MODE` env var → persisted `session.json`

## What changed

- **New global flag `--json`** in `GLOBAL_FLAGS` (`src/command-registry.ts`). Auto-flows into top-level `--help`, `parseArgs` options, and shell completions via the existing registry-driven derivations. Per the `#321` invariant (top-level help is scoped to `GLOBAL_FLAGS`), it appears in the global Flags section of `c8ctl --help`.
- **New env var `C8CTL_OUTPUT_MODE`** — values `json` or `text`. Anything else (unset, empty, typos like `yaml`) falls through to the persisted mode without erroring.
- **Override applied in `main()`** between argv parsing and logger initialization (`src/index.ts`). Plugins automatically observe it via `globalThis.c8ctl.outputMode` and `globalThis.c8ctl.getLogger()` — no plugin changes required, no plugin-flag injection needed (and built-in flags already act as a blacklist against plugin-flag shadowing).
- **No persistence leak.** `src/config.ts` now tracks a module-local `persistedOutputMode` separately from the in-memory `c8ctl.outputMode`. `saveSessionState()` defaults to the persisted value, so `c8 --json use profile foo` (which mutates session state) does **not** write `"outputMode":"json"` to disk. `setOutputMode()` — the persistent setter behind `c8 output json|text` — updates both.

## Tests

`tests/unit/output-mode-per-invocation.test.ts` — 9 tests across 4 describes:

- `--json global flag` — forces JSON / does not mutate `session.json`
- `C8CTL_OUTPUT_MODE env var` — forces JSON / does not mutate / invalid value falls back
- `Precedence` — `--json` overrides env=text; env=json overrides persisted text
- `Persistent setter still works` — `c8 output json` continues to persist (regression guard for `setOutputMode`)

All 1476 unit tests pass; typecheck and biome clean. README and `docs/command-reference.md` were regenerated by `npm run sync:readme` / `sync:docs` so the new flag appears in the command reference.

Followed the red/green discipline (tests written first, demonstrated 5 failing for the right reason against `main` before the production change).