### PR TITLE
feat: scope plugin flag conflicts to GLOBAL_FLAGS only (#373)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -442,11 +442,29 @@ async function main() {
 		}
 
 		if (cmdFlagDefs) {
-			// Use built-in flags as a blacklist: start from the full built-in
-			// option set, then add plugin flags only when the name is not already
-			// taken. This prevents a plugin flag from silently changing a built-in
-			// flag's parse type.
-			const builtinOptions = deriveParseArgsOptions();
+			// Plugin flag scoping (#373): a plugin verb's effective flag
+			// namespace is `GLOBAL_FLAGS ∪ plugin.flags`. Use ONLY the
+			// global flags as the conflict source — never the union of
+			// every built-in verb's flags. Otherwise a plugin can't declare
+			// a flag like `--limit` (which lives in SEARCH_FLAGS, valid
+			// only on `search`/`get`) without being silently blocked, even
+			// though `--limit` is irrelevant to the plugin's verb.
+			//
+			// Globals are still treated as a hard conflict because the
+			// host strips them from argv before the plugin parser sees
+			// them, so a plugin's same-named flag would never receive a
+			// value (#364).
+			const builtinOptions: Record<
+				string,
+				{ type: "string" | "boolean"; short?: string }
+			> = {};
+			for (const [name, def] of Object.entries(GLOBAL_FLAGS)) {
+				const short = "short" in def ? def.short : undefined;
+				builtinOptions[name] = {
+					type: def.type,
+					...(short && { short }),
+				};
+			}
 			const builtinShorts = new Set(
 				Object.values(builtinOptions)
 					.map((o) => o.short)
@@ -461,7 +479,7 @@ async function main() {
 			const blockedFlags = new Set<string>();
 			for (const [name, def] of Object.entries(cmdFlagDefs)) {
 				if (Object.hasOwn(builtinOptions, name)) {
-					// A required plugin flag whose name collides with a built-in
+					// A required plugin flag whose name collides with a global
 					// flag is unsatisfiable: the token is always stripped from
 					// argv before the plugin parser sees it, so the required
 					// check downstream would always fire with the misleading
@@ -470,13 +488,13 @@ async function main() {
 					// actionable error instead.
 					if (def.required === true) {
 						logger.error(
-							`Plugin flag --${name} is declared required but conflicts with a built-in flag of the same name; ` +
+							`Plugin flag --${name} is declared required but conflicts with a global c8ctl flag of the same name; ` +
 								`it can never be satisfied. The plugin must rename this flag.`,
 						);
 						process.exit(1);
 					}
 					logger.warn(
-						`Plugin flag --${name} conflicts with a built-in flag and will not be parsed`,
+						`Plugin flag --${name} conflicts with a global c8ctl flag and will not be parsed`,
 					);
 					blockedFlags.add(name);
 					continue;
@@ -485,7 +503,7 @@ async function main() {
 					def.short && builtinShorts.has(def.short) ? undefined : def.short;
 				if (def.short && !short) {
 					logger.warn(
-						`Plugin flag --${name} short alias -${def.short} conflicts with a built-in alias and will be ignored`,
+						`Plugin flag --${name} short alias -${def.short} conflicts with a global c8ctl alias and will be ignored`,
 					);
 				}
 				mergedOptions[name] = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,15 +237,23 @@ export function stripGlobalFlags(argv: string[]): string[] {
  * Remove tokens for blocked plugin flags from an argv slice so they cannot
  * shift positionals during the plugin-flag re-parse.
  *
- * The built-in may declare a blocked flag as boolean while the plugin
- * declared it as string. In that case the user supplied a value token
- * (--name value) that the built-in parser leaves in positionals. We use
- * the PLUGIN's declared type to decide whether to strip a following token.
+ * Post-#373, "blocked" exclusively means "collides with a GLOBAL flag".
+ * The user may have supplied a value token (`--name value`) intending
+ * either:
+ *   - the GLOBAL's interpretation (global type === "string"), or
+ *   - the PLUGIN's interpretation (plugin type === "string", e.g. global
+ *     is boolean but the plugin declared the same name as string).
+ *
+ * Either way the value is meaningless to both sides (plugin's flag is
+ * blocked; global is consumed by the host elsewhere) and must not leak
+ * into the plugin's positional args. Strip the following non-flag token
+ * if either side typed the flag as string.
  */
 function stripBlockedFlagTokens(
 	argv: string[],
 	blocked: Set<string>,
 	pluginFlagDefs: Record<string, { type: string }>,
+	globalFlagDefs: Record<string, { type: string }>,
 ): string[] {
 	const out: string[] = [];
 	let i = 0;
@@ -255,9 +263,12 @@ function stripBlockedFlagTokens(
 			const eqIdx = arg.indexOf("=");
 			const name = eqIdx >= 0 ? arg.slice(2, eqIdx) : arg.slice(2);
 			if (blocked.has(name)) {
+				const eitherIsString =
+					pluginFlagDefs[name]?.type === "string" ||
+					globalFlagDefs[name]?.type === "string";
 				if (
 					eqIdx < 0 &&
-					pluginFlagDefs[name]?.type === "string" &&
+					eitherIsString &&
 					i + 1 < argv.length &&
 					!argv[i + 1].startsWith("-")
 				) {
@@ -511,10 +522,19 @@ async function main() {
 					...(short && { short }),
 				};
 			}
+			// Strip blocked-flag tokens from argv before re-parse. Blocked
+			// names exclusively collide with GLOBAL_FLAGS (post-#373), but
+			// `mergedOptions` carries the global type for those names, so
+			// parseArgs alone would consume only the value of *string*
+			// globals — leaving the value of a *boolean* global behind to
+			// drift into positionals when the plugin typed the same name
+			// as string. The helper consults both type tables and strips
+			// the following non-flag token when either side is string.
 			const filteredArgv = stripBlockedFlagTokens(
 				process.argv.slice(2),
 				blockedFlags,
 				cmdFlagDefs,
+				builtinOptions,
 			);
 			let pluginParsed: ReturnType<typeof parseArgs>;
 			try {

--- a/tests/fixtures/plugins/plugin-with-verb-scoped-flag/c8ctl-plugin.js
+++ b/tests/fixtures/plugins/plugin-with-verb-scoped-flag/c8ctl-plugin.js
@@ -1,0 +1,49 @@
+/**
+ * Test fixture for #373.
+ *
+ * This plugin declares a verb (`verb-scoped-demo`) whose flags collide
+ * with **verb-scoped** built-in flag names (e.g. `limit`, which lives
+ * in `SEARCH_FLAGS` and is therefore valid only on `search` and `get`).
+ *
+ * Today's flat-namespace parser (`deriveParseArgsOptions()`) unions every
+ * verb's flags into one global option set, so the plugin pre-parse
+ * blocks `--limit` for ANY plugin verb on the grounds that it collides
+ * with the union — even though `--limit` is not a global flag and would
+ * never be relevant to this plugin's verb.
+ *
+ * Under the per-verb scoping that #373 introduces, a plugin verb's
+ * effective flag table is `GLOBAL_FLAGS ∪ plugin.flags`. `--limit` is
+ * not in `GLOBAL_FLAGS`, so the plugin's `--limit` should be parsed
+ * and forwarded to the handler.
+ *
+ * The handler echoes args + flags as JSON so the contract test can
+ * assert what value (if any) reached it.
+ */
+
+export const commands = {
+	'verb-scoped-demo': {
+		flags: {
+			limit: {
+				type: 'string',
+				description: "Plugin's own --limit (collides with SEARCH_FLAGS.limit)",
+			},
+			between: {
+				type: 'string',
+				description: "Plugin's own --between (collides with SEARCH_FLAGS.between)",
+			},
+		},
+		handler: async (args, flags) => {
+			console.log(JSON.stringify({ args, flags: flags || {} }));
+		},
+	},
+};
+
+export const metadata = {
+	name: 'plugin-with-verb-scoped-flag',
+	description: 'Fixture pinning the per-verb flag scoping contract for #373',
+	commands: {
+		'verb-scoped-demo': {
+			description: 'Echoes args and flags as JSON for contract assertions',
+		},
+	},
+};

--- a/tests/fixtures/plugins/plugin-with-verb-scoped-flag/c8ctl-plugin.js
+++ b/tests/fixtures/plugins/plugin-with-verb-scoped-flag/c8ctl-plugin.js
@@ -36,6 +36,22 @@ export const commands = {
 			console.log(JSON.stringify({ args, flags: flags || {} }));
 		},
 	},
+	// Pinned by Copilot review on PR #376: a plugin declaring a flag that
+	// collides with a *global string* flag (here `--profile`) but typing it
+	// as `boolean` must not let the global's value token leak into the
+	// plugin's positional args. Echoes args+flags so the contract test can
+	// assert positional shape.
+	'boolean-profile-collision': {
+		flags: {
+			profile: {
+				type: 'boolean',
+				description: "Plugin's own --profile typed as boolean (collides with GLOBAL --profile string)",
+			},
+		},
+		handler: async (args, flags) => {
+			console.log(JSON.stringify({ args, flags: flags || {} }));
+		},
+	},
 };
 
 export const metadata = {

--- a/tests/fixtures/plugins/plugin-with-verb-scoped-flag/package.json
+++ b/tests/fixtures/plugins/plugin-with-verb-scoped-flag/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "c8ctl-plugin-verb-scoped-flag",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "c8ctl-plugin.js",
+  "keywords": ["c8ctl-plugin"],
+  "description": "Test fixture for #373: a plugin that declares flag names which collide with verb-scoped (not global) built-in flags. Used to pin the contract that under per-verb flag scoping, a plugin verb's --limit (which is a SEARCH_FLAGS entry, not a GLOBAL_FLAGS entry) must reach the plugin handler instead of being blocked by the global-union pre-parse."
+}

--- a/tests/unit/plugin-flag-scoping-contract.test.ts
+++ b/tests/unit/plugin-flag-scoping-contract.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Plugin flag scoping contract tests for #373.
+ *
+ * Pins the contract that a plugin verb's flag namespace is scoped to
+ * `GLOBAL_FLAGS ∪ plugin.flags` — NOT the global union of every verb's
+ * flags in the registry. Today's flat-namespace parser unions every
+ * verb's flags via `deriveParseArgsOptions()` and uses that union as
+ * the blacklist for plugin flags, which silently breaks plugins that
+ * happen to declare a flag name shared with any built-in verb (e.g.
+ * `--limit`, which lives in `SEARCH_FLAGS`).
+ *
+ * The motivating user story:
+ *
+ *   > A contributed plugin wants to use `--limit` but can't because it
+ *   > is used by core (`search`).
+ *
+ * `--limit` is not in `GLOBAL_FLAGS`. Under per-verb scoping it must
+ * reach the plugin handler when the user invokes the plugin verb. Under
+ * the current flat parser, the plugin pre-parse blocks it and prints a
+ * `Plugin flag --limit conflicts with a built-in flag and will not be
+ * parsed` warning — exactly the wrong outcome.
+ *
+ * RED phase: tests assert the desired post-#373 behaviour and are
+ * expected to FAIL against `main`. They become GREEN when the per-verb
+ * flag scoping refactor lands.
+ *
+ * The fixture lives at
+ * `tests/fixtures/plugins/plugin-with-verb-scoped-flag/`. It is installed
+ * per-test into a temp `C8CTL_DATA_DIR` so other tests can't see it.
+ */
+
+import assert from "node:assert";
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, test } from "node:test";
+import { GLOBAL_FLAGS } from "../../src/command-registry.ts";
+import { isRecord } from "../../src/logger.ts";
+import { asyncSpawn, type SpawnResult } from "../utils/spawn.ts";
+
+const FIXTURE_DIR = join(
+	process.cwd(),
+	"tests",
+	"fixtures",
+	"plugins",
+	"plugin-with-verb-scoped-flag",
+);
+const PLUGIN_PKG_NAME = "c8ctl-plugin-verb-scoped-flag";
+const PLUGIN_VERB = "verb-scoped-demo";
+
+let testDataDir: string;
+
+beforeEach(() => {
+	testDataDir = mkdtempSync(join(tmpdir(), "c8ctl-flag-scope-"));
+	writeFileSync(
+		join(testDataDir, "session.json"),
+		JSON.stringify({ outputMode: "json" }),
+	);
+	const installDir = join(
+		testDataDir,
+		"plugins",
+		"node_modules",
+		PLUGIN_PKG_NAME,
+	);
+	mkdirSync(installDir, { recursive: true });
+	cpSync(FIXTURE_DIR, installDir, { recursive: true });
+});
+
+afterEach(() => {
+	rmSync(testDataDir, { recursive: true, force: true });
+});
+
+/** Spawn the CLI with the per-test data dir + plugin install. */
+async function c8Plugin(...args: string[]): Promise<SpawnResult> {
+	const env: NodeJS.ProcessEnv = {
+		...process.env,
+		CAMUNDA_BASE_URL: "http://test-cluster/v2",
+		HOME: "/tmp/c8ctl-test-nonexistent-home",
+		C8CTL_DATA_DIR: testDataDir,
+	};
+	// Mirror tests/utils/cli.ts: scrub debug env vars so host environment
+	// can't add stderr noise that breaks our warning-shape assertions.
+	delete env.DEBUG;
+	delete env.C8CTL_DEBUG;
+	delete env.NODE_DEBUG;
+	delete env.NODE_OPTIONS;
+	return asyncSpawn(
+		"node",
+		["--experimental-strip-types", "src/index.ts", ...args],
+		{
+			env,
+			timeout: 10_000,
+		},
+	);
+}
+
+function parseJsonRecord(stdout: string): Record<string, unknown> {
+	const trimmed = stdout.trim();
+	// The CLI may emit multiple JSON objects (e.g. a warning followed by
+	// the handler payload). Walk lines and return the LAST line that
+	// parses as an object — the handler payload is always last.
+	const lines = trimmed.split("\n").filter((l) => l.length > 0);
+	for (let i = lines.length - 1; i >= 0; i--) {
+		const line = lines[i];
+		if (line === undefined) continue;
+		try {
+			const parsed: unknown = JSON.parse(line);
+			if (isRecord(parsed)) return parsed;
+		} catch {
+			// Not JSON; keep walking.
+		}
+	}
+	throw new Error(`No JSON object found in stdout:\n${stdout}`);
+}
+
+// ─── A. Sanity: the fixture loads and dispatches at all ──────────────────────
+
+describe("plugin flag scoping contract: fixture is loadable", () => {
+	test("plugin verb is dispatched (sanity check)", async () => {
+		// If this fails, the entire suite is meaningless — every other test
+		// here depends on the fixture being installed and reachable.
+		const result = await c8Plugin(PLUGIN_VERB);
+		assert.strictEqual(
+			result.status,
+			0,
+			`expected exit 0, got ${result.status}. stderr: ${result.stderr}`,
+		);
+		const parsed = parseJsonRecord(result.stdout);
+		assert.ok(
+			isRecord(parsed.flags),
+			`expected handler payload with .flags, got: ${JSON.stringify(parsed)}`,
+		);
+	});
+});
+
+// ─── B. The motivating bug: --limit is verb-scoped, not global ───────────────
+
+describe("plugin flag scoping contract: verb-scoped built-in flags do not block plugins", () => {
+	test("--limit is not a global flag (precondition for the contract)", () => {
+		// If --limit ever moves to GLOBAL_FLAGS the contract changes shape:
+		// the plugin would then have to use a different name. Pin the
+		// precondition so a future global-promotion is caught loudly.
+		assert.ok(
+			!Object.hasOwn(GLOBAL_FLAGS, "limit"),
+			"--limit must remain a verb-scoped flag (currently in SEARCH_FLAGS) for #373's contract to apply.",
+		);
+	});
+
+	test("plugin verb's --limit reaches the handler with the user-supplied value", async () => {
+		// The motivating user story: a plugin declares its own --limit and
+		// the user invokes the plugin verb with --limit=42. Today the
+		// plugin pre-parse blocks --limit (because the flat union sees it
+		// in SEARCH_FLAGS) and the handler is called with empty flags.
+		// Under per-verb scoping, --limit is parsed against the plugin's
+		// own flag table and the value reaches the handler.
+		const result = await c8Plugin(PLUGIN_VERB, "--limit=42");
+		assert.strictEqual(
+			result.status,
+			0,
+			`expected exit 0, got ${result.status}. stderr: ${result.stderr}`,
+		);
+		const parsed = parseJsonRecord(result.stdout);
+		assert.ok(
+			isRecord(parsed.flags),
+			`expected handler payload, got: ${JSON.stringify(parsed)}`,
+		);
+		assert.strictEqual(
+			parsed.flags.limit,
+			"42",
+			`expected flags.limit === "42" to reach plugin handler, got: ${JSON.stringify(parsed.flags)}`,
+		);
+	});
+
+	test("no warning is printed about --limit conflicting with a built-in", async () => {
+		// Today the plugin pre-parse prints `Plugin flag --limit conflicts
+		// with a built-in flag and will not be parsed`. Under the scoped
+		// model that warning is wrong — there is no conflict in the
+		// plugin's namespace — and must not appear.
+		const result = await c8Plugin(PLUGIN_VERB, "--limit=42");
+		const combined = `${result.stdout}\n${result.stderr}`;
+		assert.ok(
+			!combined.includes("--limit conflicts with a built-in flag"),
+			`expected no built-in-conflict warning for plugin's --limit. got:\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+		);
+	});
+
+	test("class-scoped: every verb-scoped flag the plugin declares reaches the handler", async () => {
+		// Class-scoped guard against the same defect recurring on a sibling
+		// flag. The fixture declares both --limit AND --between (also in
+		// SEARCH_FLAGS). Today both are blocked; under per-verb scoping
+		// both must round-trip.
+		const result = await c8Plugin(
+			PLUGIN_VERB,
+			"--limit=7",
+			"--between=2024-01-01..2024-12-31",
+		);
+		assert.strictEqual(
+			result.status,
+			0,
+			`expected exit 0, got ${result.status}. stderr: ${result.stderr}`,
+		);
+		const parsed = parseJsonRecord(result.stdout);
+		assert.ok(
+			isRecord(parsed.flags),
+			`expected handler payload, got: ${JSON.stringify(parsed)}`,
+		);
+		assert.deepStrictEqual(
+			{ limit: parsed.flags.limit, between: parsed.flags.between },
+			{ limit: "7", between: "2024-01-01..2024-12-31" },
+			`expected both verb-scoped flags to reach the handler. got: ${JSON.stringify(parsed.flags)}`,
+		);
+	});
+});
+
+// ─── C. Globals still belong to the host, not the plugin ─────────────────────
+
+describe("plugin flag scoping contract: GLOBAL_FLAGS remain host-owned", () => {
+	test("--profile (a global) is consumed by the host even on a plugin verb", async () => {
+		// The mirror of the contract above: a global flag is owned by the
+		// host's stage-1 parse; the plugin must NOT see it in flags. This
+		// already works today (the host always strips globals before
+		// invoking the plugin) and the contract pins it so the per-verb
+		// scoping refactor cannot accidentally hand globals to plugins.
+		const result = await c8Plugin(
+			"--profile=__nonexistent__",
+			PLUGIN_VERB,
+			"--limit=1",
+		);
+		assert.strictEqual(
+			result.status,
+			0,
+			`expected exit 0, got ${result.status}. stderr: ${result.stderr}`,
+		);
+		const parsed = parseJsonRecord(result.stdout);
+		assert.ok(
+			isRecord(parsed.flags),
+			`expected handler payload, got: ${JSON.stringify(parsed)}`,
+		);
+		assert.ok(
+			!("profile" in parsed.flags),
+			`expected --profile to be consumed by the host, not visible to the plugin. got flags: ${JSON.stringify(parsed.flags)}`,
+		);
+	});
+});

--- a/tests/unit/plugin-flag-scoping-contract.test.ts
+++ b/tests/unit/plugin-flag-scoping-contract.test.ts
@@ -242,3 +242,49 @@ describe("plugin flag scoping contract: GLOBAL_FLAGS remain host-owned", () => {
 		);
 	});
 });
+
+// ─── D. Boolean-vs-string global collision must not shift positionals ────────
+
+describe("plugin flag scoping contract: global-string collision keeps plugin positionals intact", () => {
+	// Class-scoped guard for the edge case Copilot raised on PR #376:
+	// when a plugin declares a flag whose name collides with a GLOBAL
+	// string flag (e.g. --profile) but types it as `boolean`, the host
+	// must still consume the global's value token from argv. Otherwise
+	// the leftover value drifts into the plugin's positional args.
+	//
+	// Today the plugin pre-parse blocks the colliding name and the
+	// downstream `stripBlockedFlagTokens` decides whether to also strip
+	// the following token by consulting the *plugin's* declared type.
+	// Boolean → don't strip → value leaks into positionals. The fix is
+	// to consult the GLOBAL type (string) for blocked-because-global
+	// flags, or to let parseArgs consume the token via the merged
+	// options table directly (mergedOptions still carries the global's
+	// type for that name).
+	test("plugin's positional args are not shifted by a global-string flag's value", async () => {
+		const result = await c8Plugin(
+			"boolean-profile-collision",
+			"--profile",
+			"some-profile-value",
+			"pos1",
+		);
+		assert.strictEqual(
+			result.status,
+			0,
+			`expected exit 0, got ${result.status}. stderr: ${result.stderr}`,
+		);
+		const parsed = parseJsonRecord(result.stdout);
+		assert.ok(
+			Array.isArray(parsed.args),
+			`expected handler payload with .args, got: ${JSON.stringify(parsed)}`,
+		);
+		assert.deepStrictEqual(
+			parsed.args,
+			["pos1"],
+			`expected positional args to be ["pos1"]. The global --profile's value ("some-profile-value") must be consumed by the host, not leak into plugin positionals. got: ${JSON.stringify(parsed.args)}`,
+		);
+		assert.ok(
+			isRecord(parsed.flags) && !("profile" in parsed.flags),
+			`expected plugin flags to NOT include profile (it's a global). got: ${JSON.stringify(parsed.flags)}`,
+		);
+	});
+});

--- a/tests/unit/plugin-flags.test.ts
+++ b/tests/unit/plugin-flags.test.ts
@@ -240,7 +240,7 @@ describe("Plugin Flags CLI subprocess — required + built-in collision (#364)",
 		);
 		assert.ok(
 			result.stderr.includes(
-				"is declared required but conflicts with a built-in flag",
+				"is declared required but conflicts with a global c8ctl flag",
 			),
 			`expected new actionable error sentence. stderr: ${result.stderr}`,
 		);
@@ -273,8 +273,8 @@ describe("Plugin Flags CLI subprocess — required + built-in collision (#364)",
 			`expected exit 1, got ${result.status}. stderr: ${result.stderr}`,
 		);
 		assert.ok(
-			result.stderr.includes("built-in"),
-			`expected error mentioning built-in collision. stderr: ${result.stderr}`,
+			result.stderr.includes("global c8ctl flag"),
+			`expected error mentioning global flag collision. stderr: ${result.stderr}`,
 		);
 	});
 });


### PR DESCRIPTION
## Summary

Fixes the motivating bug behind #373: a contributed plugin couldn't declare common flag names like `--limit`, `--between`, `--sortBy`, `--asc`, `--desc`, or `--dateField` because the host's plugin pre-parse blacklisted the **union of every built-in verb's flags**, even though those flags are scoped to specific verbs (e.g. `--limit` is in `SEARCH_FLAGS`, valid only on `search`/`get`).

PR #374 (the `--help` gate) addressed one defect class behind #373 but left this one open. This PR closes it.

## Change

The plugin pre-parse blacklist source is now `GLOBAL_FLAGS` only (the seven flags the host always strips: `help`, `version`, `profile`, `dry-run`, `verbose`, `fields`, `json`) instead of `deriveParseArgsOptions()` (the union of every built-in verb's flags).

A plugin verb's effective flag namespace is now `GLOBAL_FLAGS ∪ plugin.flags`. Globals are still hard conflicts — they're stripped from argv before the plugin parser runs (#364), so a plugin's same-named flag would never receive a value. Verb-scoped built-in flags are no longer treated as conflicts.

The collision warning/error wording moved from "built-in flag" → "global c8ctl flag" to reflect the narrower scope.

## Tests

Two commits on this branch:

1. **RED** (`b39e6f9`): adds [tests/unit/plugin-flag-scoping-contract.test.ts](tests/unit/plugin-flag-scoping-contract.test.ts) and a fixture plugin that declares `--limit` and `--between` (both `SEARCH_FLAGS` entries). 6 tests / 3 fail on `main` for the right reasons.
2. **GREEN** (`6694892`): the production fix. All 6 contract tests pass; full unit suite 1539/1539.

Two existing assertions in [tests/unit/plugin-flags.test.ts](tests/unit/plugin-flags.test.ts) (the `#364` required-collision tests) were updated from `"built-in flag"` → `"global c8ctl flag"`. The colliding fixture there uses `--profile` (a global), so the runtime behaviour is unchanged — only the message text moved.

## Verification

- `npx tsc --noEmit -p tsconfig.check.json` — clean
- `npx biome check` — clean
- `npm run test:unit` — 1539/1539 pass

Closes #373
