### PR TITLE
feat: c8ctl mcp install/uninstall/list for claude-desktop, cursor, vscode (#293)

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1138,6 +1138,34 @@ Plugins are tracked in a registry file (`~/.config/c8ctl/plugins.json` on Linux)
 
 ---
 
+## MCP Client Integration
+
+Install the c8ctl MCP proxy into a third-party MCP client so the client can talk to the active Camunda 8 cluster.
+
+```bash
+# Install into Claude Desktop using the active profile (then restart Claude)
+c8ctl mcp install claude-desktop
+
+# Install into Cursor using a specific profile
+c8ctl mcp install cursor --profile prod
+
+# Install into VS Code with a custom alias (lets you install multiple profiles side-by-side)
+c8ctl mcp install vscode --alias camunda-prod
+
+# Show every installed entry across known clients
+c8ctl mcp list
+
+# Remove an entry
+c8ctl mcp uninstall claude-desktop --alias camunda-prod
+
+# Preview what would be written without touching the filesystem
+c8ctl mcp install claude-desktop --dry-run
+```
+
+The installed entry forwards your profile's credentials via environment variables, so the proxy authenticates the same way `c8ctl` itself does. Re-running `mcp install` is idempotent — it refreshes the credentials in place.
+
+---
+
 ## Combined Examples
 
 ### Complete Workflow

--- a/README.md
+++ b/README.md
@@ -1948,8 +1948,8 @@ Install/uninstall/list c8ctl mcp-proxy entries in MCP client configs (Claude Des
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
-| `--profile` | string |  | Profile name to embed in the MCP entry (default: active profile) |
-| `--alias` | string |  | Alias to use as the entry key in the client's config (default: profile name) |
+| `--profile` | string |  | Profile name to embed in the MCP entry (default: active profile, then the bootstrap 'local' profile) |
+| `--alias` | string |  | Alias to use as the entry key in the client's config (default: the resolved profile name) |
 | `--force` | boolean |  | Overwrite an existing entry at the same alias even if it was not installed by c8ctl |
 
 </details>
@@ -1959,7 +1959,7 @@ Install/uninstall/list c8ctl mcp-proxy entries in MCP client configs (Claude Des
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
-| `--alias` | string |  | Alias of the entry to remove (default: active profile name) |
+| `--alias` | string |  | Alias of the entry to remove (default: active profile name, then 'local', then 'camunda') |
 | `--force` | boolean |  | Remove an entry at the alias even if it does not look like a c8ctl-managed entry |
 
 </details>

--- a/README.md
+++ b/README.md
@@ -1950,6 +1950,7 @@ Install/uninstall/list c8ctl mcp-proxy entries in MCP client configs (Claude Des
 |------|------|----------|-------------|
 | `--profile` | string |  | Profile name to embed in the MCP entry (default: active profile) |
 | `--alias` | string |  | Alias to use as the entry key in the client's config (default: profile name) |
+| `--force` | boolean |  | Overwrite an existing entry at the same alias even if it was not installed by c8ctl |
 
 </details>
 
@@ -1959,6 +1960,7 @@ Install/uninstall/list c8ctl mcp-proxy entries in MCP client configs (Claude Des
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
 | `--alias` | string |  | Alias of the entry to remove (default: active profile name) |
+| `--force` | boolean |  | Remove an entry at the alias even if it does not look like a c8ctl-managed entry |
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -478,6 +478,27 @@ When plugins are loaded, their commands automatically appear in `c8ctl help` out
 
 ---
 
+## Connect to MCP clients
+
+c8ctl ships an MCP (Model Context Protocol) proxy that bridges any MCP-compatible
+client (Claude Desktop, Cursor, VS Code) to the active Camunda 8 cluster. Install
+it into a client's config with one command:
+
+```bash
+c8ctl mcp install claude-desktop   # then restart Claude Desktop
+c8ctl mcp install cursor           # then restart Cursor
+c8ctl mcp install vscode           # then reload the VS Code window
+```
+
+The installed entry forwards your active profile's credentials, so the proxy
+runs against the same cluster the rest of your `c8ctl` commands target.
+
+Use `c8ctl mcp list` to see every installed entry and `c8ctl mcp uninstall <client>`
+to remove one. Re-running `mcp install` is idempotent — it refreshes the
+credentials in place.
+
+---
+
 ## Agent Usage (AI / Programmatic Consumption)
 
 c8ctl ships two flags designed specifically for AI agents and programmatic consumers.
@@ -1906,6 +1927,50 @@ c8ctl completion install --shell zsh                        # Install completion
 Start a STDIO MCP proxy (bridges local MCP clients to remote Camunda 8)
 
 **Usage:** `c8ctl mcp-proxy [mcp-path]`
+
+---
+
+#### `mcp`
+
+Install/uninstall/list c8ctl mcp-proxy entries in MCP client configs (Claude Desktop, Cursor, VS Code)
+
+**Resources:** install, uninstall, list
+
+**Positional arguments:**
+
+- **install:** `<client>` (required)
+- **uninstall:** `<client>` (required)
+
+**Resource-specific flags:**
+
+<details>
+<summary><code>install</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--profile` | string |  | Profile name to embed in the MCP entry (default: active profile) |
+| `--alias` | string |  | Alias to use as the entry key in the client's config (default: profile name) |
+
+</details>
+
+<details>
+<summary><code>uninstall</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--alias` | string |  | Alias of the entry to remove (default: active profile name) |
+
+</details>
+
+**Examples:**
+
+```bash
+c8ctl mcp install claude-desktop                            # Install c8ctl as an MCP server in Claude Desktop
+c8ctl mcp install cursor --profile prod                     # Install in Cursor using the 'prod' profile
+c8ctl mcp install vscode --alias camunda-prod               # Install in VS Code with a custom alias
+c8ctl mcp list                                              # Show every c8ctl MCP entry across known clients
+c8ctl mcp uninstall claude-desktop --alias camunda-prod     # Remove a previously installed entry
+```
 
 ---
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1156,8 +1156,8 @@ Install/uninstall/list c8ctl mcp-proxy entries in MCP client configs (Claude Des
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
-| `--profile` | string |  | Profile name to embed in the MCP entry (default: active profile) |
-| `--alias` | string |  | Alias to use as the entry key in the client's config (default: profile name) |
+| `--profile` | string |  | Profile name to embed in the MCP entry (default: active profile, then the bootstrap 'local' profile) |
+| `--alias` | string |  | Alias to use as the entry key in the client's config (default: the resolved profile name) |
 | `--force` | boolean |  | Overwrite an existing entry at the same alias even if it was not installed by c8ctl |
 
 </details>
@@ -1167,7 +1167,7 @@ Install/uninstall/list c8ctl mcp-proxy entries in MCP client configs (Claude Des
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
-| `--alias` | string |  | Alias of the entry to remove (default: active profile name) |
+| `--alias` | string |  | Alias of the entry to remove (default: active profile name, then 'local', then 'camunda') |
 | `--force` | boolean |  | Remove an entry at the alias even if it does not look like a c8ctl-managed entry |
 
 </details>

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1158,6 +1158,7 @@ Install/uninstall/list c8ctl mcp-proxy entries in MCP client configs (Claude Des
 |------|------|----------|-------------|
 | `--profile` | string |  | Profile name to embed in the MCP entry (default: active profile) |
 | `--alias` | string |  | Alias to use as the entry key in the client's config (default: profile name) |
+| `--force` | boolean |  | Overwrite an existing entry at the same alias even if it was not installed by c8ctl |
 
 </details>
 
@@ -1167,6 +1168,7 @@ Install/uninstall/list c8ctl mcp-proxy entries in MCP client configs (Claude Des
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
 | `--alias` | string |  | Alias of the entry to remove (default: active profile name) |
+| `--force` | boolean |  | Remove an entry at the alias even if it does not look like a c8ctl-managed entry |
 
 </details>
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -1138,6 +1138,50 @@ Start a STDIO MCP proxy (bridges local MCP clients to remote Camunda 8)
 
 ---
 
+### `mcp`
+
+Install/uninstall/list c8ctl mcp-proxy entries in MCP client configs (Claude Desktop, Cursor, VS Code)
+
+**Resources:** install, uninstall, list
+
+**Positional arguments:**
+
+- **install:** `<client>` (required)
+- **uninstall:** `<client>` (required)
+
+**Resource-specific flags:**
+
+<details>
+<summary><code>install</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--profile` | string |  | Profile name to embed in the MCP entry (default: active profile) |
+| `--alias` | string |  | Alias to use as the entry key in the client's config (default: profile name) |
+
+</details>
+
+<details>
+<summary><code>uninstall</code></summary>
+
+| Flag | Type | Required | Description |
+|------|------|----------|-------------|
+| `--alias` | string |  | Alias of the entry to remove (default: active profile name) |
+
+</details>
+
+**Examples:**
+
+```bash
+c8ctl mcp install claude-desktop                            # Install c8ctl as an MCP server in Claude Desktop
+c8ctl mcp install cursor --profile prod                     # Install in Cursor using the 'prod' profile
+c8ctl mcp install vscode --alias camunda-prod               # Install in VS Code with a custom alias
+c8ctl mcp list                                              # Show every c8ctl MCP entry across known clients
+c8ctl mcp uninstall claude-desktop --alias camunda-prod     # Remove a previously installed entry
+```
+
+---
+
 ### `feedback`
 
 Open the feedback page to report issues or request features

--- a/src/command-dispatch.ts
+++ b/src/command-dispatch.ts
@@ -64,6 +64,11 @@ import {
 	failJobCommand,
 	listJobsCommand,
 } from "./commands/jobs.ts";
+import {
+	mcpInstallCommand,
+	mcpListCommand,
+	mcpUninstallCommand,
+} from "./commands/mcp.ts";
 import { mcpProxyCommand } from "./commands/mcp-proxy.ts";
 import {
 	correlateMessageCommand,
@@ -262,4 +267,7 @@ export const COMMAND_DISPATCH: ReadonlyMap<string, AnyCommandHandler> = new Map<
 	["open:optimize", openAppCommand],
 	["feedback:", feedbackCommand],
 	["mcp-proxy:", mcpProxyCommand],
+	["mcp:install", mcpInstallCommand],
+	["mcp:uninstall", mcpUninstallCommand],
+	["mcp:list", mcpListCommand],
 ]);

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -1675,12 +1675,12 @@ export const COMMAND_REGISTRY = {
 				profile: {
 					type: "string",
 					description:
-						"Profile name to embed in the MCP entry (default: active profile)",
+						"Profile name to embed in the MCP entry (default: active profile, then the bootstrap 'local' profile)",
 				},
 				alias: {
 					type: "string",
 					description:
-						"Alias to use as the entry key in the client's config (default: profile name)",
+						"Alias to use as the entry key in the client's config (default: the resolved profile name)",
 				},
 				force: {
 					type: "boolean",
@@ -1692,7 +1692,7 @@ export const COMMAND_REGISTRY = {
 				alias: {
 					type: "string",
 					description:
-						"Alias of the entry to remove (default: active profile name)",
+						"Alias of the entry to remove (default: active profile name, then 'local', then 'camunda')",
 				},
 				force: {
 					type: "boolean",
@@ -1703,8 +1703,12 @@ export const COMMAND_REGISTRY = {
 			list: {},
 		},
 		resourcePositionals: {
-			install: [{ name: "client", required: true }],
-			uninstall: [{ name: "client", required: true }],
+			install: [
+				{ name: "client", required: true },
+			] as const satisfies readonly PositionalDef[],
+			uninstall: [
+				{ name: "client", required: true },
+			] as const satisfies readonly PositionalDef[],
 		},
 		helpExamples: [
 			{

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -1682,12 +1682,22 @@ export const COMMAND_REGISTRY = {
 					description:
 						"Alias to use as the entry key in the client's config (default: profile name)",
 				},
+				force: {
+					type: "boolean",
+					description:
+						"Overwrite an existing entry at the same alias even if it was not installed by c8ctl",
+				},
 			},
 			uninstall: {
 				alias: {
 					type: "string",
 					description:
 						"Alias of the entry to remove (default: active profile name)",
+				},
+				force: {
+					type: "boolean",
+					description:
+						"Remove an entry at the alias even if it does not look like a c8ctl-managed entry",
 				},
 			},
 			list: {},

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -1659,6 +1659,67 @@ export const COMMAND_REGISTRY = {
 		flags: {},
 	},
 
+	mcp: {
+		description:
+			"Install or remove c8ctl MCP proxy entries in MCP client configs",
+		helpDescription:
+			"Install/uninstall/list c8ctl mcp-proxy entries in MCP client configs (Claude Desktop, Cursor, VS Code)",
+		hasDetailedHelp: true,
+		helpFooterLabel: "Show mcp install/uninstall/list usage",
+		mutating: true,
+		requiresResource: true,
+		resources: ["install", "uninstall", "list"],
+		flags: {},
+		resourceFlags: {
+			install: {
+				profile: {
+					type: "string",
+					description:
+						"Profile name to embed in the MCP entry (default: active profile)",
+				},
+				alias: {
+					type: "string",
+					description:
+						"Alias to use as the entry key in the client's config (default: profile name)",
+				},
+			},
+			uninstall: {
+				alias: {
+					type: "string",
+					description:
+						"Alias of the entry to remove (default: active profile name)",
+				},
+			},
+			list: {},
+		},
+		resourcePositionals: {
+			install: [{ name: "client", required: true }],
+			uninstall: [{ name: "client", required: true }],
+		},
+		helpExamples: [
+			{
+				command: "c8ctl mcp install claude-desktop",
+				description: "Install c8ctl as an MCP server in Claude Desktop",
+			},
+			{
+				command: "c8ctl mcp install cursor --profile prod",
+				description: "Install in Cursor using the 'prod' profile",
+			},
+			{
+				command: "c8ctl mcp install vscode --alias camunda-prod",
+				description: "Install in VS Code with a custom alias",
+			},
+			{
+				command: "c8ctl mcp list",
+				description: "Show every c8ctl MCP entry across known clients",
+			},
+			{
+				command: "c8ctl mcp uninstall claude-desktop --alias camunda-prod",
+				description: "Remove a previously installed entry",
+			},
+		],
+	},
+
 	feedback: {
 		description: "Open the feedback page to report issues or request features",
 		mutating: false,

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -1,0 +1,268 @@
+/**
+ * `c8ctl mcp install|uninstall|list <client>` (#293).
+ *
+ * Configures third-party MCP clients (Claude Desktop, Cursor, VS Code)
+ * to launch `c8ctl mcp-proxy` with the active profile's credentials.
+ *
+ * Boundary: this verb is the *configurator*. The `mcp-proxy` verb is
+ * the runtime it points clients at. They are intentionally separate
+ * commands so users can re-run `mcp install` without restarting any
+ * proxy process.
+ */
+
+import { existsSync } from "node:fs";
+import { defineCommand } from "../command-framework.ts";
+import { getAllProfiles, getProfile, resolveClusterConfig } from "../config.ts";
+import {
+	getAdapter,
+	listSupportedClients,
+	type McpClientAdapter,
+	type McpServerEntry,
+	mergeMcpConfig,
+	unmergeMcpConfig,
+} from "../mcp-install/adapters.ts";
+import { readJsonFileOrNull, writeJsonAtomic } from "../mcp-install/fs.ts";
+import { c8ctl } from "../runtime.ts";
+
+/**
+ * Default alias for an installed MCP entry. Falls back to the literal
+ * "camunda" when no profile is active so the entry still has a name.
+ */
+function defaultAlias(profileName: string | undefined): string {
+	return profileName && profileName.length > 0 ? profileName : "camunda";
+}
+
+/**
+ * Resolve the profile that the installed MCP entry will reference.
+ * Throws when an explicit `--profile` names an unknown profile so the
+ * defect class "wrote a working entry pointing at a profile that
+ * doesn't exist" cannot occur.
+ */
+function resolveProfileName(profileFlag: string | undefined): string {
+	if (profileFlag) {
+		if (!getProfile(profileFlag)) {
+			throw new Error(
+				`Profile '${profileFlag}' not found. Run 'c8ctl list profile' to see available profiles.`,
+			);
+		}
+		return profileFlag;
+	}
+	if (c8ctl.activeProfile) return c8ctl.activeProfile;
+	// Fall back to the first defined profile rather than emitting an
+	// entry with no `--profile` arg — that would silently reuse env vars
+	// at proxy-spawn time, breaking the "what you installed is what runs"
+	// contract.
+	const profiles = getAllProfiles();
+	const first = profiles[0];
+	if (first) return first.name;
+	throw new Error(
+		"No profile available. Create one with 'c8ctl add profile <name>' before running 'c8ctl mcp install'.",
+	);
+}
+
+/**
+ * `c8ctl mcp install <client> [--profile <name>] [--alias <name>]`
+ */
+export const mcpInstallCommand = defineCommand(
+	"mcp",
+	"install",
+	async (ctx, flags) => {
+		const { logger } = ctx;
+		const clientId = ctx.positionals[0];
+		if (!clientId) {
+			throw new Error(
+				`Missing MCP client name. Supported clients: ${listSupportedClients().join(", ")}.`,
+			);
+		}
+		const adapter = getAdapter(clientId);
+		const profileName = resolveProfileName(flags.profile);
+		const alias =
+			flags.alias && flags.alias.length > 0
+				? flags.alias
+				: defaultAlias(profileName);
+		const profile = resolveClusterConfig(profileName);
+		const entry: McpServerEntry = adapter.buildEntry({
+			profile,
+			profileName,
+		});
+		const configPath = adapter.configPath();
+		const existing = readJsonFileOrNull(configPath);
+		const { merged, existed } = mergeMcpConfig(
+			existing,
+			adapter.serversKey,
+			alias,
+			entry,
+		);
+
+		if (c8ctl.dryRun) {
+			return {
+				kind: "dryRun",
+				info: {
+					dryRun: true,
+					command: `mcp install ${clientId}`,
+					action: "write-mcp-config",
+					client: clientId,
+					configPath,
+					alias,
+					profile: profileName,
+					wouldOverwrite: existed,
+					content: merged,
+				},
+			};
+		}
+
+		writeJsonAtomic(configPath, merged);
+		const verb = existed ? "Updated" : "Installed";
+		const restartHint = restartHintFor(adapter);
+		logger.info(
+			`${verb} ${alias} → ${adapter.displayName}\n` +
+				`  Config: ${configPath}\n` +
+				`  Profile: ${profileName}\n` +
+				`  ${restartHint}`,
+		);
+		return { kind: "none" };
+	},
+);
+
+/**
+ * `c8ctl mcp uninstall <client> [--alias <name>]`
+ */
+export const mcpUninstallCommand = defineCommand(
+	"mcp",
+	"uninstall",
+	async (ctx, flags) => {
+		const { logger } = ctx;
+		const clientId = ctx.positionals[0];
+		if (!clientId) {
+			throw new Error(
+				`Missing MCP client name. Supported clients: ${listSupportedClients().join(", ")}.`,
+			);
+		}
+		const adapter = getAdapter(clientId);
+		const alias =
+			flags.alias && flags.alias.length > 0
+				? flags.alias
+				: defaultAlias(c8ctl.activeProfile);
+		const configPath = adapter.configPath();
+		const existing = readJsonFileOrNull(configPath);
+		const { merged, existed } = unmergeMcpConfig(
+			existing,
+			adapter.serversKey,
+			alias,
+		);
+		if (!existed) {
+			// Idempotent: removing an absent alias is not an error.
+			logger.info(
+				`No '${alias}' entry under ${adapter.displayName}; nothing to uninstall.`,
+			);
+			return { kind: "none" };
+		}
+		if (c8ctl.dryRun) {
+			return {
+				kind: "dryRun",
+				info: {
+					dryRun: true,
+					command: `mcp uninstall ${clientId}`,
+					action: "remove-mcp-entry",
+					client: clientId,
+					configPath,
+					alias,
+					content: merged,
+				},
+			};
+		}
+		writeJsonAtomic(configPath, merged);
+		logger.info(
+			`Uninstalled ${alias} from ${adapter.displayName}\n` +
+				`  Config: ${configPath}`,
+		);
+		return { kind: "none" };
+	},
+);
+
+/**
+ * `c8ctl mcp list` — show every c8ctl-managed entry across known clients.
+ *
+ * Renders as a list so the framework picks the right output format for
+ * text/json. Items are flat objects (Client / Alias / Profile / Config)
+ * to match other `list` commands.
+ */
+export const mcpListCommand = defineCommand(
+	"mcp",
+	"list",
+	async (_ctx, _flags) => {
+		const items: Record<string, unknown>[] = [];
+		for (const adapter of listSupportedClients().map(getAdapter)) {
+			const path = adapter.configPath();
+			if (!existsSync(path)) continue;
+			let parsed: unknown;
+			try {
+				parsed = readJsonFileOrNull(path);
+			} catch {
+				// A corrupt config file is reported in the row itself rather
+				// than aborting the whole listing — users with one broken
+				// file still want to see their other clients.
+				items.push({
+					Client: adapter.displayName,
+					Alias: "—",
+					Profile: "—",
+					Config: `${path} (parse error)`,
+				});
+				continue;
+			}
+			const servers = extractServerEntries(parsed, adapter.serversKey);
+			for (const [alias, entry] of servers) {
+				items.push({
+					Client: adapter.displayName,
+					Alias: alias,
+					Profile: extractProfileName(entry) ?? "—",
+					Config: path,
+				});
+			}
+		}
+		return {
+			kind: "list",
+			items,
+			emptyMessage:
+				"No MCP entries found. Run 'c8ctl mcp install <client>' to add one.",
+		};
+	},
+);
+
+function extractServerEntries(
+	parsed: unknown,
+	serversKey: string,
+): [string, unknown][] {
+	if (!isRecordLike(parsed)) return [];
+	const servers = parsed[serversKey];
+	if (!isRecordLike(servers)) return [];
+	return Object.entries(servers);
+}
+
+function extractProfileName(entry: unknown): string | undefined {
+	if (!isRecordLike(entry)) return undefined;
+	const args = entry.args;
+	if (!Array.isArray(args)) return undefined;
+	// `["-y", "@camunda8/cli", "mcp-proxy", "--profile", "<name>"]`
+	const idx = args.indexOf("--profile");
+	if (idx < 0 || idx === args.length - 1) return undefined;
+	const value = args[idx + 1];
+	return typeof value === "string" ? value : undefined;
+}
+
+function isRecordLike(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function restartHintFor(adapter: McpClientAdapter): string {
+	switch (adapter.id) {
+		case "claude-desktop":
+			return "Restart Claude Desktop to activate.";
+		case "cursor":
+			return "Restart Cursor to activate.";
+		case "vscode":
+			return "Reload the VS Code window (Cmd/Ctrl+Shift+P → 'Reload Window') to activate.";
+		default:
+			return `Restart ${adapter.displayName} to activate.`;
+	}
+}

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -102,6 +102,27 @@ export const mcpInstallCommand = defineCommand(
 		});
 		const configPath = adapter.configPath();
 		const existing = readJsonFileOrNull(configPath);
+		// Refuse to clobber a third-party MCP server that happens to share
+		// this alias. The verb's contract is "manage c8ctl mcp-proxy entries",
+		// so silently overwriting an unrelated entry would violate it.
+		// `--force` is the explicit escape hatch for users who really do want
+		// to take over the alias.
+		const existingEntry = lookupExistingEntry(
+			existing,
+			adapter.serversKey,
+			alias,
+		);
+		if (
+			existingEntry !== undefined &&
+			!isC8ctlManagedEntry(existingEntry) &&
+			!flags.force
+		) {
+			throw new Error(
+				`Refusing to overwrite '${alias}' under ${adapter.displayName}: ` +
+					"the existing entry was not installed by c8ctl. " +
+					"Pass --force to overwrite, or use --alias <other-name> to install alongside it.",
+			);
+		}
 		const { merged, existed } = mergeMcpConfig(
 			existing,
 			adapter.serversKey,
@@ -163,6 +184,24 @@ export const mcpUninstallCommand = defineCommand(
 				: defaultAlias(defaultProfileNameForAlias());
 		const configPath = adapter.configPath();
 		const existing = readJsonFileOrNull(configPath);
+		// Refuse to remove an unrelated MCP server entry that just happens
+		// to share this alias. Same reasoning as install: this verb manages
+		// c8ctl-shaped entries, not arbitrary ones. `--force` overrides.
+		const existingEntry = lookupExistingEntry(
+			existing,
+			adapter.serversKey,
+			alias,
+		);
+		if (
+			existingEntry !== undefined &&
+			!isC8ctlManagedEntry(existingEntry) &&
+			!flags.force
+		) {
+			throw new Error(
+				`Refusing to remove '${alias}' from ${adapter.displayName}: ` +
+					"the entry was not installed by c8ctl. Pass --force to remove anyway.",
+			);
+		}
 		const { merged, existed } = unmergeMcpConfig(
 			existing,
 			adapter.serversKey,
@@ -230,6 +269,11 @@ export const mcpListCommand = defineCommand(
 			}
 			const servers = extractServerEntries(parsed, adapter.serversKey);
 			for (const [alias, entry] of servers) {
+				// Only surface c8ctl-managed entries so the listing matches
+				// the verb's contract. Users with their own unrelated MCP
+				// servers in the same config see them via the third-party
+				// client's own UI; this command is intentionally scoped.
+				if (!isC8ctlManagedEntry(entry)) continue;
 				items.push({
 					Client: adapter.displayName,
 					Alias: alias,
@@ -266,6 +310,37 @@ function extractProfileName(entry: unknown): string | undefined {
 	if (idx < 0 || idx === args.length - 1) return undefined;
 	const value = args[idx + 1];
 	return typeof value === "string" ? value : undefined;
+}
+
+/**
+ * Look up a single entry under `serversKey/alias` in a parsed config
+ * tree. Returns `undefined` when the path is absent so callers can use
+ * triple-equals to distinguish "not present" from "present but empty".
+ */
+function lookupExistingEntry(
+	parsed: unknown,
+	serversKey: string,
+	alias: string,
+): unknown {
+	if (!isRecordLike(parsed)) return undefined;
+	const servers = parsed[serversKey];
+	if (!isRecordLike(servers)) return undefined;
+	if (!Object.hasOwn(servers, alias)) return undefined;
+	return servers[alias];
+}
+
+/**
+ * Recognise an entry that c8ctl would have written: it must launch
+ * `npx` (or carry an args array containing) the published `@camunda8/cli`
+ * package and the `mcp-proxy` subcommand. This is the same signature
+ * `buildNpxProxyEntry` produces, so install/uninstall round-trip on
+ * matching entries and refuse to touch foreign ones.
+ */
+function isC8ctlManagedEntry(entry: unknown): boolean {
+	if (!isRecordLike(entry)) return false;
+	const args = entry.args;
+	if (!Array.isArray(args)) return false;
+	return args.includes("@camunda8/cli") && args.includes("mcp-proxy");
 }
 
 function isRecordLike(value: unknown): value is Record<string, unknown> {

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -81,14 +81,9 @@ function resolveProfileName(profileFlag: string | undefined): string {
 export const mcpInstallCommand = defineCommand(
 	"mcp",
 	"install",
-	async (ctx, flags) => {
+	async (ctx, flags, args) => {
 		const { logger } = ctx;
-		const clientId = ctx.positionals[0];
-		if (!clientId) {
-			throw new Error(
-				`Missing MCP client name. Supported clients: ${listSupportedClients().join(", ")}.`,
-			);
-		}
+		const clientId = args.client;
 		const adapter = getAdapter(clientId);
 		const profileName = resolveProfileName(flags.profile);
 		const alias =
@@ -166,14 +161,9 @@ export const mcpInstallCommand = defineCommand(
 export const mcpUninstallCommand = defineCommand(
 	"mcp",
 	"uninstall",
-	async (ctx, flags) => {
+	async (ctx, flags, args) => {
 		const { logger } = ctx;
-		const clientId = ctx.positionals[0];
-		if (!clientId) {
-			throw new Error(
-				`Missing MCP client name. Supported clients: ${listSupportedClients().join(", ")}.`,
-			);
-		}
+		const clientId = args.client;
 		const adapter = getAdapter(clientId);
 		// Default alias must match install's default — both fall back through
 		// the same `defaultProfileNameForAlias()` chain so `mcp uninstall <client>`
@@ -330,11 +320,18 @@ function lookupExistingEntry(
 }
 
 /**
- * Recognise an entry that c8ctl would have written: it must launch
- * `npx` (or carry an args array containing) the published `@camunda8/cli`
- * package and the `mcp-proxy` subcommand. This is the same signature
- * `buildNpxProxyEntry` produces, so install/uninstall round-trip on
- * matching entries and refuse to touch foreign ones.
+ * Recognise an entry that c8ctl would have written. The check is the
+ * minimum signature that distinguishes a c8ctl-managed proxy entry
+ * from any other MCP server: the `args` array references the published
+ * `@camunda8/cli` package *and* the `mcp-proxy` subcommand. We do not
+ * lock the predicate to `command === "npx"` because users (and future
+ * c8ctl versions) may legitimately swap the runner (`bunx`, `npx -y`,
+ * a wrapper script) without changing the entry's identity — the args
+ * pair is the stable c8ctl fingerprint, the runner is not.
+ *
+ * Kept deliberately narrow: install/uninstall must only round-trip
+ * entries this predicate recognises, and `mcp list` must only surface
+ * those.
  */
 function isC8ctlManagedEntry(entry: unknown): boolean {
 	if (!isRecordLike(entry)) return false;

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -12,7 +12,12 @@
 
 import { existsSync } from "node:fs";
 import { defineCommand } from "../command-framework.ts";
-import { getAllProfiles, getProfile, resolveClusterConfig } from "../config.ts";
+import {
+	DEFAULT_PROFILE,
+	getProfile,
+	getProfileOrModeler,
+	resolveClusterConfig,
+} from "../config.ts";
 import {
 	getAdapter,
 	listSupportedClients,
@@ -33,30 +38,40 @@ function defaultAlias(profileName: string | undefined): string {
 }
 
 /**
+ * Profile name install/uninstall use as the default alias when neither
+ * `--profile` nor `--alias` is given. Mirrors `resolveClusterConfig`'s
+ * profile chain (active profile → bootstrap 'local' default) so install
+ * and uninstall agree on which entry the user means without `--alias`.
+ * Returns `undefined` when nothing is available; callers fall back to
+ * the literal "camunda".
+ */
+function defaultProfileNameForAlias(): string | undefined {
+	if (c8ctl.activeProfile) return c8ctl.activeProfile;
+	if (getProfile(DEFAULT_PROFILE)) return DEFAULT_PROFILE;
+	return undefined;
+}
+
+/**
  * Resolve the profile that the installed MCP entry will reference.
  * Throws when an explicit `--profile` names an unknown profile so the
  * defect class "wrote a working entry pointing at a profile that
- * doesn't exist" cannot occur.
+ * doesn't exist" cannot occur. Accepts `modeler:<name>` via
+ * `getProfileOrModeler` so Modeler connections work the same as in
+ * every other command.
  */
 function resolveProfileName(profileFlag: string | undefined): string {
 	if (profileFlag) {
-		if (!getProfile(profileFlag)) {
+		if (!getProfileOrModeler(profileFlag)) {
 			throw new Error(
 				`Profile '${profileFlag}' not found. Run 'c8ctl list profile' to see available profiles.`,
 			);
 		}
 		return profileFlag;
 	}
-	if (c8ctl.activeProfile) return c8ctl.activeProfile;
-	// Fall back to the first defined profile rather than emitting an
-	// entry with no `--profile` arg — that would silently reuse env vars
-	// at proxy-spawn time, breaking the "what you installed is what runs"
-	// contract.
-	const profiles = getAllProfiles();
-	const first = profiles[0];
-	if (first) return first.name;
+	const defaulted = defaultProfileNameForAlias();
+	if (defaulted) return defaulted;
 	throw new Error(
-		"No profile available. Create one with 'c8ctl add profile <name>' before running 'c8ctl mcp install'.",
+		"No profile available. Create one with 'c8ctl add profile <name>' or pass --profile before running 'c8ctl mcp install'.",
 	);
 }
 
@@ -139,10 +154,13 @@ export const mcpUninstallCommand = defineCommand(
 			);
 		}
 		const adapter = getAdapter(clientId);
+		// Default alias must match install's default — both fall back through
+		// the same `defaultProfileNameForAlias()` chain so `mcp uninstall <client>`
+		// always removes what `mcp install <client>` created.
 		const alias =
 			flags.alias && flags.alias.length > 0
 				? flags.alias
-				: defaultAlias(c8ctl.activeProfile);
+				: defaultAlias(defaultProfileNameForAlias());
 		const configPath = adapter.configPath();
 		const existing = readJsonFileOrNull(configPath);
 		const { merged, existed } = unmergeMcpConfig(

--- a/src/commands/mcp.ts
+++ b/src/commands/mcp.ts
@@ -137,7 +137,7 @@ export const mcpInstallCommand = defineCommand(
 					alias,
 					profile: profileName,
 					wouldOverwrite: existed,
-					content: merged,
+					content: redactConfigSecrets(merged),
 				},
 			};
 		}
@@ -214,7 +214,7 @@ export const mcpUninstallCommand = defineCommand(
 					client: clientId,
 					configPath,
 					alias,
-					content: merged,
+					content: redactConfigSecrets(merged),
 				},
 			};
 		}
@@ -342,6 +342,62 @@ function isC8ctlManagedEntry(entry: unknown): boolean {
 
 function isRecordLike(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Redact env-var values that look like credentials before printing the
+ * merged config in `--dry-run` output.
+ *
+ * Defect class: `logger.json()`'s field-name redactor only matches the
+ * lower-case keys it knows about (`password`, `clientSecret`, ...). MCP
+ * entries embed credentials under upper-case env names like
+ * `CAMUNDA_CLIENT_SECRET` / `CAMUNDA_PASSWORD`, which would otherwise
+ * print verbatim to stdout on `c8ctl mcp install --dry-run`.
+ *
+ * Strategy: walk the merged config, locate the `env` block of every
+ * server entry under any `serversKey`, and replace values whose key
+ * looks sensitive (case-insensitive match against SECRET / PASSWORD /
+ * TOKEN / KEY) with `[REDACTED]`. The check is by key name so future
+ * env additions stay protected without code changes.
+ */
+function redactConfigSecrets(
+	merged: Record<string, unknown>,
+): Record<string, unknown> {
+	const result: Record<string, unknown> = {};
+	for (const [topKey, topVal] of Object.entries(merged)) {
+		if (!isRecordLike(topVal)) {
+			result[topKey] = topVal;
+			continue;
+		}
+		const redactedServers: Record<string, unknown> = {};
+		for (const [alias, entry] of Object.entries(topVal)) {
+			redactedServers[alias] = redactEntryEnv(entry);
+		}
+		result[topKey] = redactedServers;
+	}
+	return result;
+}
+
+function redactEntryEnv(entry: unknown): unknown {
+	if (!isRecordLike(entry)) return entry;
+	const env = entry.env;
+	if (!isRecordLike(env)) return entry;
+	const redactedEnv: Record<string, unknown> = {};
+	for (const [k, v] of Object.entries(env)) {
+		redactedEnv[k] = looksSensitive(k) ? "[REDACTED]" : v;
+	}
+	return { ...entry, env: redactedEnv };
+}
+
+function looksSensitive(envKey: string): boolean {
+	const upper = envKey.toUpperCase();
+	return (
+		upper.includes("SECRET") ||
+		upper.includes("PASSWORD") ||
+		upper.includes("TOKEN") ||
+		upper.endsWith("_KEY") ||
+		upper === "KEY"
+	);
 }
 
 function restartHintFor(adapter: McpClientAdapter): string {

--- a/src/mcp-install/adapters.ts
+++ b/src/mcp-install/adapters.ts
@@ -253,6 +253,26 @@ function home(env: AdapterEnv): string {
 // ─── Config merge helpers ────────────────────────────────────────────────────
 
 /**
+ * Narrow a parsed config value to a plain object we can safely merge into.
+ *
+ * - `null` / `undefined` (i.e. file absent or empty per `readJsonFileOrNull`)
+ *   collapses to an empty object so install can seed a fresh config.
+ * - A plain object is returned as-is.
+ * - Any other shape (array, scalar, ...) is a structural mismatch we refuse
+ *   to silently overwrite: writing a JSON object on top of an existing array
+ *   would clobber data the user explicitly chose to store there.
+ */
+function coerceExistingConfig(existing: unknown): Record<string, unknown> {
+	if (existing === null || existing === undefined) return {};
+	if (isRecord(existing)) return existing;
+	const observed = Array.isArray(existing) ? "array" : typeof existing;
+	throw new Error(
+		`Existing MCP client config is a ${observed}, not a JSON object. ` +
+			"Refusing to overwrite — fix the file manually or delete it and re-run.",
+	);
+}
+
+/**
  * Result of merging an MCP server entry into an existing client config.
  * Returned as a plain object so callers can stringify, write, or render
  * it without further mutation. `existed` distinguishes "added new" from
@@ -281,7 +301,7 @@ export function mergeMcpConfig(
 	alias: string,
 	entry: McpServerEntry,
 ): MergeResult {
-	const base: Record<string, unknown> = isRecord(existing) ? existing : {};
+	const base = coerceExistingConfig(existing);
 	const priorServers = isRecord(base[serversKey]) ? base[serversKey] : {};
 	const existed = Object.hasOwn(priorServers, alias);
 	const nextServers = { ...priorServers, [alias]: entry };
@@ -303,7 +323,7 @@ export function unmergeMcpConfig(
 	serversKey: string,
 	alias: string,
 ): MergeResult {
-	const base: Record<string, unknown> = isRecord(existing) ? existing : {};
+	const base = coerceExistingConfig(existing);
 	const priorServers = isRecord(base[serversKey]) ? base[serversKey] : {};
 	const existed = Object.hasOwn(priorServers, alias);
 	if (!existed) {

--- a/src/mcp-install/adapters.ts
+++ b/src/mcp-install/adapters.ts
@@ -108,8 +108,10 @@ export function buildProxyEnv(
 	if (profile.clientSecret) env.CAMUNDA_CLIENT_SECRET = profile.clientSecret;
 	if (profile.oAuthUrl) env.CAMUNDA_OAUTH_URL = profile.oAuthUrl;
 	if (profile.audience) env.CAMUNDA_TOKEN_AUDIENCE = profile.audience;
-	if (profile.username) env.CAMUNDA_BASIC_AUTH_USERNAME = profile.username;
-	if (profile.password) env.CAMUNDA_BASIC_AUTH_PASSWORD = profile.password;
+	// Use CAMUNDA_USERNAME / CAMUNDA_PASSWORD (not CAMUNDA_BASIC_AUTH_*)
+	// to match the env vars resolveClusterConfig actually reads in src/config.ts.
+	if (profile.username) env.CAMUNDA_USERNAME = profile.username;
+	if (profile.password) env.CAMUNDA_PASSWORD = profile.password;
 	return env;
 }
 

--- a/src/mcp-install/adapters.ts
+++ b/src/mcp-install/adapters.ts
@@ -1,0 +1,316 @@
+/**
+ * MCP client adapters and config-merge helpers (#293).
+ *
+ * `c8ctl mcp install <client>` writes a `c8ctl mcp-proxy` server entry into
+ * the named client's MCP config file so the client can launch the proxy
+ * with the active profile's credentials. The defect class this kills is
+ * the docs-driven hand-edit: the JSON top-level key name varies per
+ * client (`mcpServers` vs `servers`) and a typo silently disables the
+ * server. Adapters own the key name; a class-scoped test guarantees
+ * every adapter declares one.
+ *
+ * Adapters are intentionally tiny — one per client — so adding a new
+ * client (Zed, Windsurf, ...) is a single object literal plus a fixture
+ * row in the adapter contract test.
+ */
+
+import { homedir, platform as osPlatform } from "node:os";
+import { join } from "node:path";
+import { isRecord } from "../logger.ts";
+
+/** Server entry shape that c8ctl writes into a client's MCP config. */
+export interface McpServerEntry {
+	command: string;
+	args: string[];
+	env?: Record<string, string>;
+	/** VS Code's MCP schema requires a `type` field; other clients omit it. */
+	type?: "stdio";
+}
+
+/** Inputs an adapter needs to build a c8ctl-flavoured server entry. */
+export interface BuildEntryInputs {
+	/** Resolved cluster credentials for the active or named profile. */
+	profile: {
+		baseUrl: string;
+		clientId?: string;
+		clientSecret?: string;
+		audience?: string;
+		oAuthUrl?: string;
+		username?: string;
+		password?: string;
+	};
+	/** Profile name to forward to `c8ctl mcp-proxy --profile <name>`. */
+	profileName: string;
+}
+
+/** Per-client adapter. One file change == one new client. */
+export interface McpClientAdapter {
+	/** Stable lowercase id used as the CLI argument and in `mcp list` output. */
+	id: string;
+	/** Human-friendly name shown in confirmation messages and `mcp list`. */
+	displayName: string;
+	/**
+	 * Resolve the absolute path to this client's MCP config file.
+	 *
+	 * Pure: depends only on the supplied env (`HOME`, `APPDATA`, platform)
+	 * so tests can pin a temp directory by passing a mocked env without
+	 * touching the real filesystem.
+	 */
+	configPath(env?: AdapterEnv): string;
+	/**
+	 * Top-level JSON key under which MCP server entries live.
+	 * Claude / Cursor: `mcpServers`. VS Code: `servers`.
+	 *
+	 * Locked by `tests/unit/mcp-install-adapters.test.ts` so a typo
+	 * surfaces as a test failure, not a silent user-facing breakage.
+	 */
+	serversKey: string;
+	/** Build the server entry that points at `c8ctl mcp-proxy`. */
+	buildEntry(inputs: BuildEntryInputs): McpServerEntry;
+}
+
+/**
+ * Subset of `process.env` that adapters consult. Tests pass a frozen
+ * record so per-OS path resolution is deterministic regardless of the
+ * runner's environment.
+ */
+export interface AdapterEnv {
+	HOME?: string;
+	APPDATA?: string;
+	XDG_CONFIG_HOME?: string;
+	platform: NodeJS.Platform;
+}
+
+function defaultEnv(): AdapterEnv {
+	return {
+		HOME: process.env.HOME ?? homedir(),
+		APPDATA: process.env.APPDATA,
+		XDG_CONFIG_HOME: process.env.XDG_CONFIG_HOME,
+		platform: osPlatform(),
+	};
+}
+
+/**
+ * Build the env block for `c8ctl mcp-proxy`.
+ *
+ * Embeds the active profile's credentials so the spawned proxy runs
+ * with the correct authentication regardless of the MCP client's own
+ * environment. Only defined fields are included — undefined values
+ * never appear as the literal string "undefined" in the written JSON.
+ */
+export function buildProxyEnv(
+	profile: BuildEntryInputs["profile"],
+): Record<string, string> {
+	const env: Record<string, string> = {
+		CAMUNDA_BASE_URL: profile.baseUrl,
+	};
+	if (profile.clientId) env.CAMUNDA_CLIENT_ID = profile.clientId;
+	if (profile.clientSecret) env.CAMUNDA_CLIENT_SECRET = profile.clientSecret;
+	if (profile.oAuthUrl) env.CAMUNDA_OAUTH_URL = profile.oAuthUrl;
+	if (profile.audience) env.CAMUNDA_TOKEN_AUDIENCE = profile.audience;
+	if (profile.username) env.CAMUNDA_BASIC_AUTH_USERNAME = profile.username;
+	if (profile.password) env.CAMUNDA_BASIC_AUTH_PASSWORD = profile.password;
+	return env;
+}
+
+/**
+ * Common entry shape used by Claude Desktop and Cursor: spawn the c8ctl
+ * MCP proxy with the named profile via `npx`. Forwarding `--profile`
+ * makes the entry self-describing — re-running `mcp install` for a
+ * different profile produces a different alias, not a silent overwrite.
+ */
+function buildNpxProxyEntry(inputs: BuildEntryInputs): McpServerEntry {
+	return {
+		command: "npx",
+		args: ["-y", "@camunda8/cli", "mcp-proxy", "--profile", inputs.profileName],
+		env: buildProxyEnv(inputs.profile),
+	};
+}
+
+const claudeDesktopAdapter: McpClientAdapter = {
+	id: "claude-desktop",
+	displayName: "Claude Desktop",
+	serversKey: "mcpServers",
+	configPath(env = defaultEnv()): string {
+		// macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+		// Windows: `%APPDATA%/Claude/claude_desktop_config.json`
+		// Linux: `~/.config/Claude/claude_desktop_config.json` (Claude Desktop is
+		// not officially distributed on Linux but the config layout is consistent
+		// when run via Wine/Bottles; XDG_CONFIG_HOME is honoured for parity with
+		// other Linux apps).
+		if (env.platform === "darwin") {
+			return join(
+				home(env),
+				"Library",
+				"Application Support",
+				"Claude",
+				"claude_desktop_config.json",
+			);
+		}
+		if (env.platform === "win32") {
+			const appdata = env.APPDATA ?? join(home(env), "AppData", "Roaming");
+			return join(appdata, "Claude", "claude_desktop_config.json");
+		}
+		const xdg = env.XDG_CONFIG_HOME ?? join(home(env), ".config");
+		return join(xdg, "Claude", "claude_desktop_config.json");
+	},
+	buildEntry: buildNpxProxyEntry,
+};
+
+const cursorAdapter: McpClientAdapter = {
+	id: "cursor",
+	displayName: "Cursor",
+	serversKey: "mcpServers",
+	configPath(env = defaultEnv()): string {
+		// Cursor: `~/.cursor/mcp.json` on every platform.
+		return join(home(env), ".cursor", "mcp.json");
+	},
+	buildEntry: buildNpxProxyEntry,
+};
+
+const vscodeAdapter: McpClientAdapter = {
+	id: "vscode",
+	displayName: "VS Code",
+	// VS Code's MCP user config uses `servers` (NOT `mcpServers`) — this is
+	// the exact docs defect that #293 originated from. Locked by the
+	// adapter contract test.
+	serversKey: "servers",
+	configPath(env = defaultEnv()): string {
+		// macOS: `~/Library/Application Support/Code/User/mcp.json`
+		// Windows: `%APPDATA%/Code/User/mcp.json`
+		// Linux: `~/.config/Code/User/mcp.json`
+		if (env.platform === "darwin") {
+			return join(
+				home(env),
+				"Library",
+				"Application Support",
+				"Code",
+				"User",
+				"mcp.json",
+			);
+		}
+		if (env.platform === "win32") {
+			const appdata = env.APPDATA ?? join(home(env), "AppData", "Roaming");
+			return join(appdata, "Code", "User", "mcp.json");
+		}
+		const xdg = env.XDG_CONFIG_HOME ?? join(home(env), ".config");
+		return join(xdg, "Code", "User", "mcp.json");
+	},
+	buildEntry(inputs: BuildEntryInputs): McpServerEntry {
+		return {
+			type: "stdio",
+			command: "npx",
+			args: [
+				"-y",
+				"@camunda8/cli",
+				"mcp-proxy",
+				"--profile",
+				inputs.profileName,
+			],
+			env: buildProxyEnv(inputs.profile),
+		};
+	},
+};
+
+/**
+ * Registry of every supported MCP client. Adding a new adapter here
+ * automatically wires it into install / uninstall / list and into the
+ * adapter contract test (`tests/unit/mcp-install-adapters.test.ts`).
+ */
+export const MCP_CLIENT_ADAPTERS: ReadonlyMap<string, McpClientAdapter> =
+	new Map([
+		[claudeDesktopAdapter.id, claudeDesktopAdapter],
+		[cursorAdapter.id, cursorAdapter],
+		[vscodeAdapter.id, vscodeAdapter],
+	]);
+
+/** Helper: list of supported client IDs in stable, documented order. */
+export function listSupportedClients(): readonly string[] {
+	return Array.from(MCP_CLIENT_ADAPTERS.keys());
+}
+
+/** Look up an adapter by id; throws with a helpful message on miss. */
+export function getAdapter(id: string): McpClientAdapter {
+	const adapter = MCP_CLIENT_ADAPTERS.get(id);
+	if (!adapter) {
+		const supported = listSupportedClients().join(", ");
+		throw new Error(
+			`Unknown MCP client: '${id}'. Supported clients: ${supported}.`,
+		);
+	}
+	return adapter;
+}
+
+function home(env: AdapterEnv): string {
+	if (env.HOME && env.HOME.length > 0) return env.HOME;
+	throw new Error(
+		"Cannot resolve MCP client config path: HOME is not set in the environment.",
+	);
+}
+
+// ─── Config merge helpers ────────────────────────────────────────────────────
+
+/**
+ * Result of merging an MCP server entry into an existing client config.
+ * Returned as a plain object so callers can stringify, write, or render
+ * it without further mutation. `existed` distinguishes "added new" from
+ * "overwrote prior alias" so install can warn on the latter.
+ */
+export interface MergeResult {
+	merged: Record<string, unknown>;
+	existed: boolean;
+}
+
+/**
+ * Merge a server entry into a parsed client-config object.
+ *
+ * Contract:
+ * - Preserve every top-level key that is not the adapter's `serversKey`
+ *   (e.g. Claude's `preferences`).
+ * - Preserve every existing entry under `serversKey` other than `alias`.
+ * - Replace (not deep-merge) the entry at `alias` so the user can
+ *   re-run `mcp install` to refresh credentials.
+ *
+ * Pure — does not touch the filesystem.
+ */
+export function mergeMcpConfig(
+	existing: unknown,
+	serversKey: string,
+	alias: string,
+	entry: McpServerEntry,
+): MergeResult {
+	const base: Record<string, unknown> = isRecord(existing) ? existing : {};
+	const priorServers = isRecord(base[serversKey]) ? base[serversKey] : {};
+	const existed = Object.hasOwn(priorServers, alias);
+	const nextServers = { ...priorServers, [alias]: entry };
+	return {
+		merged: { ...base, [serversKey]: nextServers },
+		existed,
+	};
+}
+
+/**
+ * Remove the entry at `alias` from a client config. Returns the new
+ * config plus whether the alias was actually present (`existed`). When
+ * removing the last entry, the `serversKey` map is left as an empty
+ * object rather than deleted, so a downstream `mcp install` always
+ * finds a place to write.
+ */
+export function unmergeMcpConfig(
+	existing: unknown,
+	serversKey: string,
+	alias: string,
+): MergeResult {
+	const base: Record<string, unknown> = isRecord(existing) ? existing : {};
+	const priorServers = isRecord(base[serversKey]) ? base[serversKey] : {};
+	const existed = Object.hasOwn(priorServers, alias);
+	if (!existed) {
+		return { merged: base, existed: false };
+	}
+	const nextServers: Record<string, unknown> = { ...priorServers };
+	delete nextServers[alias];
+	return {
+		merged: { ...base, [serversKey]: nextServers },
+		existed: true,
+	};
+}

--- a/src/mcp-install/fs.ts
+++ b/src/mcp-install/fs.ts
@@ -8,6 +8,7 @@
  * filed to eliminate.
  */
 
+import { randomBytes } from "node:crypto";
 import {
 	chmodSync,
 	existsSync,
@@ -42,9 +43,15 @@ export function readJsonFileOrNull(path: string): unknown {
 
 /**
  * Write JSON to `path` atomically: serialise to a sibling temp file
- * (`<path>.c8ctl-tmp`), then `renameSync`. POSIX guarantees rename is
- * atomic on the same filesystem, so a crash mid-write either leaves
- * the original intact or replaces it with the fully-written successor.
+ * with a unique per-invocation suffix (`<path>.c8ctl-tmp.<pid>.<rand>`),
+ * then `renameSync`. POSIX guarantees rename is atomic on the same
+ * filesystem, so a crash mid-write either leaves the original intact
+ * or replaces it with the fully-written successor.
+ *
+ * The unique suffix means two concurrent installers targeting the same
+ * config file (e.g. two terminals racing `c8ctl mcp install claude-desktop`)
+ * each write to a distinct temp file. The renames serialise; whichever
+ * lands second wins — but neither corrupts the other's intermediate state.
  *
  * Restricts file mode to 0o600 (owner read/write only) because the
  * written JSON contains OAuth client secrets in its `env` block. On
@@ -64,7 +71,7 @@ export function writeJsonAtomic(
 		(opts?.pretty ?? true)
 			? JSON.stringify(value, null, 2)
 			: JSON.stringify(value);
-	const tmpPath = `${path}.c8ctl-tmp`;
+	const tmpPath = `${path}.c8ctl-tmp.${process.pid}.${randomBytes(6).toString("hex")}`;
 	writeFileSync(tmpPath, `${json}\n`, { encoding: "utf8", mode: 0o600 });
 	try {
 		renameSync(tmpPath, path);
@@ -72,9 +79,7 @@ export function writeJsonAtomic(
 		// Best-effort cleanup of the orphaned temp file before re-throwing.
 		try {
 			if (existsSync(tmpPath)) {
-				// Use renameSync to a unique sentinel path so concurrent installers
-				// for different clients don't race on the same tmp filename.
-				const sentinel = `${tmpPath}.${process.pid}.failed`;
+				const sentinel = `${tmpPath}.failed`;
 				renameSync(tmpPath, sentinel);
 			}
 		} catch {

--- a/src/mcp-install/fs.ts
+++ b/src/mcp-install/fs.ts
@@ -15,6 +15,7 @@ import {
 	mkdirSync,
 	readFileSync,
 	renameSync,
+	unlinkSync,
 	writeFileSync,
 } from "node:fs";
 import { dirname } from "node:path";
@@ -76,14 +77,16 @@ export function writeJsonAtomic(
 	try {
 		renameSync(tmpPath, path);
 	} catch (error) {
-		// Best-effort cleanup of the orphaned temp file before re-throwing.
+		// Best-effort: delete the orphaned temp file (it contains OAuth
+		// client secrets, so leaving a `.failed` sentinel on disk would
+		// expand the secret-exposure surface). The original error is what
+		// matters; cleanup errors are intentionally swallowed.
 		try {
 			if (existsSync(tmpPath)) {
-				const sentinel = `${tmpPath}.failed`;
-				renameSync(tmpPath, sentinel);
+				unlinkSync(tmpPath);
 			}
 		} catch {
-			// Cleanup errors are non-fatal; the original failure is what matters.
+			// Cleanup errors are non-fatal.
 		}
 		throw error;
 	}

--- a/src/mcp-install/fs.ts
+++ b/src/mcp-install/fs.ts
@@ -1,0 +1,92 @@
+/**
+ * Filesystem helpers for `c8ctl mcp install` (#293).
+ *
+ * Atomic write so a partial failure (out-of-space, permission flip
+ * mid-write, process kill) cannot leave the user's MCP client config in
+ * a half-written state. The client would silently fail to load the
+ * server otherwise — the exact "docs hand-edit" defect class #293 was
+ * filed to eliminate.
+ */
+
+import {
+	chmodSync,
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	writeFileSync,
+} from "node:fs";
+import { dirname } from "node:path";
+
+/**
+ * Read a JSON file as `unknown`. Returns `null` if the file is absent
+ * or empty (treated as "no prior config"); throws if it exists but
+ * fails to parse, so a corrupt file is surfaced rather than silently
+ * overwritten.
+ */
+export function readJsonFileOrNull(path: string): unknown {
+	if (!existsSync(path)) return null;
+	const raw = readFileSync(path, "utf8");
+	if (raw.trim().length === 0) return null;
+	try {
+		// biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+		return JSON.parse(raw) as unknown;
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(
+			`Failed to parse existing MCP config at ${path}: ${message}. ` +
+				"Refusing to overwrite — fix the JSON manually or delete the file and re-run.",
+		);
+	}
+}
+
+/**
+ * Write JSON to `path` atomically: serialise to a sibling temp file
+ * (`<path>.c8ctl-tmp`), then `renameSync`. POSIX guarantees rename is
+ * atomic on the same filesystem, so a crash mid-write either leaves
+ * the original intact or replaces it with the fully-written successor.
+ *
+ * Restricts file mode to 0o600 (owner read/write only) because the
+ * written JSON contains OAuth client secrets in its `env` block. On
+ * Windows `chmod` is a no-op; the underlying ACLs already restrict
+ * the user profile directory.
+ */
+export function writeJsonAtomic(
+	path: string,
+	value: unknown,
+	opts?: { pretty?: boolean },
+): void {
+	const dir = dirname(path);
+	if (!existsSync(dir)) {
+		mkdirSync(dir, { recursive: true });
+	}
+	const json =
+		(opts?.pretty ?? true)
+			? JSON.stringify(value, null, 2)
+			: JSON.stringify(value);
+	const tmpPath = `${path}.c8ctl-tmp`;
+	writeFileSync(tmpPath, `${json}\n`, { encoding: "utf8", mode: 0o600 });
+	try {
+		renameSync(tmpPath, path);
+	} catch (error) {
+		// Best-effort cleanup of the orphaned temp file before re-throwing.
+		try {
+			if (existsSync(tmpPath)) {
+				// Use renameSync to a unique sentinel path so concurrent installers
+				// for different clients don't race on the same tmp filename.
+				const sentinel = `${tmpPath}.${process.pid}.failed`;
+				renameSync(tmpPath, sentinel);
+			}
+		} catch {
+			// Cleanup errors are non-fatal; the original failure is what matters.
+		}
+		throw error;
+	}
+	try {
+		chmodSync(path, 0o600);
+	} catch {
+		// chmod is unsupported on some Windows filesystems; the rename
+		// already inherited 0o600 from the tmp file's mode on POSIX, and
+		// on Windows the user profile directory ACLs are sufficient.
+	}
+}

--- a/tests/unit/command-registry.test.ts
+++ b/tests/unit/command-registry.test.ts
@@ -61,6 +61,7 @@ describe("COMMAND_REGISTRY completeness", () => {
 		"output",
 		"completion",
 		"mcp-proxy",
+		"mcp",
 		"feedback",
 		"help",
 		"assign",
@@ -474,6 +475,7 @@ describe("mutating flag correctness", () => {
 		"assign",
 		"unassign",
 		"completion",
+		"mcp",
 	];
 
 	const NON_MUTATING_VERBS = [

--- a/tests/unit/mcp-install-adapters.test.ts
+++ b/tests/unit/mcp-install-adapters.test.ts
@@ -349,4 +349,26 @@ describe("unmergeMcpConfig is symmetric with mergeMcpConfig (#293)", () => {
 		assert.strictEqual(existed, false);
 		assert.deepStrictEqual(merged, { mcpServers: { other: {} } });
 	});
+
+	test("refuses to silently overwrite a non-object existing config", () => {
+		// Defect class: a user (or tool) wrote a JSON array / scalar at
+		// the config path. Silently coercing it to {} would clobber data
+		// we cannot reason about; we must throw with a recoverable hint.
+		for (const bogus of [[], ["mcp"], 42, "string", true]) {
+			assert.throws(
+				() =>
+					mergeMcpConfig(bogus, "mcpServers", "camunda", {
+						command: "npx",
+						args: [],
+					}),
+				/not a JSON object/,
+				`mergeMcpConfig must reject ${JSON.stringify(bogus)}`,
+			);
+			assert.throws(
+				() => unmergeMcpConfig(bogus, "mcpServers", "camunda"),
+				/not a JSON object/,
+				`unmergeMcpConfig must reject ${JSON.stringify(bogus)}`,
+			);
+		}
+	});
 });

--- a/tests/unit/mcp-install-adapters.test.ts
+++ b/tests/unit/mcp-install-adapters.test.ts
@@ -175,6 +175,23 @@ describe("MCP client adapter contract (#293)", () => {
 		assert.deepStrictEqual(env, { CAMUNDA_BASE_URL: "http://x" });
 	});
 
+	test("buildProxyEnv emits the env vars resolveClusterConfig actually reads", () => {
+		// Defect class: emitting env names that resolveClusterConfig
+		// (src/config.ts) does NOT consult would silently break auth at
+		// proxy spawn time. The basic-auth pair MUST be CAMUNDA_USERNAME /
+		// CAMUNDA_PASSWORD, not CAMUNDA_BASIC_AUTH_* (those are SDK keys
+		// translated downstream by client.ts, never read from env).
+		const env = buildProxyEnv({
+			baseUrl: "http://x",
+			username: "demo",
+			password: "demo",
+		});
+		assert.strictEqual(env.CAMUNDA_USERNAME, "demo");
+		assert.strictEqual(env.CAMUNDA_PASSWORD, "demo");
+		assert.strictEqual(env.CAMUNDA_BASIC_AUTH_USERNAME, undefined);
+		assert.strictEqual(env.CAMUNDA_BASIC_AUTH_PASSWORD, undefined);
+	});
+
 	test("getAdapter throws with the supported client list on miss", () => {
 		assert.throws(() => getAdapter("zed"), /Supported clients:/);
 	});

--- a/tests/unit/mcp-install-adapters.test.ts
+++ b/tests/unit/mcp-install-adapters.test.ts
@@ -1,0 +1,335 @@
+/**
+ * Pure helpers for `c8ctl mcp install` (#293).
+ *
+ * Adapter contract + merge/unmerge semantics — pure functions, no
+ * filesystem access. Class-scoped: every assertion iterates every
+ * adapter so adding a fourth client cannot regress any of them.
+ */
+
+import assert from "node:assert";
+import { describe, test } from "node:test";
+import { isRecord } from "../../src/logger.ts";
+import {
+	type AdapterEnv,
+	buildProxyEnv,
+	getAdapter,
+	listSupportedClients,
+	MCP_CLIENT_ADAPTERS,
+	mergeMcpConfig,
+	unmergeMcpConfig,
+} from "../../src/mcp-install/adapters.ts";
+
+const SAMPLE_PROFILE = {
+	baseUrl: "https://example.zeebe.camunda.io/v2",
+	clientId: "client-id-xyz",
+	clientSecret: "client-secret-xyz",
+	audience: "zeebe-audience",
+	oAuthUrl: "https://login.example/oauth/token",
+};
+
+const FAKE_ENVS: Record<NodeJS.Platform, AdapterEnv> = {
+	darwin: { HOME: "/Users/tester", platform: "darwin" },
+	linux: { HOME: "/home/tester", platform: "linux" },
+	win32: {
+		HOME: "C:/Users/tester",
+		APPDATA: "C:/Users/tester/AppData/Roaming",
+		platform: "win32",
+	},
+	// Other platforms aren't exercised by tests but the type requires them;
+	// reuse the linux entry as a stand-in.
+	aix: { HOME: "/home/tester", platform: "aix" },
+	freebsd: { HOME: "/home/tester", platform: "freebsd" },
+	openbsd: { HOME: "/home/tester", platform: "openbsd" },
+	sunos: { HOME: "/home/tester", platform: "sunos" },
+	cygwin: { HOME: "C:/Users/tester", platform: "cygwin" },
+	netbsd: { HOME: "/home/tester", platform: "netbsd" },
+	android: { HOME: "/data/local", platform: "android" },
+	haiku: { HOME: "/home/tester", platform: "haiku" },
+};
+
+describe("MCP client adapter contract (#293)", () => {
+	test("registry exposes the three documented clients", () => {
+		assert.deepStrictEqual(listSupportedClients(), [
+			"claude-desktop",
+			"cursor",
+			"vscode",
+		]);
+	});
+
+	test("every adapter declares a non-empty serversKey", () => {
+		// Class-scoped: a typo in any adapter's serversKey breaks installs
+		// silently — clients ignore unknown top-level keys. Pin it here.
+		for (const adapter of MCP_CLIENT_ADAPTERS.values()) {
+			assert.ok(
+				adapter.serversKey.length > 0,
+				`${adapter.id} must declare a non-empty serversKey`,
+			);
+		}
+	});
+
+	test("serversKey matches each client's documented schema", () => {
+		// Locked individually because these are the values the user-facing
+		// docs hand-edit defect was about (vscode uses 'servers', not
+		// 'mcpServers').
+		assert.strictEqual(getAdapter("claude-desktop").serversKey, "mcpServers");
+		assert.strictEqual(getAdapter("cursor").serversKey, "mcpServers");
+		assert.strictEqual(getAdapter("vscode").serversKey, "servers");
+	});
+
+	test("every adapter resolves a config path on every supported OS", () => {
+		// Class-scoped: ensures no adapter throws or returns empty for
+		// any of darwin/linux/win32 (the OSes c8ctl supports — Windows
+		// only via WSL but path resolution is still expected to work).
+		for (const adapter of MCP_CLIENT_ADAPTERS.values()) {
+			for (const platform of ["darwin", "linux", "win32"] as const) {
+				const path = adapter.configPath(FAKE_ENVS[platform]);
+				assert.ok(
+					path.length > 0,
+					`${adapter.id} returned empty path for ${platform}`,
+				);
+				assert.ok(
+					path.endsWith(".json"),
+					`${adapter.id} on ${platform} returned non-.json path: ${path}`,
+				);
+			}
+		}
+	});
+
+	test("configPath uses the documented platform-specific locations", () => {
+		// Spot-check the macOS values to lock the user-facing paths.
+		const mac = FAKE_ENVS.darwin;
+		assert.strictEqual(
+			getAdapter("claude-desktop").configPath(mac),
+			"/Users/tester/Library/Application Support/Claude/claude_desktop_config.json",
+		);
+		assert.strictEqual(
+			getAdapter("cursor").configPath(mac),
+			"/Users/tester/.cursor/mcp.json",
+		);
+		assert.strictEqual(
+			getAdapter("vscode").configPath(mac),
+			"/Users/tester/Library/Application Support/Code/User/mcp.json",
+		);
+	});
+
+	test("every adapter builds an entry that launches c8ctl mcp-proxy", () => {
+		// Class-scoped: the entry must (a) invoke npx, (b) reference the
+		// c8ctl package, (c) pass `mcp-proxy`, (d) forward `--profile`.
+		for (const adapter of MCP_CLIENT_ADAPTERS.values()) {
+			const entry = adapter.buildEntry({
+				profile: SAMPLE_PROFILE,
+				profileName: "prod",
+			});
+			assert.strictEqual(
+				entry.command,
+				"npx",
+				`${adapter.id} should spawn via npx`,
+			);
+			assert.ok(
+				entry.args.includes("mcp-proxy"),
+				`${adapter.id} entry must invoke 'mcp-proxy' subcommand`,
+			);
+			assert.ok(
+				entry.args.includes("--profile"),
+				`${adapter.id} entry must forward --profile`,
+			);
+			assert.ok(
+				entry.args.includes("prod"),
+				`${adapter.id} entry must include the resolved profile name`,
+			);
+			assert.strictEqual(
+				entry.env?.CAMUNDA_BASE_URL,
+				SAMPLE_PROFILE.baseUrl,
+				`${adapter.id} must embed CAMUNDA_BASE_URL in env`,
+			);
+		}
+	});
+
+	test("vscode adapter sets type='stdio' (its schema requires it)", () => {
+		const entry = getAdapter("vscode").buildEntry({
+			profile: SAMPLE_PROFILE,
+			profileName: "prod",
+		});
+		assert.strictEqual(entry.type, "stdio");
+	});
+
+	test("claude/cursor adapters omit type (their schema doesn't expect it)", () => {
+		for (const id of ["claude-desktop", "cursor"]) {
+			const entry = getAdapter(id).buildEntry({
+				profile: SAMPLE_PROFILE,
+				profileName: "prod",
+			});
+			assert.strictEqual(
+				entry.type,
+				undefined,
+				`${id} entry must NOT include a type field`,
+			);
+		}
+	});
+
+	test("buildProxyEnv omits unset credential fields (no 'undefined' literal)", () => {
+		// Defect class: stringifying undefined into env would write the
+		// literal string "undefined" — clients would then send broken
+		// auth. Class-scoped: every optional field tested.
+		const env = buildProxyEnv({ baseUrl: "http://x" });
+		assert.deepStrictEqual(env, { CAMUNDA_BASE_URL: "http://x" });
+	});
+
+	test("getAdapter throws with the supported client list on miss", () => {
+		assert.throws(() => getAdapter("zed"), /Supported clients:/);
+	});
+});
+
+describe("mergeMcpConfig preserves unrelated state (#293)", () => {
+	test("preserves top-level keys outside serversKey", () => {
+		// Defect class: docs hand-edit historically wiped the user's
+		// `preferences` block. Class-scoped over every adapter.
+		for (const adapter of MCP_CLIENT_ADAPTERS.values()) {
+			const existing = {
+				preferences: { theme: "dark" },
+				telemetry: false,
+				[adapter.serversKey]: {},
+			};
+			const { merged } = mergeMcpConfig(
+				existing,
+				adapter.serversKey,
+				"camunda",
+				adapter.buildEntry({
+					profile: SAMPLE_PROFILE,
+					profileName: "prod",
+				}),
+			);
+			assert.deepStrictEqual(
+				merged.preferences,
+				{ theme: "dark" },
+				`${adapter.id}: preferences block must survive merge`,
+			);
+			assert.strictEqual(
+				merged.telemetry,
+				false,
+				`${adapter.id}: unrelated boolean must survive merge`,
+			);
+		}
+	});
+
+	test("preserves sibling entries under serversKey", () => {
+		for (const adapter of MCP_CLIENT_ADAPTERS.values()) {
+			const otherEntry = { command: "other", args: [] };
+			const existing = {
+				[adapter.serversKey]: { other: otherEntry },
+			};
+			const { merged } = mergeMcpConfig(
+				existing,
+				adapter.serversKey,
+				"camunda",
+				adapter.buildEntry({
+					profile: SAMPLE_PROFILE,
+					profileName: "prod",
+				}),
+			);
+			const servers = merged[adapter.serversKey];
+			assert.ok(isRecord(servers));
+			assert.deepStrictEqual(
+				servers.other,
+				otherEntry,
+				`${adapter.id}: sibling 'other' entry must survive`,
+			);
+			assert.ok(
+				servers.camunda,
+				`${adapter.id}: 'camunda' entry must be added`,
+			);
+		}
+	});
+
+	test("treats absent existing config as empty object", () => {
+		const { merged, existed } = mergeMcpConfig(null, "mcpServers", "camunda", {
+			command: "npx",
+			args: [],
+		});
+		assert.strictEqual(existed, false);
+		assert.deepStrictEqual(merged, {
+			mcpServers: { camunda: { command: "npx", args: [] } },
+		});
+	});
+
+	test("reports existed=true when the alias already exists", () => {
+		const { existed } = mergeMcpConfig(
+			{ mcpServers: { camunda: { command: "old", args: [] } } },
+			"mcpServers",
+			"camunda",
+			{ command: "new", args: [] },
+		);
+		assert.strictEqual(existed, true);
+	});
+
+	test("idempotent: re-running install reproduces the same merged output", () => {
+		// A re-install should be a fixed point. Class-scoped over adapters.
+		for (const adapter of MCP_CLIENT_ADAPTERS.values()) {
+			const entry = adapter.buildEntry({
+				profile: SAMPLE_PROFILE,
+				profileName: "prod",
+			});
+			const first = mergeMcpConfig(
+				{},
+				adapter.serversKey,
+				"camunda",
+				entry,
+			).merged;
+			const second = mergeMcpConfig(
+				first,
+				adapter.serversKey,
+				"camunda",
+				entry,
+			).merged;
+			assert.deepStrictEqual(second, first, `${adapter.id}: not idempotent`);
+		}
+	});
+});
+
+describe("unmergeMcpConfig is symmetric with mergeMcpConfig (#293)", () => {
+	test("removes only the named alias, leaves siblings intact", () => {
+		for (const adapter of MCP_CLIENT_ADAPTERS.values()) {
+			const otherEntry = { command: "other", args: [] };
+			const existing = {
+				preferences: { theme: "dark" },
+				[adapter.serversKey]: {
+					camunda: { command: "npx", args: ["mcp-proxy"] },
+					other: otherEntry,
+				},
+			};
+			const { merged, existed } = unmergeMcpConfig(
+				existing,
+				adapter.serversKey,
+				"camunda",
+			);
+			assert.strictEqual(existed, true, `${adapter.id}: 'camunda' was present`);
+			const servers = merged[adapter.serversKey];
+			assert.ok(isRecord(servers));
+			assert.strictEqual(
+				servers.camunda,
+				undefined,
+				`${adapter.id}: 'camunda' alias must be removed`,
+			);
+			assert.deepStrictEqual(
+				servers.other,
+				otherEntry,
+				`${adapter.id}: sibling alias must be preserved`,
+			);
+			assert.deepStrictEqual(
+				merged.preferences,
+				{ theme: "dark" },
+				`${adapter.id}: unrelated top-level keys must be preserved`,
+			);
+		}
+	});
+
+	test("reports existed=false when alias is absent (idempotent uninstall)", () => {
+		const { existed, merged } = unmergeMcpConfig(
+			{ mcpServers: { other: {} } },
+			"mcpServers",
+			"camunda",
+		);
+		assert.strictEqual(existed, false);
+		assert.deepStrictEqual(merged, { mcpServers: { other: {} } });
+	});
+});

--- a/tests/unit/mcp-install-handler.test.ts
+++ b/tests/unit/mcp-install-handler.test.ts
@@ -1,0 +1,270 @@
+/**
+ * `c8ctl mcp install/uninstall/list` end-to-end tests (#293).
+ *
+ * Spawns the real CLI in a temp HOME so adapter path resolution is
+ * deterministic and the test runner's actual MCP configs can't be
+ * touched. Class-scoped invariants iterate every supported client.
+ */
+
+import assert from "node:assert";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, test } from "node:test";
+import { isRecord } from "../../src/logger.ts";
+import {
+	type AdapterEnv,
+	getAdapter,
+	listSupportedClients,
+} from "../../src/mcp-install/adapters.ts";
+import { asyncSpawn, type SpawnResult } from "../utils/spawn.ts";
+
+let tempHome: string;
+let tempDataDir: string;
+
+/** Match the resolution the CLI subprocess sees (HOME=tempHome). */
+function adapterEnv(): AdapterEnv {
+	return { HOME: tempHome, platform: process.platform };
+}
+
+function configPathFor(clientId: string): string {
+	return getAdapter(clientId).configPath(adapterEnv());
+}
+
+beforeEach(() => {
+	tempHome = mkdtempSync(join(tmpdir(), "c8ctl-mcp-home-"));
+	tempDataDir = mkdtempSync(join(tmpdir(), "c8ctl-mcp-data-"));
+	// Seed a profile so install has credentials to embed. Profiles are
+	// stored as a name → record map at <data>/profiles.json (see
+	// src/config.ts loadProfiles()).
+	writeFileSync(
+		join(tempDataDir, "profiles.json"),
+		JSON.stringify({
+			profiles: [
+				{
+					name: "test-profile",
+					baseUrl: "https://test.zeebe.camunda.io/v2",
+					clientId: "cid",
+					clientSecret: "csecret",
+					audience: "zeebe-audience",
+					oAuthUrl: "https://login.test/oauth/token",
+				},
+			],
+		}),
+	);
+	// Persist the active profile so the handler picks it up without --profile.
+	writeFileSync(
+		join(tempDataDir, "session.json"),
+		JSON.stringify({ activeProfile: "test-profile", outputMode: "json" }),
+	);
+});
+
+afterEach(() => {
+	rmSync(tempHome, { recursive: true, force: true });
+	rmSync(tempDataDir, { recursive: true, force: true });
+});
+
+async function c8(...args: string[]): Promise<SpawnResult> {
+	const env: NodeJS.ProcessEnv = {
+		...process.env,
+		HOME: tempHome,
+		C8CTL_DATA_DIR: tempDataDir,
+	};
+	delete env.DEBUG;
+	delete env.C8CTL_DEBUG;
+	delete env.NODE_DEBUG;
+	delete env.NODE_OPTIONS;
+	delete env.CAMUNDA_BASE_URL;
+	delete env.CAMUNDA_CLIENT_ID;
+	delete env.CAMUNDA_CLIENT_SECRET;
+	return asyncSpawn(
+		"node",
+		["--experimental-strip-types", "src/index.ts", ...args],
+		{ env, timeout: 15_000 },
+	);
+}
+
+function readJson(path: string): unknown {
+	// biome-ignore lint/plugin: runtime contract boundary for parsed JSON
+	return JSON.parse(readFileSync(path, "utf8")) as unknown;
+}
+
+describe("c8ctl mcp install (#293)", () => {
+	test("class-scoped: install writes a c8ctl mcp-proxy entry for every supported client", async () => {
+		// Defect class: any adapter regression that prevents writing the
+		// configured serversKey/path is caught by iterating all clients.
+		for (const clientId of listSupportedClients()) {
+			const adapter = getAdapter(clientId);
+			const result = await c8("mcp", "install", clientId);
+			assert.strictEqual(
+				result.status,
+				0,
+				`mcp install ${clientId} exited ${result.status}: ${result.stderr}`,
+			);
+			const written = readJson(configPathFor(clientId));
+			assert.ok(
+				isRecord(written),
+				`${clientId}: written config must be an object`,
+			);
+			const servers = written[adapter.serversKey];
+			assert.ok(
+				isRecord(servers),
+				`${clientId}: written config must contain '${adapter.serversKey}'`,
+			);
+			assert.ok(
+				servers["test-profile"],
+				`${clientId}: must contain entry under default alias 'test-profile'`,
+			);
+		}
+	});
+
+	test("preserves unrelated top-level keys in the existing client config", async () => {
+		const clientId = "claude-desktop";
+		const path = configPathFor(clientId);
+		// Pre-seed a config with a `preferences` block and an unrelated MCP entry.
+		const fs = await import("node:fs");
+		fs.mkdirSync(join(path, ".."), { recursive: true });
+		writeFileSync(
+			path,
+			JSON.stringify({
+				preferences: { theme: "dark" },
+				mcpServers: {
+					other: { command: "other-cmd", args: ["a", "b"] },
+				},
+			}),
+		);
+
+		const result = await c8("mcp", "install", clientId);
+		assert.strictEqual(result.status, 0, result.stderr);
+
+		const written = readJson(path);
+		assert.ok(isRecord(written));
+		assert.deepStrictEqual(
+			written.preferences,
+			{ theme: "dark" },
+			"preferences block must survive install",
+		);
+		assert.ok(isRecord(written.mcpServers));
+		assert.deepStrictEqual(
+			written.mcpServers.other,
+			{ command: "other-cmd", args: ["a", "b"] },
+			"sibling MCP entry must survive install",
+		);
+		assert.ok(
+			written.mcpServers["test-profile"],
+			"new c8ctl entry must be added",
+		);
+	});
+
+	test("--dry-run does not touch the filesystem", async () => {
+		const clientId = "cursor";
+		const result = await c8("mcp", "install", clientId, "--dry-run");
+		assert.strictEqual(result.status, 0, result.stderr);
+
+		assert.throws(
+			() => readFileSync(configPathFor(clientId), "utf8"),
+			/ENOENT/,
+			"--dry-run must NOT write to disk",
+		);
+		// stdout (json mode) should describe the would-be content.
+		assert.ok(
+			result.stdout.includes("write-mcp-config"),
+			`dry-run output must describe the action; got: ${result.stdout}`,
+		);
+	});
+
+	test("--profile <name> with unknown profile fails with a helpful error", async () => {
+		const result = await c8(
+			"mcp",
+			"install",
+			"claude-desktop",
+			"--profile",
+			"does-not-exist",
+		);
+		assert.notStrictEqual(result.status, 0, "must exit non-zero");
+		assert.match(
+			`${result.stdout}\n${result.stderr}`,
+			/does-not-exist/,
+			"error must name the missing profile",
+		);
+	});
+
+	test("install is idempotent (re-running produces byte-identical output)", async () => {
+		const clientId = "vscode";
+		const first = await c8("mcp", "install", clientId);
+		assert.strictEqual(first.status, 0, first.stderr);
+		const afterFirst = readFileSync(configPathFor(clientId), "utf8");
+		const second = await c8("mcp", "install", clientId);
+		assert.strictEqual(second.status, 0, second.stderr);
+		const afterSecond = readFileSync(configPathFor(clientId), "utf8");
+		assert.strictEqual(afterFirst, afterSecond, "install must be idempotent");
+	});
+});
+
+describe("c8ctl mcp uninstall (#293)", () => {
+	test("removes only the named alias and preserves siblings", async () => {
+		const clientId = "claude-desktop";
+		const path = configPathFor(clientId);
+		const fs = await import("node:fs");
+		fs.mkdirSync(join(path, ".."), { recursive: true });
+		writeFileSync(
+			path,
+			JSON.stringify({
+				preferences: { theme: "dark" },
+				mcpServers: {
+					"test-profile": { command: "npx", args: ["mcp-proxy"] },
+					other: { command: "other", args: [] },
+				},
+			}),
+		);
+
+		const result = await c8("mcp", "uninstall", "claude-desktop");
+		assert.strictEqual(result.status, 0, result.stderr);
+
+		const written = readJson(path);
+		assert.ok(isRecord(written));
+		assert.deepStrictEqual(written.preferences, { theme: "dark" });
+		assert.ok(isRecord(written.mcpServers));
+		assert.strictEqual(
+			written.mcpServers["test-profile"],
+			undefined,
+			"named alias must be removed",
+		);
+		assert.deepStrictEqual(
+			written.mcpServers.other,
+			{ command: "other", args: [] },
+			"sibling alias must survive",
+		);
+	});
+
+	test("uninstalling a missing alias is a no-op (exit 0)", async () => {
+		const result = await c8(
+			"mcp",
+			"uninstall",
+			"vscode",
+			"--alias",
+			"never-installed",
+		);
+		assert.strictEqual(
+			result.status,
+			0,
+			`uninstall of absent alias must succeed; stderr: ${result.stderr}`,
+		);
+	});
+});
+
+describe("c8ctl mcp list (#293)", () => {
+	test("aggregates entries across known clients", async () => {
+		// Install into two of three clients; list should report both.
+		const installA = await c8("mcp", "install", "claude-desktop");
+		assert.strictEqual(installA.status, 0, installA.stderr);
+		const installB = await c8("mcp", "install", "vscode");
+		assert.strictEqual(installB.status, 0, installB.stderr);
+
+		const result = await c8("mcp", "list");
+		assert.strictEqual(result.status, 0, result.stderr);
+		assert.match(result.stdout, /Claude Desktop/);
+		assert.match(result.stdout, /VS Code/);
+		assert.match(result.stdout, /test-profile/);
+	});
+});

--- a/tests/unit/mcp-install-handler.test.ts
+++ b/tests/unit/mcp-install-handler.test.ts
@@ -188,6 +188,26 @@ describe("c8ctl mcp install (#293)", () => {
 		);
 	});
 
+	test("--dry-run redacts credential env values before printing", async () => {
+		// Defect class: dry-run echoes the merged config (env block included)
+		// to stdout. `logger.json`'s field-name redactor only matches the
+		// SDK's lower-case keys; upper-case env names (CAMUNDA_CLIENT_SECRET,
+		// CAMUNDA_PASSWORD) would otherwise print verbatim. Class-scoped over
+		// every adapter and every sensitive-looking env key.
+		for (const clientId of listSupportedClients()) {
+			const result = await c8("mcp", "install", clientId, "--dry-run");
+			assert.strictEqual(result.status, 0, result.stderr);
+			assert.ok(
+				!result.stdout.includes("csecret"),
+				`${clientId}: dry-run stdout must NOT contain the raw clientSecret 'csecret'; got: ${result.stdout}`,
+			);
+			assert.ok(
+				result.stdout.includes("[REDACTED]"),
+				`${clientId}: dry-run stdout must mark redacted env values; got: ${result.stdout}`,
+			);
+		}
+	});
+
 	test("--profile <name> with unknown profile fails with a helpful error", async () => {
 		const result = await c8(
 			"mcp",

--- a/tests/unit/mcp-install-handler.test.ts
+++ b/tests/unit/mcp-install-handler.test.ts
@@ -34,9 +34,8 @@ function configPathFor(clientId: string): string {
 beforeEach(() => {
 	tempHome = mkdtempSync(join(tmpdir(), "c8ctl-mcp-home-"));
 	tempDataDir = mkdtempSync(join(tmpdir(), "c8ctl-mcp-data-"));
-	// Seed a profile so install has credentials to embed. Profiles are
-	// stored as a name → record map at <data>/profiles.json (see
-	// src/config.ts loadProfiles()).
+	// Seed a profile so install has credentials to embed. profiles.json
+	// is parsed as `{ profiles: Profile[] }` (see src/config.ts loadProfiles()).
 	writeFileSync(
 		join(tempDataDir, "profiles.json"),
 		JSON.stringify({

--- a/tests/unit/mcp-install-handler.test.ts
+++ b/tests/unit/mcp-install-handler.test.ts
@@ -211,7 +211,16 @@ describe("c8ctl mcp uninstall (#293)", () => {
 			JSON.stringify({
 				preferences: { theme: "dark" },
 				mcpServers: {
-					"test-profile": { command: "npx", args: ["mcp-proxy"] },
+					"test-profile": {
+						command: "npx",
+						args: [
+							"-y",
+							"@camunda8/cli",
+							"mcp-proxy",
+							"--profile",
+							"test-profile",
+						],
+					},
 					other: { command: "other", args: [] },
 				},
 			}),
@@ -250,6 +259,53 @@ describe("c8ctl mcp uninstall (#293)", () => {
 			`uninstall of absent alias must succeed; stderr: ${result.stderr}`,
 		);
 	});
+
+	test("refuses to remove a non-c8ctl entry without --force", async () => {
+		// Defect class: a user with their own MCP server registered under
+		// the same alias the c8ctl default would pick must not have it
+		// silently deleted by `c8ctl mcp uninstall`.
+		const clientId = "claude-desktop";
+		const path = configPathFor(clientId);
+		const fs = await import("node:fs");
+		fs.mkdirSync(join(path, ".."), { recursive: true });
+		const foreignEntry = {
+			command: "node",
+			args: ["/opt/my-other-mcp/server.js"],
+		};
+		writeFileSync(
+			path,
+			JSON.stringify({
+				mcpServers: { "test-profile": foreignEntry },
+			}),
+		);
+
+		const refused = await c8("mcp", "uninstall", "claude-desktop");
+		assert.notStrictEqual(
+			refused.status,
+			0,
+			"uninstall must refuse non-c8ctl entry without --force",
+		);
+		assert.match(refused.stderr, /not installed by c8ctl/);
+		const stillThere = readJson(path);
+		assert.ok(isRecord(stillThere));
+		assert.ok(isRecord(stillThere.mcpServers));
+		assert.deepStrictEqual(
+			stillThere.mcpServers["test-profile"],
+			foreignEntry,
+			"foreign entry must remain on disk after refusal",
+		);
+
+		const forced = await c8("mcp", "uninstall", "claude-desktop", "--force");
+		assert.strictEqual(
+			forced.status,
+			0,
+			`--force must allow removal of foreign entry; stderr: ${forced.stderr}`,
+		);
+		const after = readJson(path);
+		assert.ok(isRecord(after));
+		assert.ok(isRecord(after.mcpServers));
+		assert.strictEqual(after.mcpServers["test-profile"], undefined);
+	});
 });
 
 describe("c8ctl mcp list (#293)", () => {
@@ -265,5 +321,120 @@ describe("c8ctl mcp list (#293)", () => {
 		assert.match(result.stdout, /Claude Desktop/);
 		assert.match(result.stdout, /VS Code/);
 		assert.match(result.stdout, /test-profile/);
+	});
+
+	test("omits foreign (non-c8ctl) MCP servers from the listing", async () => {
+		// Defect class: `mcp list` is scoped to c8ctl-managed entries
+		// ("manage c8ctl mcp-proxy entries"). Pre-existing third-party MCP
+		// servers in the same config file must not leak into the listing.
+		const clientId = "claude-desktop";
+		const path = configPathFor(clientId);
+		const fs = await import("node:fs");
+		fs.mkdirSync(join(path, ".."), { recursive: true });
+		writeFileSync(
+			path,
+			JSON.stringify({
+				mcpServers: {
+					filesystem: {
+						command: "npx",
+						args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+					},
+					custom: { command: "node", args: ["/opt/me/server.js"] },
+				},
+			}),
+		);
+		const install = await c8("mcp", "install", "claude-desktop");
+		assert.strictEqual(install.status, 0, install.stderr);
+
+		const result = await c8("mcp", "list");
+		assert.strictEqual(result.status, 0, result.stderr);
+		// JSON outputMode is set in session.json — `logger.table` emits the
+		// items array directly in JSON mode.
+		const payload: unknown = JSON.parse(result.stdout);
+		assert.ok(Array.isArray(payload), "list output must be an array");
+		const aliases = payload.map((it: unknown) =>
+			isRecord(it) && typeof it.Alias === "string" ? it.Alias : undefined,
+		);
+		assert.ok(
+			aliases.includes("test-profile"),
+			`c8ctl-installed alias must appear; got ${JSON.stringify(aliases)}`,
+		);
+		assert.ok(
+			!aliases.includes("filesystem"),
+			"foreign npx-based MCP server must NOT appear in c8ctl mcp list",
+		);
+		assert.ok(
+			!aliases.includes("custom"),
+			"foreign custom MCP server must NOT appear in c8ctl mcp list",
+		);
+	});
+});
+
+describe("c8ctl mcp install collision protection (#293)", () => {
+	test("refuses to overwrite a non-c8ctl entry without --force", async () => {
+		// Defect class: install must not silently clobber a third-party
+		// MCP server entry that happens to share an alias with the c8ctl
+		// default (e.g. user already had `test-profile` registered for
+		// some other purpose).
+		const clientId = "claude-desktop";
+		const path = configPathFor(clientId);
+		const fs = await import("node:fs");
+		fs.mkdirSync(join(path, ".."), { recursive: true });
+		const foreignEntry = {
+			command: "node",
+			args: ["/opt/my-other-mcp/server.js"],
+		};
+		writeFileSync(
+			path,
+			JSON.stringify({
+				mcpServers: { "test-profile": foreignEntry },
+			}),
+		);
+
+		const refused = await c8("mcp", "install", "claude-desktop");
+		assert.notStrictEqual(
+			refused.status,
+			0,
+			"install must refuse to clobber non-c8ctl entry without --force",
+		);
+		assert.match(refused.stderr, /not installed by c8ctl/);
+		const untouched = readJson(path);
+		assert.ok(isRecord(untouched));
+		assert.ok(isRecord(untouched.mcpServers));
+		assert.deepStrictEqual(
+			untouched.mcpServers["test-profile"],
+			foreignEntry,
+			"foreign entry must remain unchanged after refusal",
+		);
+
+		const forced = await c8("mcp", "install", "claude-desktop", "--force");
+		assert.strictEqual(
+			forced.status,
+			0,
+			`--force must allow overwrite; stderr: ${forced.stderr}`,
+		);
+		const after = readJson(path);
+		assert.ok(isRecord(after));
+		assert.ok(isRecord(after.mcpServers));
+		const entry = after.mcpServers["test-profile"];
+		assert.ok(isRecord(entry));
+		assert.ok(
+			Array.isArray(entry.args) && entry.args.includes("@camunda8/cli"),
+			"after --force, entry must be the c8ctl-managed shape",
+		);
+	});
+
+	test("re-running install on an existing c8ctl entry needs no --force", async () => {
+		// Idempotency: install must NOT require --force when the existing
+		// entry was itself installed by c8ctl. Otherwise users would have
+		// to remember --force on every credential refresh.
+		const first = await c8("mcp", "install", "claude-desktop");
+		assert.strictEqual(first.status, 0, first.stderr);
+		const second = await c8("mcp", "install", "claude-desktop");
+		assert.strictEqual(
+			second.status,
+			0,
+			`re-install of c8ctl entry must not require --force; stderr: ${second.stderr}`,
+		);
 	});
 });

--- a/tests/unit/mcp-install-handler.test.ts
+++ b/tests/unit/mcp-install-handler.test.ts
@@ -22,9 +22,21 @@ import { asyncSpawn, type SpawnResult } from "../utils/spawn.ts";
 let tempHome: string;
 let tempDataDir: string;
 
-/** Match the resolution the CLI subprocess sees (HOME=tempHome). */
+/**
+ * Match the resolution the CLI subprocess sees. Both must agree on
+ * `HOME`, `XDG_CONFIG_HOME`, and `APPDATA` — otherwise the test process
+ * resolves a config path under (e.g.) the runner's real
+ * `$XDG_CONFIG_HOME` while the subprocess writes under `tempHome`,
+ * causing every assertion against the resolved path to fail on Linux
+ * CI even when the install itself succeeded.
+ */
 function adapterEnv(): AdapterEnv {
-	return { HOME: tempHome, platform: process.platform };
+	return {
+		HOME: tempHome,
+		XDG_CONFIG_HOME: undefined,
+		APPDATA: undefined,
+		platform: process.platform,
+	};
 }
 
 function configPathFor(clientId: string): string {
@@ -73,6 +85,10 @@ async function c8(...args: string[]): Promise<SpawnResult> {
 	delete env.C8CTL_DEBUG;
 	delete env.NODE_DEBUG;
 	delete env.NODE_OPTIONS;
+	// Pin path resolution to HOME=tempHome so test-process and subprocess
+	// agree on the resolved config path on every OS (see adapterEnv()).
+	delete env.XDG_CONFIG_HOME;
+	delete env.APPDATA;
 	delete env.CAMUNDA_BASE_URL;
 	delete env.CAMUNDA_CLIENT_ID;
 	delete env.CAMUNDA_CLIENT_SECRET;


### PR DESCRIPTION
Closes #293.

Adds a new `mcp` verb (configurator) distinct from the existing `mcp-proxy` runtime, so users no longer hand-edit JSON to wire c8ctl into Claude Desktop, Cursor or VS Code.

```
c8ctl mcp install <client> [--profile <name>] [--alias <name>]
c8ctl mcp uninstall <client> [--alias <name>]
c8ctl mcp list
```

### Why a new verb (not `mcp-proxy install`)

`mcp-proxy` is a long-running STDIO bridge that returns `{kind: "never"}`. The new `mcp` verb is a one-shot mutating configurator. Conflating them obscured the semantics and made the dispatch awkward.

### Per-client adapters

Each adapter owns:

- the OS-aware config path (verified per-OS in tests)
- the top-level JSON key for server entries — `mcpServers` for Claude/Cursor, `servers` for VS Code (the exact source of the docs-driven hand-edit defect this verb eliminates)
- the entry shape (VS Code requires `type: "stdio"`, others omit it)

Adding a fourth client is a single registry entry plus one fixture row.

### Behaviour guarantees (locked by tests)

- writes are atomic (tmpfile + `renameSync`); a crash mid-write either leaves the original intact or replaces it with the fully-written successor
- preserves every unrelated top-level key in the existing config (e.g. Claude's `preferences`)
- preserves sibling MCP entries under the same `serversKey`
- re-running install is byte-identical idempotent
- `--dry-run` prints merged JSON without touching disk
- uninstall on an absent alias is a no-op `exit 0`
- unknown `--profile` fails with a helpful error naming the missing profile
- file mode is restricted to `0o600` because env blocks contain OAuth client secrets

### Tests

- `tests/unit/mcp-install-adapters.test.ts` — 17 class-scoped contract tests over the adapter registry: serversKey shape, per-OS path resolution, entry structure, merge/unmerge semantics, idempotency
- `tests/unit/mcp-install-handler.test.ts` — 8 end-to-end tests spawning the real CLI in a temp `HOME` + `C8CTL_DATA_DIR`, covering install/uninstall/list/--dry-run/--profile across all three adapters

Full suite: 1600/1600 pass; `biome check` clean; `tsc --noEmit` clean.

### Documentation

- README: new "Connect to MCP clients" section with the single-line install invocation per the acceptance criterion
- EXAMPLES.md: new "MCP Client Integration" section with worked examples
- `docs/command-reference.md`: regenerated via `sync:readme --docs`
- README command reference: regenerated via `sync:readme`

