### PR TITLE
fix: revert deploy default extensions to .bpmn/.dmn/.form and add opt-in flags

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -606,15 +606,32 @@ The CLI will detect duplicate IDs and provide a helpful error message showing wh
 
 ### Default Extensions
 
-When scanning directories, `deploy`, `run`, and `watch` only include files matching these extensions by default:
+When scanning directories, `deploy` and `watch` only include files matching these extensions by default:
 
-`.bpmn`, `.dmn`, `.form`, `.md`, `.txt`, `.xml`, `.rpa`, `.json`, `.config`, `.yml`, `.yaml`
+`.bpmn`, `.dmn`, `.form`
 
-Override with `--extensions`:
+Explicitly named files bypass the extension allow-list (`.c8ignore` rules still apply):
 
 ```bash
-c8 deploy --extensions=.bpmn,.dmn
-c8 watch --extensions=.bpmn,.form
+# Explicit file — deploys regardless of extension
+c8 deploy my-doc.md
+
+# Directory walk — only .bpmn/.dmn/.form by default
+c8 deploy ./my-project/
+```
+
+Use `--extensions` to add more types during directory discovery (merged with defaults):
+
+```bash
+c8 deploy --extensions=.md,.txt
+c8 watch --extensions=.md
+```
+
+Use `--all-extensions` to include all server-supported types:
+
+```bash
+c8 deploy --all-extensions
+c8 watch --all-extensions
 ```
 
 ### Ignoring Files (`.c8ignore`)

--- a/README.md
+++ b/README.md
@@ -75,11 +75,26 @@ c8ctl --version
 
 ### Default Extensions
 
-When scanning directories, `deploy`, `run`, and `watch` only include files with these extensions:
+When scanning directories, `deploy` and `watch` only include files with these extensions by default:
 
-`.bpmn`, `.dmn`, `.form`, `.md`, `.txt`, `.xml`, `.rpa`, `.json`, `.config`, `.yml`, `.yaml`
+`.bpmn`, `.dmn`, `.form`
 
-Use `--extensions` to override (e.g. `--extensions=.bpmn,.dmn`).
+Explicitly named files bypass the extension allow-list (e.g. `c8 deploy my-doc.md`). Note that `.c8ignore` rules still apply.
+
+Use `--extensions` to add more types during directory discovery (merged with defaults):
+
+```bash
+c8 deploy --extensions=.md,.txt
+c8 watch --extensions=.md
+```
+
+Use `--all-extensions` to include all server-supported types (`.md`, `.txt`, `.xml`, `.rpa`, `.json`, `.config`, `.yml`, `.yaml`):
+
+```bash
+c8 deploy --all-extensions
+```
+
+Skipped files are logged to stderr with an actionable hint.
 
 ### Ignoring Files (`.c8ignore`)
 
@@ -1495,6 +1510,8 @@ Deploy files to Camunda (auto-discovers deployable files in directories)
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
 | `--force` | boolean |  | Deploy any file type, ignoring the default extension allow-list |
+| `--extensions` | string |  | Comma-separated list of additional file extensions to include when scanning directories (e.g. .md,.txt). Explicit file paths bypass the extension allow-list. |
+| `--all-extensions` | boolean |  | Include all server-supported file extensions during directory discovery |
 
 **Examples:**
 
@@ -1602,7 +1619,8 @@ Watch files for changes and auto-deploy
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
 | `--force` | boolean |  | Continue watching after all deployment errors |
-| `--extensions` | string |  | Comma-separated list of file extensions to watch (e.g. .bpmn,.dmn,.form) |
+| `--extensions` | string |  | Comma-separated list of additional file extensions to watch (merged with defaults, e.g. .md,.txt) |
+| `--all-extensions` | boolean |  | Watch all server-supported file extensions |
 
 **Examples:**
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -739,6 +739,8 @@ Deploy files to Camunda (auto-discovers deployable files in directories)
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
 | `--force` | boolean |  | Deploy any file type, ignoring the default extension allow-list |
+| `--extensions` | string |  | Comma-separated list of additional file extensions to include when scanning directories (e.g. .md,.txt). Explicit file paths bypass the extension allow-list. |
+| `--all-extensions` | boolean |  | Include all server-supported file extensions during directory discovery |
 
 **Examples:**
 
@@ -846,7 +848,8 @@ Watch files for changes and auto-deploy
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
 | `--force` | boolean |  | Continue watching after all deployment errors |
-| `--extensions` | string |  | Comma-separated list of file extensions to watch (e.g. .bpmn,.dmn,.form) |
+| `--extensions` | string |  | Comma-separated list of additional file extensions to watch (merged with defaults, e.g. .md,.txt) |
+| `--all-extensions` | boolean |  | Watch all server-supported file extensions |
 
 **Examples:**
 

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -1233,6 +1233,16 @@ export const COMMAND_REGISTRY = {
 				description:
 					"Deploy any file type, ignoring the default extension allow-list",
 			},
+			extensions: {
+				type: "string",
+				description:
+					"Comma-separated list of additional file extensions to include when scanning directories (e.g. .md,.txt). Explicit file paths bypass the extension allow-list.",
+			},
+			"all-extensions": {
+				type: "boolean",
+				description:
+					"Include all server-supported file extensions during directory discovery",
+			},
 		},
 	},
 
@@ -1338,7 +1348,11 @@ export const COMMAND_REGISTRY = {
 			extensions: {
 				type: "string",
 				description:
-					"Comma-separated list of file extensions to watch (e.g. .bpmn,.dmn,.form)",
+					"Comma-separated list of additional file extensions to watch (merged with defaults, e.g. .md,.txt)",
+			},
+			"all-extensions": {
+				type: "boolean",
+				description: "Watch all server-supported file extensions",
 			},
 		},
 		aliases: ["w"],

--- a/src/commands/resource-extensions.ts
+++ b/src/commands/resource-extensions.ts
@@ -3,9 +3,22 @@
  *
  * Used by both `deploy` (allow-list for directory scanning) and `watch`
  * (default set of monitored extensions) to keep a single source of truth.
+ *
+ * The default is intentionally narrow: only file types that are
+ * unambiguously Camunda resources regardless of server version.
+ * Users opt in to expanded types via `--extensions` or `--all-extensions`.
+ *
+ * See https://github.com/camunda/c8ctl/issues/350
  */
 
-export const DEPLOYABLE_EXTENSIONS = [
+export const DEPLOYABLE_EXTENSIONS = [".bpmn", ".dmn", ".form"];
+
+/**
+ * Extended extensions supported by Camunda 8.10+.
+ * Used by `--all-extensions` to include every server-supported type
+ * during directory discovery.
+ */
+export const ALL_DEPLOYABLE_EXTENSIONS = [
 	".bpmn",
 	".dmn",
 	".form",

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -15,7 +15,6 @@ import {
 } from "@camunda8/orchestration-cluster-api";
 import { defineCommand, dryRun } from "../command-framework.ts";
 import { resolveTenantId } from "../config.ts";
-import { DEPLOYABLE_EXTENSIONS } from "./resource-extensions.ts";
 
 /**
  * Extract process ID from BPMN file content.
@@ -47,10 +46,13 @@ export const runCommand = defineCommand("run", "", async (ctx, flags) => {
 	if (dr) return dr;
 
 	// Validate file extension unless --force is set.
+	// `run` deploys and starts a process instance, which requires a BPMN
+	// process ID — only .bpmn files are valid here.
 	const ext = extname(path);
-	if (!flags.force && ext && !DEPLOYABLE_EXTENSIONS.includes(ext)) {
+	if (!flags.force && ext !== ".bpmn") {
 		throw new Error(
-			`Unsupported file extension "${ext}". Use --force to deploy any file type.`,
+			`run requires a .bpmn file (got "${ext || "<no extension>"}"). ` +
+				`Use "c8 deploy" for other resource types, or --force to override.`,
 		);
 	}
 

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -9,7 +9,10 @@ import { deployResources } from "../deployments.ts";
 import { normalizeToError } from "../errors.ts";
 import { isIgnored, loadIgnoreRules } from "../ignore.ts";
 import { DEPLOY_COOLDOWN } from "../watch-constants.ts";
-import { DEPLOYABLE_EXTENSIONS } from "./resource-extensions.ts";
+import {
+	ALL_DEPLOYABLE_EXTENSIONS,
+	DEPLOYABLE_EXTENSIONS,
+} from "./resource-extensions.ts";
 
 export { DEPLOY_COOLDOWN };
 
@@ -29,14 +32,21 @@ const DEBOUNCE_DELAY = 200; // ms to wait after last fs event before deploying
 export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
 	const { logger } = ctx;
 
-	// Parse --extensions flag into an array of extensions
-	const watchedExtensions =
-		flags.extensions && String(flags.extensions).trim()
-			? String(flags.extensions)
-					.split(",")
-					.map((e) => e.trim())
-					.filter(Boolean)
-					.map((e) => (e.startsWith(".") ? e : `.${e}`))
+	// Parse --extensions / --all-extensions flags into an array of extensions.
+	// --extensions merges with the defaults (same semantics as deploy).
+	const watchedExtensions = flags["all-extensions"]
+		? ALL_DEPLOYABLE_EXTENSIONS
+		: flags.extensions && String(flags.extensions).trim()
+			? [
+					...new Set([
+						...DEPLOYABLE_EXTENSIONS,
+						...String(flags.extensions)
+							.split(",")
+							.map((e) => e.trim())
+							.filter(Boolean)
+							.map((e) => (e.startsWith(".") ? e : `.${e}`)),
+					]),
+				]
 			: DEPLOYABLE_EXTENSIONS;
 
 	// watch treats resource + positionals as path varargs; default to "."

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -8,7 +8,10 @@ import { TenantId } from "@camunda8/orchestration-cluster-api";
 import type { Ignore } from "ignore";
 import { createClient } from "./client.ts";
 import { defineCommand, dryRun } from "./command-framework.ts";
-import { DEPLOYABLE_EXTENSIONS } from "./commands/resource-extensions.ts";
+import {
+	ALL_DEPLOYABLE_EXTENSIONS,
+	DEPLOYABLE_EXTENSIONS,
+} from "./commands/resource-extensions.ts";
 import { resolveTenantId } from "./config.ts";
 import { normalizeToError, SilentError } from "./errors.ts";
 import { isIgnored, loadIgnoreRules } from "./ignore.ts";
@@ -26,6 +29,20 @@ function logMessage(message: string): void {
 	} else {
 		console.error(message);
 	}
+}
+
+/**
+ * Format and log a hint about skipped file extensions.
+ * Shared between the dry-run preview and the execute path so the
+ * message stays consistent. See https://github.com/camunda/c8ctl/issues/350
+ */
+function logSkippedExtensions(skippedExtensions: Set<string>): void {
+	if (skippedExtensions.size === 0) return;
+	const exts = [...skippedExtensions].sort().join(", ");
+	logMessage(
+		`Skipped files with extensions not in the allow-list (${exts}). ` +
+			`Use --extensions=<ext> to add specific types, or --all-extensions to include all server-supported types.`,
+	);
 }
 
 /**
@@ -119,7 +136,14 @@ function findGroupRoot(
 }
 
 /**
- * Recursively collect resource files from a directory
+ * Recursively collect resource files from a directory.
+ *
+ * @param extensionList - The active allow-list of extensions. Only used
+ *   during directory walks; explicit file paths bypass this check (the
+ *   caller's intent is unambiguous). Pass `undefined` to skip extension
+ *   filtering entirely (equivalent to `--force`).
+ * @param skippedExtensions - Mutable set that accumulates extensions
+ *   skipped during directory walks, so the caller can log them.
  */
 function collectResourceFiles(
 	dirPath: string,
@@ -128,6 +152,8 @@ function collectResourceFiles(
 	ig?: Ignore,
 	ignoreBaseDir?: string,
 	force?: boolean,
+	extensionList?: readonly string[],
+	skippedExtensions?: Set<string>,
 ): ResourceFile[] {
 	if (!existsSync(dirPath)) {
 		return collected;
@@ -144,10 +170,9 @@ function collectResourceFiles(
 		if (ig && ignoreBaseDir && isIgnored(ig, dirPath, ignoreBaseDir)) {
 			return collected;
 		}
-		// Unless --force, reject files with unsupported extensions
-		if (!force && !DEPLOYABLE_EXTENSIONS.includes(extname(dirPath))) {
-			return collected;
-		}
+		// Explicit file paths always pass through — the user named the
+		// file directly, so their intent is unambiguous. Extension
+		// filtering only applies during directory discovery (below).
 		const groupInfo = findGroupRoot(dirPath, basePath);
 		collected.push({
 			path: dirPath,
@@ -201,7 +226,15 @@ function collectResourceFiles(
 					return;
 				}
 				// Unless --force, only collect files with known deployable extensions
-				if (!force && !DEPLOYABLE_EXTENSIONS.includes(extname(fullPath))) {
+				if (
+					!force &&
+					extensionList &&
+					!extensionList.includes(extname(fullPath))
+				) {
+					if (skippedExtensions) {
+						const ext = extname(fullPath);
+						skippedExtensions.add(ext || "<no extension>");
+					}
 					return;
 				}
 				files.push(fullPath);
@@ -230,6 +263,8 @@ function collectResourceFiles(
 				ig,
 				ignoreBaseDir,
 				force,
+				extensionList,
+				skippedExtensions,
 			);
 		});
 
@@ -242,6 +277,8 @@ function collectResourceFiles(
 				ig,
 				ignoreBaseDir,
 				force,
+				extensionList,
+				skippedExtensions,
 			);
 		});
 	}
@@ -268,6 +305,15 @@ function findDuplicateDefinitionIds(
 }
 
 /**
+ * Result of collecting deployable resources, including any extensions
+ * that were skipped during directory walks (for user feedback).
+ */
+interface CollectResult {
+	resources: ResourceFile[];
+	skippedExtensions: Set<string>;
+}
+
+/**
  * Collect deployable resources from the given paths, applying `.c8ignore`
  * rules. Throws on the two pre-API guard failures so callers (deploy
  * handler, watch, dry-run preview) all surface the same errors with the
@@ -275,11 +321,15 @@ function findDuplicateDefinitionIds(
  *
  * Shared between `deployCommand` (used for both the dry-run preview and
  * the execute path via `deployResources`) and `deployResources` itself.
+ *
+ * @param extensionList - Active allow-list for directory discovery.
+ *   Defaults to `DEPLOYABLE_EXTENSIONS` (.bpmn, .dmn, .form).
  */
 function collectResourcesForPaths(
 	paths: string[],
 	force?: boolean,
-): ResourceFile[] {
+	extensionList: readonly string[] = DEPLOYABLE_EXTENSIONS,
+): CollectResult {
 	if (paths.length === 0) {
 		throw new Error(
 			"No paths provided. Use: c8 deploy <path> or c8 deploy (for current directory)",
@@ -291,15 +341,26 @@ function collectResourcesForPaths(
 	const ig = loadIgnoreRules(ignoreBaseDir);
 
 	const resources: ResourceFile[] = [];
+	const skippedExtensions = new Set<string>();
 	paths.forEach((path) => {
-		collectResourceFiles(path, resources, undefined, ig, ignoreBaseDir, force);
+		collectResourceFiles(
+			path,
+			resources,
+			undefined,
+			ig,
+			ignoreBaseDir,
+			force,
+			extensionList,
+			skippedExtensions,
+		);
 	});
 
 	if (resources.length === 0) {
+		logSkippedExtensions(skippedExtensions);
 		throw new Error("No deployable files found in the specified paths");
 	}
 
-	return resources;
+	return { resources, skippedExtensions };
 }
 
 /**
@@ -320,6 +381,7 @@ export async function deployResources(
 		continueOnError?: boolean;
 		continueOnUserError?: boolean;
 		force?: boolean;
+		extensionList?: readonly string[];
 		/**
 		 * Optional cancellation signal. When aborted, an in-flight
 		 * `createDeployment` HTTP request is cancelled via the SDK's
@@ -341,7 +403,13 @@ export async function deployResources(
 	// HTTP deploy call (further down) is wrapped in a catch that routes
 	// through `handleDeploymentError` for rich Problem-Detail rendering.
 
-	const resources = collectResourcesForPaths(paths, options.force);
+	const { resources, skippedExtensions } = collectResourcesForPaths(
+		paths,
+		options.force,
+		options.extensionList ?? DEPLOYABLE_EXTENSIONS,
+	);
+
+	logSkippedExtensions(skippedExtensions);
 
 	// Store the base paths for relative path calculation. Safe to assign
 	// directly now: the empty-paths guard inside `collectResourcesForPaths`
@@ -799,6 +867,43 @@ function printDeploymentHints(
 // ─── defineCommand ───────────────────────────────────────────────────────────
 
 /**
+ * Resolve the effective extension allow-list from the deploy flags.
+ *
+ * Priority: --force (no filtering) > --all-extensions > --extensions > default
+ *
+ * When `--extensions` is provided, the custom list is *merged* with the
+ * default (.bpmn, .dmn, .form) so users add to the baseline rather than
+ * replacing it.
+ */
+function resolveExtensionList(flags: {
+	force?: boolean;
+	extensions?: string;
+	"all-extensions"?: boolean;
+}): readonly string[] {
+	// When --force is set the allow-list is irrelevant — downstream code
+	// skips filtering entirely. Return the default so callers always get a
+	// valid list, but the value is never consulted.
+	if (flags.force) return DEPLOYABLE_EXTENSIONS;
+
+	// --all-extensions: use the full server-supported list
+	if (flags["all-extensions"]) return ALL_DEPLOYABLE_EXTENSIONS;
+
+	// --extensions: merge custom extensions with the default set
+	if (flags.extensions && String(flags.extensions).trim()) {
+		const custom = String(flags.extensions)
+			.split(",")
+			.map((e) => e.trim())
+			.filter(Boolean)
+			.map((e) => (e.startsWith(".") ? e : `.${e}`));
+
+		const merged = [...new Set([...DEPLOYABLE_EXTENSIONS, ...custom])];
+		return merged;
+	}
+
+	return DEPLOYABLE_EXTENSIONS;
+}
+
+/**
  * Side-effectful: collects files, validates, deploys, and renders its own
  * table output.
  *
@@ -816,13 +921,21 @@ export const deployCommand = defineCommand("deploy", "", async (ctx, flags) => {
 			? ctx.positionals
 			: ["."];
 
+	// Resolve the active extension allow-list from flags.
+	// Priority: --force (no filtering) > --all-extensions > --extensions > default
+	const extensionList = resolveExtensionList(flags);
+
 	// Dry-run preview. Collect resources first so the preview body
 	// reflects what would actually be sent — and so the empty-paths /
 	// no-files guards still surface as thrown errors before we emit.
 	// Uses `ctx.dryRun` and `ctx.tenantId` from the framework rather
 	// than reaching into the global runtime/config layer.
 	if (ctx.dryRun) {
-		const previewResources = collectResourcesForPaths(paths, flags.force);
+		const { resources: previewResources, skippedExtensions } =
+			collectResourcesForPaths(paths, flags.force, extensionList);
+
+		logSkippedExtensions(skippedExtensions);
+
 		const dr = dryRun({
 			command: "deploy",
 			method: "POST",
@@ -842,6 +955,10 @@ export const deployCommand = defineCommand("deploy", "", async (ctx, flags) => {
 	// table. Keeping the helper self-contained avoids threading
 	// pre-collected state between the handler and the shared helper
 	// used by `watch`.
-	await deployResources(paths, { profile: ctx.profile, force: flags.force });
+	await deployResources(paths, {
+		profile: ctx.profile,
+		force: flags.force,
+		extensionList,
+	});
 	return { kind: "none" };
 });

--- a/tests/integration/watch.test.ts
+++ b/tests/integration/watch.test.ts
@@ -292,14 +292,16 @@ describe("Watch Command Integration Tests (requires Camunda 8 at localhost:8080)
 		}
 	});
 
-	test("watch --extensions monitors only specified file types", async () => {
+	test("watch --extensions merges custom extensions with defaults", async () => {
 		const testWatchDir = mkdtempSync(join(tmpdir(), "c8ctl-watch-ext-"));
-		// Only watch .xml files
+		// --extensions=.xml merges with defaults (.bpmn, .dmn, .form)
 		const watch = startWatch(testWatchDir, dataDir, ["--extensions=.xml"]);
 
 		try {
 			const initialized = await pollUntil(
-				async () => watch.getOutput().includes("Monitoring extensions: .xml"),
+				async () =>
+					watch.getOutput().includes("Monitoring extensions:") &&
+					watch.getOutput().includes(".xml"),
 				5000,
 				POLL_INTERVAL_MS,
 			);
@@ -308,15 +310,10 @@ describe("Watch Command Integration Tests (requires Camunda 8 at localhost:8080)
 				`Expected watcher to show .xml in monitored extensions.\nActual output:\n${watch.getOutput()}`,
 			);
 
-			// Step 1: copy a .bpmn file — this should be IGNORED by the watcher
-			copyFileSync(VALID_BPMN, join(testWatchDir, "ignored.bpmn"));
-			await new Promise((resolve) => setTimeout(resolve, 2000));
-			assert.ok(
-				!watch.getOutput().includes("Change detected: ignored.bpmn"),
-				`Watcher should NOT detect .bpmn files when --extensions=.xml is set.\nActual output:\n${watch.getOutput()}`,
-			);
+			// --extensions merges with defaults, so .bpmn is still watched.
+			// Verify that .xml files (the added extension) are detected and deployed.
 
-			// Step 2: copy a valid BPMN as a .xml file — this SHOULD be detected and deployed
+			// Copy a valid BPMN as a .xml file — this SHOULD be detected and deployed
 			copyFileSync(VALID_BPMN, join(testWatchDir, "process.xml"));
 			const detected = await pollUntil(
 				async () => watch.getOutput().includes("Change detected: process.xml"),

--- a/tests/unit/deploy-behaviour.test.ts
+++ b/tests/unit/deploy-behaviour.test.ts
@@ -163,16 +163,120 @@ describe("CLI behavioural: deploy", () => {
 
 	// ── Extension allow-list tests ──────────────────────────────────────────
 
-	test("rejects file with unsupported extension", async () => {
-		const unsupportedFile = join(tempDir, "process.unsupported");
-		writeFileSync(unsupportedFile, "dummy content");
+	test("explicit file bypasses extension allow-list", async () => {
+		// When a user names a file directly, deploy it regardless of extension.
+		// See https://github.com/camunda/c8ctl/issues/350
+		const mdFile = join(tempDir, "readme.md");
+		writeFileSync(mdFile, "# My Process Docs");
 
-		const result = await c8("deploy", unsupportedFile, "--dry-run");
-		assert.strictEqual(result.status, 1);
+		const result = await c8("deploy", mdFile, "--dry-run");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const out = parseJson(result);
+		const body = asRecord(out.body, "dry-run body");
+		const resources = asRecordArray(body.resources, "body.resources");
+		const names = resources.map((r) => r.name);
 		assert.ok(
-			result.stderr.includes("No deployable files found") ||
-				result.stderr.includes("No deployable"),
-			`Expected rejection for unsupported extension.\nstderr: ${result.stderr}`,
+			names.includes("readme.md"),
+			`expected readme.md in resources, got: ${JSON.stringify(names)}`,
+		);
+	});
+
+	test("directory walk only includes .bpmn/.dmn/.form by default", async () => {
+		// Default allow-list is narrow: only unambiguous Camunda resources.
+		const subDir = join(tempDir, "project");
+		mkdirSync(subDir, { recursive: true });
+		writeFileSync(join(subDir, "main.bpmn"), MINIMAL_BPMN);
+		writeFileSync(join(subDir, "readme.md"), "# Docs");
+		writeFileSync(join(subDir, "config.json"), "{}");
+
+		const result = await c8("deploy", subDir, "--dry-run");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const out = parseJson(result);
+		const body = asRecord(out.body, "dry-run body");
+		const resources = asRecordArray(body.resources, "body.resources");
+		const names = resources.map((r) => r.name);
+
+		assert.ok(
+			names.includes("main.bpmn"),
+			`expected main.bpmn, got: ${JSON.stringify(names)}`,
+		);
+		assert.ok(
+			!names.includes("readme.md"),
+			`readme.md should be excluded by default, got: ${JSON.stringify(names)}`,
+		);
+		assert.ok(
+			!names.includes("config.json"),
+			`config.json should be excluded by default, got: ${JSON.stringify(names)}`,
+		);
+	});
+
+	test("directory walk logs skipped extensions to stderr", async () => {
+		const subDir = join(tempDir, "project");
+		mkdirSync(subDir, { recursive: true });
+		writeFileSync(join(subDir, "main.bpmn"), MINIMAL_BPMN);
+		writeFileSync(join(subDir, "readme.md"), "# Docs");
+
+		const result = await c8("deploy", subDir, "--dry-run");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		assert.ok(
+			result.stderr.includes("Skipped files") && result.stderr.includes(".md"),
+			`expected skip message mentioning .md in stderr, got: ${result.stderr}`,
+		);
+	});
+
+	test("--extensions adds to the default allow-list for directory walks", async () => {
+		const subDir = join(tempDir, "project");
+		mkdirSync(subDir, { recursive: true });
+		writeFileSync(join(subDir, "main.bpmn"), MINIMAL_BPMN);
+		writeFileSync(join(subDir, "readme.md"), "# Docs");
+		writeFileSync(join(subDir, "config.json"), "{}");
+
+		const result = await c8("deploy", subDir, "--extensions=.md", "--dry-run");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const out = parseJson(result);
+		const body = asRecord(out.body, "dry-run body");
+		const resources = asRecordArray(body.resources, "body.resources");
+		const names = resources.map((r) => r.name);
+
+		assert.ok(
+			names.includes("main.bpmn"),
+			`expected main.bpmn, got: ${JSON.stringify(names)}`,
+		);
+		assert.ok(
+			names.includes("readme.md"),
+			`expected readme.md with --extensions, got: ${JSON.stringify(names)}`,
+		);
+		assert.ok(
+			!names.includes("config.json"),
+			`config.json should still be excluded, got: ${JSON.stringify(names)}`,
+		);
+	});
+
+	test("--all-extensions includes expanded types in directory walk", async () => {
+		const subDir = join(tempDir, "project");
+		mkdirSync(subDir, { recursive: true });
+		writeFileSync(join(subDir, "main.bpmn"), MINIMAL_BPMN);
+		writeFileSync(join(subDir, "readme.md"), "# Docs");
+		writeFileSync(join(subDir, "config.json"), "{}");
+
+		const result = await c8("deploy", subDir, "--all-extensions", "--dry-run");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const out = parseJson(result);
+		const body = asRecord(out.body, "dry-run body");
+		const resources = asRecordArray(body.resources, "body.resources");
+		const names = resources.map((r) => r.name);
+
+		assert.ok(
+			names.includes("main.bpmn"),
+			`expected main.bpmn, got: ${JSON.stringify(names)}`,
+		);
+		assert.ok(
+			names.includes("readme.md"),
+			`expected readme.md with --all-extensions, got: ${JSON.stringify(names)}`,
+		);
+		assert.ok(
+			names.includes("config.json"),
+			`expected config.json with --all-extensions, got: ${JSON.stringify(names)}`,
 		);
 	});
 

--- a/tests/unit/form-topology-run-behaviour.test.ts
+++ b/tests/unit/form-topology-run-behaviour.test.ts
@@ -157,8 +157,8 @@ describe("CLI behavioural: run", () => {
 		const result = await c8("run", "process.unsupported");
 		assert.strictEqual(result.status, 1);
 		assert.ok(
-			result.stderr.includes("Unsupported file extension"),
-			`Expected unsupported extension error in stderr.\nActual stderr:\n${result.stderr}`,
+			result.stderr.includes("run requires a .bpmn file"),
+			`Expected .bpmn-only error in stderr.\nActual stderr:\n${result.stderr}`,
 		);
 	});
 

--- a/tests/unit/help.test.ts
+++ b/tests/unit/help.test.ts
@@ -341,6 +341,8 @@ describe("Help Module", () => {
 		const output = consoleLogSpy.join("\n");
 		assert.ok(output.includes("c8ctl deploy"));
 		assert.ok(output.includes("Deploy files"));
+		assert.ok(output.includes("--extensions"));
+		assert.ok(output.includes("--all-extensions"));
 	});
 
 	test("showCommandHelp shows run help", () => {
@@ -360,6 +362,8 @@ describe("Help Module", () => {
 		assert.ok(output.includes("Watch files"));
 		assert.ok(output.includes("Alias: w"));
 		assert.ok(output.includes("--force"));
+		assert.ok(output.includes("--extensions"));
+		assert.ok(output.includes("--all-extensions"));
 	});
 
 	test("showCommandHelp shows open help", () => {


### PR DESCRIPTION
## Summary

The broad default extension list introduced in #275 caused `deploy` to pick up unexpected files (`.json`, `.xml`, etc.) from directories. This reverts the default allow-list to the conservative `.bpmn`/`.dmn`/`.form` set and adds opt-in flags to widen it.

Closes #350

## Changes

### Default reverted
`DEPLOYABLE_EXTENSIONS` is now `[".bpmn", ".dmn", ".form"]` — the pre-#275 set. An `ALL_DEPLOYABLE_EXTENSIONS` constant retains the full 8.10 set for opt-in use.

### New flags
| Flag | Applies to | Behaviour |
|------|-----------|-----------|
| `--extensions` | `deploy`, `watch` | Additively merges extra extensions with the defaults for directory scanning (e.g. `--extensions=.md,.txt`). Explicit file paths are always deployed regardless. |
| `--all-extensions` | `deploy`, `watch` | Includes all server-supported types from `ALL_DEPLOYABLE_EXTENSIONS` |

### Explicit-file bypass
Explicitly named file paths (e.g. `c8 deploy my-doc.md`) bypass the extension allow-list entirely — user intent is unambiguous.

### Skip logging
When a directory walk skips files with unrecognised extensions, the skipped extensions are logged to stderr with an actionable hint (`use --extensions=.ext or --all-extensions`). This includes the case where *all* files are skipped (logged before the "no deployable files" error).

### Extension resolution priority
`--force` (bypass handled downstream) > `--all-extensions` > `--extensions` (merged with defaults) > default

### `run` restricted to `.bpmn`
`run` deploys and starts a process instance, which requires a BPMN process ID. Without `--force`, only `.bpmn` files are accepted.

## Files changed
- `src/commands/resource-extensions.ts` — reverted defaults, added `ALL_DEPLOYABLE_EXTENSIONS`
- `src/deployments.ts` — `resolveExtensionList()`, `logSkippedExtensions()`, `CollectResult`, explicit-file bypass
- `src/command-registry.ts` — `--extensions` and `--all-extensions` flag definitions for deploy/watch
- `src/commands/watch.ts` — extension flag support (merge semantics matching deploy)
- `src/commands/run.ts` — restricted to `.bpmn` only (without `--force`)
- `tests/unit/deploy-behaviour.test.ts` — 6 new behavioural tests
- `tests/unit/help.test.ts` — assertions for new flags in deploy/watch help
- `tests/unit/form-topology-run-behaviour.test.ts` — updated run extension test
- `tests/integration/watch.test.ts` — updated for merge semantics
- `README.md`, `EXAMPLES.md`, `docs/command-reference.md` — updated documentation