### PR TITLE
fix: reject unsatisfiable plugin required+collision flags at dispatch (#364)

### DIFF
--- a/PLUGIN-HELP.md
+++ b/PLUGIN-HELP.md
@@ -113,6 +113,7 @@ Each flag can have the following properties:
 
 > **Important:** Plugin flags are checked against c8ctl's built-in flags at runtime with different consequences depending on where the collision occurs:
 > - **Long-name collision** (e.g. `--output`, `--verbose`, `--dry-run`): the entire plugin flag is dropped. A warning is emitted and the handler will not receive the value.
+> - **Long-name collision combined with `required: true`**: the command is **unsatisfiable** — the colliding token is always stripped from argv before the plugin parser sees it, so no user input can satisfy the requirement. c8ctl refuses to dispatch the command and exits with an actionable error directing the plugin author to rename the flag (#364).
 > - **Short-alias collision** (e.g. `-v`, `-o`, `-h`): only the short alias is stripped. The long flag name still works — `--myflag value` is parsed correctly, but `-m value` is not.
 >
 > Avoid long names like `--output`, `--limit`, `--all`, `--asc`, `--desc`, `--sort-by`, `--dry-run`, `--verbose`, `--fields`, `--profile`, `--help`, `--version`, and short aliases `-o`, `-l`, `-v`, `-p`, `-h`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -440,7 +440,12 @@ async function main() {
 					.map((o) => o.short)
 					.filter((s): s is string => s !== undefined),
 			);
-			const mergedOptions = { ...builtinOptions };
+			// Use a null-prototype object so plugin-supplied flag names like
+			// `__proto__`, `constructor`, or `prototype` cannot pollute the
+			// prototype chain when later assigned (paired with the
+			// `Object.hasOwn` collision check below).
+			const mergedOptions: Record<string, (typeof builtinOptions)[string]> =
+				Object.assign(Object.create(null), builtinOptions);
 			const blockedFlags = new Set<string>();
 			for (const [name, def] of Object.entries(cmdFlagDefs)) {
 				if (Object.hasOwn(builtinOptions, name)) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -444,6 +444,20 @@ async function main() {
 			const blockedFlags = new Set<string>();
 			for (const [name, def] of Object.entries(cmdFlagDefs)) {
 				if (name in builtinOptions) {
+					// A required plugin flag whose name collides with a built-in
+					// flag is unsatisfiable: the token is always stripped from
+					// argv before the plugin parser sees it, so the required
+					// check downstream would always fire with the misleading
+					// "--<name> is required" message even when the user did
+					// pass a value (#364). Fail fast here with a single
+					// actionable error instead.
+					if (def.required === true) {
+						logger.error(
+							`Plugin flag --${name} is declared required but conflicts with a built-in flag of the same name; ` +
+								`it can never be satisfied. The plugin must rename this flag.`,
+						);
+						process.exit(1);
+					}
 					logger.warn(
 						`Plugin flag --${name} conflicts with a built-in flag and will not be parsed`,
 					);

--- a/src/index.ts
+++ b/src/index.ts
@@ -443,7 +443,7 @@ async function main() {
 			const mergedOptions = { ...builtinOptions };
 			const blockedFlags = new Set<string>();
 			for (const [name, def] of Object.entries(cmdFlagDefs)) {
-				if (name in builtinOptions) {
+				if (Object.hasOwn(builtinOptions, name)) {
 					// A required plugin flag whose name collides with a built-in
 					// flag is unsatisfiable: the token is always stripped from
 					// argv before the plugin parser sees it, so the required

--- a/tests/fixtures/plugins/plugin-with-flags/c8ctl-plugin.js
+++ b/tests/fixtures/plugins/plugin-with-flags/c8ctl-plugin.js
@@ -55,6 +55,22 @@ export const commands = {
 			console.log(JSON.stringify({ args, flags: flags || {} }));
 		},
 	},
+
+	'test-required-collision': {
+		flags: {
+			// Collides with built-in --profile AND declared required.
+			// This combination is unsatisfiable (#364): the CLI must
+			// reject the command at dispatch with an actionable error.
+			profile: {
+				type: 'string',
+				description: 'Collides with built-in --profile flag',
+				required: true,
+			},
+		},
+		handler: async (args, flags) => {
+			console.log(JSON.stringify({ args, flags: flags || {} }));
+		},
+	},
 };
 
 export const metadata = {

--- a/tests/unit/plugin-flags.test.ts
+++ b/tests/unit/plugin-flags.test.ts
@@ -217,6 +217,56 @@ describe("Plugin Flags CLI subprocess — built-in collision", () => {
 	});
 });
 
+describe("Plugin Flags CLI subprocess — required + built-in collision (#364)", () => {
+	// A plugin flag declared `required: true` whose name collides with a
+	// built-in flag is unsatisfiable: the colliding token is always stripped
+	// from argv before the plugin parser sees it. The CLI must fail fast at
+	// dispatch with an actionable error rather than emit the misleading
+	// "--<name> is required" after the handler has been "called".
+	test("rejects unsatisfiable command with actionable error, even when user passes the flag", async () => {
+		const result = await c8plugin(
+			"test-required-collision",
+			"--profile",
+			"anything",
+		);
+		assert.strictEqual(
+			result.status,
+			1,
+			`expected exit 1, got ${result.status}. stderr: ${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("--profile"),
+			`expected error to name the colliding flag. stderr: ${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("required") && result.stderr.includes("built-in"),
+			`expected actionable error mentioning required + built-in collision. stderr: ${result.stderr}`,
+		);
+		assert.ok(
+			!result.stderr.match(/^ERROR: --profile is required\s*$/m),
+			`error must not be the misleading bare "--profile is required". stderr: ${result.stderr}`,
+		);
+		assert.strictEqual(
+			result.stdout.trim(),
+			"",
+			`handler must not run. stdout: ${result.stdout}`,
+		);
+	});
+
+	test("rejects unsatisfiable command even when user omits the flag entirely", async () => {
+		const result = await c8plugin("test-required-collision");
+		assert.strictEqual(
+			result.status,
+			1,
+			`expected exit 1, got ${result.status}. stderr: ${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("built-in"),
+			`expected error mentioning built-in collision. stderr: ${result.stderr}`,
+		);
+	});
+});
+
 describe("Plugin Flags CLI subprocess", () => {
 	test("string and boolean flags are parsed and passed to handler", async () => {
 		const result = await c8plugin(

--- a/tests/unit/plugin-flags.test.ts
+++ b/tests/unit/plugin-flags.test.ts
@@ -239,12 +239,24 @@ describe("Plugin Flags CLI subprocess — required + built-in collision (#364)",
 			`expected error to name the colliding flag. stderr: ${result.stderr}`,
 		);
 		assert.ok(
-			result.stderr.includes("required") && result.stderr.includes("built-in"),
-			`expected actionable error mentioning required + built-in collision. stderr: ${result.stderr}`,
+			result.stderr.includes(
+				"is declared required but conflicts with a built-in flag",
+			),
+			`expected new actionable error sentence. stderr: ${result.stderr}`,
 		);
+		// The misleading legacy message is the bare phrase "--profile is
+		// required" with no surrounding "declared" / "conflicts" context.
+		// Assert it is absent independently of stderr formatting (text vs
+		// JSON, ✗ prefix, etc.).
+		const legacyBareError =
+			/(?:^|[^a-zA-Z])--profile is required(?:[^a-zA-Z]|$)/;
+		const withoutNewMessage = result.stderr
+			.split("\n")
+			.filter((line) => !line.includes("is declared required but conflicts"))
+			.join("\n");
 		assert.ok(
-			!result.stderr.match(/^ERROR: --profile is required\s*$/m),
-			`error must not be the misleading bare "--profile is required". stderr: ${result.stderr}`,
+			!legacyBareError.test(withoutNewMessage),
+			`legacy bare "--profile is required" must not appear. stderr: ${result.stderr}`,
 		);
 		assert.strictEqual(
 			result.stdout.trim(),


### PR DESCRIPTION
Closes #364.

## Problem

A plugin flag declared `required: true` whose name collides with a built-in flag is **unsatisfiable**: the colliding token is always stripped from argv before the plugin parser sees it. No user input can satisfy the requirement.

Before this PR the plugin-dispatch path in `src/index.ts` exhibited Option C from the issue — the `continue` in the blacklist loop silently dropped the requirement entirely, so the handler ran with the flag `undefined` despite being declared required. (Or, depending on argv shape, the user got the misleading `--profile is required` error after they had passed it.) Both behaviours quietly break the plugin's declared contract.

## Fix

Take **Option B** from the issue: detect the unsatisfiable combination at dispatch and refuse to run the command with a single actionable error.

```ts
if (name in builtinOptions) {
  if (def.required === true) {
    logger.error(
      `Plugin flag --${name} is declared required but conflicts with a built-in flag of the same name; ` +
      `it can never be satisfied. The plugin must rename this flag.`,
    );
    process.exit(1);
  }
  logger.warn(`Plugin flag --${name} conflicts with a built-in flag and will not be parsed`);
  blockedFlags.add(name);
  continue;
}
```

The handler never runs, so plugin code cannot observe its own broken contract. The error names the colliding flag and tells the plugin author what to do.

## Tests (red/green confirmed)

New `tests/fixtures/plugins/plugin-with-flags` command `test-required-collision` declares `profile` (collides with built-in `--profile`) as `required: true`. Two class-scoped guards in `tests/unit/plugin-flags.test.ts`:

1. With the user passing `--profile anything` — asserts exit 1, error mentions `--profile` + `required` + `built-in`, handler never produces stdout, and the misleading bare `--profile is required` form is gone.
2. With the user omitting the flag entirely — asserts exit 1 + same actionable error.

Red verified by stashing `src/index.ts` on this branch: both new tests fail with the unfixed behaviour (handler runs, exits 0). Restoring the fix makes them pass.

## Docs

`PLUGIN-HELP.md` Flag Definition Structure callout now lists the unsatisfiable combination alongside long-name and short-alias collisions.

## Verification

- `npm run lint` clean
- `npm run typecheck` clean
- `npm run test:unit` — 1514 / 1514 pass (2 new tests added)
