### PR TITLE
feat: add c8ctl doctor plugin and document collision policy (#363)

### DIFF
--- a/PLUGIN-HELP.md
+++ b/PLUGIN-HELP.md
@@ -457,8 +457,9 @@ package name:
 
 - ✅ `c8ctl-plugin-mycorp` exports `mycorp-model`, `mycorp-export`
 - ✅ `c8ctl-plugin-acme` exports `acme-deploy`, `acme-status`
-- ❌ Two plugins both exporting `model` (one will be silently dropped at
-  load time, with a warning visible only on stderr)
+- ❌ Two plugins both exporting `model` (one will be dropped at load
+  time — c8ctl logs a `logger.warn` on stderr and surfaces the drop via
+  `c8ctl doctor plugin`, but the colliding command itself is unreachable)
 
 This is **not enforced** — c8ctl will load any command name that
 doesn't collide with a built-in — but a published convention reduces

--- a/PLUGIN-HELP.md
+++ b/PLUGIN-HELP.md
@@ -444,6 +444,30 @@ Choose descriptive, unique names for your plugin commands that don't conflict wi
 - ✅ `analyze-process`, `export-data`, `sync-resources`
 - ❌ `list`, `get`, `create`, `deploy`
 
+### Naming convention: prefix with your plugin's short name
+
+Plugin commands also collide with **other plugins'** commands. c8ctl
+applies first-registration-wins for plugin-vs-plugin command collisions
+and surfaces the dropped command via `c8ctl doctor plugin`, but the best
+fix is to avoid the collision in the first place.
+
+The recommended convention is to prefix every command your plugin
+exports with a short, plugin-specific tag — typically derived from the
+package name:
+
+- ✅ `c8ctl-plugin-mycorp` exports `mycorp-model`, `mycorp-export`
+- ✅ `c8ctl-plugin-acme` exports `acme-deploy`, `acme-status`
+- ❌ Two plugins both exporting `model` (one will be silently dropped at
+  load time, with a warning visible only on stderr)
+
+This is **not enforced** — c8ctl will load any command name that
+doesn't collide with a built-in — but a published convention reduces
+the rate of real-world collisions and makes the dropped-command warning
+actionable when it does fire.
+
+For the collision policy, the diagnostic output, and the reproduction
+recipe, see [docs/plugin-collisions.md](docs/plugin-collisions.md).
+
 ## Testing
 
 See [tests/unit/plugin-loader.test.ts](tests/unit/plugin-loader.test.ts) for unit tests that verify:

--- a/README.md
+++ b/README.md
@@ -1796,6 +1796,21 @@ c8ctl init plugin my-plugin                                 # Create new plugin 
 
 ---
 
+#### `doctor`
+
+Surface plugin-loading collisions detected at startup (#363). Reports loaded plugins with their command names, and any first-registration-wins drops (plugin-name or command-name).
+
+**Resources:** plugin
+
+**Examples:**
+
+```bash
+c8ctl doctor plugin                                         # List loaded plugins and any load-time collisions
+c8ctl doctor plugin --json                                  # Machine-readable doctor output
+```
+
+---
+
 #### `use`
 
 Set active profile or tenant

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1040,6 +1040,21 @@ c8ctl init plugin my-plugin                                 # Create new plugin 
 
 ---
 
+### `doctor`
+
+Surface plugin-loading collisions detected at startup (#363). Reports loaded plugins with their command names, and any first-registration-wins drops (plugin-name or command-name).
+
+**Resources:** plugin
+
+**Examples:**
+
+```bash
+c8ctl doctor plugin                                         # List loaded plugins and any load-time collisions
+c8ctl doctor plugin --json                                  # Machine-readable doctor output
+```
+
+---
+
 ### `use`
 
 Set active profile or tenant

--- a/docs/plugin-collisions.md
+++ b/docs/plugin-collisions.md
@@ -1,0 +1,150 @@
+# Plugin Collision Policy
+
+Status: implemented (current behaviour as of #366 / #367 / #363).
+Owner: c8ctl maintainers.
+Tracking issue: [#363](https://github.com/camunda/c8ctl/issues/363).
+
+## Problem
+
+Two plugins installed into the same c8ctl can collide in two ways:
+
+1. **Plugin-name collision** — both packages declare the same
+   `package.json#name`. Without a guard, the second `loadedPlugins.set(name, …)`
+   silently overwrites the first, and *all* of the first plugin's commands
+   disappear.
+2. **Command-name collision** — two plugins (with different package names)
+   each export a command under the same name (e.g. both export `model`).
+   Without a guard, `Object.assign(allCommands, plugin.commands)` overwrites
+   silently and "who wins" depends on filesystem iteration order
+   (`readdirSync`), which varies across machines, npm versions, and
+   monorepo hoisting.
+
+Either way, the user has no signal that a handler became unreachable.
+
+## Resolution policy: first-registration-wins, with diagnostics
+
+c8ctl applies first-registration-wins to **both** flavours, with three
+visibility affordances:
+
+1. **`logger.warn` at load time.** The loader writes a warning to stderr
+   naming both plugins and the affected command (or just both plugins, for
+   plugin-name collisions). This is the primary signal.
+2. **`c8ctl doctor plugin`** re-renders the same diagnostic on demand, so a
+   user who missed the load-time warning can recover it. `--json` makes it
+   scriptable.
+3. **Deterministic load order.** `loadDefaultPlugins` and
+   `loadInstalledPlugins` both `.sort()` their `readdirSync` results.
+   "Who wins" is therefore stable for a given set of installed packages
+   regardless of OS, filesystem, or install order.
+
+Default plugins always load before user-installed plugins (built-ins
+always win). User-vs-user precedence falls back to alphabetical order on
+the canonical key (`package.json#name` for plugin-name comparisons,
+install-directory entry for command-name comparisons).
+
+### What "first registration wins" means in practice
+
+- For a **command-name** collision, only the colliding command is dropped
+  from the loser. The loser's other commands continue to load and
+  dispatch normally.
+- For a **plugin-name** collision, the entire losing plugin is rejected
+  before its module body is imported. Its top-level side effects do not
+  run; none of its commands register.
+
+### Why not stricter policies
+
+The issue listed several candidates; we deliberately picked the cheapest
+one that fixes the silent-shadow problem. Brief notes on the alternatives:
+
+- **Reject-and-skip both.** Punishes the user for upstream collisions
+  they cannot fix. A user who installs two plugins for orthogonal reasons
+  loses both because the authors happened to pick the same command name.
+- **Plugin namespacing (`c8ctl <plugin> <command>`).** Removes collisions
+  by construction but is a breaking change for every existing plugin.
+  Could be added as opt-in via `metadata.namespaced: true` in a future
+  release; not required to close the silent-failure gap.
+- **User-pinned precedence (`~/.c8ctl/plugin-precedence.json`).** Most
+  flexible but also most complex. Worth revisiting if the doctor command
+  shows real-world collisions are common.
+
+The current policy keeps the door open for any of those — it just
+guarantees that, today, no command silently disappears.
+
+## Reproducing a collision (for plugin authors and reviewers)
+
+### Command-name collision
+
+Two installed plugins (different package names, same command):
+
+```sh
+mkdir -p /tmp/c8ctl-collision/plugins/node_modules/plugin-a
+mkdir -p /tmp/c8ctl-collision/plugins/node_modules/plugin-b
+cat > /tmp/c8ctl-collision/plugins/node_modules/plugin-a/package.json <<'JSON'
+{ "name": "plugin-a", "version": "0.0.0", "keywords": ["c8ctl-plugin"], "main": "c8ctl-plugin.js", "type": "module" }
+JSON
+cat > /tmp/c8ctl-collision/plugins/node_modules/plugin-a/c8ctl-plugin.js <<'JS'
+export const commands = { 'model': async () => console.log('A wins') };
+export const metadata = { name: 'plugin-a' };
+JS
+cp -R /tmp/c8ctl-collision/plugins/node_modules/plugin-{a,b}
+sed -i '' 's/plugin-a/plugin-b/g; s/A wins/B wins/' /tmp/c8ctl-collision/plugins/node_modules/plugin-b/{package.json,c8ctl-plugin.js}
+
+C8CTL_DATA_DIR=/tmp/c8ctl-collision c8ctl doctor plugin
+```
+
+Expected output: a `command-name` collision row naming `plugin-a`
+(winner) and `plugin-b` (loser) for the `model` command.
+
+### Plugin-name collision
+
+Two installed plugins with the same `package.json#name`:
+
+```sh
+mkdir -p /tmp/c8ctl-name-collision/plugins/node_modules/plugin-a-v1
+mkdir -p /tmp/c8ctl-name-collision/plugins/node_modules/plugin-a-v2
+# Both package.json#name = "plugin-a"
+```
+
+Expected output: a `plugin-name` collision row naming `plugin-a` as both
+winner and loser; the second copy's module body never executes.
+
+## Naming hygiene (recommendation, not enforcement)
+
+Plugin authors are encouraged to prefix their command names with the
+plugin's short name, e.g. `mycorp-model` rather than `model`. This is a
+documentation-only mitigation — c8ctl does not enforce it — but it
+substantially reduces the collision rate in practice. See PLUGIN-HELP.md
+for the full naming-convention guidance.
+
+## Tooling reference
+
+- `c8ctl doctor plugin` — text-mode summary of loaded plugins and any
+  detected collisions. Exit code is always 0 (the doctor reports state;
+  it does not enforce policy).
+- `c8ctl doctor plugin --json` — machine-readable form:
+
+  ```json
+  {
+    "loaded": [
+      { "name": "plugin-a", "commands": ["model"] }
+    ],
+    "collisions": [
+      {
+        "kind": "command-name",
+        "winner": "plugin-a",
+        "loser": "plugin-b",
+        "command": "model"
+      },
+      {
+        "kind": "plugin-name",
+        "winner": "plugin-x",
+        "loser": "plugin-x"
+      }
+    ]
+  }
+  ```
+
+The class-scoped guard tests that lock this contract live in
+[tests/unit/plugin-doctor.test.ts](../tests/unit/plugin-doctor.test.ts)
+and [tests/unit/plugin-passthrough.test.ts](../tests/unit/plugin-passthrough.test.ts)
+(the duplicate-name and duplicate-command sections).

--- a/docs/plugin-collisions.md
+++ b/docs/plugin-collisions.md
@@ -77,17 +77,24 @@ guarantees that, today, no command silently disappears.
 Two installed plugins (different package names, same command):
 
 ```sh
-mkdir -p /tmp/c8ctl-collision/plugins/node_modules/plugin-a
-mkdir -p /tmp/c8ctl-collision/plugins/node_modules/plugin-b
-cat > /tmp/c8ctl-collision/plugins/node_modules/plugin-a/package.json <<'JSON'
+ROOT=/tmp/c8ctl-collision/plugins/node_modules
+mkdir -p "$ROOT/plugin-a" "$ROOT/plugin-b"
+
+cat > "$ROOT/plugin-a/package.json" <<'JSON'
 { "name": "plugin-a", "version": "0.0.0", "keywords": ["c8ctl-plugin"], "main": "c8ctl-plugin.js", "type": "module" }
 JSON
-cat > /tmp/c8ctl-collision/plugins/node_modules/plugin-a/c8ctl-plugin.js <<'JS'
+cat > "$ROOT/plugin-a/c8ctl-plugin.js" <<'JS'
 export const commands = { 'model': async () => console.log('A wins') };
 export const metadata = { name: 'plugin-a' };
 JS
-cp -R /tmp/c8ctl-collision/plugins/node_modules/plugin-{a,b}
-sed -i '' 's/plugin-a/plugin-b/g; s/A wins/B wins/' /tmp/c8ctl-collision/plugins/node_modules/plugin-b/{package.json,c8ctl-plugin.js}
+
+cat > "$ROOT/plugin-b/package.json" <<'JSON'
+{ "name": "plugin-b", "version": "0.0.0", "keywords": ["c8ctl-plugin"], "main": "c8ctl-plugin.js", "type": "module" }
+JSON
+cat > "$ROOT/plugin-b/c8ctl-plugin.js" <<'JS'
+export const commands = { 'model': async () => console.log('B wins') };
+export const metadata = { name: 'plugin-b' };
+JS
 
 C8CTL_DATA_DIR=/tmp/c8ctl-collision c8ctl doctor plugin
 ```

--- a/src/command-dispatch.ts
+++ b/src/command-dispatch.ts
@@ -71,6 +71,7 @@ import {
 } from "./commands/messages.ts";
 import { feedbackCommand, openAppCommand } from "./commands/open.ts";
 import {
+	doctorPluginCommand,
 	downgradePluginCommand,
 	initPluginCommand,
 	listPluginsCommand,
@@ -145,6 +146,7 @@ export const COMMAND_DISPATCH: ReadonlyMap<string, AnyCommandHandler> = new Map<
 	["sync:plugin", syncPluginsCommand],
 	["upgrade:plugin", upgradePluginCommand],
 	["downgrade:plugin", downgradePluginCommand],
+	["doctor:plugin", doctorPluginCommand],
 	["init:plugin", initPluginCommand],
 
 	// ── Process instances ──────────────────────────────────────────────

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -1532,6 +1532,26 @@ export const COMMAND_REGISTRY = {
 		},
 	},
 
+	doctor: {
+		description: "Diagnose plugin loading state and collisions",
+		helpDescription:
+			"Surface plugin-loading collisions detected at startup (#363). Reports loaded plugins with their command names, and any first-registration-wins drops (plugin-name or command-name).",
+		mutating: false,
+		requiresResource: true,
+		helpExamples: [
+			{
+				command: "c8ctl doctor plugin",
+				description: "List loaded plugins and any load-time collisions",
+			},
+			{
+				command: "c8ctl doctor plugin --json",
+				description: "Machine-readable doctor output",
+			},
+		],
+		resources: ["plugin"],
+		flags: {},
+	},
+
 	// ── Session commands ───────────────────────────────────────────────────
 
 	use: {

--- a/src/commands/plugins.ts
+++ b/src/commands/plugins.ts
@@ -10,7 +10,11 @@ import { defineCommand } from "../command-framework.ts";
 import { ensurePluginsDir } from "../config.ts";
 import { handleCommandError } from "../errors.ts";
 import { getLogger } from "../logger.ts";
-import { clearLoadedPlugins } from "../plugin-loader.ts";
+import {
+	clearLoadedPlugins,
+	getLoadedPluginSummaries,
+	getPluginCollisions,
+} from "../plugin-loader.ts";
 import {
 	addPluginToRegistry,
 	getPluginEntry,
@@ -974,5 +978,77 @@ export const initPluginCommand = defineCommand(
 		} catch (error) {
 			handleCommandError(logger, "Failed to create plugin", error);
 		}
+	},
+);
+
+/**
+ * Doctor — surface plugin-loading collisions detected at startup
+ * (#363). The loader applies first-registration-wins for both
+ * plugin-name collisions (two packages sharing `package.json#name`)
+ * and command-name collisions (two plugins exporting the same
+ * command). Both are logged at warn level when they happen, but a
+ * user who didn't see those warnings has no way to discover what was
+ * dropped. `c8ctl doctor plugin` re-renders that diagnostic on
+ * demand.
+ *
+ * The output is two sections:
+ *   1. Loaded plugins, with the command names that survived
+ *      duplicate-name rejection.
+ *   2. Detected collisions, with kind, winner, loser, and (for
+ *      command-name collisions) the affected command.
+ *
+ * Exit code is always 0 — the doctor reports state, it doesn't
+ * enforce policy. Returning non-zero would interfere with scripted
+ * use (e.g. piping into `jq` under `--json`).
+ */
+export const doctorPluginCommand = defineCommand(
+	"doctor",
+	"plugin",
+	async (ctx, _flags, _args) => {
+		const { logger } = ctx;
+
+		const loaded = getLoadedPluginSummaries();
+		const collisions = getPluginCollisions();
+
+		if (logger.mode === "json") {
+			logger.json({ loaded, collisions });
+			return;
+		}
+
+		if (loaded.length === 0) {
+			logger.info("No plugins loaded.");
+		} else {
+			logger.info(`Loaded plugins (${loaded.length}):`);
+			logger.table(
+				loaded.map((p) => ({
+					Plugin: p.name,
+					Commands: p.commands.length === 0 ? "(none)" : p.commands.join(", "),
+				})),
+			);
+		}
+
+		if (collisions.length === 0) {
+			logger.info("");
+			logger.info("No plugin collisions detected.");
+			return;
+		}
+
+		logger.info("");
+		logger.info(`Detected collisions (${collisions.length}):`);
+		logger.table(
+			collisions.map((c) => ({
+				Kind: c.kind,
+				Winner: c.winner,
+				Loser: c.loser,
+				Command: c.command ?? "—",
+			})),
+		);
+		logger.info("");
+		logger.info(
+			"Resolution policy: first-registration-wins. The losing plugin's command (or the entire losing plugin, for plugin-name collisions) was dropped at load time.",
+		);
+		logger.info(
+			"To resolve: uninstall one of the colliding plugins, or ask the plugin author to rename. See docs/plugin-collisions.md for the full policy.",
+		);
 	},
 );

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -77,6 +77,30 @@ interface LoadedPlugin {
 const loadedPlugins = new Map<string, LoadedPlugin>();
 
 /**
+ * Structured record of a load-time collision between two plugins,
+ * surfaced by `c8ctl doctor plugin` (#363). Two flavours:
+ *
+ * - `command-name`: two plugins exported a command under the same name.
+ *   The earlier-loaded plugin's command stays in dispatch; the later
+ *   plugin's was dropped. `winner`/`loser` reflect that ordering.
+ * - `plugin-name`: two plugins shared the same `package.json#name`.
+ *   The entire later plugin was rejected (its module body was never
+ *   imported); `command` is undefined for this kind.
+ *
+ * The doctor command is the only consumer; the loader appends to this
+ * list as it discovers collisions and never reads from it. Cleared by
+ * `clearLoadedPlugins()` so test fixtures stay isolated.
+ */
+export interface PluginCollision {
+	kind: "command-name" | "plugin-name";
+	winner: string;
+	loser: string;
+	command?: string;
+}
+
+const pluginCollisions: PluginCollision[] = [];
+
+/**
  * Validate the passthrough/flags mutual-exclusion rule (#366). Removes
  * offending commands from the registered set so they cannot be invoked,
  * and emits a `logger.warn` naming the plugin and command so the
@@ -191,6 +215,12 @@ function rejectDuplicateCommandNames(plugin: LoadedPlugin): void {
 						`already provided by plugin '${existing.name}'. The first registration wins; ` +
 						`dropping the duplicate from '${plugin.name}'.`,
 				);
+				pluginCollisions.push({
+					kind: "command-name",
+					winner: existing.name,
+					loser: plugin.name,
+					command: commandName,
+				});
 				delete plugin.commands[commandName];
 				break;
 			}
@@ -219,6 +249,11 @@ function isDuplicatePluginName(pluginName: string): boolean {
 			`Plugin name '${pluginName}' is already loaded; refusing to load a second plugin ` +
 				`with the same name. The first registration wins.`,
 		);
+		pluginCollisions.push({
+			kind: "plugin-name",
+			winner: pluginName,
+			loser: pluginName,
+		});
 		return true;
 	}
 	return false;
@@ -610,4 +645,38 @@ export function isPassthroughPluginCommand(commandName: string): boolean {
  */
 export function clearLoadedPlugins(): void {
 	loadedPlugins.clear();
+	pluginCollisions.length = 0;
+}
+
+/**
+ * Snapshot of plugin collisions detected at load time (#363). Returns
+ * a defensive copy so callers cannot mutate the loader's bookkeeping.
+ * Order reflects the order in which the loader observed the
+ * collisions.
+ */
+export function getPluginCollisions(): PluginCollision[] {
+	return pluginCollisions.slice();
+}
+
+/**
+ * Snapshot of currently loaded plugins (#363). Returns the canonical
+ * `package.json#name` of each plugin together with the command names
+ * it actually registered (after duplicate-name rejection). Used by
+ * `c8ctl doctor plugin` to render an authoritative view of what was
+ * loaded vs. what was dropped.
+ */
+export interface LoadedPluginSummary {
+	name: string;
+	commands: string[];
+}
+
+export function getLoadedPluginSummaries(): LoadedPluginSummary[] {
+	const summaries: LoadedPluginSummary[] = [];
+	for (const plugin of loadedPlugins.values()) {
+		summaries.push({
+			name: plugin.name,
+			commands: Object.keys(plugin.commands),
+		});
+	}
+	return summaries;
 }

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -656,9 +656,7 @@ export function clearLoadedPlugins(): void {
  * collisions.
  */
 export function getPluginCollisions(): readonly Readonly<PluginCollision>[] {
-	return Object.freeze(
-		pluginCollisions.map((c) => Object.freeze({ ...c })),
-	);
+	return Object.freeze(pluginCollisions.map((c) => Object.freeze({ ...c })));
 }
 
 /**

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -650,12 +650,13 @@ export function clearLoadedPlugins(): void {
 
 /**
  * Snapshot of plugin collisions detected at load time (#363). Returns
- * a defensive copy so callers cannot mutate the loader's bookkeeping.
+ * a deep defensive copy of frozen records so callers cannot mutate
+ * the loader's bookkeeping (neither the array nor the entries).
  * Order reflects the order in which the loader observed the
  * collisions.
  */
-export function getPluginCollisions(): PluginCollision[] {
-	return pluginCollisions.slice();
+export function getPluginCollisions(): readonly Readonly<PluginCollision>[] {
+	return pluginCollisions.map((c) => Object.freeze({ ...c }));
 }
 
 /**

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -656,7 +656,9 @@ export function clearLoadedPlugins(): void {
  * collisions.
  */
 export function getPluginCollisions(): readonly Readonly<PluginCollision>[] {
-	return pluginCollisions.map((c) => Object.freeze({ ...c }));
+	return Object.freeze(
+		pluginCollisions.map((c) => Object.freeze({ ...c })),
+	);
 }
 
 /**

--- a/tests/unit/command-registry.test.ts
+++ b/tests/unit/command-registry.test.ts
@@ -56,6 +56,7 @@ describe("COMMAND_REGISTRY completeness", () => {
 		"downgrade",
 		"sync",
 		"init",
+		"doctor",
 		"use",
 		"output",
 		"completion",

--- a/tests/unit/plugin-doctor.test.ts
+++ b/tests/unit/plugin-doctor.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for `c8ctl doctor plugin` (#363) — surfaces plugin-loading
+ * collisions detected at startup.
+ *
+ * Class-scoped guards:
+ * - With no collisions, doctor reports loaded plugins and "no
+ *   collisions detected".
+ * - With a command-name collision, doctor reports the winner, the
+ *   loser, the affected command, and `kind: "command-name"`.
+ * - With a plugin-name collision (same `package.json#name`), doctor
+ *   reports the duplicate name and `kind: "plugin-name"`.
+ * - The `--json` form is structured so it can be piped into `jq`.
+ *
+ * Together these encode the visibility contract of #363: every
+ * dropped plugin or command is recoverable on demand even if the
+ * load-time `logger.warn` was missed.
+ */
+
+import assert from "node:assert";
+import { cpSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { asyncSpawn } from "../utils/spawn.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = "src/index.ts";
+
+const PASSTHROUGH_FIXTURE_DIR = join(
+	__dirname,
+	"../fixtures/plugins/plugin-with-passthrough",
+);
+const COMMAND_CONFLICT_FIXTURE_DIR = join(
+	__dirname,
+	"../fixtures/plugins/zzz-plugin-conflicting",
+);
+const NAME_COLLIDER_FIXTURE_DIR = join(
+	__dirname,
+	"../fixtures/plugins/zzz-plugin-name-collider",
+);
+
+function makeDataDir(
+	extraFixtures: { installDirName: string; src: string }[] = [],
+) {
+	const dir = mkdtempSync(join(tmpdir(), "c8ctl-doctor-test-"));
+	writeFileSync(
+		join(dir, "session.json"),
+		JSON.stringify({ outputMode: "text" }),
+	);
+	const installRoot = join(dir, "plugins", "node_modules");
+	const baseDst = join(installRoot, "plugin-with-passthrough");
+	mkdirSync(baseDst, { recursive: true });
+	cpSync(PASSTHROUGH_FIXTURE_DIR, baseDst, { recursive: true });
+	for (const { installDirName, src } of extraFixtures) {
+		const dst = join(installRoot, installDirName);
+		mkdirSync(dst, { recursive: true });
+		cpSync(src, dst, { recursive: true });
+	}
+	return dir;
+}
+
+async function runDoctor(
+	dataDir: string,
+	extraArgs: string[] = [],
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
+	return asyncSpawn(
+		"node",
+		["--experimental-strip-types", CLI, "doctor", "plugin", ...extraArgs],
+		{
+			env: {
+				...process.env,
+				CAMUNDA_BASE_URL: "http://test-cluster/v2",
+				HOME: "/tmp/c8ctl-doctor-test-nonexistent-home",
+				C8CTL_DATA_DIR: dataDir,
+			},
+		},
+	);
+}
+
+interface DoctorReport {
+	loaded: { name: string; commands: string[] }[];
+	collisions: {
+		kind: "command-name" | "plugin-name";
+		winner: string;
+		loser: string;
+		command?: string;
+	}[];
+}
+
+function parseDoctorJson(stdout: string): DoctorReport {
+	// biome-ignore lint/plugin: parsed-JSON contract boundary; shape asserted by callers
+	const parsed = JSON.parse(stdout) as DoctorReport;
+	return parsed;
+}
+
+describe("c8ctl doctor plugin (#363)", () => {
+	describe("No collisions", () => {
+		const DATA_DIR = makeDataDir();
+
+		test("text output names every loaded plugin and reports no collisions", async () => {
+			const result = await runDoctor(DATA_DIR);
+			assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+			assert.match(
+				result.stdout,
+				/Loaded plugins/,
+				"expected a Loaded plugins header",
+			);
+			assert.match(
+				result.stdout,
+				/plugin-with-passthrough/,
+				"expected the canonical plugin to be listed",
+			);
+			assert.match(
+				result.stdout,
+				/No plugin collisions detected/,
+				"expected explicit no-collisions message",
+			);
+		});
+
+		test("json output shape: { loaded[], collisions[] }", async () => {
+			const result = await runDoctor(DATA_DIR, ["--json"]);
+			assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+			const report = parseDoctorJson(result.stdout);
+			assert.ok(Array.isArray(report.loaded), "loaded must be an array");
+			assert.ok(
+				Array.isArray(report.collisions),
+				"collisions must be an array",
+			);
+			assert.strictEqual(report.collisions.length, 0);
+			const passthroughEntry = report.loaded.find(
+				(p) => p.name === "plugin-with-passthrough",
+			);
+			assert.ok(
+				passthroughEntry,
+				`plugin-with-passthrough should be in loaded list; got ${JSON.stringify(report.loaded)}`,
+			);
+			assert.ok(
+				passthroughEntry.commands.includes("pass-through-cmd"),
+				"pass-through-cmd should be among the registered commands",
+			);
+		});
+	});
+
+	describe("Command-name collision", () => {
+		const DATA_DIR = makeDataDir([
+			{
+				installDirName: "zzz-plugin-conflicting",
+				src: COMMAND_CONFLICT_FIXTURE_DIR,
+			},
+		]);
+
+		test("doctor reports the dropped command with kind=command-name", async () => {
+			const result = await runDoctor(DATA_DIR, ["--json"]);
+			assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+			const report = parseDoctorJson(result.stdout);
+			const commandCollisions = report.collisions.filter(
+				(c) => c.kind === "command-name",
+			);
+			assert.ok(
+				commandCollisions.length >= 1,
+				`expected at least one command-name collision; got ${JSON.stringify(report.collisions)}`,
+			);
+			const collision = commandCollisions.find(
+				(c) => c.command === "pass-through-cmd",
+			);
+			assert.ok(
+				collision,
+				`expected the pass-through-cmd command-name collision; got ${JSON.stringify(commandCollisions)}`,
+			);
+			assert.strictEqual(collision.winner, "plugin-with-passthrough");
+			assert.strictEqual(collision.loser, "zzz-plugin-conflicting");
+		});
+
+		test("doctor text output names winner, loser, and command", async () => {
+			const result = await runDoctor(DATA_DIR);
+			assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+			assert.match(
+				result.stdout,
+				/Detected collisions/,
+				"expected a Detected collisions header",
+			);
+			assert.match(result.stdout, /command-name/);
+			assert.match(result.stdout, /plugin-with-passthrough/);
+			assert.match(result.stdout, /zzz-plugin-conflicting/);
+			assert.match(result.stdout, /pass-through-cmd/);
+		});
+	});
+
+	describe("Plugin-name collision", () => {
+		const DATA_DIR = makeDataDir([
+			{
+				installDirName: "zzz-plugin-name-collider",
+				src: NAME_COLLIDER_FIXTURE_DIR,
+			},
+		]);
+
+		test("doctor reports the duplicate plugin name with kind=plugin-name", async () => {
+			const result = await runDoctor(DATA_DIR, ["--json"]);
+			assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+			const report = parseDoctorJson(result.stdout);
+			const nameCollisions = report.collisions.filter(
+				(c) => c.kind === "plugin-name",
+			);
+			assert.ok(
+				nameCollisions.length >= 1,
+				`expected at least one plugin-name collision; got ${JSON.stringify(report.collisions)}`,
+			);
+			const collision = nameCollisions.find(
+				(c) => c.winner === "plugin-with-passthrough",
+			);
+			assert.ok(
+				collision,
+				`expected a plugin-name collision naming plugin-with-passthrough; got ${JSON.stringify(nameCollisions)}`,
+			);
+			assert.strictEqual(collision.loser, "plugin-with-passthrough");
+			assert.strictEqual(collision.command, undefined);
+		});
+
+		test("doctor text output names the duplicate plugin name", async () => {
+			const result = await runDoctor(DATA_DIR);
+			assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+			assert.match(result.stdout, /plugin-name/);
+			assert.match(result.stdout, /plugin-with-passthrough/);
+		});
+	});
+
+	describe("Exit code policy", () => {
+		// The doctor reports state, it does not enforce policy. Exit
+		// code must remain 0 even when collisions exist so scripted
+		// callers can pipe `--json` output into `jq` without
+		// `set -e` aborting them.
+		test("exit code is 0 even when collisions are present", async () => {
+			const dir = makeDataDir([
+				{
+					installDirName: "zzz-plugin-conflicting",
+					src: COMMAND_CONFLICT_FIXTURE_DIR,
+				},
+			]);
+			const result = await runDoctor(dir);
+			assert.strictEqual(
+				result.status,
+				0,
+				`expected exit 0 with collisions present; stderr: ${result.stderr}`,
+			);
+		});
+	});
+});


### PR DESCRIPTION
Closes the visibility gap from #363. The loader already does first-registration-wins with a load-time `logger.warn` (from #366 / #367), but a user who didn't see those warnings had no way to recover them. This PR adds the discoverability surface, the published policy, and the recommended naming convention.

## What changes

### Loader bookkeeping (`src/plugin-loader.ts`)

- Records every drop in a module-level `pluginCollisions: PluginCollision[]` (kind / winner / loser / command).
- Exposes `getPluginCollisions()` and `getLoadedPluginSummaries()` as defensive copies.
- `clearLoadedPlugins()` resets both so test fixtures stay isolated.

### `c8ctl doctor plugin` command (`src/commands/plugins.ts`)

Renders both views. Text mode is two tables (Loaded plugins, Detected collisions) plus an actionable resolution hint. JSON mode is `{ loaded[], collisions[] }`.

```jsonc
{
  "loaded": [
    { "name": "plugin-a", "commands": ["model"] }
  ],
  "collisions": [
    {
      "kind": "command-name",
      "winner": "plugin-a",
      "loser": "plugin-b",
      "command": "model"
    },
    {
      "kind": "plugin-name",
      "winner": "plugin-x",
      "loser": "plugin-x"
    }
  ]
}
```

Exit code is always 0 — the doctor reports state, it does not enforce policy. Scripted callers under `set -e` aren't aborted by the presence of collisions.

### Tests (`tests/unit/plugin-doctor.test.ts`)

Class-scoped guards over both flavours of collision and both output modes. Reuses the existing `zzz-plugin-conflicting` and `zzz-plugin-name-collider` fixtures so the loader's actual behaviour is what's exercised — not a synthetic stub.

### Docs

- New design note `docs/plugin-collisions.md` documenting the resolution policy, why stricter alternatives (reject-and-skip-both, plugin namespacing, user-pinned precedence) were deferred, reproduction recipes for both collision flavours, and the doctor command reference.
- New "Naming convention: prefix with your plugin's short name" section in `PLUGIN-HELP.md` pointing at the design note.

## What this PR does NOT do (deferred)

The remaining items from #363 are still open:

- ❌ Plugin-namespacing (`c8ctl <plugin> <command>`) opt-in via `metadata.namespaced: true`. Breaking change for existing plugins; not required to close the silent-failure gap.
- ❌ User-pinned precedence config (`~/.c8ctl/plugin-precedence.json`). Worth revisiting if the doctor command shows real-world collisions are common.

## Verification

- `npm run lint` clean
- `npm run typecheck` clean
- `npm run test:unit` — 1512 / 1512 pass (10 new tests added)
- `npm run sync:readme` + `npm run sync:docs` ran cleanly (the new `doctor` verb is reflected in the generated command reference)

Refs #363.
