### PR TITLE
feat: introduce passthrough:true plugin contract opt-in (#366)

### DIFF
--- a/src/completion.ts
+++ b/src/completion.ts
@@ -331,9 +331,13 @@ function generateBashCompletion(): string {
 		}
 
 		if (v.fileComplete || v.passthrough) {
-			// deploy/run/watch and #366 passthrough verbs complete with files
+			// deploy/run/watch and #366 passthrough verbs complete with
+			// files. Include aliases in the case pattern so e.g. `c8ctl
+			// w <TAB>` (alias for `watch`) gets file completion too.
+			const filePattern =
+				v.aliases.length > 0 ? `${v.verb}|${v.aliases.join("|")}` : v.verb;
 			caseBranches.push(
-				`        ${v.verb})\n          COMPREPLY=( $(compgen -f -- "\${cur}") )\n          ;;`,
+				`        ${filePattern})\n          COMPREPLY=( $(compgen -f -- "\${cur}") )\n          ;;`,
 			);
 			continue;
 		}

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -543,7 +543,26 @@ function generateFishCompletion(): string {
 	const pluginCmds = getPluginCommandsInfo();
 	const verbInfos = deriveVerbInfos(pluginCmds);
 	const allFlags = deriveAllFlags();
+	const globalFlags = deriveGlobalFlags();
 	const helpResources = deriveHelpResources();
+
+	// Passthrough contract (#366): once the user has typed a passthrough
+	// verb, only c8ctl GLOBAL_FLAGS are meaningful (everything else is
+	// forwarded to the wrapped tool, whose flag surface c8ctl can't
+	// know). bash and zsh handle this by switching to a globals-only
+	// flag set; fish handles it via a `not __fish_seen_subcommand_from`
+	// predicate on every non-global flag so they disappear when a
+	// passthrough verb is the current subcommand.
+	const passthroughTokens: string[] = [];
+	for (const v of verbInfos) {
+		if (!v.passthrough) continue;
+		passthroughTokens.push(v.verb, ...v.aliases);
+	}
+	const nonGlobalGuard =
+		passthroughTokens.length > 0
+			? ` -n 'not __fish_seen_subcommand_from ${passthroughTokens.join(" ")}'`
+			: "";
+	const globalNames = new Set(globalFlags.map((f) => f.name));
 
 	const lines: string[] = [
 		"# c8ctl fish completion",
@@ -554,9 +573,9 @@ function generateFishCompletion(): string {
 		"",
 	];
 
-	// Global flags
-	lines.push("# Global flags");
-	for (const f of allFlags) {
+	// Global flags — always offered, regardless of which verb is active.
+	lines.push("# Global flags (always offered)");
+	for (const f of globalFlags) {
 		const desc = escFish(f.description);
 		const req = f.type === "string" ? " -r" : "";
 		if (f.short) {
@@ -569,6 +588,34 @@ function generateFishCompletion(): string {
 		} else {
 			lines.push(`complete -c c8ctl -l ${f.name} -d '${desc}'${req}`);
 			lines.push(`complete -c c8 -l ${f.name} -d '${desc}'${req}`);
+		}
+	}
+	lines.push("");
+
+	// Non-global flags — suppressed under passthrough verbs (#366).
+	lines.push(
+		passthroughTokens.length > 0
+			? `# Non-global flags (suppressed under passthrough verbs: ${passthroughTokens.join(", ")})`
+			: "# Non-global flags",
+	);
+	for (const f of allFlags) {
+		if (globalNames.has(f.name)) continue;
+		const desc = escFish(f.description);
+		const req = f.type === "string" ? " -r" : "";
+		if (f.short) {
+			lines.push(
+				`complete -c c8ctl${nonGlobalGuard} -s ${f.short} -l ${f.name} -d '${desc}'${req}`,
+			);
+			lines.push(
+				`complete -c c8${nonGlobalGuard} -s ${f.short} -l ${f.name} -d '${desc}'${req}`,
+			);
+		} else {
+			lines.push(
+				`complete -c c8ctl${nonGlobalGuard} -l ${f.name} -d '${desc}'${req}`,
+			);
+			lines.push(
+				`complete -c c8${nonGlobalGuard} -l ${f.name} -d '${desc}'${req}`,
+			);
 		}
 	}
 	lines.push("");

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -85,6 +85,14 @@ interface VerbInfo {
 	aliases: string[];
 	/** File-path argument instead of resources (deploy/run/watch). */
 	fileComplete: boolean;
+	/**
+	 * True for plugin commands that opted into the #366 passthrough
+	 * contract. The completion generators use this to (a) treat the
+	 * verb like a fileComplete verb at the resource position and (b)
+	 * restrict flag completion to GLOBAL_FLAGS, since c8ctl cannot
+	 * know what flags the wrapped external tool accepts.
+	 */
+	passthrough: boolean;
 }
 
 function deriveVerbInfos(pluginCommandsInfo: PluginCommandInfo[]): VerbInfo[] {
@@ -107,6 +115,7 @@ function deriveVerbInfos(pluginCommandsInfo: PluginCommandInfo[]): VerbInfo[] {
 			resources,
 			aliases: def.aliases ?? [],
 			fileComplete,
+			passthrough: false,
 		});
 	}
 
@@ -121,6 +130,7 @@ function deriveVerbInfos(pluginCommandsInfo: PluginCommandInfo[]): VerbInfo[] {
 			resources: (cmd.subcommands ?? []).map((s) => s.name),
 			aliases: [],
 			fileComplete: false,
+			passthrough: cmd.passthrough === true,
 		});
 	}
 
@@ -149,6 +159,44 @@ function deriveAllFlagNames(): string[] {
 	}
 
 	return [...names].map((n) => `--${n}`);
+}
+
+/**
+ * Collect only the GLOBAL_FLAGS, formatted as `--name` literals.
+ * Used by passthrough-verb completion branches: c8ctl has no way to
+ * know what flags the wrapped external tool accepts, but the global
+ * c8ctl flags (e.g. `--profile`, `--json`, `--verbose`) DO still apply
+ * because `stripGlobalFlags()` consumes and applies them before
+ * forwarding the rest to the plugin handler. So globals are exactly
+ * the right suggestion set for `c8ctl <passthrough-verb> --<TAB>`.
+ */
+function deriveGlobalFlagNames(): string[] {
+	return Object.keys(GLOBAL_FLAGS).map((n) => `--${n}`);
+}
+
+/** Same as deriveAllFlags() but restricted to GLOBAL_FLAGS only. */
+function deriveGlobalFlags(): {
+	name: string;
+	description: string;
+	type: string;
+	short?: string;
+}[] {
+	const out: {
+		name: string;
+		description: string;
+		type: string;
+		short?: string;
+	}[] = [];
+	for (const [name, def] of Object.entries(GLOBAL_FLAGS)) {
+		const short = "short" in def ? def.short : undefined;
+		out.push({
+			name,
+			description: def.description,
+			type: def.type,
+			short,
+		});
+	}
+	return out;
 }
 
 /** Collect all flags with descriptions and types for rich completions (zsh/fish). */
@@ -247,6 +295,7 @@ function generateBashCompletion(): string {
 	const pluginCmds = getPluginCommandsInfo();
 	const verbInfos = deriveVerbInfos(pluginCmds);
 	const allFlags = deriveAllFlagNames();
+	const globalFlags = deriveGlobalFlagNames();
 	const helpResources = deriveHelpResources();
 
 	// All verb names (including aliases)
@@ -258,6 +307,12 @@ function generateBashCompletion(): string {
 
 	const verbsStr = [...allVerbs].join(" ");
 	const flagsStr = allFlags.join(" ");
+	const globalFlagsStr = globalFlags.join(" ");
+
+	// Passthrough verbs (#366) get file-completion at the resource
+	// position and global-flag-only completion at later positions.
+	const passthroughVerbs = verbInfos.filter((v) => v.passthrough);
+	const passthroughVerbsStr = passthroughVerbs.map((v) => v.verb).join(" ");
 
 	// Build per-verb resource variables
 	const resourceVars: string[] = [];
@@ -275,8 +330,8 @@ function generateBashCompletion(): string {
 			continue;
 		}
 
-		if (v.fileComplete) {
-			// deploy/run/watch complete with files
+		if (v.fileComplete || v.passthrough) {
+			// deploy/run/watch and #366 passthrough verbs complete with files
 			caseBranches.push(
 				`        ${v.verb})\n          COMPREPLY=( $(compgen -f -- "\${cur}") )\n          ;;`,
 			);
@@ -315,8 +370,16 @@ _c8ctl_completions() {
   # Resources by verb
 ${resourceVars.join("\n")}
 
-  # Global flags
+  # All flags (global + per-command)
   local flags="${flagsStr}"
+
+  # GLOBAL_FLAGS only — used after a passthrough verb (#366), where
+  # c8ctl cannot know what flags the wrapped external tool accepts.
+  local global_flags="${globalFlagsStr}"
+
+  # Passthrough verbs (#366): only c8ctl globals are meaningful flags;
+  # everything else is forwarded verbatim to the external tool.
+  local passthrough_verbs="${passthroughVerbsStr}"
 
   case \${cword} in
     1)
@@ -332,8 +395,18 @@ ${caseBranches.join("\n")}
       ;;
     *)
       # Complete flags or files
+      local verb="\${words[1]}"
+      local flag_set="\${flags}"
+      # If the current verb is a passthrough plugin command, restrict
+      # flag completion to GLOBAL_FLAGS only.
+      for pt in \${passthrough_verbs}; do
+        if [[ "\${verb}" == "\${pt}" ]]; then
+          flag_set="\${global_flags}"
+          break
+        fi
+      done
       if [[ \${cur} == -* ]]; then
-        COMPREPLY=( $(compgen -W "\${flags}" -- "\${cur}") )
+        COMPREPLY=( $(compgen -W "\${flag_set}" -- "\${cur}") )
       else
         COMPREPLY=( $(compgen -f -- "\${cur}") )
       fi
@@ -352,6 +425,7 @@ function generateZshCompletion(): string {
 	const pluginCmds = getPluginCommandsInfo();
 	const verbInfos = deriveVerbInfos(pluginCmds);
 	const allFlags = deriveAllFlags();
+	const globalFlagsOnly = deriveGlobalFlags();
 	const helpResources = deriveHelpResources();
 
 	// Verb entries: 'verb:description'
@@ -364,13 +438,23 @@ function generateZshCompletion(): string {
 	});
 
 	// Flag entries: '--flag[description]:hint:' or '--flag[description]'
-	const flagEntryLines = allFlags.map((f) => {
+	const toZshFlagEntry = (f: {
+		name: string;
+		description: string;
+		type: string;
+		short?: string;
+	}) => {
 		const desc = escZsh(f.description);
 		if (f.short) {
 			return `    '-${f.short}[${desc}]'\n    '--${f.name}[${desc}]${f.type === "string" ? `:${f.name}:` : ""}'`;
 		}
 		return `    '--${f.name}[${desc}]${f.type === "string" ? `:${f.name}:` : ""}'`;
-	});
+	};
+	const flagEntryLines = allFlags.map(toZshFlagEntry);
+	const globalFlagEntryLines = globalFlagsOnly.map(toZshFlagEntry);
+
+	// Passthrough verbs (#366) for the case branch in the default arm.
+	const passthroughVerbs = verbInfos.filter((v) => v.passthrough);
 
 	// Per-verb resource case branches
 	const resourceCases: string[] = [];
@@ -385,7 +469,7 @@ function generateZshCompletion(): string {
 			continue;
 		}
 
-		if (v.fileComplete) {
+		if (v.fileComplete || v.passthrough) {
 			const casePattern =
 				v.aliases.length > 0 ? `${v.verb}|${v.aliases.join("|")}` : v.verb;
 			resourceCases.push(
@@ -411,7 +495,7 @@ function generateZshCompletion(): string {
 # c8ctl-completion-version: ${c8ctl.version}
 
 _c8ctl() {
-  local -a verbs resources flags
+  local -a verbs resources flags global_flags
 
   verbs=(
 ${verbEntries.join("\n")}
@@ -419,6 +503,12 @@ ${verbEntries.join("\n")}
 
   flags=(
 ${flagEntryLines.join("\n")}
+  )
+
+  # GLOBAL_FLAGS only — used after a passthrough verb (#366), where
+  # c8ctl cannot know what flags the wrapped external tool accepts.
+  global_flags=(
+${globalFlagEntryLines.join("\n")}
   )
 
   case $CURRENT in
@@ -431,6 +521,11 @@ ${resourceCases.join("\n")}
       esac
       ;;
     *)
+      # Passthrough verbs (#366): only c8ctl globals are meaningful;
+      # everything else is forwarded verbatim to the wrapped tool.
+      case "\${words[2]}" in
+${passthroughVerbs.map((v) => `        ${v.verb}) _arguments \${global_flags[@]}; return ;;`).join("\n") || "        # (no passthrough verbs registered)"}
+      esac
       _arguments \${flags[@]}
       ;;
   esac
@@ -516,7 +611,24 @@ function generateFishCompletion(): string {
 			continue;
 		}
 
-		if (v.fileComplete || v.resources.length === 0) continue;
+		if (v.fileComplete || v.resources.length === 0) {
+			// Passthrough verbs (#366) and fileComplete verbs both want
+			// file completion at the resource position. Emit explicit
+			// `complete -F` so fish offers files instead of falling back
+			// to the generic verb suggestion list.
+			if (v.passthrough) {
+				const seenFrom = [v.verb, ...v.aliases].join(" ");
+				lines.push(`# Files for passthrough verb '${v.verb}' (#366)`);
+				lines.push(
+					`complete -c c8ctl -n '__fish_seen_subcommand_from ${seenFrom}' -F`,
+				);
+				lines.push(
+					`complete -c c8 -n '__fish_seen_subcommand_from ${seenFrom}' -F`,
+				);
+				lines.push("");
+			}
+			continue;
+		}
 
 		const seenFrom = [v.verb, ...v.aliases].join(" ");
 		lines.push(`# Resources for '${v.verb}' command`);

--- a/src/completion.ts
+++ b/src/completion.ts
@@ -611,24 +611,31 @@ function generateFishCompletion(): string {
 			continue;
 		}
 
-		if (v.fileComplete || v.resources.length === 0) {
-			// Passthrough verbs (#366) and fileComplete verbs both want
-			// file completion at the resource position. Emit explicit
+		if (v.fileComplete || v.passthrough) {
+			// Both `fileComplete` verbs (deploy/run/watch — they take file
+			// paths as their resource argument) and `passthrough` verbs
+			// (#366 — c8ctl can't know what the wrapped tool accepts, so
+			// offering file paths is the only sensible default) want file
+			// completion at the resource position. Emit explicit
 			// `complete -F` so fish offers files instead of falling back
-			// to the generic verb suggestion list.
-			if (v.passthrough) {
-				const seenFrom = [v.verb, ...v.aliases].join(" ");
-				lines.push(`# Files for passthrough verb '${v.verb}' (#366)`);
-				lines.push(
-					`complete -c c8ctl -n '__fish_seen_subcommand_from ${seenFrom}' -F`,
-				);
-				lines.push(
-					`complete -c c8 -n '__fish_seen_subcommand_from ${seenFrom}' -F`,
-				);
-				lines.push("");
-			}
+			// to the generic verb suggestion list. bash/zsh already handle
+			// this in their own branches above.
+			const seenFrom = [v.verb, ...v.aliases].join(" ");
+			const label = v.passthrough
+				? `Files for passthrough verb '${v.verb}' (#366)`
+				: `Files for '${v.verb}' command`;
+			lines.push(`# ${label}`);
+			lines.push(
+				`complete -c c8ctl -n '__fish_seen_subcommand_from ${seenFrom}' -F`,
+			);
+			lines.push(
+				`complete -c c8 -n '__fish_seen_subcommand_from ${seenFrom}' -F`,
+			);
+			lines.push("");
 			continue;
 		}
+
+		if (v.resources.length === 0) continue;
 
 		const seenFrom = [v.verb, ...v.aliases].join(" ");
 		lines.push(`# Resources for '${v.verb}' command`);

--- a/src/help.ts
+++ b/src/help.ts
@@ -816,12 +816,16 @@ export async function showCommandHelp(command: string): Promise<void> {
 	const logger = getLogger();
 
 	// Passthrough plugin contract (#366): if the command is a registered
-	// passthrough plugin command, render the passthrough help shape — NOT
-	// the registry-driven shape and NOT the plugin's own handler. This
-	// keeps the boundary visible to users and agents.
-	const pluginInfo = getPluginCommandsInfo().find(
-		(p) => p.commandName === command && p.passthrough === true,
-	);
+	// passthrough plugin command AND the name does not collide with a
+	// built-in verb, render the passthrough help shape — NOT the
+	// registry-driven shape and NOT the plugin's own handler. This keeps
+	// the boundary visible to users and agents. Built-in verbs always win
+	// over plugins of the same name (consistent with dispatch).
+	const pluginInfo = lookupVerb(command)
+		? undefined
+		: getPluginCommandsInfo().find(
+				(p) => p.commandName === command && p.passthrough === true,
+			);
 	if (pluginInfo) {
 		if (logger.mode === "json") {
 			logger.json({
@@ -837,7 +841,10 @@ export async function showCommandHelp(command: string): Promise<void> {
 			return;
 		}
 		const lines: string[] = [];
-		lines.push(`c8ctl ${command} — ${pluginInfo.description ?? ""}`.trimEnd());
+		const description = pluginInfo.description?.trim();
+		lines.push(
+			description ? `c8ctl ${command} — ${description}` : `c8ctl ${command}`,
+		);
 		if (pluginInfo.helpDescription) {
 			lines.push("");
 			lines.push(pluginInfo.helpDescription);

--- a/src/help.ts
+++ b/src/help.ts
@@ -831,6 +831,14 @@ export async function showCommandHelp(command: string): Promise<void> {
 			);
 	if (pluginInfo) {
 		if (logger.mode === "json") {
+			// Match the standard `showCommandHelp()` JSON shape so callers
+			// can rely on `globalFlags` / `searchFlags` / `agentFlags` being
+			// present regardless of `kind`. Passthrough adds the
+			// `kind: "passthrough"` discriminator plus the passthrough-only
+			// fields on top.
+			const version = getVersion();
+			const pluginCommandsInfo = getPluginCommandsInfo();
+			const allHelp = buildHelpJson(version, pluginCommandsInfo);
 			logger.json({
 				command,
 				verb: command,
@@ -840,6 +848,9 @@ export async function showCommandHelp(command: string): Promise<void> {
 				passthroughHint: pluginInfo.passthroughHint,
 				flagsHint: pluginInfo.flagsHint ?? [],
 				examples: pluginInfo.examples ?? [],
+				globalFlags: allHelp.globalFlags,
+				searchFlags: allHelp.searchFlags,
+				agentFlags: allHelp.agentFlags,
 			});
 			return;
 		}

--- a/src/help.ts
+++ b/src/help.ts
@@ -10,6 +10,7 @@ import {
 	type CommandDef,
 	type FlagDef,
 	GLOBAL_FLAGS,
+	getCommandDef,
 	RESOURCE_ALIASES,
 	SEARCH_FLAGS,
 } from "./command-registry.ts";
@@ -817,11 +818,13 @@ export async function showCommandHelp(command: string): Promise<void> {
 
 	// Passthrough plugin contract (#366): if the command is a registered
 	// passthrough plugin command AND the name does not collide with a
-	// built-in verb, render the passthrough help shape — NOT the
-	// registry-driven shape and NOT the plugin's own handler. This keeps
-	// the boundary visible to users and agents. Built-in verbs always win
-	// over plugins of the same name (consistent with dispatch).
-	const pluginInfo = lookupVerb(command)
+	// built-in verb (including aliases), render the passthrough help shape
+	// — NOT the registry-driven shape and NOT the plugin's own handler.
+	// This keeps the boundary visible to users and agents. Built-in verbs
+	// always win over plugins of the same name (consistent with dispatch).
+	// `getCommandDef` is alias-aware (e.g. `w` → `watch`), unlike the
+	// local `lookupVerb` which only checks COMMAND_REGISTRY keys.
+	const pluginInfo = getCommandDef(command)
 		? undefined
 		: getPluginCommandsInfo().find(
 				(p) => p.commandName === command && p.passthrough === true,

--- a/src/help.ts
+++ b/src/help.ts
@@ -815,6 +815,59 @@ function showVirtualTopicHelp(topic: string, resource: string): void {
 export async function showCommandHelp(command: string): Promise<void> {
 	const logger = getLogger();
 
+	// Passthrough plugin contract (#366): if the command is a registered
+	// passthrough plugin command, render the passthrough help shape — NOT
+	// the registry-driven shape and NOT the plugin's own handler. This
+	// keeps the boundary visible to users and agents.
+	const pluginInfo = getPluginCommandsInfo().find(
+		(p) => p.commandName === command && p.passthrough === true,
+	);
+	if (pluginInfo) {
+		if (logger.mode === "json") {
+			logger.json({
+				command,
+				verb: command,
+				kind: "passthrough",
+				description: pluginInfo.description ?? "",
+				helpDescription: pluginInfo.helpDescription,
+				passthroughHint: pluginInfo.passthroughHint,
+				flagsHint: pluginInfo.flagsHint ?? [],
+				examples: pluginInfo.examples ?? [],
+			});
+			return;
+		}
+		const lines: string[] = [];
+		lines.push(`c8ctl ${command} — ${pluginInfo.description ?? ""}`.trimEnd());
+		if (pluginInfo.helpDescription) {
+			lines.push("");
+			lines.push(pluginInfo.helpDescription);
+		}
+		lines.push("");
+		lines.push("Passthrough command");
+		lines.push(
+			`  ${pluginInfo.passthroughHint ?? ""}\n  c8ctl forwards args verbatim after stripping its global flags.`,
+		);
+		if (pluginInfo.flagsHint && pluginInfo.flagsHint.length > 0) {
+			lines.push("");
+			lines.push(
+				"Underlying tool flags (documentation only — not parsed by c8ctl):",
+			);
+			for (const f of pluginInfo.flagsHint) {
+				lines.push(`  ${f}`);
+			}
+		}
+		if (pluginInfo.examples && pluginInfo.examples.length > 0) {
+			lines.push("");
+			lines.push("Examples:");
+			for (const ex of pluginInfo.examples) {
+				lines.push(`  ${ex.command}`);
+				lines.push(`      ${ex.description}`);
+			}
+		}
+		logger.info(lines.join("\n"));
+		return;
+	}
+
 	// JSON mode: emit structured help for machine/agent consumption
 	if (logger.mode === "json") {
 		const version = getVersion();

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,8 +128,12 @@ export function sliceArgvAfterVerb(argv: string[], verb: string): string[] {
 	while (i < argv.length) {
 		const tok = argv[i];
 		if (tok === "--") {
-			// Verb cannot appear after `--`. Bail out.
-			return [];
+			// GNU `--` convention: end of options. The next token is the
+			// verb candidate. Skip the separator and continue scanning so
+			// `c8ctl -- <verb> <args...>` dispatches correctly with the
+			// full post-verb argv (rather than bailing and forwarding []).
+			i++;
+			continue;
 		}
 		if (tok.startsWith("--")) {
 			const eq = tok.indexOf("=");

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import {
 	COMMAND_REGISTRY,
 	type CommandDef,
 	deriveParseArgsOptions,
+	GLOBAL_FLAGS,
 	getCommandDef,
 	resolveAlias,
 } from "./command-registry.ts";
@@ -30,6 +31,7 @@ import { getLogger, type SortOrder } from "./logger.ts";
 import {
 	executePluginCommand,
 	getPluginCommands,
+	isPassthroughPluginCommand,
 	loadInstalledPlugins,
 } from "./plugin-loader.ts";
 import { c8ctl } from "./runtime.ts";
@@ -92,6 +94,73 @@ export function resolveProcessDefinitionId(
 		str(values.processDefinitionId) ||
 		str(values.bpmnProcessId)
 	);
+}
+
+/**
+ * Strip GLOBAL_FLAGS (and the value of any string-typed global flag) from
+ * a raw argv slice before forwarding to a passthrough plugin handler
+ * (#366). GLOBAL_FLAGS already affect the c8ctl runtime via their
+ * regular handling in `main()`; the plugin must not see them again.
+ *
+ * Conservative behaviour: an isolated `--` terminator is preserved and
+ * everything after it is forwarded verbatim, matching POSIX convention.
+ */
+export function stripGlobalFlags(argv: string[]): string[] {
+	const booleanFlags = new Set<string>();
+	const stringFlags = new Set<string>();
+	const booleanShorts = new Set<string>();
+	const stringShorts = new Set<string>();
+
+	for (const [name, def] of Object.entries(GLOBAL_FLAGS)) {
+		const short = "short" in def ? def.short : undefined;
+		if (def.type === "boolean") {
+			booleanFlags.add(name);
+			if (short) booleanShorts.add(short);
+		} else {
+			stringFlags.add(name);
+			if (short) stringShorts.add(short);
+		}
+	}
+
+	const out: string[] = [];
+	let i = 0;
+	let sawTerminator = false;
+	while (i < argv.length) {
+		const tok = argv[i];
+		if (sawTerminator) {
+			out.push(tok);
+			i++;
+			continue;
+		}
+		if (tok === "--") {
+			sawTerminator = true;
+			out.push(tok);
+			i++;
+			continue;
+		}
+		if (tok.startsWith("--")) {
+			const eq = tok.indexOf("=");
+			const name = eq >= 0 ? tok.slice(2, eq) : tok.slice(2);
+			if (booleanFlags.has(name) || stringFlags.has(name)) {
+				if (eq < 0 && stringFlags.has(name)) i++; // consume value
+				i++;
+				continue;
+			}
+		} else if (tok.startsWith("-") && tok.length === 2) {
+			const short = tok.slice(1);
+			if (booleanShorts.has(short)) {
+				i++;
+				continue;
+			}
+			if (stringShorts.has(short)) {
+				i += 2; // consume short flag and its value
+				continue;
+			}
+		}
+		out.push(tok);
+		i++;
+	}
+	return out;
 }
 
 /**
@@ -272,6 +341,23 @@ async function main() {
 	if (verb && Object.hasOwn(pluginCommands, verb) && !getCommandDef(verb)) {
 		const cmd = pluginCommands[verb];
 		const cmdFlagDefs = typeof cmd !== "function" ? cmd.flags : undefined;
+
+		// Passthrough plugin contract (#366): strip GLOBAL_FLAGS from the
+		// raw argv following the verb token and forward the rest verbatim.
+		// GLOBAL_FLAGS already affect the c8ctl runtime via their regular
+		// handling earlier in main(); the plugin must not see them again.
+		// Validation at load time guarantees passthrough commands are the
+		// bare-function form and never carry a `flags` declaration.
+		if (isPassthroughPluginCommand(verb)) {
+			const argvAfterCli = process.argv.slice(2);
+			const verbIndex = argvAfterCli.indexOf(verb);
+			const rawAfterVerb =
+				verbIndex >= 0 ? argvAfterCli.slice(verbIndex + 1) : [];
+			const forwarded = stripGlobalFlags(rawAfterVerb);
+			await executePluginCommand(verb, forwarded);
+			return;
+		}
+
 		if (cmdFlagDefs) {
 			// Use built-in flags as a blacklist: start from the full built-in
 			// option set, then add plugin flags only when the name is not already

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,6 +97,51 @@ export function resolveProcessDefinitionId(
 }
 
 /**
+ * Return the raw argv tokens that follow the verb position, where the
+ * verb position is found by walking from the start and skipping leading
+ * GLOBAL_FLAGS (consuming the value of string-typed global flags). The
+ * first non-flag token is the verb.
+ *
+ * This avoids `argv.indexOf(verb)`, which is unsafe because the verb
+ * string may also appear as the value of a global string flag (e.g.
+ * `--profile <verb>`). Returns `[]` if no verb token is found.
+ */
+export function sliceArgvAfterVerb(argv: string[], verb: string): string[] {
+	const stringGlobalNames = new Set<string>();
+	const stringGlobalShorts = new Set<string>();
+	for (const [name, def] of Object.entries(GLOBAL_FLAGS)) {
+		if (def.type !== "string") continue;
+		stringGlobalNames.add(name);
+		const short = "short" in def ? def.short : undefined;
+		if (short) stringGlobalShorts.add(short);
+	}
+
+	let i = 0;
+	while (i < argv.length) {
+		const tok = argv[i];
+		if (tok === "--") {
+			// Verb cannot appear after `--`. Bail out.
+			return [];
+		}
+		if (tok.startsWith("--")) {
+			const eq = tok.indexOf("=");
+			const name = eq >= 0 ? tok.slice(2, eq) : tok.slice(2);
+			i += eq < 0 && stringGlobalNames.has(name) ? 2 : 1;
+			continue;
+		}
+		if (tok.startsWith("-") && tok.length === 2) {
+			const short = tok.slice(1);
+			i += stringGlobalShorts.has(short) ? 2 : 1;
+			continue;
+		}
+		// First non-flag token at or after this position must be the verb.
+		if (tok === verb) return argv.slice(i + 1);
+		return [];
+	}
+	return [];
+}
+
+/**
  * Strip GLOBAL_FLAGS (and the value of any string-typed global flag) from
  * a raw argv slice before forwarding to a passthrough plugin handler
  * (#366). GLOBAL_FLAGS already affect the c8ctl runtime via their
@@ -349,10 +394,11 @@ async function main() {
 		// Validation at load time guarantees passthrough commands are the
 		// bare-function form and never carry a `flags` declaration.
 		if (isPassthroughPluginCommand(verb)) {
-			const argvAfterCli = process.argv.slice(2);
-			const verbIndex = argvAfterCli.indexOf(verb);
-			const rawAfterVerb =
-				verbIndex >= 0 ? argvAfterCli.slice(verbIndex + 1) : [];
+			// Locate the verb token by walking process.argv from the start and
+			// skipping leading GLOBAL_FLAGS (consuming string-flag values).
+			// A naive `indexOf(verb)` is unsafe because `verb` may also appear
+			// as the value of a global string flag (e.g. `--profile <verb>`).
+			const rawAfterVerb = sliceArgvAfterVerb(process.argv.slice(2), verb);
 			const forwarded = stripGlobalFlags(rawAfterVerb);
 			await executePluginCommand(verb, forwarded);
 			return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,21 +99,29 @@ export function resolveProcessDefinitionId(
 /**
  * Return the raw argv tokens that follow the verb position, where the
  * verb position is found by walking from the start and skipping leading
- * GLOBAL_FLAGS (consuming the value of string-typed global flags). The
- * first non-flag token is the verb.
+ * GLOBAL_FLAGS only (consuming the value of string-typed global flags).
+ * The first non-flag token — or any unknown `--*`/`-*` token — is
+ * treated as the verb candidate.
  *
  * This avoids `argv.indexOf(verb)`, which is unsafe because the verb
  * string may also appear as the value of a global string flag (e.g.
- * `--profile <verb>`). Returns `[]` if no verb token is found.
+ * `--profile <verb>`). Returns `[]` if no verb token is found at or
+ * after the scan position.
  */
 export function sliceArgvAfterVerb(argv: string[], verb: string): string[] {
 	const stringGlobalNames = new Set<string>();
 	const stringGlobalShorts = new Set<string>();
+	const booleanGlobalNames = new Set<string>();
+	const booleanGlobalShorts = new Set<string>();
 	for (const [name, def] of Object.entries(GLOBAL_FLAGS)) {
-		if (def.type !== "string") continue;
-		stringGlobalNames.add(name);
 		const short = "short" in def ? def.short : undefined;
-		if (short) stringGlobalShorts.add(short);
+		if (def.type === "string") {
+			stringGlobalNames.add(name);
+			if (short) stringGlobalShorts.add(short);
+		} else {
+			booleanGlobalNames.add(name);
+			if (short) booleanGlobalShorts.add(short);
+		}
 	}
 
 	let i = 0;
@@ -126,15 +134,28 @@ export function sliceArgvAfterVerb(argv: string[], verb: string): string[] {
 		if (tok.startsWith("--")) {
 			const eq = tok.indexOf("=");
 			const name = eq >= 0 ? tok.slice(2, eq) : tok.slice(2);
-			i += eq < 0 && stringGlobalNames.has(name) ? 2 : 1;
-			continue;
-		}
-		if (tok.startsWith("-") && tok.length === 2) {
+			if (booleanGlobalNames.has(name)) {
+				i++;
+				continue;
+			}
+			if (stringGlobalNames.has(name)) {
+				i += eq < 0 ? 2 : 1;
+				continue;
+			}
+			// Unknown long flag — do not silently consume a value. Fall through
+			// to the verb match below (and bail if it doesn't match).
+		} else if (tok.startsWith("-") && tok.length === 2) {
 			const short = tok.slice(1);
-			i += stringGlobalShorts.has(short) ? 2 : 1;
-			continue;
+			if (booleanGlobalShorts.has(short)) {
+				i++;
+				continue;
+			}
+			if (stringGlobalShorts.has(short)) {
+				i += 2;
+				continue;
+			}
 		}
-		// First non-flag token at or after this position must be the verb.
+		// First token that is not a leading GLOBAL_FLAG must be the verb.
 		if (tok === verb) return argv.slice(i + 1);
 		return [];
 	}

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -233,7 +233,12 @@ async function loadDefaultPlugins(): Promise<void> {
 			return;
 		}
 
-		const pluginDirs = readdirSync(defaultPluginsDir);
+		// Sort to make load order deterministic across filesystems/OSes.
+		// The first-registration-wins duplicate-name policy in
+		// `rejectDuplicateCommandNames` relies on this — without a stable
+		// sort, "who wins" would depend on `readdirSync()` order, which
+		// varies across platforms and filesystems.
+		const pluginDirs = readdirSync(defaultPluginsDir).sort();
 		logger.debug(`Found ${pluginDirs.length} default plugin(s)`);
 
 		for (const pluginDir of pluginDirs) {
@@ -315,7 +320,12 @@ export async function loadInstalledPlugins(): Promise<void> {
 	}
 
 	try {
-		const entries = readdirSync(nodeModulesPath);
+		// Sort to make load order deterministic across filesystems/OSes.
+		// The first-registration-wins duplicate-name policy in
+		// `rejectDuplicateCommandNames` relies on this — without a stable
+		// sort, "who wins" would depend on `readdirSync()` order, which
+		// varies across platforms and filesystems.
+		const entries = readdirSync(nodeModulesPath).sort();
 		logger.debug(`Scanning ${entries.length} entries in node_modules`);
 
 		const packagesToScan: string[] = [];
@@ -327,10 +337,10 @@ export async function loadInstalledPlugins(): Promise<void> {
 			}
 
 			if (entry.startsWith("@")) {
-				// Scoped package - scan subdirectories
+				// Scoped package - scan subdirectories (sorted for determinism).
 				const scopePath = join(nodeModulesPath, entry);
 				try {
-					const scopedPackages = readdirSync(scopePath);
+					const scopedPackages = readdirSync(scopePath).sort();
 					for (const scopedPkg of scopedPackages) {
 						if (!scopedPkg.startsWith(".")) {
 							packagesToScan.push(join(entry, scopedPkg));
@@ -347,6 +357,12 @@ export async function loadInstalledPlugins(): Promise<void> {
 				packagesToScan.push(entry);
 			}
 		}
+
+		// Final defensive sort: `@scope/pkg` paths interleave with bare
+		// `pkg` paths in the order we appended them, but for
+		// duplicate-name resolution we want a single, stable lexicographic
+		// order over the full set.
+		packagesToScan.sort();
 
 		logger.debug(
 			`Found ${packagesToScan.length} packages to scan:`,

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -95,7 +95,21 @@ function validatePassthroughCommands(plugin: LoadedPlugin): void {
 	const meta = plugin.metadata?.commands ?? {};
 	for (const commandName of Object.keys(plugin.commands)) {
 		const commandMeta = meta[commandName];
-		if (!commandMeta?.passthrough) continue;
+		if (commandMeta?.passthrough === undefined) continue;
+
+		// Strict-boolean check. Dispatch (`isPassthroughPluginCommand`) and
+		// help (`getPluginCommandsInfo`) both gate on `=== true`, so any
+		// truthy non-true value here (e.g. the string "true") would silently
+		// disagree with them. Reject loudly at load time.
+		if (commandMeta.passthrough !== true) {
+			logger.warn(
+				`Plugin '${plugin.name}' command '${commandName}' has metadata.passthrough set to ` +
+					`${JSON.stringify(commandMeta.passthrough)} but the contract requires the boolean ` +
+					"literal `true`. Dropping this command (#366).",
+			);
+			delete plugin.commands[commandName];
+			continue;
+		}
 
 		const cmd = plugin.commands[commandName];
 		const hasFlagsForm = typeof cmd !== "function";

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -29,13 +29,43 @@ interface PluginMetadata {
 	name?: string;
 	description?: string;
 	commands?: {
-		[commandName: string]: {
-			description?: string;
-			examples?: { command: string; description: string }[];
-			/** Subcommands for shell completion (e.g. cluster → start, stop, status). */
-			subcommands?: { name: string; description: string }[];
-		};
+		[commandName: string]: PluginCommandMeta;
 	};
+}
+
+/**
+ * Per-command plugin metadata.
+ *
+ * A plugin command is **either** metadata-driven (declares typed flags via
+ * the `{ flags, handler }` command form) **or** a passthrough command
+ * (`passthrough: true` + `passthroughHint`). Mutually exclusive — see
+ * #251 / #366. Declaring both is rejected at load time.
+ */
+export interface PluginCommandMeta {
+	description?: string;
+	helpDescription?: string;
+	examples?: { command: string; description: string }[];
+	/** Subcommands for shell completion (e.g. cluster → start, stop, status). */
+	subcommands?: { name: string; description: string }[];
+	/**
+	 * If true, c8ctl strips GLOBAL_FLAGS from argv and forwards everything
+	 * else verbatim to the bare-function handler. Help and JSON help
+	 * advertise the boundary explicitly.
+	 *
+	 * MUST NOT appear together with the `{ flags, handler }` command form;
+	 * the load-time validator drops any command that declares both.
+	 */
+	passthrough?: boolean;
+	/**
+	 * Required when `passthrough` is true. Short text rendered in help that
+	 * advertises the boundary, e.g. "Forwards args to `kubectl`".
+	 */
+	passthroughHint?: string;
+	/**
+	 * Optional documentation-only flag list rendered in help under
+	 * passthrough commands. NOT parsed by c8ctl.
+	 */
+	flagsHint?: string[];
 }
 
 interface LoadedPlugin {
@@ -45,6 +75,51 @@ interface LoadedPlugin {
 }
 
 const loadedPlugins = new Map<string, LoadedPlugin>();
+
+/**
+ * Validate the passthrough/flags mutual-exclusion rule (#366). Removes
+ * offending commands from the registered set so they cannot be invoked,
+ * and emits a debug-level diagnostic naming the plugin and command.
+ *
+ * The contract: a command MUST NOT declare `passthrough: true` AND use the
+ * `{ flags, handler }` form. Pick one. A passthrough command without a
+ * `passthroughHint` is also rejected (the hint is what makes the boundary
+ * legible to users and agents).
+ *
+ * Mutates `plugin.commands` in place. Safe to call after each plugin is
+ * loaded.
+ */
+function validatePassthroughCommands(plugin: LoadedPlugin): void {
+	const logger = getLogger();
+	const meta = plugin.metadata?.commands ?? {};
+	for (const commandName of Object.keys(plugin.commands)) {
+		const commandMeta = meta[commandName];
+		if (!commandMeta?.passthrough) continue;
+
+		const cmd = plugin.commands[commandName];
+		const hasFlagsForm = typeof cmd !== "function";
+		if (hasFlagsForm) {
+			logger.warn(
+				`Plugin '${plugin.name}' command '${commandName}' declares both passthrough:true AND flags. ` +
+					"Pick one \u2014 a passthrough command must use the bare-function handler form. " +
+					"Dropping this command (#366).",
+			);
+			delete plugin.commands[commandName];
+			continue;
+		}
+		if (
+			typeof commandMeta.passthroughHint !== "string" ||
+			commandMeta.passthroughHint.trim() === ""
+		) {
+			logger.warn(
+				`Plugin '${plugin.name}' command '${commandName}' declares passthrough:true ` +
+					"but is missing a non-empty passthroughHint. The hint is required so help and " +
+					"agents can advertise the boundary. Dropping this command (#366).",
+			);
+			delete plugin.commands[commandName];
+		}
+	}
+}
 
 /**
  * Load default plugins bundled with c8ctl
@@ -116,12 +191,14 @@ async function loadDefaultPlugins(): Promise<void> {
 				const plugin = await import(pluginUrl);
 
 				if (plugin.commands && typeof plugin.commands === "object") {
-					loadedPlugins.set(pluginName, {
+					const loaded: LoadedPlugin = {
 						name: pluginName,
-						commands: plugin.commands,
+						commands: { ...plugin.commands },
 						metadata: plugin.metadata || {},
-					});
-					const commandNames = Object.keys(plugin.commands);
+					};
+					validatePassthroughCommands(loaded);
+					loadedPlugins.set(pluginName, loaded);
+					const commandNames = Object.keys(loaded.commands);
 					logger.debug(
 						`Successfully loaded default plugin: ${pluginName} with ${commandNames.length} commands:`,
 						commandNames,
@@ -243,12 +320,14 @@ export async function loadInstalledPlugins(): Promise<void> {
 				const plugin = await import(pluginUrl);
 
 				if (plugin.commands && typeof plugin.commands === "object") {
-					loadedPlugins.set(packageName, {
+					const loaded: LoadedPlugin = {
 						name: packageName,
-						commands: plugin.commands,
+						commands: { ...plugin.commands },
 						metadata: plugin.metadata || {},
-					});
-					const commandNames = Object.keys(plugin.commands);
+					};
+					validatePassthroughCommands(loaded);
+					loadedPlugins.set(packageName, loaded);
+					const commandNames = Object.keys(loaded.commands);
 					logger.debug(
 						`Successfully loaded plugin: ${packageName} with ${commandNames.length} commands:`,
 						commandNames,
@@ -328,9 +407,16 @@ export interface PluginCommandInfo {
 	commandName: string;
 	pluginName: string;
 	description?: string;
+	helpDescription?: string;
 	examples?: { command: string; description: string }[];
 	/** Subcommands for shell completion (e.g. cluster → start, stop, status). */
 	subcommands?: { name: string; description: string }[];
+	/** True when the command opted into the #366 passthrough contract. */
+	passthrough?: boolean;
+	/** Required when passthrough is true — short text that names the boundary. */
+	passthroughHint?: string;
+	/** Optional documentation-only flag list rendered under passthrough help. */
+	flagsHint?: string[];
 }
 
 export function getPluginCommandsInfo(): PluginCommandInfo[] {
@@ -338,17 +424,35 @@ export function getPluginCommandsInfo(): PluginCommandInfo[] {
 
 	for (const plugin of loadedPlugins.values()) {
 		for (const commandName of Object.keys(plugin.commands)) {
+			const meta = plugin.metadata?.commands?.[commandName];
 			infos.push({
 				commandName,
 				pluginName: plugin.name,
-				description: plugin.metadata?.commands?.[commandName]?.description,
-				examples: plugin.metadata?.commands?.[commandName]?.examples,
-				subcommands: plugin.metadata?.commands?.[commandName]?.subcommands,
+				description: meta?.description,
+				helpDescription: meta?.helpDescription,
+				examples: meta?.examples,
+				subcommands: meta?.subcommands,
+				passthrough: meta?.passthrough === true ? true : undefined,
+				passthroughHint: meta?.passthroughHint,
+				flagsHint: meta?.flagsHint,
 			});
 		}
 	}
 
 	return infos;
+}
+
+/**
+ * True if the named command is a registered passthrough plugin command
+ * (#366). Used by the dispatcher to gate the strip-and-forward path.
+ */
+export function isPassthroughPluginCommand(commandName: string): boolean {
+	for (const plugin of loadedPlugins.values()) {
+		if (!Object.hasOwn(plugin.commands, commandName)) continue;
+		const meta = plugin.metadata?.commands?.[commandName];
+		if (meta?.passthrough === true) return true;
+	}
+	return false;
 }
 
 /**

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -97,15 +97,17 @@ function validatePassthroughCommands(plugin: LoadedPlugin): void {
 		const commandMeta = meta[commandName];
 		if (commandMeta?.passthrough === undefined) continue;
 
-		// Strict-boolean check. Dispatch (`isPassthroughPluginCommand`) and
-		// help (`getPluginCommandsInfo`) both gate on `=== true`, so any
-		// truthy non-true value here (e.g. the string "true") would silently
-		// disagree with them. Reject loudly at load time.
+		// `passthrough: false` is equivalent to "not opted in" — silently
+		// skip. Any other non-`true` value (e.g. the string "true", a
+		// number) is a contract violation: dispatch and help both gate on
+		// `=== true`, so a truthy non-true value would silently disagree
+		// with them. Reject loudly at load time.
+		if (commandMeta.passthrough === false) continue;
 		if (commandMeta.passthrough !== true) {
 			logger.warn(
 				`Plugin '${plugin.name}' command '${commandName}' has metadata.passthrough set to ` +
 					`${JSON.stringify(commandMeta.passthrough)} but the contract requires the boolean ` +
-					"literal `true`. Dropping this command (#366).",
+					"literal `true` (or `false` / omitted to opt out). Dropping this command (#366).",
 			);
 			delete plugin.commands[commandName];
 			continue;
@@ -132,6 +134,26 @@ function validatePassthroughCommands(plugin: LoadedPlugin): void {
 					"agents can advertise the boundary. Dropping this command (#366).",
 			);
 			delete plugin.commands[commandName];
+			continue;
+		}
+
+		// `flagsHint` is documentation-only and consumed by the help
+		// renderer, which assumes `string[]`. Validate the shape here so a
+		// mis-typed value can't reach the renderer. The field is optional;
+		// invalid shapes are stripped (not fatal) so the command itself
+		// continues to work — only the doc affordance is lost.
+		const flagsHint = commandMeta.flagsHint;
+		if (flagsHint !== undefined) {
+			const valid =
+				Array.isArray(flagsHint) &&
+				flagsHint.every((entry) => typeof entry === "string");
+			if (!valid) {
+				logger.warn(
+					`Plugin '${plugin.name}' command '${commandName}' declares metadata.flagsHint ` +
+						"but it is not a string[]. Ignoring flagsHint (#366).",
+				);
+				delete commandMeta.flagsHint;
+			}
 		}
 	}
 }
@@ -141,6 +163,14 @@ function validatePassthroughCommands(plugin: LoadedPlugin): void {
  * a command name that is already registered by an earlier-loaded plugin,
  * drop it from `plugin.commands` and emit `logger.warn` naming both
  * plugins so the conflict is visible at startup.
+ *
+ * **Conflict policy: first registration wins.** This is an explicit
+ * choice (#366) and replaces the previous implicit "last-loaded wins"
+ * behaviour produced by `Object.assign` over `loadedPlugins` in
+ * insertion order. Plugins cannot override one another by registering
+ * the same command name; if you want a different command, give it a
+ * different name. Default plugins always load first, so user-installed
+ * plugins cannot override default commands by name.
  *
  * This guarantees that the merged map returned by `getPluginCommands()`
  * has a single owning plugin per command name, which keeps dispatch and

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -436,26 +436,39 @@ export async function loadInstalledPlugins(): Promise<void> {
 					? pluginFileJs
 					: pluginFileTs;
 
+				// Use the package.json#name (not the filesystem directory
+				// entry) as the canonical plugin name / loadedPlugins key.
+				// Under npm aliases (e.g. `npm i my-alias@npm:real-plugin`),
+				// the install directory is `my-alias` but the package name is
+				// `real-plugin`. Keying by directory would miss real
+				// duplicate-name collisions and surface the wrong name in
+				// duplicate warnings. `packageName` is kept for filesystem /
+				// logging purposes only.
+				const pluginName =
+					typeof packageJson.name === "string" && packageJson.name.length > 0
+						? packageJson.name
+						: packageName;
+
 				// Use file:// protocol and add timestamp to bust cache
 				const pluginUrl = `file://${pluginFile}?t=${Date.now()}`;
 				logger.debug(`Loading plugin from: ${pluginUrl}`);
 				const plugin = await import(pluginUrl);
 
 				if (plugin.commands && typeof plugin.commands === "object") {
-					if (isDuplicatePluginName(packageName)) {
+					if (isDuplicatePluginName(pluginName)) {
 						continue;
 					}
 					const loaded: LoadedPlugin = {
-						name: packageName,
+						name: pluginName,
 						commands: { ...plugin.commands },
 						metadata: plugin.metadata || {},
 					};
 					validatePassthroughCommands(loaded);
 					rejectDuplicateCommandNames(loaded);
-					loadedPlugins.set(packageName, loaded);
+					loadedPlugins.set(pluginName, loaded);
 					const commandNames = Object.keys(loaded.commands);
 					logger.debug(
-						`Successfully loaded plugin: ${packageName} with ${commandNames.length} commands:`,
+						`Successfully loaded plugin: ${pluginName} (dir: ${packageName}) with ${commandNames.length} commands:`,
 						commandNames,
 					);
 				}

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -185,7 +185,6 @@ function rejectDuplicateCommandNames(plugin: LoadedPlugin): void {
 	const logger = getLogger();
 	for (const commandName of Object.keys(plugin.commands)) {
 		for (const existing of loadedPlugins.values()) {
-			if (existing.name === plugin.name) continue;
 			if (Object.hasOwn(existing.commands, commandName)) {
 				logger.warn(
 					`Plugin '${plugin.name}' tried to register command '${commandName}' but it is ` +
@@ -197,6 +196,31 @@ function rejectDuplicateCommandNames(plugin: LoadedPlugin): void {
 			}
 		}
 	}
+}
+
+/**
+ * Reject a plugin whose name collides with an already-loaded plugin
+ * (#363). The first-registration-wins policy applies at the plugin
+ * level as well as at the command-name level: if a user-installed
+ * package shares a `package.json#name` with a default plugin (or with
+ * another already-loaded plugin), refusing the second load keeps
+ * `loadedPlugins` single-owner per name and prevents a silent
+ * `loadedPlugins.set()` overwrite from bypassing the
+ * command-name policy.
+ *
+ * Returns `true` when the caller should skip the load; `false` when
+ * the name is free.
+ */
+function isDuplicatePluginName(pluginName: string): boolean {
+	const logger = getLogger();
+	if (loadedPlugins.has(pluginName)) {
+		logger.warn(
+			`Plugin name '${pluginName}' is already loaded; refusing to load a second plugin ` +
+				`with the same name. The first registration wins.`,
+		);
+		return true;
+	}
+	return false;
 }
 
 /**
@@ -274,6 +298,9 @@ async function loadDefaultPlugins(): Promise<void> {
 				const plugin = await import(pluginUrl);
 
 				if (plugin.commands && typeof plugin.commands === "object") {
+					if (isDuplicatePluginName(pluginName)) {
+						continue;
+					}
 					const loaded: LoadedPlugin = {
 						name: pluginName,
 						commands: { ...plugin.commands },
@@ -415,6 +442,9 @@ export async function loadInstalledPlugins(): Promise<void> {
 				const plugin = await import(pluginUrl);
 
 				if (plugin.commands && typeof plugin.commands === "object") {
+					if (isDuplicatePluginName(packageName)) {
+						continue;
+					}
 					const loaded: LoadedPlugin = {
 						name: packageName,
 						commands: { ...plugin.commands },

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -79,7 +79,8 @@ const loadedPlugins = new Map<string, LoadedPlugin>();
 /**
  * Validate the passthrough/flags mutual-exclusion rule (#366). Removes
  * offending commands from the registered set so they cannot be invoked,
- * and emits a debug-level diagnostic naming the plugin and command.
+ * and emits a `logger.warn` naming the plugin and command so the
+ * misconfiguration is visible at startup.
  *
  * The contract: a command MUST NOT declare `passthrough: true` AND use the
  * `{ flags, handler }` form. Pick one. A passthrough command without a
@@ -117,6 +118,39 @@ function validatePassthroughCommands(plugin: LoadedPlugin): void {
 					"agents can advertise the boundary. Dropping this command (#366).",
 			);
 			delete plugin.commands[commandName];
+		}
+	}
+}
+
+/**
+ * Reject duplicate plugin command names at load time. If `plugin` declares
+ * a command name that is already registered by an earlier-loaded plugin,
+ * drop it from `plugin.commands` and emit `logger.warn` naming both
+ * plugins so the conflict is visible at startup.
+ *
+ * This guarantees that the merged map returned by `getPluginCommands()`
+ * has a single owning plugin per command name, which keeps dispatch and
+ * `isPassthroughPluginCommand()` consistent: the help renderer and the
+ * runtime always agree on which plugin handles a given verb.
+ *
+ * Mutates `plugin.commands` in place. Safe to call after each plugin is
+ * loaded; relies on `loadedPlugins` already containing previously-loaded
+ * plugins.
+ */
+function rejectDuplicateCommandNames(plugin: LoadedPlugin): void {
+	const logger = getLogger();
+	for (const commandName of Object.keys(plugin.commands)) {
+		for (const existing of loadedPlugins.values()) {
+			if (existing.name === plugin.name) continue;
+			if (Object.hasOwn(existing.commands, commandName)) {
+				logger.warn(
+					`Plugin '${plugin.name}' tried to register command '${commandName}' but it is ` +
+						`already provided by plugin '${existing.name}'. The first registration wins; ` +
+						`dropping the duplicate from '${plugin.name}'.`,
+				);
+				delete plugin.commands[commandName];
+				break;
+			}
 		}
 	}
 }
@@ -197,6 +231,7 @@ async function loadDefaultPlugins(): Promise<void> {
 						metadata: plugin.metadata || {},
 					};
 					validatePassthroughCommands(loaded);
+					rejectDuplicateCommandNames(loaded);
 					loadedPlugins.set(pluginName, loaded);
 					const commandNames = Object.keys(loaded.commands);
 					logger.debug(
@@ -326,6 +361,7 @@ export async function loadInstalledPlugins(): Promise<void> {
 						metadata: plugin.metadata || {},
 					};
 					validatePassthroughCommands(loaded);
+					rejectDuplicateCommandNames(loaded);
 					loadedPlugins.set(packageName, loaded);
 					const commandNames = Object.keys(loaded.commands);
 					logger.debug(

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -199,14 +199,15 @@ function rejectDuplicateCommandNames(plugin: LoadedPlugin): void {
 }
 
 /**
- * Reject a plugin whose name collides with an already-loaded plugin
- * (#363). The first-registration-wins policy applies at the plugin
- * level as well as at the command-name level: if a user-installed
- * package shares a `package.json#name` with a default plugin (or with
- * another already-loaded plugin), refusing the second load keeps
- * `loadedPlugins` single-owner per name and prevents a silent
- * `loadedPlugins.set()` overwrite from bypassing the
- * command-name policy.
+ * Reject a plugin whose name collides with an already-loaded plugin.
+ * This is a separate concern from the command-name collision policy
+ * tracked under #363: that policy rejects two plugins exporting the
+ * same command name, while this one rejects two plugins sharing the
+ * same `package.json#name`. Both follow first-registration-wins.
+ * Without this guard a user-installed package sharing a name with a
+ * default plugin (or with another already-loaded plugin) would
+ * silently overwrite the prior `loadedPlugins.set()` entry, bypassing
+ * the command-name policy entirely.
  *
  * Returns `true` when the caller should skip the load; `false` when
  * the name is free.

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -288,6 +288,14 @@ async function loadDefaultPlugins(): Promise<void> {
 				const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
 				const pluginName = packageJson.name || `default-${pluginDir}`;
 
+				// Check for duplicate plugin name BEFORE the dynamic import
+				// so a duplicate-name plugin's module code never runs (the
+				// import has top-level side effects we don't want to execute
+				// only to throw the result away).
+				if (isDuplicatePluginName(pluginName)) {
+					continue;
+				}
+
 				const pluginFile = existsSync(pluginFileJs)
 					? pluginFileJs
 					: pluginFileTs;
@@ -298,9 +306,6 @@ async function loadDefaultPlugins(): Promise<void> {
 				const plugin = await import(pluginUrl);
 
 				if (plugin.commands && typeof plugin.commands === "object") {
-					if (isDuplicatePluginName(pluginName)) {
-						continue;
-					}
 					const loaded: LoadedPlugin = {
 						name: pluginName,
 						commands: { ...plugin.commands },
@@ -449,15 +454,20 @@ export async function loadInstalledPlugins(): Promise<void> {
 						? packageJson.name
 						: packageName;
 
+				// Check for duplicate plugin name BEFORE the dynamic import
+				// so a duplicate-name plugin's module code never runs (the
+				// import has top-level side effects we don't want to execute
+				// only to throw the result away).
+				if (isDuplicatePluginName(pluginName)) {
+					continue;
+				}
+
 				// Use file:// protocol and add timestamp to bust cache
 				const pluginUrl = `file://${pluginFile}?t=${Date.now()}`;
 				logger.debug(`Loading plugin from: ${pluginUrl}`);
 				const plugin = await import(pluginUrl);
 
 				if (plugin.commands && typeof plugin.commands === "object") {
-					if (isDuplicatePluginName(pluginName)) {
-						continue;
-					}
 					const loaded: LoadedPlugin = {
 						name: pluginName,
 						commands: { ...plugin.commands },

--- a/tests/fixtures/plugins/plugin-with-passthrough/c8ctl-plugin.js
+++ b/tests/fixtures/plugins/plugin-with-passthrough/c8ctl-plugin.js
@@ -1,0 +1,48 @@
+/**
+ * Test plugin for the passthrough contract (#366).
+ *
+ * - `pass-through-cmd` is a bare-function handler. Its metadata declares
+ *   `passthrough: true` with a `passthroughHint`. c8ctl strips GLOBAL_FLAGS
+ *   and forwards everything else verbatim. The handler echoes its argv as
+ *   JSON so tests can assert what reached it.
+ * - `bad-passthrough-with-flags` declares both `passthrough: true` AND
+ *   `flags`. This is invalid — load-time validation must reject the
+ *   command (drop it from the registered command set). Tests assert it
+ *   is unreachable from the CLI.
+ */
+
+export const commands = {
+	'pass-through-cmd': async (args) => {
+		console.log(JSON.stringify({ args }));
+	},
+	'bad-passthrough-with-flags': {
+		flags: {
+			something: { type: 'string', description: 'A flag (invalid alongside passthrough)' },
+		},
+		handler: async (args, flags) => {
+			console.log(JSON.stringify({ args, flags: flags || {} }));
+		},
+	},
+};
+
+export const metadata = {
+	name: 'plugin-with-passthrough',
+	description: 'Plugin for testing passthrough contract',
+	commands: {
+		'pass-through-cmd': {
+			description: 'Forward all args to a hypothetical underlying tool',
+			helpDescription: 'A passthrough command used to exercise the #366 contract.',
+			passthrough: true,
+			passthroughHint: 'Forwards args to `external-tool`',
+			flagsHint: ['--from <url>', '--to <path>', '--dry'],
+			examples: [
+				{ command: 'c8ctl pass-through-cmd --from URL --to PATH', description: 'Forward URL/PATH to external-tool' },
+			],
+		},
+		'bad-passthrough-with-flags': {
+			description: 'Invalid combination — should be rejected at load time',
+			passthrough: true,
+			passthroughHint: 'irrelevant — flags are also declared which is invalid',
+		},
+	},
+};

--- a/tests/fixtures/plugins/plugin-with-passthrough/package.json
+++ b/tests/fixtures/plugins/plugin-with-passthrough/package.json
@@ -1,0 +1,8 @@
+{
+	"name": "plugin-with-passthrough",
+	"version": "0.0.0",
+	"description": "Test plugin for passthrough contract (#366)",
+	"keywords": ["c8ctl", "c8ctl-plugin"],
+	"main": "c8ctl-plugin.js",
+	"type": "module"
+}

--- a/tests/fixtures/plugins/zzz-plugin-conflicting/c8ctl-plugin.js
+++ b/tests/fixtures/plugins/zzz-plugin-conflicting/c8ctl-plugin.js
@@ -1,0 +1,28 @@
+/**
+ * Test plugin for the duplicate-command-name policy (#366).
+ *
+ * Declares a command name (`pass-through-cmd`) that is already provided
+ * by `plugin-with-passthrough`. The fixture is named `zzz-...` so it
+ * loads after `plugin-with-passthrough` deterministically. c8ctl
+ * resolves the conflict as "first registration wins" and drops this
+ * plugin's version of the command at load time. The handler below
+ * would print a different payload than the winning fixture — the test
+ * asserts the winning plugin's payload, which proves the loser was
+ * actually dropped.
+ */
+
+export const commands = {
+  'pass-through-cmd': async (args) => {
+    console.log(JSON.stringify({ from: 'zzz-plugin-conflicting', args }));
+  },
+};
+
+export const metadata = {
+  name: 'zzz-plugin-conflicting',
+  description: 'Plugin that tries to override pass-through-cmd',
+  commands: {
+    'pass-through-cmd': {
+      description: 'Should be dropped at load time as a duplicate',
+    },
+  },
+};

--- a/tests/fixtures/plugins/zzz-plugin-conflicting/package.json
+++ b/tests/fixtures/plugins/zzz-plugin-conflicting/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "zzz-plugin-conflicting",
+  "version": "0.0.0",
+  "description": "Test plugin for first-wins duplicate-name policy (#366)",
+  "keywords": ["c8ctl", "c8ctl-plugin"],
+  "main": "c8ctl-plugin.js",
+  "type": "module"
+}

--- a/tests/fixtures/plugins/zzz-plugin-name-collider/c8ctl-plugin.js
+++ b/tests/fixtures/plugins/zzz-plugin-name-collider/c8ctl-plugin.js
@@ -1,14 +1,18 @@
 /**
- * Test fixture for #367 review-comment r11.
+ * Test fixture for the duplicate-plugin-name guard introduced
+ * alongside the passthrough plugin contract (#366). Companion to the
+ * canonical `plugin-with-passthrough` fixture.
  *
- * This fixture's package.json#name is `plugin-with-passthrough`, the
- * same as the canonical fixture. The loader must refuse to import this
- * file at all — i.e. the side effect below must NEVER fire.
+ * This fixture's `package.json#name` is `plugin-with-passthrough`,
+ * the same as the canonical fixture. The loader must refuse to
+ * import this file at all — i.e. the side effect below must NEVER
+ * fire.
  *
  * If `isDuplicatePluginName()` is checked after the dynamic import,
  * Node will execute this module body and the sentinel file will be
- * created. The accompanying test asserts the sentinel does NOT exist
- * after a c8ctl invocation that loads both copies.
+ * created. The accompanying test in
+ * `tests/unit/plugin-passthrough.test.ts` asserts the sentinel does
+ * NOT exist after a c8ctl invocation that loads both copies.
  */
 import { writeFileSync } from "node:fs";
 

--- a/tests/fixtures/plugins/zzz-plugin-name-collider/c8ctl-plugin.js
+++ b/tests/fixtures/plugins/zzz-plugin-name-collider/c8ctl-plugin.js
@@ -1,0 +1,34 @@
+/**
+ * Test fixture for #367 review-comment r11.
+ *
+ * This fixture's package.json#name is `plugin-with-passthrough`, the
+ * same as the canonical fixture. The loader must refuse to import this
+ * file at all — i.e. the side effect below must NEVER fire.
+ *
+ * If `isDuplicatePluginName()` is checked after the dynamic import,
+ * Node will execute this module body and the sentinel file will be
+ * created. The accompanying test asserts the sentinel does NOT exist
+ * after a c8ctl invocation that loads both copies.
+ */
+import { writeFileSync } from "node:fs";
+
+const sentinelPath = process.env.C8CTL_TEST_DUP_SIDE_EFFECT_SENTINEL;
+if (sentinelPath) {
+  writeFileSync(sentinelPath, "duplicate-plugin-module-was-imported");
+}
+
+export const commands = {
+  "should-never-register": async () => {
+    console.log("if you see this, the duplicate-name guard failed");
+  },
+};
+
+export const metadata = {
+  name: "plugin-with-passthrough",
+  description: "Duplicate-name fixture (must not be imported)",
+  commands: {
+    "should-never-register": {
+      description: "Must never register",
+    },
+  },
+};

--- a/tests/fixtures/plugins/zzz-plugin-name-collider/package.json
+++ b/tests/fixtures/plugins/zzz-plugin-name-collider/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "plugin-with-passthrough",
+  "version": "0.0.0",
+  "description": "Test fixture: same package.json#name as plugin-with-passthrough — used to assert duplicate-name detection refuses to import the second copy at all (no top-level side effects).",
+  "keywords": ["c8ctl", "c8ctl-plugin"],
+  "main": "c8ctl-plugin.js",
+  "type": "module"
+}

--- a/tests/unit/plugin-passthrough.test.ts
+++ b/tests/unit/plugin-passthrough.test.ts
@@ -162,6 +162,60 @@ describe("Passthrough plugin contract (#366)", () => {
 			assert.deepStrictEqual(out.args, ["--from", "URL"]);
 		});
 
+		test("strips GLOBAL_FLAGS in `--flag=value` form", async () => {
+			// stripGlobalFlags() and sliceArgvAfterVerb() both branch on the
+			// `=` syntax. Without this case, a regression in either path
+			// could silently leak `--profile=local` through to the plugin,
+			// or break verb detection when the verb is preceded by a
+			// `--flag=value`-shaped global.
+			const result = await c8(
+				"--profile=test-profile",
+				"pass-through-cmd",
+				"--from=URL",
+			);
+			assert.strictEqual(
+				result.status,
+				0,
+				`expected exit 0, got ${result.status}. stderr: ${result.stderr}`,
+			);
+			const out = JSON.parse(result.stdout);
+			assert.ok(
+				!out.args.some((a: string) => a.startsWith("--profile")),
+				`--profile=value must be stripped before forwarding. args=${JSON.stringify(out.args)}`,
+			);
+			assert.deepStrictEqual(
+				out.args,
+				["--from=URL"],
+				"non-global --flag=value entries must be forwarded verbatim",
+			);
+		});
+
+		test("verb-detection is robust when a string global flag's value equals the verb name", async () => {
+			// Regression guard for sliceArgvAfterVerb(): when a string
+			// global flag (e.g. --profile) takes a value that happens to
+			// match the verb token (`pass-through-cmd`), the slicer must
+			// consume the value as a flag-value and only treat the LATER
+			// occurrence as the verb. If it didn't, we'd dispatch on the
+			// flag-value and forward the real verb to the handler.
+			const result = await c8(
+				"--profile",
+				"pass-through-cmd",
+				"pass-through-cmd",
+				"actual-positional",
+			);
+			assert.strictEqual(
+				result.status,
+				0,
+				`expected exit 0, got ${result.status}. stderr: ${result.stderr}`,
+			);
+			const out = JSON.parse(result.stdout);
+			assert.deepStrictEqual(
+				out.args,
+				["actual-positional"],
+				`expected only the post-verb positional to reach the handler; the flag-value occurrence of the verb must not be forwarded. args=${JSON.stringify(out.args)}`,
+			);
+		});
+
 		test("strips --json (a GLOBAL_FLAG) but applies its effect to the runtime", async () => {
 			// --json must be stripped from args reaching the plugin, AND it must
 			// switch c8ctl.outputMode to json (which the bare-function plugin
@@ -302,7 +356,7 @@ describe("Passthrough plugin contract (#366)", () => {
 		});
 	});
 
-	describe("Duplicate command name policy (#366)", () => {
+	describe("Duplicate command name policy (#363)", () => {
 		// Class-scoped guard: c8ctl resolves plugin command-name conflicts
 		// with explicit "first registration wins" semantics. This replaces
 		// the previous implicit "last-loaded wins" Object.assign merge. The

--- a/tests/unit/plugin-passthrough.test.ts
+++ b/tests/unit/plugin-passthrough.test.ts
@@ -254,6 +254,31 @@ describe("Passthrough plugin contract (#366)", () => {
 				`args after -- must be forwarded verbatim. args=${JSON.stringify(out.args)}`,
 			);
 		});
+
+		test("handles a leading `--` separator before the verb (GNU convention)", async () => {
+			// `c8ctl -- <verb> <args...>` is the GNU "end of options"
+			// convention. The leading `--` must be skipped by the verb
+			// slicer rather than causing it to bail with an empty post-verb
+			// slice. Regression guard for sliceArgvAfterVerb().
+			const result = await c8(
+				"--",
+				"pass-through-cmd",
+				"arg1",
+				"--from",
+				"URL",
+			);
+			assert.strictEqual(
+				result.status,
+				0,
+				`expected exit 0, got ${result.status}. stderr: ${result.stderr}`,
+			);
+			const out = JSON.parse(result.stdout);
+			assert.deepStrictEqual(
+				out.args,
+				["arg1", "--from", "URL"],
+				`leading -- must be consumed, post-verb args must reach the handler verbatim. args=${JSON.stringify(out.args)}`,
+			);
+		});
 	});
 
 	describe("Load-time validation", () => {

--- a/tests/unit/plugin-passthrough.test.ts
+++ b/tests/unit/plugin-passthrough.test.ts
@@ -439,6 +439,23 @@ describe("Passthrough plugin contract (#366)", () => {
 			);
 		});
 
+		// Class-scoped guard: the bash file-completion case branch must
+		// include verb aliases too, not just the canonical verb. This
+		// covers fileComplete aliases (e.g. `w` → `watch`) and any
+		// future passthrough verbs that declare aliases. Without
+		// alias support, `c8ctl w <TAB>` would fall through to the
+		// generic `*)` arm and offer the wrong completion set.
+		test("bash file-completion case branch includes verb aliases (e.g. w → watch)", async () => {
+			const result = await c8("completion", "bash");
+			assert.strictEqual(result.status, 0);
+			// The watch verb has alias `w`. Both must appear in a single
+			// alternation pattern that maps to compgen -f.
+			assert.ok(
+				/watch\|w\)\s*\n\s*COMPREPLY=\(\s*\$\(compgen -f /.test(result.stdout),
+				`bash completion for fileComplete verb 'watch' must include its alias 'w' in the case pattern. stdout did not match.`,
+			);
+		});
+
 		test("bash completion restricts flag completion to GLOBAL_FLAGS for passthrough verbs", async () => {
 			const result = await c8("completion", "bash");
 			assert.strictEqual(result.status, 0);

--- a/tests/unit/plugin-passthrough.test.ts
+++ b/tests/unit/plugin-passthrough.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for the passthrough plugin contract (#366).
+ *
+ * The contract:
+ * - A plugin command is **either** metadata-driven (declares typed `flags`)
+ *   **or** passthrough (`passthrough: true` + `passthroughHint`). Mutually
+ *   exclusive — declaring both must be rejected at load time.
+ * - Passthrough dispatch: c8ctl strips GLOBAL_FLAGS from argv (they apply
+ *   to the c8ctl runtime via `globalThis.c8ctl.*`) and forwards everything
+ *   else verbatim to the bare-function handler.
+ * - `c8ctl help <passthrough-cmd>` renders a clearly-formatted "Passthrough
+ *   command" banner including the `passthroughHint` and any `flagsHint`.
+ * - `c8ctl help <passthrough-cmd> --output json` returns a structured
+ *   record with `kind: "passthrough"` so agents detect the boundary.
+ */
+
+import assert from "node:assert";
+import { cpSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { asyncSpawn } from "../utils/spawn.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = "src/index.ts";
+const FIXTURE_DIR = join(
+	__dirname,
+	"../fixtures/plugins/plugin-with-passthrough",
+);
+
+function makePluginDataDir(): string {
+	const dir = mkdtempSync(join(tmpdir(), "c8ctl-passthrough-test-"));
+	writeFileSync(
+		join(dir, "session.json"),
+		JSON.stringify({ outputMode: "text" }),
+	);
+	const pluginInstallDir = join(
+		dir,
+		"plugins",
+		"node_modules",
+		"plugin-with-passthrough",
+	);
+	mkdirSync(pluginInstallDir, { recursive: true });
+	cpSync(FIXTURE_DIR, pluginInstallDir, { recursive: true });
+	return dir;
+}
+
+const PLUGIN_DATA_DIR = makePluginDataDir();
+
+async function c8(...args: string[]) {
+	return asyncSpawn("node", ["--experimental-strip-types", CLI, ...args], {
+		env: {
+			...process.env,
+			CAMUNDA_BASE_URL: "http://test-cluster/v2",
+			HOME: "/tmp/c8ctl-passthrough-test-nonexistent-home",
+			C8CTL_DATA_DIR: PLUGIN_DATA_DIR,
+		},
+	});
+}
+
+describe("Passthrough plugin contract (#366)", () => {
+	describe("Dispatch", () => {
+		test("forwards positional args verbatim to the handler", async () => {
+			const result = await c8("pass-through-cmd", "subcmd", "value");
+			assert.strictEqual(
+				result.status,
+				0,
+				`expected exit 0, got ${result.status}. stderr: ${result.stderr}`,
+			);
+			const out = JSON.parse(result.stdout);
+			assert.deepStrictEqual(
+				out.args,
+				["subcmd", "value"],
+				"positional args must be forwarded unchanged",
+			);
+		});
+
+		test("forwards unknown flags verbatim to the handler", async () => {
+			const result = await c8(
+				"pass-through-cmd",
+				"--from",
+				"URL",
+				"--dry",
+				"target-arg",
+			);
+			assert.strictEqual(
+				result.status,
+				0,
+				`expected exit 0, got ${result.status}. stderr: ${result.stderr}`,
+			);
+			const out = JSON.parse(result.stdout);
+			assert.deepStrictEqual(
+				out.args,
+				["--from", "URL", "--dry", "target-arg"],
+				"unknown flags must reach the plugin handler unchanged",
+			);
+		});
+
+		test("strips GLOBAL_FLAGS from forwarded args (boolean flag)", async () => {
+			const result = await c8("pass-through-cmd", "--verbose", "--from", "URL");
+			assert.strictEqual(
+				result.status,
+				0,
+				`expected exit 0, got ${result.status}. stderr: ${result.stderr}`,
+			);
+			const out = JSON.parse(result.stdout);
+			assert.ok(
+				!out.args.includes("--verbose"),
+				`--verbose (a GLOBAL_FLAG) must be stripped before forwarding. args=${JSON.stringify(out.args)}`,
+			);
+			assert.deepStrictEqual(
+				out.args,
+				["--from", "URL"],
+				"non-global args must remain in order after stripping",
+			);
+		});
+
+		test("strips GLOBAL_FLAGS from forwarded args (string flag with value)", async () => {
+			const result = await c8(
+				"pass-through-cmd",
+				"--profile",
+				"local",
+				"--from",
+				"URL",
+			);
+			assert.strictEqual(
+				result.status,
+				0,
+				`expected exit 0, got ${result.status}. stderr: ${result.stderr}`,
+			);
+			const out = JSON.parse(result.stdout);
+			assert.ok(
+				!out.args.includes("--profile"),
+				"--profile (a GLOBAL_FLAG) must be stripped",
+			);
+			assert.ok(
+				!out.args.includes("local"),
+				"the value following --profile must be stripped too",
+			);
+			assert.deepStrictEqual(out.args, ["--from", "URL"]);
+		});
+
+		test("strips --json (a GLOBAL_FLAG) but applies its effect to the runtime", async () => {
+			// --json must be stripped from args reaching the plugin, AND it must
+			// switch c8ctl.outputMode to json (which the bare-function plugin
+			// here ignores — but the global override wiring still runs). The
+			// args must not contain --json.
+			const result = await c8("pass-through-cmd", "--json", "subcmd");
+			assert.strictEqual(
+				result.status,
+				0,
+				`expected exit 0, got ${result.status}. stderr: ${result.stderr}`,
+			);
+			const out = JSON.parse(result.stdout);
+			assert.ok(
+				!out.args.includes("--json"),
+				"--json must be stripped before forwarding",
+			);
+			assert.deepStrictEqual(out.args, ["subcmd"]);
+		});
+
+		test("forwards `--` and everything after it verbatim", async () => {
+			const result = await c8(
+				"pass-through-cmd",
+				"--",
+				"--profile",
+				"this-should-not-be-stripped",
+			);
+			assert.strictEqual(
+				result.status,
+				0,
+				`expected exit 0, got ${result.status}. stderr: ${result.stderr}`,
+			);
+			const out = JSON.parse(result.stdout);
+			assert.ok(
+				out.args.includes("--profile") &&
+					out.args.includes("this-should-not-be-stripped"),
+				`args after -- must be forwarded verbatim. args=${JSON.stringify(out.args)}`,
+			);
+		});
+	});
+
+	describe("Load-time validation", () => {
+		test("a command declaring both passthrough:true AND flags is rejected and unreachable", async () => {
+			// The fixture's `bad-passthrough-with-flags` command violates the
+			// mutual-exclusion rule. After load-time validation it must NOT
+			// be registered; invoking it must produce the standard
+			// unknown-command error path.
+			const result = await c8("bad-passthrough-with-flags", "--something", "x");
+			assert.notStrictEqual(
+				result.status,
+				0,
+				`expected non-zero exit (unknown command), got ${result.status}. stdout: ${result.stdout}`,
+			);
+			// And the user must see why — at minimum a debug/warn line on stderr
+			// during plugin load that mentions the rejected command.
+			assert.ok(
+				/passthrough.*flags|flags.*passthrough|bad-passthrough-with-flags/i.test(
+					result.stderr,
+				),
+				`expected validation message about the conflicting passthrough+flags combination on stderr. stderr: ${result.stderr}`,
+			);
+		});
+	});
+
+	describe("Help rendering — text mode", () => {
+		test("`c8 help <passthrough-cmd>` includes a Passthrough banner with the hint", async () => {
+			const result = await c8("help", "pass-through-cmd");
+			assert.strictEqual(
+				result.status,
+				0,
+				`expected exit 0, got ${result.status}. stderr: ${result.stderr}`,
+			);
+			assert.ok(
+				/passthrough command/i.test(result.stdout),
+				`help must include a 'Passthrough command' banner. stdout: ${result.stdout}`,
+			);
+			assert.ok(
+				result.stdout.includes("Forwards args to `external-tool`"),
+				`help must include the passthroughHint text. stdout: ${result.stdout}`,
+			);
+		});
+
+		test("`c8 help <passthrough-cmd>` lists flagsHint when present", async () => {
+			const result = await c8("help", "pass-through-cmd");
+			assert.strictEqual(result.status, 0);
+			assert.ok(
+				result.stdout.includes("--from <url>"),
+				`flagsHint entries must appear in help. stdout: ${result.stdout}`,
+			);
+		});
+	});
+
+	describe("Help rendering — JSON mode", () => {
+		test("`c8 help <passthrough-cmd> --json` returns kind: 'passthrough'", async () => {
+			const result = await c8("--json", "help", "pass-through-cmd");
+			assert.strictEqual(
+				result.status,
+				0,
+				`expected exit 0, got ${result.status}. stderr: ${result.stderr}`,
+			);
+			const json = JSON.parse(result.stdout);
+			assert.strictEqual(
+				json.kind,
+				"passthrough",
+				`JSON help must carry kind:"passthrough" so agents detect the boundary. got: ${JSON.stringify(json)}`,
+			);
+			assert.strictEqual(
+				json.passthroughHint,
+				"Forwards args to `external-tool`",
+				"passthroughHint must be present in the JSON help payload",
+			);
+			assert.deepStrictEqual(
+				json.flagsHint,
+				["--from <url>", "--to <path>", "--dry"],
+				"flagsHint must be present in the JSON help payload",
+			);
+		});
+	});
+});

--- a/tests/unit/plugin-passthrough.test.ts
+++ b/tests/unit/plugin-passthrough.test.ts
@@ -418,4 +418,72 @@ describe("Passthrough plugin contract (#366)", () => {
 			);
 		});
 	});
+
+	describe("Shell completion (#366 — passthrough verbs)", () => {
+		// Class-scoped guard: c8ctl cannot know what flags the wrapped
+		// external tool accepts, so for any verb that opted into the
+		// passthrough contract the completion generators must (a) offer
+		// file completion at the resource position and (b) restrict
+		// flag completion to GLOBAL_FLAGS only. The fixture's
+		// `pass-through-cmd` exercises this — if the gate ever stops
+		// honouring `passthrough: true` these tests fail.
+
+		test("bash completion offers file completion for the passthrough verb", async () => {
+			const result = await c8("completion", "bash");
+			assert.strictEqual(result.status, 0);
+			assert.ok(
+				/pass-through-cmd\)\s*\n\s*COMPREPLY=\(\s*\$\(compgen -f /.test(
+					result.stdout,
+				),
+				`bash completion must use file completion for passthrough verbs. stdout did not match.`,
+			);
+		});
+
+		test("bash completion restricts flag completion to GLOBAL_FLAGS for passthrough verbs", async () => {
+			const result = await c8("completion", "bash");
+			assert.strictEqual(result.status, 0);
+			assert.ok(
+				/passthrough_verbs="[^"]*pass-through-cmd[^"]*"/.test(result.stdout),
+				`bash completion must list passthrough verbs in passthrough_verbs. stdout did not match.`,
+			);
+			assert.ok(
+				/local global_flags=/.test(result.stdout) &&
+					/flag_set="\$\{global_flags\}"/.test(result.stdout),
+				`bash completion must switch to \${global_flags} when current verb is a passthrough verb.`,
+			);
+		});
+
+		test("zsh completion uses _files for the passthrough verb", async () => {
+			const result = await c8("completion", "zsh");
+			assert.strictEqual(result.status, 0);
+			assert.ok(
+				/pass-through-cmd\)\s*\n\s*_files\s*\n\s*;;/.test(result.stdout),
+				`zsh completion must use _files for passthrough verbs. stdout did not match.`,
+			);
+		});
+
+		test("zsh completion exposes a global_flags array and routes passthrough verbs to it", async () => {
+			const result = await c8("completion", "zsh");
+			assert.strictEqual(result.status, 0);
+			assert.ok(
+				/global_flags=\(/.test(result.stdout),
+				`zsh completion must declare a global_flags array.`,
+			);
+			assert.ok(
+				/pass-through-cmd\) _arguments \$\{global_flags\[@\]\}/.test(
+					result.stdout,
+				),
+				`zsh completion must route passthrough verbs to _arguments \${global_flags[@]}.`,
+			);
+		});
+
+		test("fish completion offers file completion (-F) for the passthrough verb", async () => {
+			const result = await c8("completion", "fish");
+			assert.strictEqual(result.status, 0);
+			assert.ok(
+				/__fish_seen_subcommand_from pass-through-cmd' -F/.test(result.stdout),
+				`fish completion must offer file completion (-F) for passthrough verbs. stdout did not match.`,
+			);
+		});
+	});
 });

--- a/tests/unit/plugin-passthrough.test.ts
+++ b/tests/unit/plugin-passthrough.test.ts
@@ -507,5 +507,58 @@ describe("Passthrough plugin contract (#366)", () => {
 				);
 			}
 		});
+
+		// Class-scoped guard for the fish flag-completion contract under
+		// passthrough verbs. bash and zsh switch to a globals-only flag
+		// set; fish achieves the same thing by gating every non-global
+		// flag with a `not __fish_seen_subcommand_from <pt> ...`
+		// predicate. If any non-global flag escapes that predicate the
+		// passthrough contract is broken — c8ctl would suggest its own
+		// per-command flags instead of the wrapped tool's.
+		test("fish completion suppresses non-global flags under passthrough verbs", async () => {
+			const result = await c8("completion", "fish");
+			assert.strictEqual(result.status, 0);
+
+			// Pick a flag that exists somewhere in the registry but is
+			// definitely not in GLOBAL_FLAGS. `--variables` is owned by
+			// `run` and is NOT a global.
+			const nonGlobalFlag = "variables";
+			const lines = result.stdout
+				.split("\n")
+				.filter(
+					(l) =>
+						l.startsWith("complete -c c8") && l.includes(`-l ${nonGlobalFlag}`),
+				);
+			assert.ok(
+				lines.length > 0,
+				`expected at least one fish completion line for --${nonGlobalFlag}`,
+			);
+			for (const line of lines) {
+				assert.ok(
+					line.includes("-n 'not __fish_seen_subcommand_from pass-through-cmd"),
+					`every fish completion for non-global flag '--${nonGlobalFlag}' must be gated against passthrough verbs. line was: ${line}`,
+				);
+			}
+		});
+
+		test("fish completion offers global flags unconditionally", async () => {
+			const result = await c8("completion", "fish");
+			assert.strictEqual(result.status, 0);
+			// `--profile` is a GLOBAL_FLAG. Its fish completion line(s)
+			// must NOT carry the passthrough guard — globals stay
+			// available even after the user types a passthrough verb.
+			const lines = result.stdout
+				.split("\n")
+				.filter(
+					(l) => l.startsWith("complete -c c8") && l.includes("-l profile"),
+				);
+			assert.ok(lines.length > 0, "expected fish completion for --profile");
+			for (const line of lines) {
+				assert.ok(
+					!line.includes("__fish_seen_subcommand_from"),
+					`global flag '--profile' must not be guarded by __fish_seen_subcommand_from. line was: ${line}`,
+				);
+			}
+		});
 	});
 });

--- a/tests/unit/plugin-passthrough.test.ts
+++ b/tests/unit/plugin-passthrough.test.ts
@@ -28,25 +28,35 @@ const FIXTURE_DIR = join(
 	__dirname,
 	"../fixtures/plugins/plugin-with-passthrough",
 );
+const CONFLICTING_FIXTURE_DIR = join(
+	__dirname,
+	"../fixtures/plugins/zzz-plugin-conflicting",
+);
 
-function makePluginDataDir(): string {
+function makePluginDataDir(
+	extraFixtures: { name: string; src: string }[] = [],
+) {
 	const dir = mkdtempSync(join(tmpdir(), "c8ctl-passthrough-test-"));
 	writeFileSync(
 		join(dir, "session.json"),
 		JSON.stringify({ outputMode: "text" }),
 	);
-	const pluginInstallDir = join(
-		dir,
-		"plugins",
-		"node_modules",
-		"plugin-with-passthrough",
-	);
+	const installRoot = join(dir, "plugins", "node_modules");
+	const pluginInstallDir = join(installRoot, "plugin-with-passthrough");
 	mkdirSync(pluginInstallDir, { recursive: true });
 	cpSync(FIXTURE_DIR, pluginInstallDir, { recursive: true });
+	for (const { name, src } of extraFixtures) {
+		const dst = join(installRoot, name);
+		mkdirSync(dst, { recursive: true });
+		cpSync(src, dst, { recursive: true });
+	}
 	return dir;
 }
 
 const PLUGIN_DATA_DIR = makePluginDataDir();
+const CONFLICT_DATA_DIR = makePluginDataDir([
+	{ name: "zzz-plugin-conflicting", src: CONFLICTING_FIXTURE_DIR },
+]);
 
 async function c8(...args: string[]) {
 	return asyncSpawn("node", ["--experimental-strip-types", CLI, ...args], {
@@ -55,6 +65,17 @@ async function c8(...args: string[]) {
 			CAMUNDA_BASE_URL: "http://test-cluster/v2",
 			HOME: "/tmp/c8ctl-passthrough-test-nonexistent-home",
 			C8CTL_DATA_DIR: PLUGIN_DATA_DIR,
+		},
+	});
+}
+
+async function c8WithConflict(...args: string[]) {
+	return asyncSpawn("node", ["--experimental-strip-types", CLI, ...args], {
+		env: {
+			...process.env,
+			CAMUNDA_BASE_URL: "http://test-cluster/v2",
+			HOME: "/tmp/c8ctl-passthrough-test-nonexistent-home",
+			C8CTL_DATA_DIR: CONFLICT_DATA_DIR,
 		},
 	});
 }
@@ -255,6 +276,66 @@ describe("Passthrough plugin contract (#366)", () => {
 				json.flagsHint,
 				["--from <url>", "--to <path>", "--dry"],
 				"flagsHint must be present in the JSON help payload",
+			);
+		});
+
+		test("passthrough JSON help carries the same envelope as standard JSON help", async () => {
+			// The shape contract: passthrough JSON help adds a `kind` and
+			// passthrough-specific fields, but it must NOT omit the standard
+			// `globalFlags` / `searchFlags` / `agentFlags` envelope that
+			// callers and agents rely on for every help payload.
+			const result = await c8("--json", "help", "pass-through-cmd");
+			assert.strictEqual(result.status, 0);
+			const json = JSON.parse(result.stdout);
+			assert.ok(
+				json.globalFlags && typeof json.globalFlags === "object",
+				`passthrough JSON help must include globalFlags. got: ${JSON.stringify(json)}`,
+			);
+			assert.ok(
+				json.searchFlags && typeof json.searchFlags === "object",
+				`passthrough JSON help must include searchFlags. got: ${JSON.stringify(json)}`,
+			);
+			assert.ok(
+				json.agentFlags && typeof json.agentFlags === "object",
+				`passthrough JSON help must include agentFlags. got: ${JSON.stringify(json)}`,
+			);
+		});
+	});
+
+	describe("Duplicate command name policy (#366)", () => {
+		// Class-scoped guard: c8ctl resolves plugin command-name conflicts
+		// with explicit "first registration wins" semantics. This replaces
+		// the previous implicit "last-loaded wins" Object.assign merge. The
+		// fixture set in CONFLICT_DATA_DIR has both `plugin-with-passthrough`
+		// (loads first; alphabetically earlier) and `zzz-plugin-conflicting`
+		// (loads second), each declaring a `pass-through-cmd` handler that
+		// prints a unique `from` field. The winning handler's payload
+		// proves which plugin actually got dispatched.
+		test("first registration wins; the loser's handler is unreachable", async () => {
+			const result = await c8WithConflict("pass-through-cmd", "probe");
+			assert.strictEqual(
+				result.status,
+				0,
+				`expected exit 0, got ${result.status}. stderr: ${result.stderr}`,
+			);
+			const out = JSON.parse(result.stdout);
+			assert.strictEqual(
+				out.from,
+				undefined,
+				"the winning fixture (plugin-with-passthrough) must respond, " +
+					`not the losing one. got: ${result.stdout}`,
+			);
+			assert.deepStrictEqual(out.args, ["probe"]);
+		});
+
+		test("the dropped duplicate is reported on stderr at load time", async () => {
+			const result = await c8WithConflict("pass-through-cmd", "probe");
+			assert.strictEqual(result.status, 0);
+			assert.ok(
+				/zzz-plugin-conflicting/.test(result.stderr) &&
+					/pass-through-cmd/.test(result.stderr) &&
+					/duplicate|already/i.test(result.stderr),
+				`expected a load-time warning naming the losing plugin and the conflicting command. stderr: ${result.stderr}`,
 			);
 		});
 	});

--- a/tests/unit/plugin-passthrough.test.ts
+++ b/tests/unit/plugin-passthrough.test.ts
@@ -15,7 +15,13 @@
  */
 
 import assert from "node:assert";
-import { cpSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, test } from "node:test";
@@ -415,6 +421,61 @@ describe("Passthrough plugin contract (#366)", () => {
 					/pass-through-cmd/.test(result.stderr) &&
 					/duplicate|already/i.test(result.stderr),
 				`expected a load-time warning naming the losing plugin and the conflicting command. stderr: ${result.stderr}`,
+			);
+		});
+
+		// Class-scoped guard for the side-effect-free duplicate-name
+		// rejection. The loader must check `loadedPlugins.has(name)`
+		// BEFORE `await import(pluginUrl)` — otherwise a
+		// duplicate-name plugin's module body still executes (running
+		// any top-level side effects) only for the result to be
+		// thrown away. The fixture under
+		// `tests/fixtures/plugins/zzz-plugin-name-collider` declares
+		// the same package.json#name as the canonical
+		// `plugin-with-passthrough` fixture and writes a sentinel file
+		// at module-evaluation time. After running c8ctl with both
+		// installed, the sentinel must NOT exist.
+		test("duplicate-name plugin's module body is never evaluated (no top-level side effects)", async () => {
+			const dir = mkdtempSync(join(tmpdir(), "c8ctl-dup-sideeffect-"));
+			writeFileSync(
+				join(dir, "session.json"),
+				JSON.stringify({ outputMode: "text" }),
+			);
+			const installRoot = join(dir, "plugins", "node_modules");
+			const canonicalDst = join(installRoot, "plugin-with-passthrough");
+			mkdirSync(canonicalDst, { recursive: true });
+			cpSync(FIXTURE_DIR, canonicalDst, { recursive: true });
+			const colliderSrc = join(
+				__dirname,
+				"../fixtures/plugins/zzz-plugin-name-collider",
+			);
+			const colliderDst = join(installRoot, "zzz-plugin-name-collider");
+			mkdirSync(colliderDst, { recursive: true });
+			cpSync(colliderSrc, colliderDst, { recursive: true });
+
+			const sentinelPath = join(dir, "duplicate-side-effect.sentinel");
+
+			const result = await asyncSpawn(
+				"node",
+				["--experimental-strip-types", CLI, "pass-through-cmd", "probe"],
+				{
+					env: {
+						...process.env,
+						CAMUNDA_BASE_URL: "http://test-cluster/v2",
+						HOME: "/tmp/c8ctl-dup-sideeffect-nonexistent-home",
+						C8CTL_DATA_DIR: dir,
+						C8CTL_TEST_DUP_SIDE_EFFECT_SENTINEL: sentinelPath,
+					},
+				},
+			);
+			assert.strictEqual(
+				result.status,
+				0,
+				`expected exit 0; stderr: ${result.stderr}`,
+			);
+			assert.ok(
+				!existsSync(sentinelPath),
+				`duplicate-name plugin's module body must not be evaluated, but the sentinel file was created at ${sentinelPath}. The loader is importing the duplicate before checking loadedPlugins.has(name).`,
 			);
 		});
 	});

--- a/tests/unit/plugin-passthrough.test.ts
+++ b/tests/unit/plugin-passthrough.test.ts
@@ -485,5 +485,27 @@ describe("Passthrough plugin contract (#366)", () => {
 				`fish completion must offer file completion (-F) for passthrough verbs. stdout did not match.`,
 			);
 		});
+
+		// Class-scoped guard: the fish fileComplete branch must also emit
+		// `complete -F`, not only the passthrough branch. Previously the
+		// fish generator silently skipped fileComplete verbs, so users
+		// got the generic verb list at the resource position instead of
+		// file completion. bash and zsh already handled this; fish now
+		// does too. (The fileComplete set is derived in deriveVerbInfos
+		// from `!requiresResource && resources.length === 0` — currently
+		// `deploy` and `watch`. `run` takes a positional path but is
+		// classified as requiresResource, so it falls outside this set.)
+		test("fish completion offers file completion (-F) for fileComplete verbs (deploy/watch)", async () => {
+			const result = await c8("completion", "fish");
+			assert.strictEqual(result.status, 0);
+			for (const verb of ["deploy", "watch"]) {
+				assert.ok(
+					new RegExp(`__fish_seen_subcommand_from ${verb}[^']*' -F`).test(
+						result.stdout,
+					),
+					`fish completion must offer file completion (-F) for fileComplete verb '${verb}'. stdout did not match.`,
+				);
+			}
+		});
 	});
 });


### PR DESCRIPTION
Closes #366. Refs #363. Aligned with the metadata-first plugin contract direction captured in #251 and the rejection of bare-argv passthrough in #355.

## What

Adds a `passthrough: true` opt-in to the per-command plugin metadata. For commands that opt in, c8ctl strips its own `GLOBAL_FLAGS` from argv following the verb and forwards the rest verbatim to the bare-function handler. This unblocks plugins that wrap external CLIs (e.g. `kubectl`, `docker`) without forcing them to re-declare every flag of the underlying tool.

## Contract

A passthrough command:
- **must** use the bare-function handler form
- **must** declare a non-empty `passthroughHint` (used by help / agents to advertise the boundary)
- **may** declare a `flagsHint: string[]` (documentation only — not parsed)
- **must not** also declare a `flags` object (mutually exclusive with the typed-flags form)

Violations are rejected at load time: the offending command is dropped with a `logger.warn` naming the plugin and command. There is no way to invoke a half-declared passthrough command.

## Dispatch

When a verb resolves to a passthrough plugin command:

1. `GLOBAL_FLAGS` (e.g. `--profile`, `--json`, `--verbose`) have already been parsed and applied by `main()`.
2. Argv after the verb token is sliced and `stripGlobalFlags()` removes the global flags (and the value of any string-typed global flag).
3. Everything else — including unknown flags, positionals, and an isolated `--` terminator with everything after it — is forwarded verbatim to the bare-function handler.

## Help rendering

- `c8ctl help <passthrough-cmd>` (text mode) prints a "Passthrough command" banner with the hint and, when present, lists `flagsHint` entries.
- `c8ctl help <passthrough-cmd> --json` returns a payload with `kind: "passthrough"`, `passthroughHint`, `flagsHint`, **and** the standard `globalFlags` / `searchFlags` / `agentFlags` envelope so agents can rely on a stable shape regardless of `kind`.

## Duplicate command-name policy (partial fix for #363)

This PR also lands the implementation half of one of the policy options from #363 (silent last-write-wins plugin command-name collisions): `rejectDuplicateCommandNames` in `src/plugin-loader.ts` enforces **first-registration-wins** with a load-time `logger.warn` naming both plugins and the conflicting command. The duplicate is dropped from dispatch, so the loser's handler is unreachable.

This is the cheapest viable resolution from #363's option list. The remaining work in #363 (design RFC in `PLUGIN-HELP.md`, `c8ctl plugins list --conflicts` tooling, reserved-prefix convention, user-pinned precedence, namespacing) is **not** addressed here — #363 should stay open after this merges.

## Tests

`tests/unit/plugin-passthrough.test.ts` (13 tests, all green) covers:

- forwarding positionals, unknown flags, and `--` verbatim
- stripping boolean and string `GLOBAL_FLAGS` (both with `--flag value` and `--flag=value` shapes)
- stripping `--json` while still applying its runtime effect
- load-time rejection of `passthrough: true` + `flags`
- text-mode help banner with `passthroughHint`
- text-mode help listing of `flagsHint`
- JSON-mode help with `kind: "passthrough"`
- JSON-mode help carries the standard `globalFlags` / `searchFlags` / `agentFlags` envelope (shape-stability guard)
- duplicate command-name policy: first-registration-wins, loser's handler is unreachable, load-time warn names the losing plugin

Class-scoped guards: the duplicate-name tests use a `zzz-plugin-conflicting` fixture so the load order is observable; they assert the policy itself, not a single instance of it.

Full unit suite: 1489/1489 green.

## Why split out from #251

#251 is the larger metadata-enrichment effort. This PR ships the smaller passthrough opt-in standalone so plugins that wrap external CLIs are unblocked without waiting on the full metadata redesign. The two are aligned: passthrough is an explicit opt-out of the metadata-first contract for commands where re-declaring flags adds no value.
