### PR TITLE
feat: surface plugin collisions in `c8ctl list plugin` (#363)

### DIFF
--- a/docs/plugin-collisions.md
+++ b/docs/plugin-collisions.md
@@ -36,6 +36,23 @@ visibility affordances:
    `loadInstalledPlugins` both `.sort()` their `readdirSync` results.
    "Who wins" is therefore stable for a given set of installed packages
    regardless of OS, filesystem, or install order.
+4. **`c8ctl list plugin`** prints a one-line stderr summary when any
+   collisions were detected at load time, pointing the user at
+   `c8ctl doctor plugin` for the full breakdown. The `--json` payload
+   on stdout remains a plain array so existing scripted callers are
+   unaffected.
+
+> **Cross-machine determinism caveat.** Sorting `readdirSync` makes
+> "who wins" deterministic *for a given set of installed plugin
+> directories on a single machine*. Two machines that have installed
+> the same logical plugins can still disagree if the install layouts
+> differ — npm hoisting, monorepo workspaces, `npm link` symlinks,
+> different package versions resolved to different physical
+> directories, or simply a different set of installed plugins will
+> all change the sort key set. If you need bit-for-bit reproducible
+> precedence across machines (e.g. for CI), pin the exact set of
+> plugin packages and use `c8ctl doctor plugin --json` to verify the
+> `loaded[]` order matches what you expect.
 
 Default plugins always load before user-installed plugins (built-ins
 always win). User-vs-user precedence falls back to alphabetical order on

--- a/src/commands/plugins.ts
+++ b/src/commands/plugins.ts
@@ -601,6 +601,35 @@ export const listPluginsCommand = defineCommand(
 					'Some plugins are out of sync. Run "c8ctl sync plugins" to synchronize your plugins',
 				);
 			}
+
+			// Surface load-time plugin collisions inline (#363). The full
+			// breakdown lives in `c8ctl doctor plugin`; we only summarise
+			// here so users notice from the verb they reach for first.
+			// Emitted via `logger.warn` (stderr) so the JSON shape of
+			// `list plugin --json` (a plain array) stays unchanged.
+			const collisions = getPluginCollisions();
+			if (collisions.length > 0) {
+				const commandCollisions = collisions.filter(
+					(c) => c.kind === "command-name",
+				).length;
+				const nameCollisions = collisions.filter(
+					(c) => c.kind === "plugin-name",
+				).length;
+				const parts: string[] = [];
+				if (commandCollisions > 0) {
+					parts.push(
+						`${commandCollisions} command-name collision${commandCollisions === 1 ? "" : "s"}`,
+					);
+				}
+				if (nameCollisions > 0) {
+					parts.push(
+						`${nameCollisions} plugin-name collision${nameCollisions === 1 ? "" : "s"}`,
+					);
+				}
+				logger.warn(
+					`${parts.join(", ")} detected at load time. Run "c8ctl doctor plugin" for details.`,
+				);
+			}
 		} catch (error) {
 			handleCommandError(logger, "Failed to list plugins", error);
 		}

--- a/tests/unit/plugin-list-collisions.test.ts
+++ b/tests/unit/plugin-list-collisions.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for `c8ctl list plugin` collision summary (#363).
+ *
+ * The full per-collision breakdown lives in `c8ctl doctor plugin`.
+ * `list plugin` is the verb users reach for first when they want to
+ * inspect installed plugins, so the policy here is: surface a brief
+ * stderr summary pointing at `doctor plugin`. The JSON shape of
+ * `list plugin --json` (a plain array) must not change so existing
+ * scripted callers keep working.
+ *
+ * Class-scoped guards:
+ * - With no collisions, the summary line is absent.
+ * - With a command-name collision, stderr names the collision count
+ *   and points at `doctor plugin`.
+ * - With a plugin-name collision, stderr names that count too.
+ * - In `--json` mode the stdout payload remains a plain array
+ *   (no extra `collisions` field appended) so the contract is
+ *   preserved.
+ */
+
+import assert from "node:assert";
+import { cpSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { asyncSpawn } from "../utils/spawn.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = "src/index.ts";
+
+const PASSTHROUGH_FIXTURE_DIR = join(
+	__dirname,
+	"../fixtures/plugins/plugin-with-passthrough",
+);
+const COMMAND_CONFLICT_FIXTURE_DIR = join(
+	__dirname,
+	"../fixtures/plugins/zzz-plugin-conflicting",
+);
+const NAME_COLLIDER_FIXTURE_DIR = join(
+	__dirname,
+	"../fixtures/plugins/zzz-plugin-name-collider",
+);
+
+function makeDataDir(
+	extraFixtures: { installDirName: string; src: string }[] = [],
+) {
+	const dir = mkdtempSync(join(tmpdir(), "c8ctl-list-collisions-"));
+	writeFileSync(
+		join(dir, "session.json"),
+		JSON.stringify({ outputMode: "text" }),
+	);
+	const installRoot = join(dir, "plugins", "node_modules");
+	const baseDst = join(installRoot, "plugin-with-passthrough");
+	mkdirSync(baseDst, { recursive: true });
+	cpSync(PASSTHROUGH_FIXTURE_DIR, baseDst, { recursive: true });
+	for (const { installDirName, src } of extraFixtures) {
+		const dst = join(installRoot, installDirName);
+		mkdirSync(dst, { recursive: true });
+		cpSync(src, dst, { recursive: true });
+	}
+	return dir;
+}
+
+async function runListPlugin(
+	dataDir: string,
+	extraArgs: string[] = [],
+): Promise<{ status: number | null; stdout: string; stderr: string }> {
+	return asyncSpawn(
+		"node",
+		["--experimental-strip-types", CLI, "list", "plugin", ...extraArgs],
+		{
+			env: {
+				...process.env,
+				CAMUNDA_BASE_URL: "http://test-cluster/v2",
+				HOME: "/tmp/c8ctl-list-collisions-nonexistent-home",
+				C8CTL_DATA_DIR: dataDir,
+			},
+		},
+	);
+}
+
+describe("c8ctl list plugin — collision summary (#363)", () => {
+	describe("No collisions", () => {
+		const DATA_DIR = makeDataDir();
+
+		test("no collision summary appears on stderr", async () => {
+			const result = await runListPlugin(DATA_DIR);
+			assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+			assert.ok(
+				!/collision/i.test(result.stderr),
+				`stderr must not mention collisions when there are none. stderr: ${result.stderr}`,
+			);
+		});
+	});
+
+	describe("Command-name collision", () => {
+		const DATA_DIR = makeDataDir([
+			{
+				installDirName: "zzz-plugin-conflicting",
+				src: COMMAND_CONFLICT_FIXTURE_DIR,
+			},
+		]);
+
+		test("stderr summarises command-name collision and points at doctor plugin", async () => {
+			const result = await runListPlugin(DATA_DIR);
+			assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+			assert.ok(
+				/command-name collision/i.test(result.stderr),
+				`expected command-name collision summary on stderr. stderr: ${result.stderr}`,
+			);
+			assert.ok(
+				/doctor plugin/.test(result.stderr),
+				`summary must point at doctor plugin. stderr: ${result.stderr}`,
+			);
+		});
+
+		test("--json stdout payload remains a plain array (no shape change)", async () => {
+			const result = await runListPlugin(DATA_DIR, ["--json"]);
+			assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+			// biome-ignore lint/plugin: parsed-JSON contract boundary; shape asserted below
+			const parsed = JSON.parse(result.stdout) as unknown;
+			assert.ok(
+				Array.isArray(parsed),
+				`list plugin --json must remain a plain array; got: ${result.stdout}`,
+			);
+			// Collision summary still goes to stderr in JSON mode so the
+			// stdout payload is unchanged but the user is still warned.
+			assert.ok(
+				/collision/i.test(result.stderr),
+				`collision summary must still surface on stderr in JSON mode. stderr: ${result.stderr}`,
+			);
+		});
+	});
+
+	describe("Plugin-name collision", () => {
+		const DATA_DIR = makeDataDir([
+			{
+				installDirName: "zzz-plugin-name-collider",
+				src: NAME_COLLIDER_FIXTURE_DIR,
+			},
+		]);
+
+		test("stderr summarises plugin-name collision", async () => {
+			const result = await runListPlugin(DATA_DIR);
+			assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+			assert.ok(
+				/plugin-name collision/i.test(result.stderr),
+				`expected plugin-name collision summary on stderr. stderr: ${result.stderr}`,
+			);
+		});
+	});
+});


### PR DESCRIPTION
Closes #363.

The silent-shadow problem was the core defect. It's fixed by what's already merged:

- **#367** — first-registration-wins resolution + `logger.warn` at load time + sorted `readdirSync` for per-machine determinism.
- **#369** — `c8ctl doctor plugin` (text + `--json`) + `docs/plugin-collisions.md` RFC + reserved-prefix naming convention in `PLUGIN-HELP.md`.

This PR closes the last visibility gap and the cross-machine caveat that the issue called out. Two small additions:

## 1. `c8ctl list plugin` summarises collisions inline

`doctor plugin` is the authoritative view, but `list plugin` is the verb users reach for first when inspecting installed plugins. After the existing plugins table, `list plugin` now emits a one-line **stderr** summary like:

```
WARN: 1 command-name collision detected at load time. Run "c8ctl doctor plugin" for details.
```

…when `getPluginCollisions()` is non-empty.

The summary stays on stderr deliberately so the **JSON shape on stdout is unchanged** (`list plugin --json` is still a plain array). Existing scripted callers keep working; the warning still surfaces in JSON mode because stderr is independent.

## 2. Cross-machine determinism caveat in the design note

Sorting `readdirSync` makes "who wins" deterministic *for a given set of installed plugin directories on a single machine*. Two machines that have installed the same logical plugins can still disagree if install layouts differ — npm hoisting, monorepo workspaces, `npm link` symlinks, or different resolved versions can all change the sort key set.

Added an explicit caveat to `docs/plugin-collisions.md` directing CI users to pin their plugin set and use `doctor plugin --json` to verify `loaded[]` order if they need bit-for-bit reproducibility.

## Tests

`tests/unit/plugin-list-collisions.test.ts` — class-scoped guards over both collision flavours and the JSON-shape preservation, reusing the existing `zzz-plugin-conflicting` and `zzz-plugin-name-collider` fixtures.

## What this PR does NOT do (deferred)

The issue listed two further items that are nice-to-haves without a current concrete user request:

- ❌ **User-pinned precedence config** (`~/.c8ctl/plugin-precedence.json`)
- ❌ **Plugin-namespacing opt-in** (`metadata.namespaced: true` → `c8ctl <plugin> <command>`)

Both can be tracked in fresh issues if the doctor command starts surfacing real-world collisions in users' setups. Closing #363 because the silent-failure surface is now fully covered.

## Verification

- `npm run lint` clean
- `npm run typecheck` clean
- `npm run test:unit` — 1518 / 1518 pass (4 new tests)
