### PR TITLE
chore(cluster): bump alpha alias to 8.10

### DIFF
--- a/default-plugins/cluster/package.json
+++ b/default-plugins/cluster/package.json
@@ -8,7 +8,7 @@
   "c8ctl": {
     "versionAliases": {
       "stable": "8.9",
-      "alpha": "8.10-alpha1"
+      "alpha": "8.10"
     }
   }
 }

--- a/default-plugins/cluster/package.json
+++ b/default-plugins/cluster/package.json
@@ -8,7 +8,7 @@
   "c8ctl": {
     "versionAliases": {
       "stable": "8.9",
-      "alpha": "8.9"
+      "alpha": "8.10-alpha1"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Update the `alpha` fallback alias in `default-plugins/cluster/package.json` from `8.9` to `8.10` ahead of the 8.10-alpha1 release.
- The download center serves the latest alpha c8run at the rolling-minor path `/c8run/8.10/` — currently the 8.10-alpha1 build, rolling forward as later alphas land. Using `8.10` matches the shape returned by `discoverLatestVersions()` (`{ alpha: "X.Y" }`) and the previous `stable: "8.9"` pattern.
- Promised follow-up to c91be8e (`chore(cluster): set stable alias to 8.9`), which noted: _"keeping 8.9 also as alpha as there is no 8.10 alpha yet. Will update this in a month"_.

The dynamic alias resolver (driven by `parseRemoteListing`) is unaffected — this only changes the offline/fallback value embedded in the plugin's `package.json`.

## Test plan

- [x] `npx node --experimental-strip-types --test tests/unit/cluster-plugin.test.ts` — 121/121 pass
- [x] `npm run build` succeeds
- [x] Verified server layout: `/c8run/8.10/camunda8-run-8.10-...` resolves (302); `/c8run/8.10-alpha1/...` 404s
- [ ] Verify `c8ctl cluster start alpha` resolves to the 8.10 train when the remote listing is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)