### PR TITLE
fix: resolve .c8ignore from target directory instead of cwd

### DIFF
--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -7,7 +7,7 @@ import { basename, extname, resolve } from "node:path";
 import { defineCommand } from "../command-framework.ts";
 import { deployResources } from "../deployments.ts";
 import { normalizeToError } from "../errors.ts";
-import { isIgnored, loadIgnoreRules } from "../ignore.ts";
+import { isIgnored, loadIgnoreRules, resolveIgnoreBaseDir } from "../ignore.ts";
 import { DEPLOY_COOLDOWN } from "../watch-constants.ts";
 import {
 	ALL_DEPLOYABLE_EXTENSIONS,
@@ -64,8 +64,9 @@ export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
 		}
 	}
 
-	// Load .c8ignore rules from the working directory
-	const ignoreBaseDir = resolve(process.cwd());
+	// Load .c8ignore rules from the target directory (not cwd) so that
+	// `c8 watch <target>` picks up the .c8ignore inside the target. (#258)
+	const ignoreBaseDir = resolveIgnoreBaseDir(resolvedPaths);
 	const ig = loadIgnoreRules(ignoreBaseDir);
 
 	// Keep track of recently deployed files to avoid duplicate deploys

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -3,7 +3,7 @@
  */
 
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { basename, dirname, extname, join, relative, resolve } from "node:path";
+import { basename, dirname, extname, join, relative } from "node:path";
 import { TenantId } from "@camunda8/orchestration-cluster-api";
 import type { Ignore } from "ignore";
 import { createClient } from "./client.ts";
@@ -14,7 +14,7 @@ import {
 } from "./commands/resource-extensions.ts";
 import { resolveTenantId } from "./config.ts";
 import { normalizeToError, SilentError } from "./errors.ts";
-import { isIgnored, loadIgnoreRules } from "./ignore.ts";
+import { isIgnored, loadIgnoreRules, resolveIgnoreBaseDir } from "./ignore.ts";
 import { getLogger, isRecord } from "./logger.ts";
 import { c8ctl } from "./runtime.ts";
 
@@ -336,8 +336,9 @@ function collectResourcesForPaths(
 		);
 	}
 
-	// Load .c8ignore rules from the working directory
-	const ignoreBaseDir = resolve(process.cwd());
+	// Load .c8ignore rules from the target directory (not cwd) so that
+	// `c8 deploy <target>` picks up the .c8ignore inside the target. (#258)
+	const ignoreBaseDir = resolveIgnoreBaseDir(paths);
 	const ig = loadIgnoreRules(ignoreBaseDir);
 
 	const resources: ResourceFile[] = [];

--- a/src/ignore.ts
+++ b/src/ignore.ts
@@ -6,7 +6,9 @@
  *   target/
  *   .git/
  *
- * Users can override or extend via a `.c8ignore` file in the working directory.
+ * The `.c8ignore` file is resolved from the deploy/watch target directory
+ * (via `resolveIgnoreBaseDir`), falling back to `process.cwd()` when no
+ * target is specified. See #258.
  */
 
 import { existsSync, readFileSync, statSync } from "node:fs";
@@ -97,5 +99,9 @@ export function resolveIgnoreBaseDir(paths: string[]): string {
 		}
 	}
 
-	return common.length > 0 ? common.join(sep) : resolve(process.cwd());
+	if (common.length === 0) return resolve(process.cwd());
+
+	// Normalize filesystem root: on POSIX [''] → '/', on Windows ['C:'] → 'C:\'
+	const joined = common.join(sep);
+	return joined === "" || joined.endsWith(":") ? resolve(joined + sep) : joined;
 }

--- a/src/ignore.ts
+++ b/src/ignore.ts
@@ -9,8 +9,8 @@
  * Users can override or extend via a `.c8ignore` file in the working directory.
  */
 
-import { existsSync, readFileSync } from "node:fs";
-import { join, relative, sep } from "node:path";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve, sep } from "node:path";
 import ignore, { type Ignore } from "ignore";
 
 const DEFAULT_PATTERNS = ["node_modules/", "target/", ".git/"];
@@ -56,4 +56,46 @@ export function isIgnored(
 		return false;
 	}
 	return ig.ignores(rel);
+}
+
+/**
+ * Determine the base directory for `.c8ignore` lookup from the paths the
+ * user passed to `deploy` or `watch`.
+ *
+ * - Single directory path → use that directory.
+ * - Single file path → use its parent directory.
+ * - Multiple paths → deepest common ancestor directory.
+ * - No paths → fall back to `process.cwd()`.
+ *
+ * When no target is specified the CLI defaults to `["."]`, so
+ * `resolve(".")` === `process.cwd()` — backward-compatible.
+ */
+export function resolveIgnoreBaseDir(paths: string[]): string {
+	if (paths.length === 0) return resolve(process.cwd());
+
+	const dirs = paths.map((p) => {
+		const abs = resolve(p);
+		try {
+			return statSync(abs).isDirectory() ? abs : dirname(abs);
+		} catch {
+			// Path may not exist yet; use parent directory
+			return dirname(abs);
+		}
+	});
+
+	if (dirs.length === 1) return dirs[0];
+
+	// Multiple paths: find deepest common ancestor
+	const segments = dirs.map((d) => d.split(sep));
+	const minLen = Math.min(...segments.map((s) => s.length));
+	const common: string[] = [];
+	for (let i = 0; i < minLen; i++) {
+		if (segments.every((s) => s[i] === segments[0][i])) {
+			common.push(segments[0][i]);
+		} else {
+			break;
+		}
+	}
+
+	return common.length > 0 ? common.join(sep) : resolve(process.cwd());
 }

--- a/src/ignore.ts
+++ b/src/ignore.ts
@@ -87,12 +87,18 @@ export function resolveIgnoreBaseDir(paths: string[]): string {
 
 	if (dirs.length === 1) return dirs[0];
 
-	// Multiple paths: find deepest common ancestor
+	// Multiple paths: find deepest common ancestor.
+	// On Windows, drive letters are case-insensitive (c:\ === C:\),
+	// so we compare segments case-insensitively on win32.
+	const caseFold =
+		process.platform === "win32"
+			? (s: string) => s.toLowerCase()
+			: (s: string) => s;
 	const segments = dirs.map((d) => d.split(sep));
 	const minLen = Math.min(...segments.map((s) => s.length));
 	const common: string[] = [];
 	for (let i = 0; i < minLen; i++) {
-		if (segments.every((s) => s[i] === segments[0][i])) {
+		if (segments.every((s) => caseFold(s[i]) === caseFold(segments[0][i]))) {
 			common.push(segments[0][i]);
 		} else {
 			break;

--- a/tests/unit/c8ignore.test.ts
+++ b/tests/unit/c8ignore.test.ts
@@ -449,21 +449,23 @@ describe(".c8ignore", () => {
 			assert.deepStrictEqual(names, ["main.bpmn"]);
 		});
 
-		test("deploy explicit file uses parent dir for .c8ignore", () => {
-			// When deploying a single file, .c8ignore in the file's parent
-			// directory should be picked up as the base dir. We verify this
-			// by placing two files in the directory and ignoring one — the
-			// deploy of a single explicit file still uses that .c8ignore
-			// for its ignore-base resolution.
+		test("deploy explicit file resolves .c8ignore from file's parent dir", () => {
+			// When deploying an explicit file path, resolveIgnoreBaseDir
+			// should use the file's parent directory. We verify by deploying
+			// two explicit files from a directory that has a .c8ignore —
+			// one file matches the ignore rule and should be filtered out.
 			const projectDir = join(testDir, "project");
 			mkdirSync(projectDir, { recursive: true });
 			writeFileSync(join(projectDir, ".c8ignore"), "draft-*.bpmn\n");
 			writeFileSync(join(projectDir, "main.bpmn"), "<bpmn/>");
 			writeFileSync(join(projectDir, "draft-wip.bpmn"), "<bpmn/>");
 
-			// Deploying the directory from the parent — the .c8ignore in
-			// projectDir should filter out draft-wip.bpmn
-			const result = dryRunDeploy(testDir, ["./project/"]);
+			// Deploy two explicit files from the parent dir — .c8ignore in
+			// projectDir should filter out the draft file
+			const result = dryRunDeploy(testDir, [
+				"./project/main.bpmn",
+				"./project/draft-wip.bpmn",
+			]);
 			const names = resourceNames(result);
 			assert.deepStrictEqual(
 				names,

--- a/tests/unit/c8ignore.test.ts
+++ b/tests/unit/c8ignore.test.ts
@@ -379,6 +379,29 @@ describe(".c8ignore", () => {
 			const result = resolveIgnoreBaseDir([]);
 			assert.strictEqual(result, process.cwd());
 		});
+
+		test("resolveIgnoreBaseDir returns common ancestor for multiple sibling dirs", () => {
+			const dirA = join(testDir, "projA");
+			const dirB = join(testDir, "projB");
+			mkdirSync(dirA, { recursive: true });
+			mkdirSync(dirB, { recursive: true });
+			assert.strictEqual(
+				resolveIgnoreBaseDir([dirA, dirB]),
+				testDir,
+				"common ancestor of sibling dirs should be their parent",
+			);
+		});
+
+		test("resolveIgnoreBaseDir returns valid path for root-level divergence", () => {
+			// When paths diverge at the filesystem root, the result must
+			// still be a valid directory, not an empty string or bare drive.
+			const result = resolveIgnoreBaseDir([
+				join(testDir, "a"),
+				join(testDir, "b"),
+			]);
+			assert.ok(result.length > 0, "should not return an empty string");
+			assert.ok(!result.endsWith(":"), "should not return a bare drive letter");
+		});
 	});
 
 	// ── Target-directory resolution (#258) ───────────────────────────
@@ -509,6 +532,60 @@ describe(".c8ignore", () => {
 			assert.ok(
 				!output.includes("Change detected"),
 				`Watch should not detect changes in ignored directories, but got:\n${output}`,
+			);
+		});
+
+		test("watch target dir picks up .c8ignore from that dir (#258)", () => {
+			// Watch from a parent directory, targeting a subdirectory that has .c8ignore
+			const projectDir = join(testDir, "project");
+			mkdirSync(projectDir, { recursive: true });
+			writeFileSync(join(projectDir, ".c8ignore"), "ignored/\n");
+			mkdirSync(join(projectDir, "ignored"), { recursive: true });
+			writeFileSync(join(projectDir, "ignored", "hidden.bpmn"), "<bpmn/>");
+			writeFileSync(join(projectDir, "visible.bpmn"), "<bpmn/>");
+
+			const helperScript = `
+        const { spawn } = require('node:child_process');
+        const { writeFileSync } = require('node:fs');
+        const { join } = require('node:path');
+
+        const proc = spawn('node', [
+          '--experimental-strip-types',
+          ${JSON.stringify(CLI_ENTRY)},
+          'watch', './project/',
+        ], { stdio: 'pipe', cwd: ${JSON.stringify(testDir)} });
+
+        let output = '';
+        proc.stdout.on('data', d => output += d);
+        proc.stderr.on('data', d => output += d);
+
+        setTimeout(() => {
+          writeFileSync(join(${JSON.stringify(projectDir)}, 'ignored', 'hidden.bpmn'), '<updated/>');
+          setTimeout(() => {
+            proc.kill('SIGTERM');
+            process.stdout.write(output);
+            process.exit(0);
+          }, 1500);
+        }, 500);
+      `;
+
+			const result = spawnSync("node", ["-e", helperScript], {
+				encoding: "utf-8",
+				timeout: 5000,
+				cwd: testDir,
+				env: {
+					...process.env,
+					XDG_DATA_HOME: join(tmpdir(), `c8ctl-watch-ign-${Date.now()}`),
+				},
+			});
+
+			const output = (result.stdout ?? "") + (result.stderr ?? "");
+
+			// .c8ignore from project/ dir should be picked up even though
+			// watch was started from the parent (testDir)
+			assert.ok(
+				!output.includes("Change detected"),
+				`Watch should pick up .c8ignore from target dir, but got:\n${output}`,
 			);
 		});
 	});

--- a/tests/unit/c8ignore.test.ts
+++ b/tests/unit/c8ignore.test.ts
@@ -392,15 +392,20 @@ describe(".c8ignore", () => {
 			);
 		});
 
-		test("resolveIgnoreBaseDir returns valid path for root-level divergence", () => {
-			// When paths diverge at the filesystem root, the result must
-			// still be a valid directory, not an empty string or bare drive.
+		test("resolveIgnoreBaseDir always returns a normalized path", () => {
+			// The result must always be a valid directory path — never an
+			// empty string or a bare drive letter like "C:".
 			const result = resolveIgnoreBaseDir([
 				join(testDir, "a"),
 				join(testDir, "b"),
 			]);
 			assert.ok(result.length > 0, "should not return an empty string");
 			assert.ok(!result.endsWith(":"), "should not return a bare drive letter");
+			assert.strictEqual(
+				result,
+				testDir,
+				"should return common ancestor of sibling paths",
+			);
 		});
 	});
 
@@ -445,19 +450,26 @@ describe(".c8ignore", () => {
 		});
 
 		test("deploy explicit file uses parent dir for .c8ignore", () => {
-			// When deploying a single file, .c8ignore in the file's directory
-			// should be checked (though the explicit file itself bypasses
-			// extension filtering, it should still honour ignore rules for
-			// the base-dir resolution).
+			// When deploying a single file, .c8ignore in the file's parent
+			// directory should be picked up as the base dir. We verify this
+			// by placing two files in the directory and ignoring one — the
+			// deploy of a single explicit file still uses that .c8ignore
+			// for its ignore-base resolution.
 			const projectDir = join(testDir, "project");
 			mkdirSync(projectDir, { recursive: true });
-			writeFileSync(join(projectDir, ".c8ignore"), "");
+			writeFileSync(join(projectDir, ".c8ignore"), "draft-*.bpmn\n");
 			writeFileSync(join(projectDir, "main.bpmn"), "<bpmn/>");
+			writeFileSync(join(projectDir, "draft-wip.bpmn"), "<bpmn/>");
 
-			// Deploying a single explicit file from the parent dir
-			const result = dryRunDeploy(testDir, ["./project/main.bpmn"]);
+			// Deploying the directory from the parent — the .c8ignore in
+			// projectDir should filter out draft-wip.bpmn
+			const result = dryRunDeploy(testDir, ["./project/"]);
 			const names = resourceNames(result);
-			assert.deepStrictEqual(names, ["main.bpmn"]);
+			assert.deepStrictEqual(
+				names,
+				["main.bpmn"],
+				"draft-wip.bpmn should be ignored by project/.c8ignore",
+			);
 		});
 
 		test("deploy subdirectory picks up .c8ignore from subdirectory", () => {
@@ -544,6 +556,8 @@ describe(".c8ignore", () => {
 			writeFileSync(join(projectDir, "ignored", "hidden.bpmn"), "<bpmn/>");
 			writeFileSync(join(projectDir, "visible.bpmn"), "<bpmn/>");
 
+			// Helper waits for the "Watching for changes" readiness banner
+			// before writing a file, ensuring the watcher is actually live.
 			const helperScript = `
         const { spawn } = require('node:child_process');
         const { writeFileSync } = require('node:fs');
@@ -556,22 +570,45 @@ describe(".c8ignore", () => {
         ], { stdio: 'pipe', cwd: ${JSON.stringify(testDir)} });
 
         let output = '';
-        proc.stdout.on('data', d => output += d);
-        proc.stderr.on('data', d => output += d);
+        let ready = false;
+        proc.stdout.on('data', d => {
+          output += d;
+          if (!ready && output.includes('Watching for changes')) {
+            ready = true;
+            writeFileSync(join(${JSON.stringify(projectDir)}, 'ignored', 'hidden.bpmn'), '<updated/>');
+            setTimeout(() => {
+              proc.kill('SIGTERM');
+              process.stdout.write(output);
+              process.exit(0);
+            }, 1500);
+          }
+        });
+        proc.stderr.on('data', d => {
+          output += d;
+          if (!ready && output.includes('Watching for changes')) {
+            ready = true;
+            writeFileSync(join(${JSON.stringify(projectDir)}, 'ignored', 'hidden.bpmn'), '<updated/>');
+            setTimeout(() => {
+              proc.kill('SIGTERM');
+              process.stdout.write(output);
+              process.exit(0);
+            }, 1500);
+          }
+        });
 
+        // Safety timeout: if watch never starts, fail explicitly
         setTimeout(() => {
-          writeFileSync(join(${JSON.stringify(projectDir)}, 'ignored', 'hidden.bpmn'), '<updated/>');
-          setTimeout(() => {
+          if (!ready) {
             proc.kill('SIGTERM');
-            process.stdout.write(output);
-            process.exit(0);
-          }, 1500);
-        }, 500);
+            process.stderr.write('WATCH_NEVER_READY: ' + output);
+            process.exit(1);
+          }
+        }, 4000);
       `;
 
 			const result = spawnSync("node", ["-e", helperScript], {
 				encoding: "utf-8",
-				timeout: 5000,
+				timeout: 8000,
 				cwd: testDir,
 				env: {
 					...process.env,
@@ -580,6 +617,17 @@ describe(".c8ignore", () => {
 			});
 
 			const output = (result.stdout ?? "") + (result.stderr ?? "");
+
+			// Assert the watcher actually started (didn't silently fail)
+			assert.ok(
+				!output.includes("WATCH_NEVER_READY"),
+				`Watcher never reached readiness:\n${output}`,
+			);
+			assert.strictEqual(
+				result.status,
+				0,
+				`Helper script should exit cleanly, got status ${result.status}:\n${output}`,
+			);
 
 			// .c8ignore from project/ dir should be picked up even though
 			// watch was started from the parent (testDir)

--- a/tests/unit/c8ignore.test.ts
+++ b/tests/unit/c8ignore.test.ts
@@ -323,11 +323,13 @@ describe(".c8ignore", () => {
 		// Import the module functions directly
 		let loadIgnoreRules: typeof import("../../src/ignore.ts").loadIgnoreRules;
 		let isIgnored: typeof import("../../src/ignore.ts").isIgnored;
+		let resolveIgnoreBaseDir: typeof import("../../src/ignore.ts").resolveIgnoreBaseDir;
 
 		beforeEach(async () => {
 			const mod = await import("../../src/ignore.ts");
 			loadIgnoreRules = mod.loadIgnoreRules;
 			isIgnored = mod.isIgnored;
+			resolveIgnoreBaseDir = mod.resolveIgnoreBaseDir;
 		});
 
 		test("loadIgnoreRules returns ignore instance with defaults", () => {
@@ -358,6 +360,98 @@ describe(".c8ignore", () => {
 			assert.strictEqual(
 				isIgnored(ig, "/some/other/path/file.bpmn", testDir),
 				false,
+			);
+		});
+
+		test("resolveIgnoreBaseDir returns directory for a directory path", () => {
+			const subDir = join(testDir, "myproject");
+			mkdirSync(subDir, { recursive: true });
+			assert.strictEqual(resolveIgnoreBaseDir([subDir]), subDir);
+		});
+
+		test("resolveIgnoreBaseDir returns parent for a file path", () => {
+			const file = join(testDir, "process.bpmn");
+			writeFileSync(file, "<bpmn/>");
+			assert.strictEqual(resolveIgnoreBaseDir([file]), testDir);
+		});
+
+		test("resolveIgnoreBaseDir defaults to cwd for empty array", () => {
+			const result = resolveIgnoreBaseDir([]);
+			assert.strictEqual(result, process.cwd());
+		});
+	});
+
+	// ── Target-directory resolution (#258) ───────────────────────────
+
+	describe(".c8ignore resolves from target directory, not cwd (#258)", () => {
+		test("deploy target dir picks up .c8ignore from that dir", () => {
+			// Scenario from #258:
+			//   testDir/           ← cwd (no .c8ignore here)
+			//     project/
+			//       .c8ignore      ← contains "dist/"
+			//       main.bpmn
+			//       dist/
+			//         output.bpmn  ← should be ignored
+			const projectDir = join(testDir, "project");
+			mkdirSync(projectDir, { recursive: true });
+			writeFileSync(join(projectDir, ".c8ignore"), "dist/\n");
+			writeFileSync(join(projectDir, "main.bpmn"), "<bpmn/>");
+			mkdirSync(join(projectDir, "dist"), { recursive: true });
+			writeFileSync(join(projectDir, "dist", "output.bpmn"), "<bpmn/>");
+
+			// Deploy from parent (testDir as cwd), targeting ./project/
+			const result = dryRunDeploy(testDir, ["./project/"]);
+			const names = resourceNames(result);
+			assert.deepStrictEqual(
+				names,
+				["main.bpmn"],
+				"dist/output.bpmn should be ignored by project/.c8ignore",
+			);
+		});
+
+		test("deploy with no target still uses cwd (backward compat)", () => {
+			// .c8ignore at cwd should still work when no target is specified
+			writeFileSync(join(testDir, ".c8ignore"), "dist/\n");
+			writeFileSync(join(testDir, "main.bpmn"), "<bpmn/>");
+			mkdirSync(join(testDir, "dist"), { recursive: true });
+			writeFileSync(join(testDir, "dist", "output.bpmn"), "<bpmn/>");
+
+			const result = dryRunDeploy(testDir);
+			const names = resourceNames(result);
+			assert.deepStrictEqual(names, ["main.bpmn"]);
+		});
+
+		test("deploy explicit file uses parent dir for .c8ignore", () => {
+			// When deploying a single file, .c8ignore in the file's directory
+			// should be checked (though the explicit file itself bypasses
+			// extension filtering, it should still honour ignore rules for
+			// the base-dir resolution).
+			const projectDir = join(testDir, "project");
+			mkdirSync(projectDir, { recursive: true });
+			writeFileSync(join(projectDir, ".c8ignore"), "");
+			writeFileSync(join(projectDir, "main.bpmn"), "<bpmn/>");
+
+			// Deploying a single explicit file from the parent dir
+			const result = dryRunDeploy(testDir, ["./project/main.bpmn"]);
+			const names = resourceNames(result);
+			assert.deepStrictEqual(names, ["main.bpmn"]);
+		});
+
+		test("deploy subdirectory picks up .c8ignore from subdirectory", () => {
+			// .c8ignore in a subdirectory, deploy that subdirectory from grandparent
+			const subDir = join(testDir, "a", "b");
+			mkdirSync(subDir, { recursive: true });
+			writeFileSync(join(subDir, ".c8ignore"), "scratch/\n");
+			writeFileSync(join(subDir, "process.bpmn"), "<bpmn/>");
+			mkdirSync(join(subDir, "scratch"), { recursive: true });
+			writeFileSync(join(subDir, "scratch", "draft.bpmn"), "<bpmn/>");
+
+			const result = dryRunDeploy(testDir, ["./a/b/"]);
+			const names = resourceNames(result);
+			assert.deepStrictEqual(
+				names,
+				["process.bpmn"],
+				"scratch/draft.bpmn should be ignored by a/b/.c8ignore",
 			);
 		});
 	});


### PR DESCRIPTION
## Problem

When running `c8 deploy <target-directory>`, the `.c8ignore` file is loaded from `process.cwd()` rather than the target directory. This means ignore rules placed alongside the project are silently skipped when deploying from a parent directory.

```
/home/user/
  my-project/
    .c8ignore       ← expects this to be used
    main.bpmn
    dist/
      output.bpmn   ← should be ignored

$ cd /home/user
$ c8 deploy ./my-project/
# .c8ignore is looked up in /home/user/, not /home/user/my-project/
# → dist/output.bpmn is NOT ignored
```

## Fix

Add `resolveIgnoreBaseDir(paths)` in `src/ignore.ts` that determines the `.c8ignore` lookup directory from the paths passed to `deploy` or `watch`:

| Input | Base dir |
|-------|----------|
| Single directory | That directory |
| Single file | Its parent directory |
| Multiple paths | Deepest common ancestor |
| No args (default `["."]`) | `process.cwd()` (backward-compatible) |

Both `collectResourcesForPaths` (deploy) and the watch command now call `resolveIgnoreBaseDir()` instead of hardcoding `resolve(process.cwd())`.

## Tests

7 new tests in `tests/unit/c8ignore.test.ts`:
- **4 end-to-end** (via `dryRunDeploy`): target dir scenario from #258, backward compat, explicit file path, nested subdirectory
- **3 unit** for `resolveIgnoreBaseDir`: directory path, file path, empty array fallback

All 50 tests across c8ignore + deploy suites pass with zero regressions.

## Phase 1 of #260

This is the low-risk first phase of the [Process Application design epic](https://github.com/camunda/c8ctl/issues/260) — a standalone bugfix with no dependency on `.process-application` detection. Future phases will add upward traversal bounded by `.process-application`.

Closes #258