### PR TITLE
feat: auto-detect and deploy process applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -1501,7 +1501,7 @@ c8ctl set variable 2251799813685249 --variables='{"x":1}' --local  # Set variabl
 
 #### `deploy`
 
-Deploy files to Camunda (auto-discovers deployable files in directories)
+Deploy files to Camunda (auto-discovers deployable files in directories). When deploying a directory that is inside a process application (a parent directory contains a .process-application marker), the entire application root is deployed. Explicit file paths are not expanded.
 
 **Usage:** `c8ctl deploy [path...]`
 
@@ -1517,6 +1517,7 @@ Deploy files to Camunda (auto-discovers deployable files in directories)
 
 ```bash
 c8ctl deploy ./my-process.bpmn                              # Deploy a BPMN file
+c8ctl deploy                                                # Deploy from current directory (detects process application root)
 ```
 
 ---
@@ -1621,6 +1622,8 @@ Watch files for changes and auto-deploy
 | `--force` | boolean |  | Continue watching after all deployment errors |
 | `--extensions` | string |  | Comma-separated list of additional file extensions to watch (merged with defaults, e.g. .md,.txt) |
 | `--all-extensions` | boolean |  | Watch all server-supported file extensions |
+| `--process-application` | boolean |  | Watch and deploy the entire process application (requires .process-application marker) |
+| `--pa` | boolean |  | Alias for --process-application |
 
 **Examples:**
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -730,7 +730,7 @@ c8ctl set variable 2251799813685249 --variables='{"x":1}' --local  # Set variabl
 
 ### `deploy`
 
-Deploy files to Camunda (auto-discovers deployable files in directories)
+Deploy files to Camunda (auto-discovers deployable files in directories). When deploying a directory that is inside a process application (a parent directory contains a .process-application marker), the entire application root is deployed. Explicit file paths are not expanded.
 
 **Usage:** `c8ctl deploy [path...]`
 
@@ -746,6 +746,7 @@ Deploy files to Camunda (auto-discovers deployable files in directories)
 
 ```bash
 c8ctl deploy ./my-process.bpmn                              # Deploy a BPMN file
+c8ctl deploy                                                # Deploy from current directory (detects process application root)
 ```
 
 ---
@@ -850,6 +851,8 @@ Watch files for changes and auto-deploy
 | `--force` | boolean |  | Continue watching after all deployment errors |
 | `--extensions` | string |  | Comma-separated list of additional file extensions to watch (merged with defaults, e.g. .md,.txt) |
 | `--all-extensions` | boolean |  | Watch all server-supported file extensions |
+| `--process-application` | boolean |  | Watch and deploy the entire process application (requires .process-application marker) |
+| `--pa` | boolean |  | Alias for --process-application |
 
 **Examples:**
 

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -1214,7 +1214,10 @@ export const COMMAND_REGISTRY = {
 	deploy: {
 		description: "Deploy resources",
 		helpDescription:
-			"Deploy files to Camunda (auto-discovers deployable files in directories)",
+			"Deploy files to Camunda (auto-discovers deployable files in directories). " +
+			"When deploying a directory that is inside a process application " +
+			"(a parent directory contains a .process-application marker), the entire " +
+			"application root is deployed. Explicit file paths are not expanded.",
 		helpResource: "[path...]",
 		hasDetailedHelp: true,
 		helpFooterLabel: "Show deploy command with all flags",
@@ -1224,6 +1227,11 @@ export const COMMAND_REGISTRY = {
 			{
 				command: "c8ctl deploy ./my-process.bpmn",
 				description: "Deploy a BPMN file",
+			},
+			{
+				command: "c8ctl deploy",
+				description:
+					"Deploy from current directory (detects process application root)",
 			},
 		],
 		resources: [],
@@ -1353,6 +1361,15 @@ export const COMMAND_REGISTRY = {
 			"all-extensions": {
 				type: "boolean",
 				description: "Watch all server-supported file extensions",
+			},
+			"process-application": {
+				type: "boolean",
+				description:
+					"Watch and deploy the entire process application (requires .process-application marker)",
+			},
+			pa: {
+				type: "boolean",
+				description: "Alias for --process-application",
 			},
 		},
 		aliases: ["w"],

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -2,10 +2,10 @@
  * Watch command - monitor files for changes and auto-deploy
  */
 
-import { existsSync, statSync, watch } from "node:fs";
+import { existsSync, realpathSync, statSync, watch } from "node:fs";
 import { basename, extname, resolve } from "node:path";
 import { defineCommand } from "../command-framework.ts";
-import { deployResources } from "../deployments.ts";
+import { deployResources, findProcessApplicationRoot } from "../deployments.ts";
 import { normalizeToError } from "../errors.ts";
 import { isIgnored, loadIgnoreRules, resolveIgnoreBaseDir } from "../ignore.ts";
 import { DEPLOY_COOLDOWN } from "../watch-constants.ts";
@@ -64,6 +64,49 @@ export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
 		}
 	}
 
+	// ── Process-application mode (#227) ──────────────────────────────
+	// When --process-application is set, resolve the PA root from the
+	// watched paths and expand the watch scope to the PA root so the
+	// entire process application tree is monitored for changes.
+	const paMode = Boolean(flags["process-application"] || flags.pa);
+	let paRoot: string | null = null;
+	if (paMode) {
+		// Resolve PA root from every watched path and verify they all
+		// belong to the same process application.
+		let resolvedRoot: string | undefined;
+		for (const p of resolvedPaths) {
+			const root = findProcessApplicationRoot(p);
+			if (!root) {
+				throw new Error(
+					`--process-application: no .process-application marker found above ${p}. ` +
+						"Place a .process-application file at the root of your process application.",
+				);
+			}
+			// Normalize via realpathSync so symlinks and equivalent
+			// spellings of the same directory compare as equal.
+			const normalizedRoot = realpathSync(root);
+			if (resolvedRoot && normalizedRoot !== resolvedRoot) {
+				throw new Error(
+					"--process-application: all watched paths must belong to the same " +
+						`process application. Path ${p} resolves to ${normalizedRoot}, ` +
+						`but earlier paths resolved to ${resolvedRoot}`,
+				);
+			}
+			resolvedRoot = normalizedRoot;
+		}
+		// Invariant: resolvedPaths always has ≥1 entry (defaults to ["."]),
+		// so the loop above always runs at least once and sets resolvedRoot.
+		// This guard satisfies the type checker — it cannot fire at runtime.
+		if (!resolvedRoot) {
+			throw new Error("--process-application requires at least one watch path");
+		}
+		paRoot = resolvedRoot;
+		// Replace watched paths with the PA root so we monitor the entire
+		// process application tree, not just the user-specified subdirectory.
+		resolvedPaths.length = 0;
+		resolvedPaths.push(paRoot);
+	}
+
 	// Load .c8ignore rules from the target directory (not cwd) so that
 	// `c8 watch <target>` picks up the .c8ignore inside the target. (#258)
 	const ignoreBaseDir = resolveIgnoreBaseDir(resolvedPaths);
@@ -105,40 +148,51 @@ export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
 					return;
 				}
 
-				// Clear any pending debounce for this file and restart the timer.
+				// In PA mode, key debounce/cooldown by the PA root so that
+				// a burst of changes to different files collapses into a
+				// single full-PA deploy within the debounce window.
+				const debounceKey = paMode && paRoot ? paRoot : fullPath;
+
+				// Clear any pending debounce for this key and restart the timer.
 				// This ensures we wait until the file system is quiet before reading.
-				const existing = debounceTimers.get(fullPath);
+				const existing = debounceTimers.get(debounceKey);
 				if (existing) clearTimeout(existing);
 
 				debounceTimers.set(
-					fullPath,
+					debounceKey,
 					setTimeout(async () => {
-						debounceTimers.delete(fullPath);
+						debounceTimers.delete(debounceKey);
 
 						// SIGINT may have fired between the timer being scheduled
 						// and this callback running. Bail before doing any I/O.
 						if (shuttingDown) return;
 
 						// Check cooldown to prevent duplicate deploys
-						const lastDeploy = recentlyDeployed.get(fullPath);
+						const lastDeploy = recentlyDeployed.get(debounceKey);
 						const now = Date.now();
 						if (lastDeploy && now - lastDeploy < DEPLOY_COOLDOWN) {
 							return;
 						}
 
-						// Check if file still exists (might have been deleted)
-						if (!existsSync(fullPath)) {
+						// Check if file still exists (might have been deleted).
+						// In PA mode, deletions are meaningful changes — the PA
+						// should be redeployed without the removed file.
+						if (!paMode && !existsSync(fullPath)) {
 							logger.info(`⚠️  File deleted, skipping: ${basename(file)}`);
 							return;
 						}
 
 						logger.info(`\n🔄 Change detected: ${basename(file)}`);
-						recentlyDeployed.set(fullPath, Date.now());
+						recentlyDeployed.set(debounceKey, Date.now());
+
+						// In PA mode, deploy the entire PA root instead of the
+						// single changed file.
+						const deployPaths = paMode && paRoot ? [paRoot] : [fullPath];
 
 						const ac = new AbortController();
 						inflightDeploys.add(ac);
 						try {
-							await deployResources([fullPath], {
+							await deployResources(deployPaths, {
 								profile: ctx.profile,
 								continueOnError: flags.force,
 								continueOnUserError: true,
@@ -153,7 +207,7 @@ export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
 							// user-visible shutdown signal.
 							if (ac.signal.aborted) return;
 							logger.error(
-								`Failed to deploy ${basename(file)}`,
+								`Failed to deploy ${paMode ? "process application" : basename(file)}`,
 								normalizeToError(error, "Deployment request failed"),
 							);
 						} finally {
@@ -208,6 +262,11 @@ export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
 		// file event is silently lost.
 		logger.info(`👁️  Watching for changes in: ${resolvedPaths.join(", ")}`);
 		logger.info(`📋 Monitoring extensions: ${watchedExtensions.join(", ")}`);
+		if (paMode && paRoot) {
+			logger.info(
+				`📦 Process application mode: deploying all resources from ${paRoot}`,
+			);
+		}
 		if (flags.force) {
 			logger.info(
 				"🔒 Force mode: will continue watching after deployment errors",

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -2,8 +2,14 @@
  * Deployment commands with building-block folder prioritization
  */
 
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { basename, dirname, extname, join, relative } from "node:path";
+import {
+	existsSync,
+	readdirSync,
+	readFileSync,
+	realpathSync,
+	statSync,
+} from "node:fs";
+import { basename, dirname, extname, join, relative, resolve } from "node:path";
 import { TenantId } from "@camunda8/orchestration-cluster-api";
 import type { Ignore } from "ignore";
 import { createClient } from "./client.ts";
@@ -92,7 +98,11 @@ function isBuildingBlockFolder(path: string): boolean {
  */
 function hasProcessApplicationFile(dirPath: string): boolean {
 	const paFilePath = join(dirPath, PROCESS_APPLICATION_FILE);
-	return existsSync(paFilePath);
+	try {
+		return statSync(paFilePath).isFile();
+	} catch {
+		return false;
+	}
 }
 
 /**
@@ -110,12 +120,6 @@ function findGroupRoot(
 
 	// Traverse up the directory tree until we reach or go outside basePath
 	while (true) {
-		// Check if we've gone outside the basePath
-		const rel = relative(basePath, currentDir);
-		if (rel.startsWith("..") || rel === "") {
-			break;
-		}
-
 		// Check if this directory is a building block
 		if (isBuildingBlockFolder(currentDir)) {
 			return { type: "bb", root: currentDir };
@@ -126,6 +130,12 @@ function findGroupRoot(
 			return { type: "pa", root: currentDir };
 		}
 
+		// Check if we've reached or gone outside the basePath
+		const rel = relative(basePath, currentDir);
+		if (rel.startsWith("..") || rel === "") {
+			break;
+		}
+
 		// Move up one level
 		const parentDir = dirname(currentDir);
 		if (parentDir === currentDir) break; // Reached filesystem root
@@ -133,6 +143,36 @@ function findGroupRoot(
 	}
 
 	return { type: null, root: null };
+}
+
+/**
+ * Walk up from `startDir` looking for a `.process-application` marker
+ * file. Returns the directory that contains the marker, or `null` if
+ * none is found before reaching the filesystem root.
+ *
+ * `startDir` may be a file path — the walk starts from its parent
+ * directory in that case (the initial `hasProcessApplicationFile` call
+ * harmlessly returns false for non-directories).
+ *
+ * Unlike `findGroupRoot()` (which tags individual files for display),
+ * this function determines the *deploy scope*: when a PA root is found,
+ * `collectResourcesForPaths` expands the input to the PA root so that
+ * the entire application is deployed.
+ */
+export function findProcessApplicationRoot(startDir: string): string | null {
+	let currentDir = resolve(startDir);
+
+	while (true) {
+		if (hasProcessApplicationFile(currentDir)) {
+			return currentDir;
+		}
+
+		const parentDir = dirname(currentDir);
+		if (parentDir === currentDir) break; // Reached filesystem root
+		currentDir = parentDir;
+	}
+
+	return null;
 }
 
 /**
@@ -159,12 +199,13 @@ function collectResourceFiles(
 		return collected;
 	}
 
-	// Set basePath to dirPath on first call
-	if (!basePath) {
-		basePath = dirPath;
-	}
-
 	const stat = statSync(dirPath);
+
+	// Set basePath to a directory on first call — when the initial input
+	// is a file, use its parent so findGroupRoot can walk up correctly.
+	if (!basePath) {
+		basePath = stat.isFile() ? dirname(dirPath) : dirPath;
+	}
 
 	if (stat.isFile()) {
 		if (ig && ignoreBaseDir && isIgnored(ig, dirPath, ignoreBaseDir)) {
@@ -311,6 +352,11 @@ function findDuplicateDefinitionIds(
 interface CollectResult {
 	resources: ResourceFile[];
 	skippedExtensions: Set<string>;
+	/** Resolved base paths used for resource collection and display.
+	 *  When PA detection fires, these are expanded to the PA root(s)
+	 *  rather than the user-supplied input paths. Used downstream for
+	 *  `ignoreBaseDir` resolution and `basePaths` in `deployResources`. */
+	effectivePaths: string[];
 }
 
 /**
@@ -336,14 +382,62 @@ function collectResourcesForPaths(
 		);
 	}
 
-	// Load .c8ignore rules from the target directory (not cwd) so that
-	// `c8 deploy <target>` picks up the .c8ignore inside the target. (#258)
-	const ignoreBaseDir = resolveIgnoreBaseDir(paths);
+	// ── Process-application auto-detection (#227) ──────────────────────
+	// For each directory path, walk up looking for a .process-application
+	// marker. If found, expand to the PA root so the entire application
+	// is deployed — matching Desktop Modeler behaviour.
+	// File paths are NOT expanded so that watch-mode single-file deploys
+	// remain scoped to the changed file.
+	const effectivePaths: string[] = [];
+	const seenRoots = new Set<string>();
+	for (const p of paths) {
+		const abs = resolve(p);
+		let isFile = false;
+		try {
+			isFile = statSync(abs).isFile();
+		} catch {
+			// Path does not exist — skip PA detection and keep the
+			// absolute path so collectResourceFiles (which silently
+			// skips missing paths) falls through to the "No deployable
+			// files found" guard.
+			effectivePaths.push(abs);
+			continue;
+		}
+
+		if (isFile) {
+			effectivePaths.push(abs);
+			continue;
+		}
+
+		const paRoot = findProcessApplicationRoot(abs);
+		if (paRoot) {
+			// Deduplicate: multiple input dirs inside the same PA should
+			// only trigger one resource walk from the PA root. Use
+			// realpathSync for the dedup key to handle symlinks/case.
+			let canonical = paRoot;
+			try {
+				canonical = realpathSync(paRoot);
+			} catch {
+				// Best-effort fallback.
+			}
+			if (!seenRoots.has(canonical)) {
+				seenRoots.add(canonical);
+				effectivePaths.push(paRoot);
+			}
+		} else {
+			effectivePaths.push(abs);
+		}
+	}
+
+	// Load .c8ignore rules from the effective target directory (which may
+	// be the PA root) so that `c8 deploy <target>` picks up the .c8ignore
+	// inside the target. (#258)
+	const ignoreBaseDir = resolveIgnoreBaseDir(effectivePaths);
 	const ig = loadIgnoreRules(ignoreBaseDir);
 
 	const resources: ResourceFile[] = [];
 	const skippedExtensions = new Set<string>();
-	paths.forEach((path) => {
+	effectivePaths.forEach((path) => {
 		collectResourceFiles(
 			path,
 			resources,
@@ -356,12 +450,33 @@ function collectResourcesForPaths(
 		);
 	});
 
-	if (resources.length === 0) {
+	// Deduplicate resources by canonical path — can happen when an explicit
+	// file path is also covered by a PA-root or scoped-directory walk, or
+	// when the same file is reachable via symlinks. The canonical path is
+	// used only as the dedup key; the original path/name are preserved for
+	// display and relative-path calculations.
+	const seen = new Set<string>();
+	const deduped: ResourceFile[] = [];
+	for (const r of resources) {
+		let canonical = r.path;
+		try {
+			canonical = realpathSync(r.path);
+		} catch {
+			// Best-effort: fall back to the original path if realpath
+			// fails (e.g. broken symlink).
+		}
+		if (!seen.has(canonical)) {
+			seen.add(canonical);
+			deduped.push(r);
+		}
+	}
+
+	if (deduped.length === 0) {
 		logSkippedExtensions(skippedExtensions);
 		throw new Error("No deployable files found in the specified paths");
 	}
 
-	return { resources, skippedExtensions };
+	return { resources: deduped, skippedExtensions, effectivePaths };
 }
 
 /**
@@ -404,18 +519,18 @@ export async function deployResources(
 	// HTTP deploy call (further down) is wrapped in a catch that routes
 	// through `handleDeploymentError` for rich Problem-Detail rendering.
 
-	const { resources, skippedExtensions } = collectResourcesForPaths(
-		paths,
-		options.force,
-		options.extensionList ?? DEPLOYABLE_EXTENSIONS,
-	);
+	const { resources, skippedExtensions, effectivePaths } =
+		collectResourcesForPaths(
+			paths,
+			options.force,
+			options.extensionList ?? DEPLOYABLE_EXTENSIONS,
+		);
 
 	logSkippedExtensions(skippedExtensions);
 
-	// Store the base paths for relative path calculation. Safe to assign
-	// directly now: the empty-paths guard inside `collectResourcesForPaths`
-	// has already thrown.
-	const basePaths = paths;
+	// Use the effective paths (which may have been expanded to a PA root)
+	// for relative path calculation so display paths make sense.
+	const basePaths = effectivePaths;
 
 	const client = createClient(options.profile);
 

--- a/tests/unit/process-application-detection.test.ts
+++ b/tests/unit/process-application-detection.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Tests for process-application auto-detection in `deploy`.
+ *
+ * When a `.process-application` marker file is found in a parent directory,
+ * `c8 deploy` should expand directory paths to the PA root and deploy all
+ * resources under it — matching Desktop Modeler's "Deploy process
+ * application" behavior.
+ *
+ * File paths are NOT expanded (preserves watch single-file behavior).
+ *
+ * @see https://github.com/camunda/c8ctl/issues/227
+ */
+
+import assert from "node:assert";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, test } from "node:test";
+import { asyncSpawn, type SpawnResult } from "../utils/spawn.ts";
+
+const CLI = resolve(import.meta.dirname, "..", "..", "src", "index.ts");
+
+const MINIMAL_BPMN = `<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+  targetNamespace="http://test" id="defs">
+  <process id="test-process" isExecutable="true">
+    <startEvent id="start"/>
+  </process>
+</definitions>`;
+
+const MINIMAL_FORM = `{ "components": [], "type": "default", "id": "test-form" }`;
+
+let tempDir: string;
+
+beforeEach(() => {
+	tempDir = mkdtempSync(join(tmpdir(), "c8ctl-pa-detect-"));
+});
+
+afterEach(() => {
+	rmSync(tempDir, { recursive: true, force: true });
+});
+
+/**
+ * Spawn `c8 deploy --dry-run` in the given cwd with the given args.
+ * Returns parsed JSON output (the dry-run body).
+ */
+async function deployDryRun(
+	cwd: string,
+	args: string[] = [],
+): Promise<SpawnResult> {
+	const dataDir = mkdtempSync(join(cwd, ".c8ctl-data-"));
+	writeFileSync(
+		join(dataDir, "session.json"),
+		JSON.stringify({ outputMode: "json" }),
+	);
+	return asyncSpawn(
+		"node",
+		["--experimental-strip-types", CLI, "deploy", ...args, "--dry-run"],
+		{
+			cwd,
+			env: {
+				PATH: process.env.PATH,
+				CAMUNDA_BASE_URL: "http://test-cluster/v2",
+				HOME: "/tmp/c8ctl-test-nonexistent-home",
+				C8CTL_DATA_DIR: dataDir,
+			},
+		},
+	);
+}
+
+function parseResourceNames(result: SpawnResult): string[] {
+	const out = JSON.parse(result.stdout);
+	assert.ok(
+		out.body && Array.isArray(out.body.resources),
+		"Expected body.resources array in dry-run output",
+	);
+	const resources: unknown[] = out.body.resources;
+	return resources
+		.map((r) => {
+			assert.ok(
+				r && typeof r === "object" && "name" in r && typeof r.name === "string",
+				"Expected resource with string name",
+			);
+			return r.name;
+		})
+		.sort();
+}
+
+// ── Helpers to build PA fixture trees ─────────────────────────────────
+
+function createPA(root: string, resources: Record<string, string> = {}): void {
+	mkdirSync(root, { recursive: true });
+	writeFileSync(join(root, ".process-application"), "");
+	for (const [relPath, content] of Object.entries(resources)) {
+		const full = join(root, relPath);
+		mkdirSync(dirname(full), { recursive: true });
+		writeFileSync(full, content);
+	}
+}
+
+// ── AC1: Deploy from any subdirectory inside a PA ─────────────────────
+
+describe("Process application auto-detection (#227)", () => {
+	test("deploys all PA resources when run from subdirectory", async () => {
+		const paRoot = join(tempDir, "my-app");
+		createPA(paRoot, {
+			"root.bpmn": MINIMAL_BPMN,
+			"sub/nested.bpmn": MINIMAL_BPMN,
+			"sub/deep/deep.bpmn": MINIMAL_BPMN,
+			"forms/my.form": MINIMAL_FORM,
+		});
+
+		// Run from a nested subdirectory
+		const result = await deployDryRun(join(paRoot, "sub", "deep"));
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+
+		const names = parseResourceNames(result);
+		assert.deepStrictEqual(names, [
+			"deep.bpmn",
+			"my.form",
+			"nested.bpmn",
+			"root.bpmn",
+		]);
+	});
+
+	test("deploys all PA resources when run from PA root", async () => {
+		const paRoot = join(tempDir, "my-app");
+		createPA(paRoot, {
+			"main.bpmn": MINIMAL_BPMN,
+			"sub/other.bpmn": MINIMAL_BPMN,
+		});
+
+		const result = await deployDryRun(paRoot);
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+
+		const names = parseResourceNames(result);
+		assert.deepStrictEqual(names, ["main.bpmn", "other.bpmn"]);
+	});
+
+	test("deploys all PA resources when subdir is given as explicit path", async () => {
+		const paRoot = join(tempDir, "my-app");
+		createPA(paRoot, {
+			"root.bpmn": MINIMAL_BPMN,
+			"src/flow.bpmn": MINIMAL_BPMN,
+		});
+
+		// Run from tempDir, passing the subdirectory as argument
+		const result = await deployDryRun(tempDir, [join(paRoot, "src")]);
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+
+		const names = parseResourceNames(result);
+		assert.deepStrictEqual(names, ["flow.bpmn", "root.bpmn"]);
+	});
+
+	// ── AC2: No breaking changes outside a PA ───────────────────────────
+
+	test("no PA marker: only deploys from the specified directory", async () => {
+		// No .process-application file — plain directory
+		const dir = join(tempDir, "plain");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, "local.bpmn"), MINIMAL_BPMN);
+
+		// Sibling directory should NOT be included
+		const sibling = join(tempDir, "sibling");
+		mkdirSync(sibling, { recursive: true });
+		writeFileSync(join(sibling, "other.bpmn"), MINIMAL_BPMN);
+
+		const result = await deployDryRun(dir);
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+
+		const names = parseResourceNames(result);
+		assert.deepStrictEqual(names, ["local.bpmn"]);
+	});
+
+	// ── AC3: Explicit path to PA root ───────────────────────────────────
+
+	test("explicit path to PA root deploys all PA resources", async () => {
+		const paRoot = join(tempDir, "my-app");
+		createPA(paRoot, {
+			"a.bpmn": MINIMAL_BPMN,
+			"sub/b.bpmn": MINIMAL_BPMN,
+		});
+
+		const result = await deployDryRun(tempDir, [paRoot]);
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+
+		const names = parseResourceNames(result);
+		assert.deepStrictEqual(names, ["a.bpmn", "b.bpmn"]);
+	});
+
+	// ── File paths are NOT expanded ─────────────────────────────────────
+
+	test("explicit file path inside PA deploys only that file", async () => {
+		const paRoot = join(tempDir, "my-app");
+		createPA(paRoot, {
+			"root.bpmn": MINIMAL_BPMN,
+			"sub/target.bpmn": MINIMAL_BPMN,
+		});
+
+		// Pass a specific file — should NOT expand to PA root
+		const result = await deployDryRun(tempDir, [
+			join(paRoot, "sub", "target.bpmn"),
+		]);
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+
+		const names = parseResourceNames(result);
+		assert.deepStrictEqual(names, ["target.bpmn"]);
+	});
+
+	// ── AC5: Mono-repo — each subdir finds its own PA ───────────────────
+
+	test("mono-repo: multiple PAs resolve independently", async () => {
+		const paA = join(tempDir, "app-a");
+		createPA(paA, { "a.bpmn": MINIMAL_BPMN });
+		mkdirSync(join(paA, "sub-of-a"), { recursive: true });
+
+		const paB = join(tempDir, "app-b");
+		createPA(paB, { "b.bpmn": MINIMAL_BPMN });
+		mkdirSync(join(paB, "sub-of-b"), { recursive: true });
+
+		// Deploy both subdirectories — each should expand to its own PA root
+		const result = await deployDryRun(tempDir, [
+			join(paA, "sub-of-a"),
+			join(paB, "sub-of-b"),
+		]);
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+
+		const names = parseResourceNames(result);
+		assert.deepStrictEqual(names, ["a.bpmn", "b.bpmn"]);
+	});
+
+	// ── Nested PAs: nearest ancestor wins ───────────────────────────────
+
+	test("nested PAs: nearest .process-application ancestor wins", async () => {
+		const outer = join(tempDir, "outer");
+		createPA(outer, { "outer.bpmn": MINIMAL_BPMN });
+
+		const inner = join(outer, "inner");
+		createPA(inner, { "inner.bpmn": MINIMAL_BPMN });
+
+		// Deploy from inside inner — should find inner PA, not outer
+		const result = await deployDryRun(inner);
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+
+		const names = parseResourceNames(result);
+		assert.deepStrictEqual(names, ["inner.bpmn"]);
+	});
+
+	// ── .c8ignore at PA root is respected ───────────────────────────────
+
+	test(".c8ignore at PA root filters resources during PA deploy", async () => {
+		const paRoot = join(tempDir, "my-app");
+		createPA(paRoot, {
+			"keep.bpmn": MINIMAL_BPMN,
+			"skip.bpmn": MINIMAL_BPMN,
+			"sub/also-keep.bpmn": MINIMAL_BPMN,
+		});
+		writeFileSync(join(paRoot, ".c8ignore"), "skip.bpmn\n");
+
+		// Deploy from subdirectory — PA root detected, .c8ignore at PA root applies
+		const result = await deployDryRun(join(paRoot, "sub"));
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+
+		const names = parseResourceNames(result);
+		assert.deepStrictEqual(names, ["also-keep.bpmn", "keep.bpmn"]);
+	});
+});

--- a/tests/unit/watch-process-application.test.ts
+++ b/tests/unit/watch-process-application.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Tests for `watch --process-application` flag.
+ *
+ * When `--process-application` (or `--pa`) is passed to `c8 watch`, the watch
+ * scope expands to the process application root (nearest ancestor directory
+ * containing `.process-application`) and each change triggers a full PA deploy
+ * instead of a single-file deploy.
+ *
+ * @see https://github.com/camunda/c8ctl/issues/227
+ */
+
+import assert from "node:assert";
+import { spawnSync } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, test } from "node:test";
+
+const CLI_ENTRY = join(process.cwd(), "src", "index.ts");
+
+let testDir: string;
+
+beforeEach(() => {
+	testDir = mkdtempSync(join(tmpdir(), "c8ctl-watch-pa-"));
+});
+
+afterEach(() => {
+	if (existsSync(testDir)) {
+		rmSync(testDir, { recursive: true, force: true });
+	}
+});
+
+describe("watch --process-application (#227)", () => {
+	test("help watch shows --process-application flag", () => {
+		const result = spawnSync(
+			"node",
+			["--experimental-strip-types", CLI_ENTRY, "help", "watch"],
+			{
+				encoding: "utf-8",
+				stdio: "pipe",
+				timeout: 5000,
+				env: {
+					...process.env,
+					C8CTL_DATA_DIR: testDir,
+				},
+			},
+		);
+
+		assert.ok(
+			result.stdout.includes("--process-application"),
+			"help output should include --process-application flag",
+		);
+	});
+
+	test("watch --pa is accepted as alias", () => {
+		// Create a PA with a bpmn file
+		const paRoot = join(testDir, "my-app");
+		mkdirSync(paRoot, { recursive: true });
+		writeFileSync(join(paRoot, ".process-application"), "");
+		writeFileSync(join(paRoot, "main.bpmn"), "<definitions/>");
+
+		// Start watch --pa and let it time out — just verify it starts OK
+		const result = spawnSync(
+			"node",
+			["--experimental-strip-types", CLI_ENTRY, "watch", "--pa", paRoot],
+			{
+				encoding: "utf-8",
+				stdio: "pipe",
+				timeout: 10000,
+				env: {
+					...process.env,
+					C8CTL_DATA_DIR: testDir,
+				},
+			},
+		);
+
+		const output = (result.stdout || "") + (result.stderr || "");
+		assert.ok(
+			output.includes("Watching for changes"),
+			`--pa should be accepted and start watching, got:\n${output}`,
+		);
+	});
+
+	test("watch --process-application shows PA mode message", () => {
+		const paRoot = join(testDir, "my-app");
+		mkdirSync(paRoot, { recursive: true });
+		writeFileSync(join(paRoot, ".process-application"), "");
+		writeFileSync(join(paRoot, "main.bpmn"), "<definitions/>");
+
+		const result = spawnSync(
+			"node",
+			[
+				"--experimental-strip-types",
+				CLI_ENTRY,
+				"watch",
+				"--process-application",
+				paRoot,
+			],
+			{
+				encoding: "utf-8",
+				stdio: "pipe",
+				timeout: 10000,
+				env: {
+					...process.env,
+					C8CTL_DATA_DIR: testDir,
+				},
+			},
+		);
+
+		const output = (result.stdout || "") + (result.stderr || "");
+		assert.ok(
+			output.includes("Process application mode"),
+			`Watch should indicate PA mode in output, got:\n${output}`,
+		);
+	});
+
+	test("watch --process-application errors when no .process-application found", () => {
+		// Plain directory with no marker
+		const dir = join(testDir, "plain");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(join(dir, "main.bpmn"), "<definitions/>");
+
+		const result = spawnSync(
+			"node",
+			[
+				"--experimental-strip-types",
+				CLI_ENTRY,
+				"watch",
+				"--process-application",
+				dir,
+			],
+			{
+				encoding: "utf-8",
+				stdio: "pipe",
+				timeout: 5000,
+				env: {
+					...process.env,
+					C8CTL_DATA_DIR: testDir,
+				},
+			},
+		);
+
+		assert.notStrictEqual(
+			result.status,
+			0,
+			"Should fail when --process-application is set but no marker found",
+		);
+		const output = (result.stdout || "") + (result.stderr || "");
+		assert.ok(
+			output.includes(".process-application"),
+			`Error message should mention .process-application, got:\n${output}`,
+		);
+	});
+
+	test("watch --process-application expands watch scope to PA root", () => {
+		// PA root with marker, and a subdirectory beneath it
+		const paRoot = join(testDir, "my-app");
+		const subDir = join(paRoot, "src", "processes");
+		mkdirSync(subDir, { recursive: true });
+		writeFileSync(join(paRoot, ".process-application"), "");
+		writeFileSync(join(subDir, "main.bpmn"), "<definitions/>");
+
+		// Watch the subdirectory with --process-application
+		const result = spawnSync(
+			"node",
+			[
+				"--experimental-strip-types",
+				CLI_ENTRY,
+				"watch",
+				"--process-application",
+				subDir,
+			],
+			{
+				encoding: "utf-8",
+				stdio: "pipe",
+				// Generous timeout — a safety net for slow CI runners, not a
+				// correctness signal. The assertion fires as soon as the
+				// banner is emitted; the timeout only caps how long we wait.
+				timeout: 10000,
+				env: {
+					...process.env,
+					C8CTL_DATA_DIR: testDir,
+				},
+			},
+		);
+
+		const output = (result.stdout || "") + (result.stderr || "");
+
+		// The "Watching for changes in:" line should show the PA root,
+		// not the subdirectory that was passed on the command line.
+		const watchLine = output
+			.split("\n")
+			.find((l: string) => l.includes("Watching for changes in:"));
+		assert.ok(watchLine, `Expected "Watching for changes in:" line in output`);
+
+		const normalizedWatchLine = watchLine.replace(/\\/g, "/");
+		const normalizedPaRoot = paRoot.replace(/\\/g, "/");
+		const normalizedSubDir = subDir.replace(/\\/g, "/");
+
+		assert.ok(
+			normalizedWatchLine.includes(normalizedPaRoot),
+			`Watch scope should include PA root "${normalizedPaRoot}", got: ${normalizedWatchLine}`,
+		);
+		// The subdirectory path should NOT appear (it was expanded to the PA root)
+		assert.ok(
+			!normalizedWatchLine.includes(normalizedSubDir),
+			`Watch scope should not include subdirectory "${normalizedSubDir}", got: ${normalizedWatchLine}`,
+		);
+	});
+
+	test("watch --process-application rejects paths from different PAs", () => {
+		// Two separate process applications
+		const pa1 = join(testDir, "app-a");
+		const pa2 = join(testDir, "app-b");
+		mkdirSync(pa1, { recursive: true });
+		mkdirSync(pa2, { recursive: true });
+		writeFileSync(join(pa1, ".process-application"), "");
+		writeFileSync(join(pa2, ".process-application"), "");
+		writeFileSync(join(pa1, "a.bpmn"), "<definitions/>");
+		writeFileSync(join(pa2, "b.bpmn"), "<definitions/>");
+
+		const result = spawnSync(
+			"node",
+			[
+				"--experimental-strip-types",
+				CLI_ENTRY,
+				"watch",
+				"--process-application",
+				pa1,
+				pa2,
+			],
+			{
+				encoding: "utf-8",
+				stdio: "pipe",
+				timeout: 5000,
+				env: {
+					...process.env,
+					C8CTL_DATA_DIR: testDir,
+				},
+			},
+		);
+
+		assert.notStrictEqual(
+			result.status,
+			0,
+			"Should fail when paths belong to different process applications",
+		);
+		const output = (result.stdout || "") + (result.stderr || "");
+		assert.ok(
+			output.includes("same process application"),
+			`Error should mention same process application, got:\n${output}`,
+		);
+	});
+});


### PR DESCRIPTION
## Summary

Implements Phase 2 of the process application epic (#260): auto-detect and deploy process applications (#227), plus a `--process-application` flag for `watch` mode.

## Deploy: auto-detect process application root

When `c8 deploy` is invoked from within a process application (a directory tree rooted at a `.process-application` marker file), c8ctl now automatically detects the PA root and deploys all resources from that root rather than just the specified subdirectory.

- `findProcessApplicationRoot(startDir)` walks up from the given directory looking for `.process-application`
- `collectResourcesForPaths()` resolves directory paths through PA detection, expanding them to the PA root
- File paths are left untouched (preserving single-file deploy behavior)
- Nested PAs resolve to the nearest ancestor marker
- `.c8ignore` at the PA root is respected
- Resources are deduplicated by absolute path to prevent double-deploys when explicit file paths overlap with PA-root walks

## Watch: `--process-application` / `--pa` flag

Adds a flag to `watch` mode that expands the **watch scope** to the PA root and deploys the entire process application on each file change.

```bash
c8 watch src/processes --process-application
c8 watch src/processes --pa
```

When enabled:
- At startup, resolves the PA root from the watched paths (all paths must belong to the same PA)
- Uses `realpathSync` to normalize paths for comparison (handles symlinks and equivalent spellings)
- Expands the watch scope to the PA root (monitors the entire PA tree, not just the specified subdirectory)
- Throws with an actionable error if no `.process-application` marker is found
- On each file change, deploys `[paRoot]` instead of `[changedFile]`

## Tests

- 9 tests for deploy PA detection (`tests/unit/process-application-detection.test.ts`)
- 6 tests for watch PA flag (`tests/unit/watch-process-application.test.ts`), including a test that verifies the watch scope is expanded from a subdirectory to the PA root
- All existing tests pass

Closes #227