### PR TITLE
feat: plugin host context, declarative --help, and --version (#377)

### DIFF
--- a/src/help.ts
+++ b/src/help.ts
@@ -16,7 +16,6 @@ import {
 } from "./command-registry.ts";
 import { getLogger } from "./logger.ts";
 import {
-	executePluginCommand,
 	getPluginCommandsInfo,
 	isPluginCommand,
 	type PluginCommandInfo,
@@ -810,6 +809,98 @@ function showVirtualTopicHelp(topic: string, resource: string): void {
 }
 
 /**
+ * Render help for a flag-aware (non-passthrough) plugin command (#377).
+ *
+ * The host owns rendering so the boundary stays declarative: plugins
+ * declare metadata + typed `flags`, the host renders. In JSON mode the
+ * payload mirrors the registry-driven `showCommandHelp` shape with a
+ * `kind: "plugin"` discriminator and `pluginName` / `pluginVersion`
+ * identification, so agents can tell a plugin verb apart from a
+ * built-in.
+ */
+function showFlagAwarePluginHelp(command: string): void {
+	const logger = getLogger();
+	const pluginInfo = getPluginCommandsInfo().find(
+		(p) => p.commandName === command,
+	);
+	if (!pluginInfo) {
+		showGenericVerbHelp(command);
+		return;
+	}
+
+	if (logger.mode === "json") {
+		const version = getVersion();
+		const pluginCommandsInfo = getPluginCommandsInfo();
+		const allHelp = buildHelpJson(version, pluginCommandsInfo);
+		logger.json({
+			command,
+			verb: command,
+			kind: "plugin",
+			pluginName: pluginInfo.pluginName,
+			pluginVersion: pluginInfo.pluginVersion,
+			description: pluginInfo.description ?? "",
+			helpDescription: pluginInfo.helpDescription,
+			flags: pluginInfo.flags
+				? Object.fromEntries(
+						Object.entries(pluginInfo.flags).map(([name, def]) => [
+							name,
+							{
+								type: def.type,
+								description: def.description ?? "",
+								...(def.short ? { short: def.short } : {}),
+								...(def.required ? { required: true } : {}),
+							},
+						]),
+					)
+				: {},
+			examples: pluginInfo.examples ?? [],
+			globalFlags: allHelp.globalFlags,
+			searchFlags: allHelp.searchFlags,
+			agentFlags: allHelp.agentFlags,
+		});
+		return;
+	}
+
+	const lines: string[] = [];
+	const description = pluginInfo.description?.trim();
+	lines.push(
+		description ? `c8ctl ${command} — ${description}` : `c8ctl ${command}`,
+	);
+	lines.push(
+		`  (plugin: ${pluginInfo.pluginName} ${pluginInfo.pluginVersion})`,
+	);
+	if (pluginInfo.helpDescription) {
+		lines.push("");
+		lines.push(pluginInfo.helpDescription);
+	}
+	if (pluginInfo.flags && Object.keys(pluginInfo.flags).length > 0) {
+		lines.push("");
+		lines.push("Flags:");
+		const FLAG_COL = 28;
+		for (const [name, def] of Object.entries(pluginInfo.flags)) {
+			lines.push(formatFlag(name, def, FLAG_COL));
+		}
+	}
+	if (pluginInfo.subcommands && pluginInfo.subcommands.length > 0) {
+		lines.push("");
+		lines.push("Subcommands:");
+		const SUB_COL = 16;
+		for (const sub of pluginInfo.subcommands) {
+			lines.push(`  ${sub.name.padEnd(SUB_COL)}${sub.description}`);
+		}
+	}
+	if (pluginInfo.examples && pluginInfo.examples.length > 0) {
+		lines.push("");
+		lines.push("Examples:");
+		for (const ex of pluginInfo.examples) {
+			lines.push(`  ${ex.command}`);
+			lines.push(`      ${ex.description}`);
+		}
+	}
+	logger.info(lines.join("\n"));
+}
+
+/**
  * Show detailed help for a specific command.
  * Dispatches to the generic renderer for all verbs.
  */
@@ -930,10 +1021,15 @@ export async function showCommandHelp(command: string): Promise<void> {
 	}
 
 	// If the verb is still not in the registry, check if it's a plugin command.
-	// Delegate to the plugin's own handler which renders its own help output.
+	// Render the plugin's declarative help (#377) — derived from
+	// `metadata.commands[verb]` plus typed `flags` declarations. The
+	// plugin's own handler is NOT invoked; previously help was rendered
+	// by side-effect of calling the handler with no args, which leaked
+	// the boundary between host and plugin (the plugin had to know it
+	// was being asked for help, parse argv itself, and produce a
+	// consistent shape — none of which it could be relied on to do).
 	if (!lookupVerb(resolvedVerb) && isPluginCommand(resolvedVerb)) {
-		// Plugin handlers show help when called with no valid subcommand
-		await executePluginCommand(resolvedVerb, []);
+		showFlagAwarePluginHelp(resolvedVerb);
 		return;
 	}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,8 +31,10 @@ import { getLogger, type SortOrder } from "./logger.ts";
 import {
 	executePluginCommand,
 	getPluginCommands,
+	getPluginVersionForCommand,
 	isPassthroughPluginCommand,
 	loadInstalledPlugins,
+	type PluginCtx,
 } from "./plugin-loader.ts";
 import { c8ctl } from "./runtime.ts";
 import { printUpdateNotification, startUpdateCheck } from "./update-check.ts";
@@ -435,6 +437,47 @@ async function main() {
 		const cmd = pluginCommands[verb];
 		const cmdFlagDefs = typeof cmd !== "function" ? cmd.flags : undefined;
 
+		// Plugin --version (#377): when a plugin verb is invoked with
+		// --version, print the plugin's package version and identifying
+		// name, not c8ctl's. Routed before any other plugin dispatch so
+		// the handler is never called.
+		if (values.version) {
+			const info = getPluginVersionForCommand(verb);
+			if (info) {
+				if (logger.mode === "json") {
+					logger.json({
+						kind: "plugin-version",
+						verb,
+						pluginName: info.pluginName,
+						version: info.version,
+					});
+				} else {
+					logger.info(`${info.pluginName} ${info.version}`);
+				}
+				return;
+			}
+		}
+
+		// Construct the plugin host context (#377). Lazy `client` getter
+		// mirrors the built-in CommandContext pattern so plugins that
+		// never touch a Camunda client (e.g. local-only utilities) do
+		// not trigger credential resolution by virtue of receiving ctx.
+		const pluginProfile =
+			str(values.profile) ?? c8ctl.activeProfile ?? "default";
+		let _pluginClient: ReturnType<typeof createClient> | undefined;
+		const pluginCtx: PluginCtx = {
+			profile: pluginProfile,
+			dryRun: c8ctl.dryRun === true,
+			verbose: c8ctl.verbose === true,
+			outputMode: c8ctl.outputMode,
+			fields: c8ctl.fields,
+			logger,
+			get client() {
+				if (!_pluginClient) _pluginClient = createClient(pluginProfile);
+				return _pluginClient;
+			},
+		};
+
 		// Passthrough plugin contract (#366): strip GLOBAL_FLAGS from the
 		// raw argv following the verb token and forward the rest verbatim.
 		// GLOBAL_FLAGS already affect the c8ctl runtime via their regular
@@ -572,9 +615,15 @@ async function main() {
 				verb,
 				_resource ? [_resource, ...pluginArgs] : pluginArgs,
 				extractedFlags,
+				pluginCtx,
 			);
 		} else {
-			await executePluginCommand(verb, resource ? [resource, ...args] : args);
+			await executePluginCommand(
+				verb,
+				resource ? [resource, ...args] : args,
+				undefined,
+				pluginCtx,
+			);
 		}
 		return;
 	}

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -4,14 +4,52 @@
 
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import type { CamundaClient } from "@camunda8/orchestration-cluster-api";
 import type { FlagDef } from "./command-registry.ts";
 import { ensurePluginsDir } from "./config.ts";
-import { getLogger } from "./logger.ts";
+import { getLogger, type Logger, type OutputMode } from "./logger.ts";
 import { c8ctl } from "./runtime.ts";
+
+/**
+ * Typed, documented host context passed to plugin command handlers as
+ * the third argument (#377).
+ *
+ * Reflects every member of `GLOBAL_FLAGS` whose value is meaningful to
+ * a plugin handler; `help` and `version` are intentionally absent
+ * because they are intercepted by the host before dispatch. The
+ * class-scoped contract test
+ * (`tests/unit/plugin-host-context-contract.test.ts`) pins this
+ * relationship.
+ *
+ * `client` is exposed as a lazy getter so plugins that never need a
+ * Camunda client (e.g. local-only utilities, session inspectors) do
+ * not trigger credential resolution simply by receiving the ctx.
+ *
+ * Plugins authored before #377 use the two-argument signature
+ * `(args, flags)` — the third argument is additive and JavaScript's
+ * variadic call semantics keep those handlers working unchanged.
+ */
+export interface PluginCtx {
+	/** Resolved active profile name (from `--profile` or session). */
+	profile: string;
+	/** True when `--dry-run` is set. Plugins SHOULD honour this. */
+	dryRun: boolean;
+	/** True when `--verbose` is set. */
+	verbose: boolean;
+	/** Effective output mode (`--json` toggles to `json`). */
+	outputMode: OutputMode;
+	/** Parsed `--fields a,b,c` list, or undefined when not set. */
+	fields?: string[];
+	/** Host logger — use `logger.json(...)` for structured output. */
+	logger: Logger;
+	/** Lazily-resolved Camunda client. Reading triggers credential resolution. */
+	readonly client: CamundaClient;
+}
 
 type CommandHandler = (
 	args: string[],
 	flags?: Record<string, unknown>,
+	ctx?: PluginCtx,
 ) => Promise<void>;
 
 interface CommandWithFlags {
@@ -70,6 +108,8 @@ export interface PluginCommandMeta {
 
 interface LoadedPlugin {
 	name: string;
+	/** Plugin package version from its `package.json#version`. */
+	version: string;
 	commands: PluginCommands;
 	metadata?: PluginMetadata;
 }
@@ -323,6 +363,11 @@ async function loadDefaultPlugins(): Promise<void> {
 				// Read package.json
 				const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
 				const pluginName = packageJson.name || `default-${pluginDir}`;
+				const pluginVersion =
+					typeof packageJson.version === "string" &&
+					packageJson.version.length > 0
+						? packageJson.version
+						: "0.0.0";
 
 				// Check for duplicate plugin name BEFORE the dynamic import
 				// so a duplicate-name plugin's module code never runs (the
@@ -344,6 +389,7 @@ async function loadDefaultPlugins(): Promise<void> {
 				if (plugin.commands && typeof plugin.commands === "object") {
 					const loaded: LoadedPlugin = {
 						name: pluginName,
+						version: pluginVersion,
 						commands: { ...plugin.commands },
 						metadata: plugin.metadata || {},
 					};
@@ -489,6 +535,11 @@ export async function loadInstalledPlugins(): Promise<void> {
 					typeof packageJson.name === "string" && packageJson.name.length > 0
 						? packageJson.name
 						: packageName;
+				const pluginVersion =
+					typeof packageJson.version === "string" &&
+					packageJson.version.length > 0
+						? packageJson.version
+						: "0.0.0";
 
 				// Check for duplicate plugin name BEFORE the dynamic import
 				// so a duplicate-name plugin's module code never runs (the
@@ -506,6 +557,7 @@ export async function loadInstalledPlugins(): Promise<void> {
 				if (plugin.commands && typeof plugin.commands === "object") {
 					const loaded: LoadedPlugin = {
 						name: pluginName,
+						version: pluginVersion,
 						commands: { ...plugin.commands },
 						metadata: plugin.metadata || {},
 					};
@@ -542,12 +594,19 @@ export function getPluginCommands(): PluginCommands {
 }
 
 /**
- * Execute a plugin command if it exists
+ * Execute a plugin command if it exists.
+ *
+ * `ctx` is the typed host context introduced in #377. When provided it
+ * is passed as the third handler argument; legacy two-argument
+ * handlers ignore it. When omitted the call site is treating the
+ * plugin as a fire-and-forget passthrough/help-render shim and
+ * intentionally does not construct a client.
  */
 export async function executePluginCommand(
 	commandName: string,
 	args: string[],
 	flags?: Record<string, unknown>,
+	ctx?: PluginCtx,
 ): Promise<boolean> {
 	const commands = getPluginCommands();
 	const cmd = Object.hasOwn(commands, commandName)
@@ -556,18 +615,36 @@ export async function executePluginCommand(
 
 	if (cmd) {
 		if (typeof cmd === "function") {
-			if (flags !== undefined) {
+			if (ctx !== undefined) {
+				await cmd(args, flags, ctx);
+			} else if (flags !== undefined) {
 				await cmd(args, flags);
 			} else {
 				await cmd(args);
 			}
 		} else {
-			await cmd.handler(args, flags);
+			await cmd.handler(args, flags, ctx);
 		}
 		return true;
 	}
 
 	return false;
+}
+
+/**
+ * Look up the loaded version of a plugin by command name. Returns
+ * `undefined` if no plugin owns the command. Used by `--version` on a
+ * plugin verb to print the plugin's package version (#377).
+ */
+export function getPluginVersionForCommand(
+	commandName: string,
+): { pluginName: string; version: string } | undefined {
+	for (const plugin of loadedPlugins.values()) {
+		if (Object.hasOwn(plugin.commands, commandName)) {
+			return { pluginName: plugin.name, version: plugin.version };
+		}
+	}
+	return undefined;
 }
 
 /**
@@ -591,6 +668,8 @@ export function getPluginCommandNames(): string[] {
 export interface PluginCommandInfo {
 	commandName: string;
 	pluginName: string;
+	/** Plugin package version (`package.json#version`). */
+	pluginVersion: string;
 	description?: string;
 	helpDescription?: string;
 	examples?: { command: string; description: string }[];
@@ -602,6 +681,8 @@ export interface PluginCommandInfo {
 	passthroughHint?: string;
 	/** Optional documentation-only flag list rendered under passthrough help. */
 	flagsHint?: string[];
+	/** Typed flag declarations for flag-aware (non-passthrough) commands. */
+	flags?: Record<string, FlagDef>;
 }
 
 export function getPluginCommandsInfo(): PluginCommandInfo[] {
@@ -610,9 +691,12 @@ export function getPluginCommandsInfo(): PluginCommandInfo[] {
 	for (const plugin of loadedPlugins.values()) {
 		for (const commandName of Object.keys(plugin.commands)) {
 			const meta = plugin.metadata?.commands?.[commandName];
+			const cmd = plugin.commands[commandName];
+			const flags = typeof cmd !== "function" ? cmd.flags : undefined;
 			infos.push({
 				commandName,
 				pluginName: plugin.name,
+				pluginVersion: plugin.version,
 				description: meta?.description,
 				helpDescription: meta?.helpDescription,
 				examples: meta?.examples,
@@ -620,6 +704,7 @@ export function getPluginCommandsInfo(): PluginCommandInfo[] {
 				passthrough: meta?.passthrough === true ? true : undefined,
 				passthroughHint: meta?.passthroughHint,
 				flagsHint: meta?.flagsHint,
+				flags,
 			});
 		}
 	}

--- a/tests/fixtures/plugins/plugin-with-host-context/c8ctl-plugin.js
+++ b/tests/fixtures/plugins/plugin-with-host-context/c8ctl-plugin.js
@@ -1,0 +1,78 @@
+/**
+ * Test fixture for plugin host context (#377).
+ *
+ * Verb `echo-ctx` echoes the third `ctx` argument as JSON so the
+ * contract test can assert which globals were reflected and with what
+ * values.
+ *
+ * Verb `dry-run-echo` honours `ctx.dryRun` end-to-end: it prints a
+ * dry-run summary instead of the "real" action so the contract test
+ * can prove that `--dry-run` reached the plugin handler as a typed
+ * boolean.
+ */
+
+export const commands = {
+  'echo-ctx': {
+    flags: {
+      flag1: { type: 'string', description: 'A plugin-declared flag' },
+    },
+    handler: async (args, flags, ctx) => {
+      // Snapshot only the documented shape — skip the lazy client getter
+      // so JSON.stringify doesn't trigger credential resolution.
+      const ctxSnapshot = ctx
+        ? {
+            dryRun: ctx.dryRun,
+            verbose: ctx.verbose,
+            outputMode: ctx.outputMode,
+            fields: ctx.fields ?? null,
+            profile: ctx.profile,
+            hasLogger: typeof ctx.logger === 'object' && ctx.logger !== null,
+            // hasClient: just probe whether the getter exists. Do NOT
+            // read it — that resolves credentials.
+            hasClient: 'client' in ctx,
+          }
+        : null;
+      console.log(JSON.stringify({ args, flags: flags || {}, ctx: ctxSnapshot }));
+    },
+  },
+  'dry-run-echo': {
+    flags: {},
+    handler: async (_args, _flags, ctx) => {
+      if (ctx && ctx.dryRun) {
+        console.log(JSON.stringify({ kind: 'dry-run', message: 'would do X' }));
+        return;
+      }
+      console.log(JSON.stringify({ kind: 'executed' }));
+    },
+  },
+  'legacy-two-arg': {
+    flags: {},
+    // Intentional: handler signature is `(args, flags)` only.
+    // Backward-compat: a plugin written before #377 must still work
+    // when the host passes a third arg.
+    handler: async (args, flags) => {
+      console.log(JSON.stringify({ args, flags: flags || {}, sawCtx: false }));
+    },
+  },
+};
+
+export const metadata = {
+  name: 'plugin-with-host-context',
+  description: 'Fixture for #377: plugin host context, --help, --version',
+  commands: {
+    'echo-ctx': {
+      description: 'Echoes the host context as JSON',
+      helpDescription:
+        'Inspects ctx.{dryRun,verbose,outputMode,fields,profile,logger,client} and prints the snapshot.',
+      examples: [
+        { command: 'c8ctl echo-ctx --flag1 hello', description: 'Echo with a plugin flag' },
+      ],
+    },
+    'dry-run-echo': {
+      description: 'Demonstrates honouring ctx.dryRun',
+    },
+    'legacy-two-arg': {
+      description: 'Legacy 2-arg handler — must keep working after #377',
+    },
+  },
+};

--- a/tests/fixtures/plugins/plugin-with-host-context/package.json
+++ b/tests/fixtures/plugins/plugin-with-host-context/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "c8ctl-plugin-host-context",
+  "version": "9.9.9",
+  "description": "Fixture for plugin host context (#377): ctx third arg, plugin --help, plugin --version",
+  "type": "module",
+  "main": "c8ctl-plugin.js",
+  "keywords": ["c8ctl-plugin"]
+}

--- a/tests/unit/plugin-host-context-contract.test.ts
+++ b/tests/unit/plugin-host-context-contract.test.ts
@@ -1,0 +1,339 @@
+/**
+ * Plugin host context contract tests (#377).
+ *
+ * Pins three contracts:
+ *
+ *   A. Flag-aware plugin handlers receive a third `ctx` argument
+ *      exposing the resolved host globals (`dryRun`, `verbose`,
+ *      `outputMode`, `fields`, `profile`, `logger`, lazy `client`).
+ *      Every member of `GLOBAL_FLAGS` is either reflected in `ctx`
+ *      or has an explicit, named host-only reason.
+ *
+ *   B. A plugin can opt into `ctx.dryRun` and have it work end-to-end.
+ *
+ *   C. Plugin-authored `--help` and `--version`:
+ *      - `c8ctl <plugin-verb> --help` renders the plugin's declarative
+ *        help (description, helpDescription, flags, examples) instead
+ *        of dispatching the handler.
+ *      - `c8ctl <plugin-verb> --version` prints the plugin's
+ *        `package.json#version`, not the c8ctl version.
+ *
+ *   D. Backward compatibility: a plugin whose handler is declared
+ *      with the legacy `(args, flags)` signature must keep working
+ *      when the host passes a third arg.
+ *
+ * Fixture: tests/fixtures/plugins/plugin-with-host-context/. Installed
+ * per-test into a temp `C8CTL_DATA_DIR` so other tests can't see it.
+ */
+
+import assert from "node:assert";
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, test } from "node:test";
+import { GLOBAL_FLAGS } from "../../src/command-registry.ts";
+import { isRecord } from "../../src/logger.ts";
+import { asyncSpawn, type SpawnResult } from "../utils/spawn.ts";
+
+const FIXTURE_DIR = join(
+	process.cwd(),
+	"tests",
+	"fixtures",
+	"plugins",
+	"plugin-with-host-context",
+);
+const PLUGIN_PKG_NAME = "c8ctl-plugin-host-context";
+const PLUGIN_VERSION = "9.9.9"; // matches fixture package.json
+// The loader uses `package.json#name` as the canonical plugin name
+// (not `metadata.name`), so --version output identifies the plugin
+// by its package name.
+const PLUGIN_NAME = PLUGIN_PKG_NAME;
+
+let testDataDir: string;
+
+beforeEach(() => {
+	testDataDir = mkdtempSync(join(tmpdir(), "c8ctl-plugin-ctx-"));
+	writeFileSync(
+		join(testDataDir, "session.json"),
+		JSON.stringify({ outputMode: "json" }),
+	);
+	const installDir = join(
+		testDataDir,
+		"plugins",
+		"node_modules",
+		PLUGIN_PKG_NAME,
+	);
+	mkdirSync(installDir, { recursive: true });
+	cpSync(FIXTURE_DIR, installDir, { recursive: true });
+});
+
+afterEach(() => {
+	rmSync(testDataDir, { recursive: true, force: true });
+});
+
+async function c8Plugin(...args: string[]): Promise<SpawnResult> {
+	const env: NodeJS.ProcessEnv = {
+		...process.env,
+		CAMUNDA_BASE_URL: "http://test-cluster/v2",
+		HOME: "/tmp/c8ctl-test-nonexistent-home",
+		C8CTL_DATA_DIR: testDataDir,
+	};
+	delete env.DEBUG;
+	delete env.C8CTL_DEBUG;
+	delete env.NODE_DEBUG;
+	delete env.NODE_OPTIONS;
+	return asyncSpawn(
+		"node",
+		["--experimental-strip-types", "src/index.ts", ...args],
+		{
+			env,
+			timeout: 10_000,
+		},
+	);
+}
+
+/**
+ * Walk stdout from end and return the last line that parses to a record.
+ * The CLI may emit a warning JSON before the handler payload.
+ */
+function lastJsonRecord(stdout: string): Record<string, unknown> {
+	const lines = stdout
+		.trim()
+		.split("\n")
+		.filter((l) => l.length > 0);
+	for (let i = lines.length - 1; i >= 0; i--) {
+		const line = lines[i];
+		if (line === undefined) continue;
+		try {
+			const parsed: unknown = JSON.parse(line);
+			if (isRecord(parsed)) return parsed;
+		} catch {
+			// keep walking
+		}
+	}
+	throw new Error(`No JSON object found in stdout:\n${stdout}`);
+}
+
+// ─── A. Plugin ctx third arg ─────────────────────────────────────────────────
+
+describe("plugin host context: ctx is passed as the third handler argument", () => {
+	test("sanity: ctx is an object on a flag-aware handler", async () => {
+		const result = await c8Plugin("echo-ctx");
+		assert.strictEqual(
+			result.status,
+			0,
+			`expected exit 0, got ${result.status}. stderr: ${result.stderr}`,
+		);
+		const parsed = lastJsonRecord(result.stdout);
+		assert.ok(
+			isRecord(parsed.ctx),
+			`expected ctx to be an object on the handler payload. got: ${JSON.stringify(parsed)}`,
+		);
+	});
+
+	test("ctx.dryRun reflects --dry-run", async () => {
+		const result = await c8Plugin("echo-ctx", "--dry-run");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const parsed = lastJsonRecord(result.stdout);
+		assert.ok(isRecord(parsed.ctx));
+		assert.strictEqual(
+			parsed.ctx.dryRun,
+			true,
+			`expected ctx.dryRun=true with --dry-run. got: ${JSON.stringify(parsed.ctx)}`,
+		);
+	});
+
+	test("ctx.dryRun is false when --dry-run is omitted", async () => {
+		const result = await c8Plugin("echo-ctx");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const parsed = lastJsonRecord(result.stdout);
+		assert.ok(isRecord(parsed.ctx));
+		assert.strictEqual(parsed.ctx.dryRun, false);
+	});
+
+	test("ctx.verbose reflects --verbose", async () => {
+		const result = await c8Plugin("echo-ctx", "--verbose");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const parsed = lastJsonRecord(result.stdout);
+		assert.ok(isRecord(parsed.ctx));
+		assert.strictEqual(parsed.ctx.verbose, true);
+	});
+
+	test("ctx.profile reflects --profile", async () => {
+		const result = await c8Plugin("echo-ctx", "--profile", "myprofile");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const parsed = lastJsonRecord(result.stdout);
+		assert.ok(isRecord(parsed.ctx));
+		assert.strictEqual(parsed.ctx.profile, "myprofile");
+	});
+
+	test("ctx.outputMode is 'json' when --json is set", async () => {
+		const result = await c8Plugin("echo-ctx", "--json");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const parsed = lastJsonRecord(result.stdout);
+		assert.ok(isRecord(parsed.ctx));
+		assert.strictEqual(parsed.ctx.outputMode, "json");
+	});
+
+	test("ctx.fields reflects --fields (parsed to array)", async () => {
+		const result = await c8Plugin("echo-ctx", "--fields", "a,b,c");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const parsed = lastJsonRecord(result.stdout);
+		assert.ok(isRecord(parsed.ctx));
+		assert.deepStrictEqual(parsed.ctx.fields, ["a", "b", "c"]);
+	});
+
+	test("ctx.logger is exposed (object reference)", async () => {
+		const result = await c8Plugin("echo-ctx");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const parsed = lastJsonRecord(result.stdout);
+		assert.ok(isRecord(parsed.ctx));
+		assert.strictEqual(
+			parsed.ctx.hasLogger,
+			true,
+			"ctx.logger must be present and non-null",
+		);
+	});
+
+	test("ctx.client getter is exposed (lazy — not eagerly resolved)", async () => {
+		// The contract: `client` is a getter so plugins that never touch
+		// it (session/profile commands) don't trigger credential resolution.
+		const result = await c8Plugin("echo-ctx");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const parsed = lastJsonRecord(result.stdout);
+		assert.ok(isRecord(parsed.ctx));
+		assert.strictEqual(
+			parsed.ctx.hasClient,
+			true,
+			"ctx.client property must be present (lazy getter)",
+		);
+	});
+
+	// Class-scoped guard: every GLOBAL_FLAGS member is reflected in ctx
+	// OR appears in the documented host-only exemption set.
+	test("class-scoped: every GLOBAL_FLAGS entry is reflected in ctx or documented host-only", () => {
+		// `help` and `version` are intercepted by the host BEFORE the
+		// plugin handler runs (rendering happens out-of-band). Listing
+		// them here makes the exemption explicit and reviewable.
+		const HOST_ONLY: ReadonlySet<string> = new Set(["help", "version"]);
+		const CTX_REFLECTIONS: ReadonlyMap<string, string> = new Map([
+			["profile", "profile"],
+			["dry-run", "dryRun"],
+			["verbose", "verbose"],
+			["fields", "fields"],
+			["json", "outputMode"], // --json toggles outputMode
+		]);
+		const missing: string[] = [];
+		for (const name of Object.keys(GLOBAL_FLAGS)) {
+			if (HOST_ONLY.has(name)) continue;
+			if (!CTX_REFLECTIONS.has(name)) missing.push(name);
+		}
+		assert.deepStrictEqual(
+			missing,
+			[],
+			`Every GLOBAL_FLAGS entry must be reflected in PluginCtx or appear in HOST_ONLY. Missing: ${missing.join(", ")}`,
+		);
+	});
+});
+
+// ─── B. End-to-end honouring of ctx.dryRun ───────────────────────────────────
+
+describe("plugin host context: a plugin can honour --dry-run via ctx", () => {
+	test("plugin emits a dry-run summary when --dry-run is set", async () => {
+		const result = await c8Plugin("dry-run-echo", "--dry-run");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const parsed = lastJsonRecord(result.stdout);
+		assert.strictEqual(parsed.kind, "dry-run");
+		assert.strictEqual(parsed.message, "would do X");
+	});
+
+	test("plugin executes normally when --dry-run is omitted", async () => {
+		const result = await c8Plugin("dry-run-echo");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const parsed = lastJsonRecord(result.stdout);
+		assert.strictEqual(parsed.kind, "executed");
+	});
+});
+
+// ─── C. Plugin-authored --help and --version ─────────────────────────────────
+
+describe("plugin host context: plugin-authored --help", () => {
+	test("--help on a plugin verb renders plugin metadata, not the handler", async () => {
+		// In JSON mode (set by the session fixture), help renders as JSON.
+		// The plugin handler must NOT be invoked — if it were, we'd see
+		// the echo-ctx payload shape `{args, flags, ctx}` instead.
+		const result = await c8Plugin("echo-ctx", "--help");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const parsed = lastJsonRecord(result.stdout);
+		// Help renderer payload shape — not the handler's `{args, flags, ctx}`.
+		assert.ok(
+			!("ctx" in parsed),
+			`expected help renderer output, not handler echo. got: ${JSON.stringify(parsed).slice(0, 200)}`,
+		);
+		// The plugin's verb name must appear somewhere identifying.
+		const stringifiedJson = JSON.stringify(parsed);
+		assert.ok(
+			stringifiedJson.includes("echo-ctx"),
+			`expected help payload to identify the verb. got: ${stringifiedJson.slice(0, 200)}`,
+		);
+	});
+
+	test("--help payload includes the plugin's declared flags", async () => {
+		const result = await c8Plugin("echo-ctx", "--help");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const stringifiedJson = JSON.stringify(lastJsonRecord(result.stdout));
+		assert.ok(
+			stringifiedJson.includes("flag1"),
+			`expected plugin's declared --flag1 to appear in help. got: ${stringifiedJson.slice(0, 400)}`,
+		);
+	});
+
+	test("--help payload includes the plugin's examples", async () => {
+		const result = await c8Plugin("echo-ctx", "--help");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const stringifiedJson = JSON.stringify(lastJsonRecord(result.stdout));
+		// The fixture declares an example with this exact string.
+		assert.ok(
+			stringifiedJson.includes("Echo with a plugin flag"),
+			`expected plugin example to appear in help. got: ${stringifiedJson.slice(0, 400)}`,
+		);
+	});
+});
+
+describe("plugin host context: plugin-authored --version", () => {
+	test("--version on a plugin verb prints the plugin's version (not c8ctl's)", async () => {
+		const result = await c8Plugin("echo-ctx", "--version");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const combined = `${result.stdout}\n${result.stderr}`;
+		assert.ok(
+			combined.includes(PLUGIN_VERSION),
+			`expected plugin version "${PLUGIN_VERSION}" in output. got stdout: ${result.stdout} stderr: ${result.stderr}`,
+		);
+	});
+
+	test("--version on a plugin verb identifies the plugin by name", async () => {
+		const result = await c8Plugin("echo-ctx", "--version");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const combined = `${result.stdout}\n${result.stderr}`;
+		assert.ok(
+			combined.includes(PLUGIN_NAME),
+			`expected plugin name "${PLUGIN_NAME}" in --version output. got: ${combined}`,
+		);
+	});
+});
+
+// ─── D. Backward compatibility ───────────────────────────────────────────────
+
+describe("plugin host context: backward compatibility for 2-arg handlers", () => {
+	test("a legacy (args, flags) handler still runs when host passes 3 args", async () => {
+		const result = await c8Plugin("legacy-two-arg", "pos1");
+		assert.strictEqual(
+			result.status,
+			0,
+			`legacy 2-arg plugin handler must keep working. stderr: ${result.stderr}`,
+		);
+		const parsed = lastJsonRecord(result.stdout);
+		assert.deepStrictEqual(parsed.args, ["pos1"]);
+		assert.strictEqual(parsed.sawCtx, false);
+	});
+});


### PR DESCRIPTION
## Summary

Implements the plugin host context contract from #377: plugin command handlers now receive a typed third `ctx: PluginCtx` argument, plugin verbs render help declaratively from metadata, and `--version` on a plugin verb prints the plugin's `package.json#version`.

Closes #377.

## What changes

1. **`PluginCtx` (third handler argument).** `executePluginCommand` now passes `ctx` as the third arg to plugin handlers. `PluginCtx` exposes `{ profile, dryRun, verbose, outputMode, fields, logger, client }`. `client` is a lazy getter — plugins that never need a Camunda client (e.g. local-only utilities) do not trigger credential resolution by virtue of receiving ctx. The `globalThis.c8ctl` side channel that previously carried this state still works for legacy plugins.

2. **Declarative plugin `--help`.** `c8ctl <plugin-verb> --help` renders help from `metadata.commands[verb]` + typed `flags` declarations. The plugin handler is **not** invoked. JSON mode emits a structured payload with `kind: "plugin"` and `pluginName` / `pluginVersion` so agents can tell a plugin verb apart from a built-in.

3. **Plugin `--version`.** `c8ctl <plugin-verb> --version` prints `<pluginName> <pluginVersion>` from the plugin's `package.json`, not c8ctl's. The loader now captures `packageJson.version` alongside `packageJson.name`.

## Class-scoped contract test

`tests/unit/plugin-host-context-contract.test.ts` pins:

- Every `GLOBAL_FLAGS` entry is **either** reflected in `PluginCtx` **or** appears in a documented `HOST_ONLY` allow-list (`help`, `version` — handled out-of-band by the host). Adding a new global flag without updating one of these surfaces fails the test loudly.
- Each ctx field round-trips end-to-end from `--<flag>` to the plugin handler.
- `--help` on a plugin verb renders metadata, not the handler.
- `--version` on a plugin verb prints `<pluginName> <version>`.
- A legacy `(args, flags)` handler still runs when the host passes a third arg (JavaScript variadic call ignore — verified, not assumed).

## Test results

- `npm run test:unit` — **1558 / 1558 pass** (18 new tests for #377).
- `npx biome check` — clean.
- `npx tsc --noEmit -p tsconfig.check.json` — clean.

## Red / green discipline

Tests were written first (12/18 failing on `main` before any production change), then minimal production fix landed each one. The class-scoped meta-test (`every GLOBAL_FLAGS entry is reflected in ctx or HOST_ONLY`) protects the contract against future flag additions.

## Files

- `src/plugin-loader.ts` — `PluginCtx`, version capture, `getPluginVersionForCommand`, ctx-aware dispatch.
- `src/index.ts` — ctx construction, plugin `--version` interception, lazy `client` getter.
- `src/help.ts` — `showFlagAwarePluginHelp` declarative renderer (text + JSON).
- `tests/fixtures/plugins/plugin-with-host-context/` — new fixture.
- `tests/unit/plugin-host-context-contract.test.ts` — class-scoped contract test.
