### PR TITLE
fix(element-template plugin): cache safety + explicit sync

### DIFF
--- a/default-plugins/element-template/AGENTS.md
+++ b/default-plugins/element-template/AGENTS.md
@@ -26,15 +26,32 @@ version resolution.
   `.camunda-connector-templates.json`.** Don't change the format
   without reason — `metadata.upstreamRef` is the dedup key for
   incremental sync.
-- **`get` deliberately does NOT auto-bootstrap.** Bootstrap progress
+- **No subcommand auto-bootstraps the cache.** OOTB-id resolution
+  is guarded by `requireCachePresent()` in `marketplace.ts`, which
+  throws the shared `CACHE_NOT_FOUND_MESSAGE` when the cache is
+  absent. The reason auto-bootstrap is forbidden: bootstrap progress
   goes through `logger.info`, which writes to stdout in text mode —
-  that would corrupt `get <id> > template.json` redirects. Cache miss
-  surfaces as an explicit error pointing at `sync`. Don't add a
-  bootstrap call to `getSubcommand` without changing the logger story
-  first.
-- **Path/URL apply paths must not trigger the index bootstrap.**
+  it would corrupt `apply | bpmn lint` and `get <id> > template.json`
+  pipelines, and racing cold-cache invocations would both fetch the
+  same ~14 MB index. Don't re-add a bootstrap call to any subcommand
+  without changing the logger story first.
+- **Path/URL apply paths must not trigger the cache check.**
   Detection happens in `parseTemplateRef()` in `template-ref.ts`
   before any cache call.
+- **`saveCache` and `apply --in-place` writes are atomic.** Both
+  use a sibling temp file + `renameSync`. Anything else that
+  overwrites a user-owned file (cache or BPMN) must follow the same
+  pattern — a kill mid-write must not leave a truncated file.
+- **`syncTemplates` is serialised by an advisory lockfile.** The
+  helper `withSyncLock` in `marketplace.ts` holds
+  `<cacheDir>/.sync.lock` while the body runs, with stale-lock
+  recovery (dead PID or > 10 min old) and signal handlers
+  (SIGINT/SIGTERM/SIGHUP) that release before re-raising. Don't
+  bypass it from new code paths.
+- **`apply` and `get` install an EPIPE handler before writing to
+  stdout** (`installStdoutEpipeHandler()` in `helpers.ts`). New
+  subcommands that write to stdout must do the same — otherwise
+  `... | head -c N` closing the pipe early crashes the process.
 - **JSON output uses element-templates schema field names verbatim.**
   No invented derivations — `binding`, `optional`, `value`, `condition`,
   `group` (id), `elementType: { value }`, `engines: { camunda }`. The

--- a/default-plugins/element-template/AGENTS.md
+++ b/default-plugins/element-template/AGENTS.md
@@ -45,7 +45,7 @@ version resolution.
 - **`syncTemplates` is serialised by an advisory lockfile.** The
   helper `withSyncLock` in `marketplace.ts` holds
   `<cacheDir>/.sync.lock` while the body runs, with stale-lock
-  recovery (dead PID or > 10 min old) and signal handlers
+  recovery (dead PID or > 60 min old) and signal handlers
   (SIGINT/SIGTERM/SIGHUP) that release before re-raising. Don't
   bypass it from new code paths.
 - **`apply` and `get` install an EPIPE handler before writing to

--- a/default-plugins/element-template/README.md
+++ b/default-plugins/element-template/README.md
@@ -17,11 +17,17 @@ The verb is organized as a workflow: discover → inspect → act → export →
 | `get-properties <template> [<name>...]` | List settable properties — condensed by default, `--detailed` for full cards. |
 | `apply <template> <element-id> [<file.bpmn>]` | Apply a template to a BPMN element (in place, or to stdout). |
 | `get <template>` | Print the raw template JSON to stdout (pipe-friendly). |
-| `sync` | Refresh the local OOTB template cache. |
+| `sync` | Populate / refresh the local OOTB template cache. **Run this once before any other OOTB subcommand.** |
 
 `<template>` is a local path, an `https://` URL, or an OOTB template id
 (optionally pinned: `<id>@<version>`). GitHub blob URLs are
 auto-rewritten to raw content URLs — paste straight from the address bar.
+
+> **First-run setup:** OOTB-id subcommands (`search`, `info`,
+> `get-properties`, `apply <id>`, `get <id>`) need a populated cache.
+> Run `c8ctl element-template sync` once per machine; subsequent commands
+> read from it. A missing cache surfaces a one-line error pointing back
+> at `sync`.
 
 ## Usage
 
@@ -297,22 +303,25 @@ warning at the end (the property won't be applied).
    (`https://marketplace.cloud.camunda.io/api/v1/ootb-connectors`) — the
    same source Desktop Modeler uses. Override via
    `C8CTL_OOTB_ELEMENT_TEMPLATES_URL` for testing.
-2. **First use** of `search`, `info`, `get-properties`, `apply`, or
-   `sync`: a one-shot bootstrap downloads ~459 templates with visible
-   progress; per-template failures are logged but don't abort the run.
-3. **`get` does NOT auto-bootstrap.** It exits with a hint to run
-   `sync` first if the cache is missing — bootstrap progress would
-   otherwise corrupt redirected stdout (`get <id> > template.json`).
-4. **Local file or URL** template args (paths containing `/` or `\`,
+2. **Populate the cache once** via `c8ctl element-template sync`.
+   Subcommands that resolve OOTB ids (`search`, `info`, `get-properties`,
+   `apply`, `get`) exit non-zero with a hint to run `sync` when the
+   cache is missing — no auto-download. This keeps pipelines clean:
+   bootstrap progress would otherwise land on stdout and corrupt
+   `apply | bpmn lint` or `get <id> > template.json`.
+3. **Local file or URL** template args (paths containing `/` or `\`,
    starting with `.`, ending in `.json`, or starting with `http(s)://`)
    skip the index entirely.
-5. **Version selection** uses `semver.satisfies` against the BPMN's
+4. **Version selection** uses `semver.satisfies` against the BPMN's
    `modeler:executionPlatformVersion` and each template's
    `engines.camunda` constraint. Without `@<version>`, the highest
    compatible version wins.
-6. **Stale cache** (>7 days) prints a hint to run `sync`. No automatic
+5. **Stale cache** (>7 days) prints a hint to run `sync`. No automatic
    refresh — `sync` only fetches refs not already cached (commit-pinned
    URLs make incremental sync free).
+6. **Concurrent syncs** are serialised by an advisory lock at
+   `<cache-dir>/.sync.lock`. A second `sync` started while one is
+   already running exits non-zero rather than racing.
 
 ### Cache locations
 

--- a/default-plugins/element-template/commands/apply.ts
+++ b/default-plugins/element-template/commands/apply.ts
@@ -3,7 +3,7 @@
  * element via the prebuilt bpmn-js + bpmn-js-element-templates vendor bundle.
  */
 
-import { existsSync, writeFileSync } from "node:fs";
+import { existsSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, resolve as resolvePath } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -11,6 +11,8 @@ import type {} from "../../../src/runtime.ts";
 import {
 	applySetOverrides,
 	findPropertiesByBindingName,
+	installStdoutEpipeHandler,
+	isRecord,
 	parseArgs,
 	parseSetArg,
 	type Template,
@@ -325,6 +327,10 @@ async function applyElementTemplate(
 
 export async function applySubcommand(args: string[]): Promise<void> {
 	const logger = c8ctl.getLogger();
+	// applySubcommand writes BPMN XML to stdout in the non-in-place path;
+	// install the EPIPE handler before any downstream `head -c N` or
+	// `| less` can sever the pipe.
+	installStdoutEpipeHandler();
 	const parsed = parseArgs(args);
 
 	if (parsed.error) {
@@ -453,10 +459,44 @@ export async function applySubcommand(args: string[]): Promise<void> {
 	}
 
 	if (parsed.inPlace && bpmnFilePath) {
-		writeFileSync(resolvePath(bpmnFilePath), resultXml, "utf-8");
+		atomicOverwriteFile(bpmnFilePath, resultXml);
 		logger.info(`Updated ${bpmnFilePath}`);
 		return;
 	}
 
 	process.stdout.write(resultXml);
+}
+
+/**
+ * Overwrite `targetPath` atomically: write to a sibling temp file in
+ * the same directory, then `renameSync` over the target. POSIX
+ * `rename` is atomic on the same filesystem, so a kill mid-write
+ * never destroys the user's BPMN file.
+ *
+ * Falls back to a direct `writeFileSync` if the rename fails with
+ * EXDEV (cross-device link) — vanishingly rare for a file's own
+ * sibling, but covers exotic setups like FUSE mounts.
+ */
+function atomicOverwriteFile(targetPath: string, contents: string): void {
+	const target = resolvePath(targetPath);
+	const tmp = `${target}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
+	try {
+		writeFileSync(tmp, contents, "utf-8");
+		renameSync(tmp, target);
+	} catch (error) {
+		try {
+			unlinkSync(tmp);
+		} catch {
+			// Best-effort cleanup — the original error is what matters.
+		}
+		const code =
+			isRecord(error) && typeof error.code === "string"
+				? error.code
+				: undefined;
+		if (code === "EXDEV") {
+			writeFileSync(target, contents, "utf-8");
+			return;
+		}
+		throw error;
+	}
 }

--- a/default-plugins/element-template/commands/get.ts
+++ b/default-plugins/element-template/commands/get.ts
@@ -15,11 +15,21 @@
  */
 
 import type {} from "../../../src/runtime.ts";
-import { parseTemplateJson, readFileOrUrl, type Template } from "../helpers.ts";
+import {
+	installStdoutEpipeHandler,
+	parseTemplateJson,
+	readFileOrUrl,
+	type Template,
+} from "../helpers.ts";
 import { requireCachePresent } from "../marketplace.ts";
 import { parseTemplateRef, resolveOotbTemplate } from "../template-ref.ts";
 
 export async function getSubcommand(args: string[]): Promise<void> {
+	// `get` writes raw template JSON straight to stdout; consumers that
+	// take only a prefix (e.g. `get <id> | head -c N`) close the pipe
+	// early and would otherwise crash the process with an unhandled
+	// EPIPE event.
+	installStdoutEpipeHandler();
 	const usage = "Usage: c8ctl element-template get <template> [--no-icon]";
 
 	let templateArg: string | undefined;

--- a/default-plugins/element-template/commands/get.ts
+++ b/default-plugins/element-template/commands/get.ts
@@ -16,7 +16,7 @@
 
 import type {} from "../../../src/runtime.ts";
 import { parseTemplateJson, readFileOrUrl, type Template } from "../helpers.ts";
-import { loadCache } from "../marketplace.ts";
+import { requireCachePresent } from "../marketplace.ts";
 import { parseTemplateRef, resolveOotbTemplate } from "../template-ref.ts";
 
 export async function getSubcommand(args: string[]): Promise<void> {
@@ -76,15 +76,10 @@ export async function getSubcommand(args: string[]): Promise<void> {
 	}
 
 	// OOTB id: no upstream bytes available — stringify the cached object.
-	// We deliberately do NOT auto-bootstrap here: the bootstrap log lines
-	// would interleave with the JSON payload on stdout and corrupt any
-	// shell redirect (`> template.json`). Surface the missing-cache case
-	// as an explicit error pointing at `sync`.
-	if (loadCache() === null) {
-		throw new Error(
-			"Element template cache not found. Run 'c8ctl element-template sync' first.",
-		);
-	}
+	// `resolveOotbTemplate` calls `requireCachePresent` under the hood, so
+	// a missing cache surfaces with the same "run sync first" message every
+	// other subcommand uses.
+	requireCachePresent();
 	const template = await resolveOotbTemplate(ref);
 
 	// The cache injects `metadata.upstreamRef` (our internal pointer for

--- a/default-plugins/element-template/commands/get.ts
+++ b/default-plugins/element-template/commands/get.ts
@@ -21,7 +21,6 @@ import {
 	readFileOrUrl,
 	type Template,
 } from "../helpers.ts";
-import { requireCachePresent } from "../marketplace.ts";
 import { parseTemplateRef, resolveOotbTemplate } from "../template-ref.ts";
 
 export async function getSubcommand(args: string[]): Promise<void> {
@@ -89,7 +88,6 @@ export async function getSubcommand(args: string[]): Promise<void> {
 	// `resolveOotbTemplate` calls `requireCachePresent` under the hood, so
 	// a missing cache surfaces with the same "run sync first" message every
 	// other subcommand uses.
-	requireCachePresent();
 	const template = await resolveOotbTemplate(ref);
 
 	// The cache injects `metadata.upstreamRef` (our internal pointer for

--- a/default-plugins/element-template/commands/search.ts
+++ b/default-plugins/element-template/commands/search.ts
@@ -1,13 +1,14 @@
 /**
  * `c8ctl element-template search` — search the local cache of OOTB
- * element templates by name/id, with auto-bootstrap on first run.
+ * element templates by name/id. Requires the cache to be populated;
+ * run `c8ctl element-template sync` once first.
  */
 
 import { styleText } from "node:util";
 import type {} from "../../../src/runtime.ts";
 import {
-	bootstrapIfNeeded,
 	nudgeIfStale,
+	requireCachePresent,
 	searchTemplates,
 } from "../marketplace.ts";
 import { buildTemplateSummary, formatTemplateHeaderLines } from "./info.ts";
@@ -58,7 +59,7 @@ export async function searchSubcommand(args: string[]): Promise<void> {
 		throw new Error(`Missing query. ${usage}`);
 	}
 
-	await bootstrapIfNeeded({ logger });
+	requireCachePresent();
 	nudgeIfStale(logger);
 
 	// Deprecated filtering and per-id latest-version reduction are done

--- a/default-plugins/element-template/docs/design.md
+++ b/default-plugins/element-template/docs/design.md
@@ -65,14 +65,18 @@ We mirror Desktop Modeler's approach
 
 ### Lifecycle
 
-- **First time the index is needed** (search, sync, or
-  `apply`/`get-properties`/`info` with an `<id>` arg): bootstrap
-  auto-runs — full fetch, ~459 templates, visible per-template
-  progress. `get` deliberately does NOT bootstrap (its progress
-  logs would corrupt `get <id> > template.json` redirects).
+- **Cache must be populated explicitly via `sync`.** Subcommands that
+  need to resolve an OOTB id (`search`, `info`, `get-properties`,
+  `apply <id>`, `get <id>`) fail fast with a one-line error pointing
+  back at `sync` when the cache is absent. We deliberately do not
+  auto-bootstrap: bootstrap progress goes through `logger.info`,
+  which writes to stdout in text mode, and would corrupt the
+  pipelines the README advertises (`apply ... | bpmn lint`,
+  `get <id> > template.json`). It also avoids the concurrent-bootstrap
+  race when several cold-cache invocations land at once.
 - **Local file or URL paths** for `apply`/`get-properties`/`info`:
-  never trigger bootstrap. The plugin classifies the template arg
-  before touching the cache.
+  never touch the cache at all. The plugin classifies the template
+  arg in `parseTemplateRef` before any cache call.
 - **Stale cache** (>7 days since `fetched-at`): warn-only, suggesting
   `c8ctl element-template sync`. We don't auto-refresh — surprise
   network activity inside `apply` is undesirable and the index is
@@ -80,8 +84,16 @@ We mirror Desktop Modeler's approach
 - **`sync`** always re-fetches the index but skips already-cached
   refs. **`sync --prune`** drops cached entries no longer in the
   fresh index (opt-in: a user may keep a legacy version intentionally).
-- **First-run + offline**: hard-fail with a clear message. No bundled
-  fallback.
+- **Atomicity**: `sync` writes `templates.json` and `fetched-at`
+  via a sibling temp file + `renameSync`, so a kill mid-sync leaves
+  the previous cache intact. `apply --in-place` uses the same recipe
+  for the user's BPMN file.
+- **Concurrent syncs** are serialised by an advisory lock
+  (`<cacheDir>/.sync.lock`) holding `{pid, startedAt}`. A second
+  `sync` exits non-zero with a pointer to the lockfile; stale locks
+  (dead PID or > 10 min old) are auto-recovered.
+- **No cache, no network**: hard-fail with a clear message. No
+  bundled fallback — `sync` is the one explicit step.
 
 ### Why not lazy per-template fetch on apply?
 

--- a/default-plugins/element-template/docs/design.md
+++ b/default-plugins/element-template/docs/design.md
@@ -91,7 +91,8 @@ We mirror Desktop Modeler's approach
 - **Concurrent syncs** are serialised by an advisory lock
   (`<cacheDir>/.sync.lock`) holding `{pid, startedAt}`. A second
   `sync` exits non-zero with a pointer to the lockfile; stale locks
-  (dead PID or > 10 min old) are auto-recovered.
+  (dead PID, or > 60 min old as a backstop against PID-recycle ghost
+  locks) are auto-recovered.
 - **No cache, no network**: hard-fail with a clear message. No
   bundled fallback — `sync` is the one explicit step.
 

--- a/default-plugins/element-template/helpers.ts
+++ b/default-plugins/element-template/helpers.ts
@@ -17,6 +17,32 @@ const c8ctl = globalThis.c8ctl;
  */
 export const USER_AGENT = `c8ctl-plugin-element-template/${c8ctl.version}`;
 
+/**
+ * Subcommands that write the primary payload to stdout (apply, get)
+ * must call this once before the first write. Closing the downstream
+ * pipe early (e.g. `apply <id> ... | head -c 100`) raises EPIPE on
+ * `process.stdout`; without a listener Node treats it as an
+ * uncaught 'error' event and crashes with a stack trace. Swallow it
+ * and exit cleanly — there's no useful work left to do once the
+ * consumer has gone away.
+ *
+ * Idempotent: the handler is registered at most once per process so
+ * repeated calls from different subcommand modules don't accumulate.
+ */
+let stdoutEpipeInstalled = false;
+export function installStdoutEpipeHandler(): void {
+	if (stdoutEpipeInstalled) {
+		return;
+	}
+	stdoutEpipeInstalled = true;
+	process.stdout.on("error", (err: NodeJS.ErrnoException) => {
+		if (err.code === "EPIPE") {
+			process.exit(0);
+		}
+		throw err;
+	});
+}
+
 export function isRecord(value: unknown): value is Record<string, unknown> {
 	return value != null && typeof value === "object" && !Array.isArray(value);
 }

--- a/default-plugins/element-template/marketplace.ts
+++ b/default-plugins/element-template/marketplace.ts
@@ -224,7 +224,8 @@ function releaseSyncLock(): void {
  * Run `body` while the sync lock is held. Installs signal handlers
  * so the lock is released on SIGINT/SIGTERM (otherwise a Ctrl-C
  * during sync would orphan the lockfile, leaving the next run to
- * wait the 10-minute stale window). Prior listeners are restored.
+ * wait the stale window). Only the lock-release handlers we add are
+ * removed in `finally`; any pre-existing listeners are left untouched.
  */
 async function withSyncLock<T>(
 	logger: Logger,

--- a/default-plugins/element-template/marketplace.ts
+++ b/default-plugins/element-template/marketplace.ts
@@ -585,16 +585,23 @@ async function syncTemplatesLocked({
 }
 
 /**
- * Run a sync if the cache doesn't exist yet. No-op if cache is present.
+ * Sentinel error message used by all subcommands that need the cache
+ * present. Phrased as a directive so callers don't have to invent
+ * their own copy.
  */
-export async function bootstrapIfNeeded({
-	logger,
-}: {
-	logger: Logger;
-}): Promise<void> {
+export const CACHE_NOT_FOUND_MESSAGE =
+	"Element template cache not found. Run 'c8ctl element-template sync' to download it first.";
+
+/**
+ * Throw a uniform error when the cache is missing. We deliberately do
+ * NOT auto-bootstrap — bootstrap progress goes to stdout via
+ * `logger.info`, which would corrupt any pipe the caller has set up
+ * (apply | bpmn lint, get > template.json, ...). Sync is one explicit
+ * command and the error tells the user to run it.
+ */
+export function requireCachePresent(): void {
 	if (existsSync(getCachePath())) return;
-	logger.info("Element template cache not found — running first-time sync...");
-	await syncTemplates({ logger });
+	throw new Error(CACHE_NOT_FOUND_MESSAGE);
 }
 
 // ---------------------------------------------------------------------------

--- a/default-plugins/element-template/marketplace.ts
+++ b/default-plugins/element-template/marketplace.ts
@@ -11,7 +11,14 @@
  * approach in `app/lib/template-updater/util.js`).
  */
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	mkdirSync,
+	readFileSync,
+	renameSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { join } from "node:path";
 import semver from "semver";
 import { isRecord, type Logger, type Template, USER_AGENT } from "./helpers.ts";
@@ -116,15 +123,35 @@ function loadFetchedAt(): number | null {
 	return Number.isFinite(ms) ? ms : null;
 }
 
+/**
+ * Write `contents` to `target` via a sibling temp file + atomic
+ * `renameSync`. Readers either see the old file or the new file —
+ * never a truncated mid-write state. POSIX `rename` is atomic on the
+ * same filesystem (which a sibling in the same directory always is).
+ */
+function atomicWriteFileSync(target: string, contents: string): void {
+	const tmp = `${target}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
+	try {
+		writeFileSync(tmp, contents, "utf-8");
+		renameSync(tmp, target);
+	} catch (error) {
+		try {
+			unlinkSync(tmp);
+		} catch {
+			// Best-effort cleanup — the original error is the one that matters.
+		}
+		throw error;
+	}
+}
+
 function saveCache(templates: Template[]): void {
 	const dir = getCacheDir();
 	mkdirSync(dir, { recursive: true });
-	writeFileSync(
+	atomicWriteFileSync(
 		getCachePath(),
 		`${JSON.stringify(templates, null, 2)}\n`,
-		"utf-8",
 	);
-	writeFileSync(getFetchedAtPath(), String(Date.now()), "utf-8");
+	atomicWriteFileSync(getFetchedAtPath(), String(Date.now()));
 }
 
 export function isCacheStale(): boolean {

--- a/default-plugins/element-template/marketplace.ts
+++ b/default-plugins/element-template/marketplace.ts
@@ -546,14 +546,16 @@ async function syncTemplatesLocked({
 	}
 	next.push(...fetchedTemplates);
 
+	// `pruned` = cached entries whose upstreamRef no longer appears in the
+	// fresh index (or that never had one). The "without --prune" branch
+	// below preserves these entries; with --prune we drop them, and the
+	// summary line reports that count to the user.
 	let pruned = 0;
 	if (prune) {
-		pruned =
-			existing.length -
-			next.filter((t) => {
-				const ref = t.metadata?.upstreamRef;
-				return ref !== undefined && byUpstreamRef.has(ref);
-			}).length;
+		pruned = existing.filter((t) => {
+			const ref = t.metadata?.upstreamRef;
+			return ref === undefined || !freshRefs.has(ref);
+		}).length;
 	}
 
 	// Without --prune, keep templates whose upstreamRef vanished from the index

--- a/default-plugins/element-template/marketplace.ts
+++ b/default-plugins/element-template/marketplace.ts
@@ -12,12 +12,15 @@
  */
 
 import {
+	closeSync,
 	existsSync,
 	mkdirSync,
+	openSync,
 	readFileSync,
 	renameSync,
 	unlinkSync,
 	writeFileSync,
+	writeSync,
 } from "node:fs";
 import { join } from "node:path";
 import semver from "semver";
@@ -28,6 +31,7 @@ const DEFAULT_OOTB_URL =
 const FETCH_CONCURRENCY = 12;
 const STALE_AFTER_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const FETCH_TIMEOUT_MS = 30_000; // 30 s per HTTP request
+const SYNC_LOCK_STALE_AFTER_MS = 10 * 60 * 1000; // 10 minutes
 
 // ---------------------------------------------------------------------------
 // Index entry types
@@ -79,6 +83,159 @@ function getCachePath(): string {
 
 function getFetchedAtPath(): string {
 	return join(getCacheDir(), "fetched-at");
+}
+
+function getSyncLockPath(): string {
+	return join(getCacheDir(), ".sync.lock");
+}
+
+// ---------------------------------------------------------------------------
+// Sync lock — serialises concurrent `sync` runs so they don't silently
+// undo each other's `--prune` (atomic rename prevents torn files but
+// not stale-read clobbers).
+// ---------------------------------------------------------------------------
+
+type SyncLockPayload = { pid: number; startedAt: number };
+
+function isProcessAlive(pid: number): boolean {
+	try {
+		// Signal 0 doesn't deliver a signal — it just tests permission /
+		// existence. ESRCH means the PID is gone.
+		process.kill(pid, 0);
+		return true;
+	} catch (error) {
+		const code = (error as NodeJS.ErrnoException).code;
+		// EPERM means the process exists but we lack permission — still alive.
+		return code === "EPERM";
+	}
+}
+
+function readLockPayload(path: string): SyncLockPayload | null {
+	try {
+		const raw = readFileSync(path, "utf-8");
+		const parsed: unknown = JSON.parse(raw);
+		if (
+			isRecord(parsed) &&
+			typeof parsed.pid === "number" &&
+			typeof parsed.startedAt === "number"
+		) {
+			return { pid: parsed.pid, startedAt: parsed.startedAt };
+		}
+	} catch {
+		// Unreadable / unparsable lock counts as stale.
+	}
+	return null;
+}
+
+function tryCreateLock(path: string, payload: SyncLockPayload): boolean {
+	try {
+		const fd = openSync(path, "wx", 0o644);
+		try {
+			writeSync(fd, JSON.stringify(payload));
+		} finally {
+			closeSync(fd);
+		}
+		return true;
+	} catch (error) {
+		if ((error as NodeJS.ErrnoException).code === "EEXIST") return false;
+		throw error;
+	}
+}
+
+/**
+ * Acquire the sync lock or throw with a user-actionable message.
+ *
+ * The lock is a regular file at `<cacheDir>/.sync.lock` holding
+ * `{pid, startedAt}` JSON. We use `openSync("wx")` for atomic create —
+ * two concurrent attempts cannot both win on the same filesystem.
+ *
+ * If an existing lock is from a dead PID or older than
+ * `SYNC_LOCK_STALE_AFTER_MS`, we treat it as stale, log, and retry
+ * the create once. A persistent EEXIST after that is a real race with
+ * another live sync — surface it.
+ */
+function acquireSyncLock(logger: Logger): void {
+	const dir = getCacheDir();
+	mkdirSync(dir, { recursive: true });
+	const path = getSyncLockPath();
+	const payload: SyncLockPayload = {
+		pid: process.pid,
+		startedAt: Date.now(),
+	};
+	if (tryCreateLock(path, payload)) return;
+
+	const existing = readLockPayload(path);
+	const age = existing ? Date.now() - existing.startedAt : Infinity;
+	const stale =
+		existing === null ||
+		!isProcessAlive(existing.pid) ||
+		age > SYNC_LOCK_STALE_AFTER_MS;
+
+	if (stale) {
+		if (existing) {
+			logger.warn(
+				`Removed stale sync lock from pid ${existing.pid} (age ${Math.round(age / 1000)}s).`,
+			);
+		}
+		try {
+			unlinkSync(path);
+		} catch {
+			// Someone else may have just cleaned it up — fine, we'll retry below.
+		}
+		if (tryCreateLock(path, payload)) return;
+	}
+
+	const detail = existing
+		? `pid ${existing.pid}, started ${new Date(existing.startedAt).toISOString()}`
+		: "unknown owner";
+	throw new Error(
+		`Another sync is in progress (${detail}). ` +
+			`Wait for it to finish or remove ${path} if you're sure no other sync is running.`,
+	);
+}
+
+function releaseSyncLock(): void {
+	try {
+		unlinkSync(getSyncLockPath());
+	} catch {
+		// Best-effort — the lock may already be gone if a signal handler
+		// raced with the normal `finally`.
+	}
+}
+
+/**
+ * Run `body` while the sync lock is held. Installs signal handlers
+ * so the lock is released on SIGINT/SIGTERM (otherwise a Ctrl-C
+ * during sync would orphan the lockfile, leaving the next run to
+ * wait the 10-minute stale window). Prior listeners are restored.
+ */
+async function withSyncLock<T>(
+	logger: Logger,
+	body: () => Promise<T>,
+): Promise<T> {
+	acquireSyncLock(logger);
+	const signals: NodeJS.Signals[] = ["SIGINT", "SIGTERM", "SIGHUP"];
+	const handlers = new Map<NodeJS.Signals, () => void>();
+	for (const sig of signals) {
+		const handler = () => {
+			releaseSyncLock();
+			// Re-raise the signal with the default action so the process
+			// actually exits with the expected status. Remove our listener
+			// first so we don't recurse.
+			process.removeListener(sig, handler);
+			process.kill(process.pid, sig);
+		};
+		handlers.set(sig, handler);
+		process.on(sig, handler);
+	}
+	try {
+		return await body();
+	} finally {
+		for (const [sig, handler] of handlers) {
+			process.removeListener(sig, handler);
+		}
+		releaseSyncLock();
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -305,6 +462,16 @@ export async function syncTemplates({
 }: {
 	logger: Logger;
 	prune?: boolean;
+}): Promise<SyncSummary> {
+	return withSyncLock(logger, () => syncTemplatesLocked({ logger, prune }));
+}
+
+async function syncTemplatesLocked({
+	logger,
+	prune,
+}: {
+	logger: Logger;
+	prune: boolean;
 }): Promise<SyncSummary> {
 	logger.info(`Fetching index from ${getMarketplaceUrl()} ...`);
 	const index = await fetchIndex();

--- a/default-plugins/element-template/marketplace.ts
+++ b/default-plugins/element-template/marketplace.ts
@@ -31,7 +31,10 @@ const DEFAULT_OOTB_URL =
 const FETCH_CONCURRENCY = 12;
 const STALE_AFTER_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 const FETCH_TIMEOUT_MS = 30_000; // 30 s per HTTP request
-const SYNC_LOCK_STALE_AFTER_MS = 10 * 60 * 1000; // 10 minutes
+// Backstop for ghost locks left by PID-recycled crashed syncs. Kept
+// well above realistic sync runtimes so a live but slow sync's lock
+// is never reclaimed.
+const SYNC_LOCK_STALE_AFTER_MS = 60 * 60 * 1000; // 60 minutes
 
 // ---------------------------------------------------------------------------
 // Index entry types

--- a/default-plugins/element-template/marketplace.ts
+++ b/default-plugins/element-template/marketplace.ts
@@ -97,6 +97,18 @@ function getSyncLockPath(): string {
 
 type SyncLockPayload = { pid: number; startedAt: number };
 
+/**
+ * Read `error.code` if the thrown value carries one. Errors from the
+ * `node:fs` and `node:process` APIs all set `code` to a `string`; this
+ * narrows safely without an `as NodeJS.ErrnoException` cast.
+ */
+function getErrorCode(error: unknown): string | undefined {
+	if (isRecord(error) && typeof error.code === "string") {
+		return error.code;
+	}
+	return undefined;
+}
+
 function isProcessAlive(pid: number): boolean {
 	try {
 		// Signal 0 doesn't deliver a signal — it just tests permission /
@@ -104,9 +116,8 @@ function isProcessAlive(pid: number): boolean {
 		process.kill(pid, 0);
 		return true;
 	} catch (error) {
-		const code = (error as NodeJS.ErrnoException).code;
 		// EPERM means the process exists but we lack permission — still alive.
-		return code === "EPERM";
+		return getErrorCode(error) === "EPERM";
 	}
 }
 
@@ -137,7 +148,9 @@ function tryCreateLock(path: string, payload: SyncLockPayload): boolean {
 		}
 		return true;
 	} catch (error) {
-		if ((error as NodeJS.ErrnoException).code === "EEXIST") return false;
+		if (getErrorCode(error) === "EEXIST") {
+			return false;
+		}
 		throw error;
 	}
 }
@@ -162,7 +175,9 @@ function acquireSyncLock(logger: Logger): void {
 		pid: process.pid,
 		startedAt: Date.now(),
 	};
-	if (tryCreateLock(path, payload)) return;
+	if (tryCreateLock(path, payload)) {
+		return;
+	}
 
 	const existing = readLockPayload(path);
 	const age = existing ? Date.now() - existing.startedAt : Infinity;
@@ -182,7 +197,9 @@ function acquireSyncLock(logger: Logger): void {
 		} catch {
 			// Someone else may have just cleaned it up — fine, we'll retry below.
 		}
-		if (tryCreateLock(path, payload)) return;
+		if (tryCreateLock(path, payload)) {
+			return;
+		}
 	}
 
 	const detail = existing
@@ -602,7 +619,9 @@ export const CACHE_NOT_FOUND_MESSAGE =
  * command and the error tells the user to run it.
  */
 export function requireCachePresent(): void {
-	if (existsSync(getCachePath())) return;
+	if (existsSync(getCachePath())) {
+		return;
+	}
 	throw new Error(CACHE_NOT_FOUND_MESSAGE);
 }
 

--- a/default-plugins/element-template/template-ref.ts
+++ b/default-plugins/element-template/template-ref.ts
@@ -22,10 +22,10 @@ import {
 	type TemplateProperty,
 } from "./helpers.ts";
 import {
-	bootstrapIfNeeded,
 	findById,
 	nudgeIfStale,
 	pickVersion,
+	requireCachePresent,
 } from "./marketplace.ts";
 
 if (!globalThis.c8ctl) throw new Error("c8ctl runtime not initialised");
@@ -203,7 +203,7 @@ export async function resolveOotbTemplate(
 	}: { executionPlatformVersion?: string | null } = {},
 ): Promise<Template> {
 	const logger = c8ctl.getLogger();
-	await bootstrapIfNeeded({ logger });
+	requireCachePresent();
 	nudgeIfStale(logger);
 
 	const candidates = findById(ref.id);

--- a/tests/unit/element-template.test.ts
+++ b/tests/unit/element-template.test.ts
@@ -5,12 +5,15 @@
 
 import assert from "node:assert";
 import {
+	existsSync,
 	mkdirSync,
 	mkdtempSync,
+	readdirSync,
 	readFileSync,
 	rmSync,
 	writeFileSync,
 } from "node:fs";
+import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, test } from "node:test";
@@ -1650,5 +1653,518 @@ describe("CLI behavioural: element-template apply --dry-run", () => {
 			output.includes("MissingElement_xyz") && output.includes("not found"),
 			`Should report the missing element id. Got: ${output.slice(0, 300)}`,
 		);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// element-template — cold-cache failures (no auto-bootstrap)
+// ---------------------------------------------------------------------------
+
+/**
+ * Spawn the CLI against a fresh, empty `C8CTL_DATA_DIR`. The cache
+ * is intentionally absent so we exercise the missing-cache path.
+ * Caller is responsible for cleaning up `dataDir`.
+ */
+async function spawnAgainstEmptyCache(...args: string[]) {
+	const dataDir = mkdtempSync(join(tmpdir(), "c8ctl-et-cold-"));
+	try {
+		const result = await asyncSpawn(
+			"node",
+			["--experimental-strip-types", CLI, "element-template", ...args],
+			{
+				env: {
+					...process.env,
+					CAMUNDA_BASE_URL: "http://test-cluster/v2",
+					HOME: "/tmp/c8ctl-test-nonexistent-home",
+					C8CTL_DATA_DIR: dataDir,
+				},
+			},
+		);
+		return { ...result, dataDir };
+	} finally {
+		rmSync(dataDir, { recursive: true, force: true });
+	}
+}
+
+describe("CLI behavioural: element-template cold-cache failures", () => {
+	const COLD_CASES: Array<{ label: string; args: string[] }> = [
+		{ label: "search", args: ["search", "anything"] },
+		{ label: "info", args: ["info", "io.camunda.connectors.HttpJson.v2"] },
+		{
+			label: "get-properties",
+			args: ["get-properties", "io.camunda.connectors.HttpJson.v2"],
+		},
+		{
+			label: "apply",
+			args: [
+				"apply",
+				"io.camunda.connectors.HttpJson.v2",
+				"Activity_17s7axj",
+				BPMN_FILE,
+			],
+		},
+		{ label: "get", args: ["get", "io.camunda.connectors.HttpJson.v2"] },
+	];
+
+	for (const { label, args } of COLD_CASES) {
+		test(`${label}: exits 1 with 'run sync first' hint and no stdout contamination`, async () => {
+			const result = await spawnAgainstEmptyCache(...args);
+			assert.strictEqual(
+				result.status,
+				1,
+				`${label} should exit 1 on cold cache. stderr: ${result.stderr}`,
+			);
+			const combined = result.stdout + result.stderr;
+			assert.ok(
+				combined.includes("element-template sync"),
+				`${label} error should point at 'sync'. Got: ${combined.slice(0, 300)}`,
+			);
+			// Critical pipeline-safety guarantee: a cold-cache failure must
+			// not write any payload (BPMN XML, template JSON, search rows)
+			// to stdout. The error itself goes to stderr via logger.error.
+			assert.strictEqual(
+				result.stdout.trim(),
+				"",
+				`${label} must not write to stdout when the cache is missing. ` +
+					`Got stdout: ${result.stdout.slice(0, 300)}`,
+			);
+		});
+	}
+});
+
+// ---------------------------------------------------------------------------
+// element-template — sync lockfile + --prune count
+// ---------------------------------------------------------------------------
+
+/**
+ * In-process marketplace stub. Serves a configurable
+ * `/ootb-connectors` index and an arbitrary number of per-ref
+ * templates under `/t/<id>@<version>`. Each call to `serveIndex`
+ * swaps the index in place so a test can simulate "the upstream
+ * dropped a template" without restarting the server.
+ */
+type StubServer = {
+	url: string;
+	close: () => Promise<void>;
+	setIndex: (index: Record<string, Array<unknown>>) => void;
+};
+
+/**
+ * Pull the listening port off a Node `http.Server` without an `as`
+ * cast — `server.address()` returns `string | AddressInfo | null` and
+ * the plugin lint forbids the unsafe assertion.
+ */
+function getServerPort(server: Server): number {
+	const addr = server.address();
+	if (isRecord(addr) && typeof addr.port === "number") {
+		return addr.port;
+	}
+	throw new Error("stub server has no port (not listening?)");
+}
+
+async function startMarketplaceStub(
+	templates: Array<Record<string, unknown>>,
+): Promise<StubServer> {
+	type IndexEntry = {
+		version: number;
+		ref: string;
+		engine: { camunda: string };
+	};
+	let currentIndex: Record<string, IndexEntry[]> = {};
+	const templatesByRef = new Map<string, Record<string, unknown>>();
+
+	const buildIndex = (entries: Array<Record<string, unknown>>) => {
+		const idx: Record<string, IndexEntry[]> = {};
+		templatesByRef.clear();
+		for (const tpl of entries) {
+			const id = String(tpl.id);
+			const version = Number(tpl.version);
+			const ref = `/t/${encodeURIComponent(id)}@${version}`;
+			idx[id] = idx[id] || [];
+			idx[id].push({
+				version,
+				ref: `__BASE__${ref}`,
+				engine: { camunda: "^8.0" },
+			});
+			templatesByRef.set(ref, tpl);
+		}
+		return idx;
+	};
+	currentIndex = buildIndex(templates);
+
+	const server: Server = createServer((req, res) => {
+		if (!req.url) {
+			res.statusCode = 400;
+			res.end();
+			return;
+		}
+		if (req.url === "/ootb-connectors") {
+			// Stamp the real listening URL into ref placeholders so the
+			// client follows them back to us.
+			const baseUrl = `http://127.0.0.1:${getServerPort(server)}`;
+			const rewritten: Record<string, IndexEntry[]> = {};
+			for (const [id, versions] of Object.entries(currentIndex)) {
+				rewritten[id] = versions.map((v) => ({
+					...v,
+					ref: v.ref.replace("__BASE__", baseUrl),
+				}));
+			}
+			res.setHeader("content-type", "application/json");
+			res.end(JSON.stringify(rewritten));
+			return;
+		}
+		const tpl = templatesByRef.get(req.url);
+		if (tpl) {
+			res.setHeader("content-type", "application/json");
+			res.end(JSON.stringify(tpl));
+			return;
+		}
+		res.statusCode = 404;
+		res.end();
+	});
+
+	await new Promise<void>((resolveListen, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => resolveListen());
+	});
+	const port = getServerPort(server);
+	return {
+		url: `http://127.0.0.1:${port}/ootb-connectors`,
+		setIndex: (next) => {
+			// Accept the public-facing index shape — caller crafts entries
+			// matching IndexEntry. Currently unused by the tests but kept
+			// on the API so a test can simulate "upstream changed" without
+			// restarting the server.
+			const reshaped: Record<string, IndexEntry[]> = {};
+			for (const [id, versions] of Object.entries(next)) {
+				if (!Array.isArray(versions)) continue;
+				reshaped[id] = versions
+					.filter(isRecord)
+					.filter(
+						(v): v is IndexEntry =>
+							typeof v.version === "number" && typeof v.ref === "string",
+					);
+			}
+			currentIndex = reshaped;
+		},
+		close: () =>
+			new Promise<void>((resolveClose) => server.close(() => resolveClose())),
+	};
+}
+
+describe("CLI behavioural: element-template sync lockfile", () => {
+	test("second concurrent sync exits non-zero pointing at the lockfile", async () => {
+		// Pre-seed a live lock owned by THIS test process. The lock helper
+		// recognises an alive PID and refuses to acquire — exactly the
+		// "two shells racing" scenario without the timing flakiness of
+		// actually running two syncs in parallel.
+		const stub = await startMarketplaceStub([
+			{
+				id: "io.example.locked",
+				name: "Locked",
+				version: 1,
+				properties: [],
+			},
+		]);
+		const dataDir = mkdtempSync(join(tmpdir(), "c8ctl-et-lock-"));
+		const cacheDir = join(dataDir, "element-templates");
+		mkdirSync(cacheDir, { recursive: true });
+		writeFileSync(
+			join(cacheDir, ".sync.lock"),
+			JSON.stringify({ pid: process.pid, startedAt: Date.now() }),
+		);
+		try {
+			const result = await asyncSpawn(
+				"node",
+				["--experimental-strip-types", CLI, "element-template", "sync"],
+				{
+					env: {
+						...process.env,
+						HOME: "/tmp/c8ctl-test-nonexistent-home",
+						C8CTL_DATA_DIR: dataDir,
+						C8CTL_OOTB_ELEMENT_TEMPLATES_URL: stub.url,
+					},
+				},
+			);
+			assert.strictEqual(
+				result.status,
+				1,
+				`Second sync should fail when a live lock is held. stderr: ${result.stderr}`,
+			);
+			const combined = result.stdout + result.stderr;
+			assert.ok(
+				combined.includes("Another sync is in progress"),
+				`Expected lockfile contention message. Got: ${combined.slice(0, 300)}`,
+			);
+			// Pre-seeded lock must survive the failed attempt.
+			assert.ok(
+				existsSync(join(cacheDir, ".sync.lock")),
+				"Lockfile from the simulated 'live' holder should not be removed by the loser.",
+			);
+		} finally {
+			await stub.close();
+			rmSync(dataDir, { recursive: true, force: true });
+		}
+	});
+
+	test("stale lock (dead PID) is recovered and sync proceeds", async () => {
+		const stub = await startMarketplaceStub([
+			{
+				id: "io.example.stale",
+				name: "Stale",
+				version: 1,
+				properties: [],
+			},
+		]);
+		const dataDir = mkdtempSync(join(tmpdir(), "c8ctl-et-stale-"));
+		const cacheDir = join(dataDir, "element-templates");
+		mkdirSync(cacheDir, { recursive: true });
+		// PID 1 (init) is reliably alive on every platform; pick a PID
+		// that won't ever map to a process: process.pid + a huge offset
+		// is the cheap version but we can't guarantee uniqueness. Use a
+		// startedAt 11 minutes in the past so the age-based recovery
+		// path fires regardless of PID liveness.
+		writeFileSync(
+			join(cacheDir, ".sync.lock"),
+			JSON.stringify({
+				pid: process.pid,
+				startedAt: Date.now() - 11 * 60 * 1000,
+			}),
+		);
+		try {
+			const result = await asyncSpawn(
+				"node",
+				["--experimental-strip-types", CLI, "element-template", "sync"],
+				{
+					env: {
+						...process.env,
+						HOME: "/tmp/c8ctl-test-nonexistent-home",
+						C8CTL_DATA_DIR: dataDir,
+						C8CTL_OOTB_ELEMENT_TEMPLATES_URL: stub.url,
+					},
+				},
+			);
+			assert.strictEqual(
+				result.status,
+				0,
+				`Sync should recover from a stale lock. stderr: ${result.stderr}`,
+			);
+			assert.ok(
+				result.stderr.includes("stale sync lock") ||
+					result.stdout.includes("stale sync lock"),
+				`Expected a 'stale sync lock' warning. Got: ${(result.stderr + result.stdout).slice(0, 300)}`,
+			);
+			// And the cache must have been written.
+			assert.ok(
+				existsSync(join(cacheDir, "templates.json")),
+				"templates.json should exist after a successful recovery sync.",
+			);
+		} finally {
+			await stub.close();
+			rmSync(dataDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("CLI behavioural: element-template sync --prune count", () => {
+	test("reports the number of cache entries dropped from the fresh index", async () => {
+		const dataDir = mkdtempSync(join(tmpdir(), "c8ctl-et-prune-"));
+		const cacheDir = join(dataDir, "element-templates");
+		mkdirSync(cacheDir, { recursive: true });
+		// Seed the cache with TWO entries, one of which the upstream
+		// will drop. Each entry carries `metadata.upstreamRef` matching
+		// the stub's URL scheme so `byUpstreamRef` looks them up cleanly.
+		const stub = await startMarketplaceStub([
+			{
+				id: "io.example.kept",
+				name: "Kept",
+				version: 1,
+				properties: [],
+			},
+			// Note: "dropped" is NOT included here, so the fresh index
+			// will lack it after sync.
+		]);
+		const keptRefUrl = `${stub.url.replace("/ootb-connectors", "")}/t/${encodeURIComponent("io.example.kept")}@1`;
+		const droppedRefUrl = `${stub.url.replace("/ootb-connectors", "")}/t/${encodeURIComponent("io.example.dropped")}@1`;
+		writeFileSync(
+			join(cacheDir, "templates.json"),
+			JSON.stringify(
+				[
+					{
+						id: "io.example.kept",
+						name: "Kept",
+						version: 1,
+						properties: [],
+						metadata: { upstreamRef: keptRefUrl },
+					},
+					{
+						id: "io.example.dropped",
+						name: "Dropped",
+						version: 1,
+						properties: [],
+						metadata: { upstreamRef: droppedRefUrl },
+					},
+				],
+				null,
+				2,
+			),
+		);
+		writeFileSync(join(cacheDir, "fetched-at"), String(Date.now()));
+		try {
+			const result = await asyncSpawn(
+				"node",
+				[
+					"--experimental-strip-types",
+					CLI,
+					"--json",
+					"element-template",
+					"sync",
+					"--prune",
+				],
+				{
+					env: {
+						...process.env,
+						HOME: "/tmp/c8ctl-test-nonexistent-home",
+						C8CTL_DATA_DIR: dataDir,
+						C8CTL_OOTB_ELEMENT_TEMPLATES_URL: stub.url,
+						C8CTL_OUTPUT_MODE: "json",
+					},
+				},
+			);
+			assert.strictEqual(
+				result.status,
+				0,
+				`sync --prune should succeed. stderr: ${result.stderr}`,
+			);
+			// The summary line is the last JSON object on stdout.
+			const summaryLine = result.stdout
+				.trim()
+				.split("\n")
+				.reverse()
+				.find((line) => line.startsWith("{") && line.includes("pruned"));
+			assert.ok(
+				summaryLine,
+				`expected a summary JSON line. Got stdout: ${result.stdout.slice(0, 500)}`,
+			);
+			const summary = JSON.parse(summaryLine ?? "{}");
+			assert.strictEqual(
+				summary.pruned,
+				1,
+				`Expected pruned=1 (the 'dropped' entry). Got summary: ${summaryLine}`,
+			);
+		} finally {
+			await stub.close();
+			rmSync(dataDir, { recursive: true, force: true });
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// element-template — atomic in-place write + EPIPE
+// ---------------------------------------------------------------------------
+
+describe("CLI behavioural: element-template apply --in-place atomicity", () => {
+	test("leaves no .tmp file in the BPMN directory after a successful apply", async () => {
+		const dataDir = mkdtempSync(join(tmpdir(), "c8ctl-et-tmp-"));
+		const bpmnDir = mkdtempSync(join(tmpdir(), "c8ctl-et-bpmn-"));
+		const bpmnPath = join(bpmnDir, "process.bpmn");
+		writeFileSync(bpmnPath, readFileSync(BPMN_FILE, "utf-8"));
+		try {
+			const result = await asyncSpawn(
+				"node",
+				[
+					"--experimental-strip-types",
+					CLI,
+					"element-template",
+					"apply",
+					"-i",
+					TEMPLATE_FILE,
+					"Activity_17s7axj",
+					bpmnPath,
+				],
+				{
+					env: {
+						...process.env,
+						CAMUNDA_BASE_URL: "http://test-cluster/v2",
+						HOME: "/tmp/c8ctl-test-nonexistent-home",
+						C8CTL_DATA_DIR: dataDir,
+					},
+				},
+			);
+			assert.strictEqual(
+				result.status,
+				0,
+				`apply -i should succeed. stderr: ${result.stderr}`,
+			);
+			const leftovers = readdirSync(bpmnDir).filter((name) =>
+				name.endsWith(".tmp"),
+			);
+			assert.deepStrictEqual(
+				leftovers,
+				[],
+				`No .tmp file should survive a clean apply. Found: ${leftovers.join(", ")}`,
+			);
+			// And the file must have been updated (contains zeebe namespace
+			// after applying the HTTP JSON connector template).
+			const updated = readFileSync(bpmnPath, "utf-8");
+			assert.ok(
+				updated.includes("zeebe:taskDefinition"),
+				"BPMN file should contain the applied template's zeebe:taskDefinition",
+			);
+		} finally {
+			rmSync(dataDir, { recursive: true, force: true });
+			rmSync(bpmnDir, { recursive: true, force: true });
+		}
+	});
+});
+
+describe("CLI behavioural: element-template stdout EPIPE handling", () => {
+	test("apply: closing the downstream pipe early exits cleanly without an unhandled error stack", async () => {
+		const dataDir = mkdtempSync(join(tmpdir(), "c8ctl-et-epipe-"));
+		try {
+			// Use a template file (no cache lookup) so we test the EPIPE
+			// path itself, not the OOTB resolution path.
+			// Pipe the apply output into `head -c 1` to slam the pipe shut
+			// just after the first byte; without the EPIPE handler this
+			// crashes the child process with an 'Unhandled error' stack.
+			const child = await asyncSpawn(
+				"sh",
+				[
+					"-c",
+					[
+						"node",
+						"--experimental-strip-types",
+						CLI,
+						"element-template",
+						"apply",
+						JSON.stringify(TEMPLATE_FILE),
+						"Activity_17s7axj",
+						JSON.stringify(BPMN_FILE),
+						"| head -c 1 > /dev/null",
+					].join(" "),
+				],
+				{
+					env: {
+						...process.env,
+						CAMUNDA_BASE_URL: "http://test-cluster/v2",
+						HOME: "/tmp/c8ctl-test-nonexistent-home",
+						C8CTL_DATA_DIR: dataDir,
+					},
+				},
+			);
+			// The child invokes node + head; sh's exit status is head's
+			// (always 0 here). What we really care about is no unhandled
+			// error stack on stderr from the node child.
+			assert.ok(
+				!child.stderr.includes("Unhandled"),
+				`stderr should not contain an unhandled-error stack. Got: ${child.stderr.slice(0, 300)}`,
+			);
+			assert.ok(
+				!child.stderr.includes("EPIPE"),
+				`stderr should not surface a raw EPIPE. Got: ${child.stderr.slice(0, 300)}`,
+			);
+		} finally {
+			rmSync(dataDir, { recursive: true, force: true });
+		}
 	});
 });

--- a/tests/unit/element-template.test.ts
+++ b/tests/unit/element-template.test.ts
@@ -4,6 +4,7 @@
  */
 
 import assert from "node:assert";
+import { spawnSync } from "node:child_process";
 import {
 	existsSync,
 	mkdirSync,
@@ -1919,16 +1920,18 @@ describe("CLI behavioural: element-template sync lockfile", () => {
 		const dataDir = mkdtempSync(join(tmpdir(), "c8ctl-et-stale-"));
 		const cacheDir = join(dataDir, "element-templates");
 		mkdirSync(cacheDir, { recursive: true });
-		// PID 1 (init) is reliably alive on every platform; pick a PID
-		// that won't ever map to a process: process.pid + a huge offset
-		// is the cheap version but we can't guarantee uniqueness. Use a
-		// startedAt 11 minutes in the past so the age-based recovery
-		// path fires regardless of PID liveness.
+		// Spawn-then-await a no-op child to obtain a PID that's guaranteed
+		// to have exited by the time we use it. (Hard-coded large PIDs can
+		// collide on some platforms; this is portable across Linux/macOS/
+		// Windows.)
+		const exitedChild = spawnSync(process.execPath, ["-e", ""]);
+		const exitedPid = exitedChild.pid;
+		assert.ok(exitedPid, "Failed to obtain an exited PID for the test");
 		writeFileSync(
 			join(cacheDir, ".sync.lock"),
 			JSON.stringify({
-				pid: process.pid,
-				startedAt: Date.now() - 11 * 60 * 1000,
+				pid: exitedPid,
+				startedAt: Date.now(),
 			}),
 		);
 		try {

--- a/tests/unit/element-template.test.ts
+++ b/tests/unit/element-template.test.ts
@@ -1663,12 +1663,13 @@ describe("CLI behavioural: element-template apply --dry-run", () => {
 /**
  * Spawn the CLI against a fresh, empty `C8CTL_DATA_DIR`. The cache
  * is intentionally absent so we exercise the missing-cache path.
- * Caller is responsible for cleaning up `dataDir`.
+ * The temp dir is created and removed inside this helper — callers
+ * just consume the spawn result.
  */
 async function spawnAgainstEmptyCache(...args: string[]) {
 	const dataDir = mkdtempSync(join(tmpdir(), "c8ctl-et-cold-"));
 	try {
-		const result = await asyncSpawn(
+		return await asyncSpawn(
 			"node",
 			["--experimental-strip-types", CLI, "element-template", ...args],
 			{
@@ -1680,7 +1681,6 @@ async function spawnAgainstEmptyCache(...args: string[]) {
 				},
 			},
 		);
-		return { ...result, dataDir };
 	} finally {
 		rmSync(dataDir, { recursive: true, force: true });
 	}


### PR DESCRIPTION
## Description

Four bugs in the element-template plugin:

- `saveCache` was a plain `writeFileSync`, so a kill mid-sync or two concurrent syncs could leave `templates.json` truncated and every subsequent command would refuse to start.
- The implicit bootstrap inside `search`/`apply`/etc. wrote progress to **stdout**, breaking the README-advertised pipelines on a cold cache.
- `apply --in-place` had the same truncate-then-write window — but on the user's own BPMN file, with no recovery path.
- The `--prune` summary number wasn't actually counting what `--prune` does.

## What changed

- **Atomic writes everywhere we own a user file.** `saveCache` and `apply --in-place` now write to a sibling temp file and `renameSync` over the target. A POSIX `rename` is atomic, so readers see either the old file or the new file — never a partial.
- **Sync is serialised by an advisory lockfile** (`<cache>/.sync.lock`) holding `{pid, startedAt}`. A second concurrent sync exits cleanly with a pointer to the lock; stale locks (dead PID or > 60 min old) are auto-recovered. Signal handlers release on Ctrl-C.
- **No more implicit bootstrap.** A missing cache surfaces a single shared message: "run `sync` first". This is the move that unbreaks pipelines — bootstrap progress can no longer leak onto stdout because there is no bootstrap.
- **EPIPE-safe stdout.** `apply` and `get` install a small handler so `... | head -c N` closing the pipe early exits cleanly instead of crashing with an unhandled error.
- **`--prune` count** is now derived directly from `existing ∖ freshRefs`.

## Verification

- `npm test` clean
- Live-marketplace smoke: cold cache → explicit `sync` → warm `apply | head -c 200` outputs clean BPMN XML
- Concurrent sync probe: the second invocation refuses with "Another sync is in progress" while the first runs to completion