### PR TITLE
fix(bpmn plugin): plugin behaviour fixes

### DIFF
--- a/default-plugins/bpmn/README.md
+++ b/default-plugins/bpmn/README.md
@@ -51,6 +51,8 @@ c8ctl bpmn lint process.bpmn
 
 1. If a `.bpmnlintrc` is present in the working directory, it's used
    verbatim — same behaviour as the standalone `bpmnlint` CLI.
+   **Only JSON `.bpmnlintrc` is supported**; for YAML or JS configs,
+   run the upstream `bpmnlint` CLI directly.
 2. Otherwise, if the BPMN file has both
    `modeler:executionPlatform="Camunda Cloud"` and a
    `modeler:executionPlatformVersion`, the plugin picks the matching

--- a/default-plugins/bpmn/lint.ts
+++ b/default-plugins/bpmn/lint.ts
@@ -145,7 +145,17 @@ function buildLintConfig(
 ): Record<string, unknown> {
 	const rcPath = resolvePath(".bpmnlintrc");
 	if (existsSync(rcPath)) {
-		const parsed: unknown = JSON.parse(readFileSync(rcPath, "utf-8"));
+		const raw = readFileSync(rcPath, "utf-8");
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(raw);
+		} catch (error) {
+			const detail = error instanceof Error ? error.message : String(error);
+			throw new Error(
+				`Failed to parse .bpmnlintrc: only JSON is supported (${detail}). ` +
+					"For YAML or JS configs, use the standalone `bpmnlint` CLI.",
+			);
+		}
 		if (!isRecord(parsed)) {
 			throw new Error(".bpmnlintrc must contain a JSON object");
 		}

--- a/default-plugins/bpmn/lint.ts
+++ b/default-plugins/bpmn/lint.ts
@@ -108,36 +108,59 @@ function detectCamundaCloudVersion(
 	return match ? match[1] : null;
 }
 
-function resolveCamundaCompatConfig(version: string): string | null {
+type ConfigResolution =
+	| { kind: "exact"; config: string }
+	| { kind: "above-range"; config: string; highest: string }
+	| { kind: "below-range"; lowest: string };
+
+function parseVersionParts(s: string): number[] {
+	return s.replace("camunda-cloud-", "").split("-").map(Number);
+}
+
+function compareVersionParts(a: number[], b: number[]): number {
+	for (let i = 0; i < Math.max(a.length, b.length); i++) {
+		const diff = (a[i] || 0) - (b[i] || 0);
+		if (diff !== 0) {
+			return diff;
+		}
+	}
+	return 0;
+}
+
+function resolveCamundaCompatConfig(version: string): ConfigResolution | null {
 	const plugin = require("bpmnlint-plugin-camunda-compat");
 	const configs = plugin.configs;
 
 	const configName = `camunda-cloud-${version.replace(".", "-")}`;
 	if (configName in configs) {
-		return `plugin:camunda-compat/${configName}`;
+		return { kind: "exact", config: `plugin:camunda-compat/${configName}` };
 	}
 
 	const cloudConfigs = Object.keys(configs)
 		.filter((k) => k.startsWith("camunda-cloud-"))
-		.sort((a, b) => {
-			const parse = (s: string) =>
-				s.replace("camunda-cloud-", "").split("-").map(Number);
-			const va = parse(a);
-			const vb = parse(b);
-			for (let i = 0; i < Math.max(va.length, vb.length); i++) {
-				const diff = (va[i] || 0) - (vb[i] || 0);
-				if (diff !== 0) {
-					return diff;
-				}
-			}
-			return 0;
-		});
+		.sort((a, b) =>
+			compareVersionParts(parseVersionParts(a), parseVersionParts(b)),
+		);
 
-	if (cloudConfigs.length > 0) {
-		return `plugin:camunda-compat/${cloudConfigs[cloudConfigs.length - 1]}`;
+	if (cloudConfigs.length === 0) {
+		return null;
 	}
 
-	return null;
+	const requested = parseVersionParts(
+		`camunda-cloud-${version.replace(".", "-")}`,
+	);
+	const lowest = cloudConfigs[0];
+	const highest = cloudConfigs[cloudConfigs.length - 1];
+
+	if (compareVersionParts(requested, parseVersionParts(lowest)) < 0) {
+		return { kind: "below-range", lowest };
+	}
+
+	return {
+		kind: "above-range",
+		config: `plugin:camunda-compat/${highest}`,
+		highest,
+	};
 }
 
 function buildLintConfig(
@@ -166,8 +189,18 @@ function buildLintConfig(
 
 	const version = detectCamundaCloudVersion(rootElement);
 	if (version) {
-		const compatConfig = resolveCamundaCompatConfig(version);
-		if (compatConfig) config.extends.push(compatConfig);
+		const resolution = resolveCamundaCompatConfig(version);
+		if (resolution?.kind === "exact" || resolution?.kind === "above-range") {
+			config.extends.push(resolution.config);
+		}
+		if (resolution?.kind === "above-range") {
+			c8ctl
+				.getLogger()
+				.warn(
+					`No camunda-compat config for ${version}; falling back to ${resolution.highest}. ` +
+						"Update c8ctl for newer rulesets.",
+				);
+		}
 	}
 
 	return config;

--- a/default-plugins/bpmn/lint.ts
+++ b/default-plugins/bpmn/lint.ts
@@ -79,16 +79,31 @@ async function readBpmnInput(
 	return null;
 }
 
+type PlatformInfo = {
+	executionPlatform: string;
+	version: string | null;
+};
+
+function extractPlatformInfo(
+	rootElement: BpmnModdleElement,
+): PlatformInfo | null {
+	const attrs = rootElement.$attrs ?? {};
+	const executionPlatform = attrs["modeler:executionPlatform"];
+	if (!executionPlatform) {
+		return null;
+	}
+	const version = attrs["modeler:executionPlatformVersion"] ?? null;
+	return { executionPlatform, version };
+}
+
 function detectCamundaCloudVersion(
 	rootElement: BpmnModdleElement,
 ): string | null {
-	const attrs = rootElement.$attrs ?? {};
-	const platform = attrs["modeler:executionPlatform"];
-	const version = attrs["modeler:executionPlatformVersion"];
-	if (platform !== "Camunda Cloud" || !version) {
+	const info = extractPlatformInfo(rootElement);
+	if (!info || info.executionPlatform !== "Camunda Cloud" || !info.version) {
 		return null;
 	}
-	const match = version.match(/^(\d+\.\d+)/);
+	const match = info.version.match(/^(\d+\.\d+)/);
 	return match ? match[1] : null;
 }
 
@@ -200,6 +215,37 @@ function collectLintResult(results: LintResults): LintResult {
 	}
 
 	return { rows, issues, errorCount, warningCount };
+}
+
+function renderDryRun(
+	logger: Logger,
+	source: string,
+	platform: PlatformInfo | null,
+	config: Record<string, unknown>,
+): void {
+	const sourceLabel = source === "stdin" ? "stdin" : resolvePath(source);
+	if (c8ctl.outputMode === "json") {
+		logger.json({
+			dryRun: true,
+			command: "bpmn lint",
+			source: sourceLabel,
+			platform,
+			config,
+		});
+		return;
+	}
+
+	const platformLabel = platform
+		? `${platform.executionPlatform}${platform.version ? ` ${platform.version}` : ""}`
+		: "not declared";
+	logger.output("Dry run — no lint performed.");
+	logger.output(`  Source: ${sourceLabel}`);
+	logger.output(`  Platform: ${platformLabel}`);
+	logger.output("  Config:");
+	const configLines = JSON.stringify(config, null, 2).split("\n");
+	for (const line of configLines) {
+		logger.output(`    ${line}`);
+	}
 }
 
 function renderLintJson(
@@ -335,6 +381,17 @@ export async function lintSubcommand(args: string[]): Promise<void> {
 	}
 
 	const config = buildLintConfig(rootElement);
+
+	if (c8ctl.dryRun) {
+		renderDryRun(
+			logger,
+			input.source,
+			extractPlatformInfo(rootElement),
+			config,
+		);
+		return;
+	}
+
 	const { Linter } = require("bpmnlint");
 	const NodeResolver = require("bpmnlint/lib/resolver/node-resolver");
 

--- a/default-plugins/bpmn/lint.ts
+++ b/default-plugins/bpmn/lint.ts
@@ -23,20 +23,21 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 type BpmnInput = { xml: string; source: string };
 
+type Severity = "error" | "warning";
+
 type LintIssue = {
 	rule: string;
 	elementId: string | null;
 	message: string;
-	category: string;
+	category: Severity;
 	path?: ReadonlyArray<string | number>;
 };
 
 type LintRow = {
 	elementRef: string;
-	severity: "error" | "warning";
+	severity: Severity;
 	message: string;
 	displayName: string;
-	category: string;
 };
 
 type LintResult = {
@@ -189,27 +190,27 @@ function collectLintResult(results: LintResults): LintResult {
 		for (const report of reports) {
 			const elementRef = formatElementRef(report, pathStringify);
 			const displayName = report.name ?? ruleName;
-			const severity = report.category === "error" ? "error" : "warning";
+			const severity: Severity =
+				report.category === "error" ? "error" : "warning";
 			rows.push({
 				elementRef,
 				severity,
 				message: report.message,
 				displayName,
-				category: report.category,
 			});
 
 			const issue: LintIssue = {
 				rule: report.name ?? ruleName,
 				elementId: report.id || null,
 				message: report.message,
-				category: report.category === "warn" ? "warning" : report.category,
+				category: severity,
 			};
 			if (report.path) {
 				issue.path = report.path;
 			}
 			issues.push(issue);
 
-			if (report.category === "error") errorCount++;
+			if (severity === "error") errorCount++;
 			else warningCount++;
 		}
 	}
@@ -298,7 +299,7 @@ function renderLintText(
 	logger.output("");
 	logger.output(styleText("underline", sourceLabel));
 	for (const r of rows) {
-		const severityColor = r.category === "error" ? "red" : "yellow";
+		const severityColor = r.severity === "error" ? "red" : "yellow";
 		const severityCell = styleText(
 			severityColor,
 			padEnd(r.severity, widths.severity),

--- a/tests/unit/bpmn-plugin.test.ts
+++ b/tests/unit/bpmn-plugin.test.ts
@@ -141,6 +141,73 @@ describe("CLI behavioural: bpmn lint", () => {
 		);
 	});
 
+	test("below-range Cloud version: falls through to bpmnlint:recommended only", async () => {
+		// 0.5.0 is below the lowest shipped camunda-compat config
+		// (camunda-cloud-1-0). The plugin should skip the Camunda
+		// ruleset entirely rather than silently apply the wrong one.
+		const tempDir = mkdtempSync(join(tmpdir(), "c8ctl-bpmn-below-"));
+		const file = join(tempDir, "ancient.bpmn");
+		writeFileSync(
+			file,
+			`<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:modeler="http://camunda.org/schema/modeler/1.0"
+                  modeler:executionPlatform="Camunda Cloud"
+                  modeler:executionPlatformVersion="0.5.0">
+  <bpmn:process id="p1" isExecutable="true" />
+</bpmn:definitions>`,
+		);
+		try {
+			const result = await c8text("bpmn", "lint", "--dry-run", file);
+			assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+			const out = result.stdout;
+			assert.ok(
+				!out.includes("camunda-compat"),
+				`extends should NOT include any camunda-compat config. Got: ${out}`,
+			);
+			assert.ok(
+				!(result.stderr + result.stdout).includes("falling back"),
+				"below-range should fall through silently, no warning",
+			);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("above-range Cloud version: warns and uses highest available config", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "c8ctl-bpmn-above-"));
+		const file = join(tempDir, "future.bpmn");
+		writeFileSync(
+			file,
+			`<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:modeler="http://camunda.org/schema/modeler/1.0"
+                  modeler:executionPlatform="Camunda Cloud"
+                  modeler:executionPlatformVersion="8.99.0">
+  <bpmn:process id="p1" isExecutable="true" />
+</bpmn:definitions>`,
+		);
+		try {
+			const result = await c8text("bpmn", "lint", "--dry-run", file);
+			assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+			const combined = result.stdout + result.stderr;
+			assert.ok(
+				combined.includes("No camunda-compat config for 8.99"),
+				`expected fallback warning. Got: ${combined.slice(0, 400)}`,
+			);
+			assert.ok(
+				combined.includes("Update c8ctl"),
+				"warning should hint that updating c8ctl might help",
+			);
+			assert.ok(
+				/plugin:camunda-compat\/camunda-cloud-\d+-\d+/.test(result.stdout),
+				"dry-run extends should still include a camunda-compat config (the highest)",
+			);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
 	test("lint invalid XML exits 1", async () => {
 		const tempDir = mkdtempSync(join(tmpdir(), "c8ctl-bpmn-test-"));
 		const tempFile = join(tempDir, "invalid.bpmn");

--- a/tests/unit/bpmn-plugin.test.ts
+++ b/tests/unit/bpmn-plugin.test.ts
@@ -409,6 +409,140 @@ describe("CLI behavioural: bpmn lint output formatting", () => {
 });
 
 // ---------------------------------------------------------------------------
+// bpmn lint — ruleset routing
+// ---------------------------------------------------------------------------
+
+describe("CLI behavioural: bpmn lint ruleset routing", () => {
+	test("Cloud 8.7 file routes to camunda-cloud-8-7", async () => {
+		// Pins the major.minor → ruleset mapping. We assert via --dry-run
+		// because it surfaces the resolved extends list without depending
+		// on which specific rules fire in each version.
+		const tempDir = mkdtempSync(join(tmpdir(), "c8ctl-bpmn-route-"));
+		const file = join(tempDir, "v87.bpmn");
+		writeFileSync(
+			file,
+			`<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:modeler="http://camunda.org/schema/modeler/1.0"
+                  modeler:executionPlatform="Camunda Cloud"
+                  modeler:executionPlatformVersion="8.7.0">
+  <bpmn:process id="p1" isExecutable="true" />
+</bpmn:definitions>`,
+		);
+		try {
+			const result = await c8text("bpmn", "lint", "--dry-run", file);
+			assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+			assert.ok(
+				result.stdout.includes("plugin:camunda-compat/camunda-cloud-8-7"),
+				`expected camunda-cloud-8-7 in extends. Got: ${result.stdout}`,
+			);
+			assert.ok(
+				!/camunda-cloud-8-[89]/.test(result.stdout),
+				"should not pull in 8-8 or 8-9 configs",
+			);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("Camunda Platform (non-Cloud) file skips camunda-compat", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "c8ctl-bpmn-platform-"));
+		const file = join(tempDir, "platform.bpmn");
+		writeFileSync(
+			file,
+			`<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:modeler="http://camunda.org/schema/modeler/1.0"
+                  modeler:executionPlatform="Camunda Platform"
+                  modeler:executionPlatformVersion="7.20.0">
+  <bpmn:process id="p1" isExecutable="true" />
+</bpmn:definitions>`,
+		);
+		try {
+			const result = await c8text("bpmn", "lint", "--dry-run", file);
+			assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+			const out = result.stdout;
+			assert.ok(
+				out.includes("Platform: Camunda Platform 7.20.0"),
+				"platform line should reflect the declared (non-Cloud) platform",
+			);
+			assert.ok(
+				!out.includes("camunda-compat"),
+				"non-Cloud platform should not add a camunda-compat config",
+			);
+			assert.ok(
+				out.includes("bpmnlint:recommended"),
+				"bpmnlint:recommended should still apply",
+			);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test("mixed errors + warnings: summary line uses the red branch", async () => {
+		// renderLintText picks ["bold", "red"] when errorCount > 0 and
+		// yellow otherwise. Stand up a fixture + .bpmnlintrc that
+		// produces at least one of each, then assert the summary line
+		// carries the red ANSI escape (\x1b[31m).
+		const externalDir = mkdtempSync(join(tmpdir(), "c8ctl-bpmn-mixed-"));
+		const file = join(externalDir, "test.bpmn");
+		// duplicate-ids/process-a.bpmn fires both label-required and
+		// no-bpmndi. Demoting one to "warn" gives us one error + one
+		// warning category deterministically.
+		writeFileSync(
+			file,
+			readFileSync(
+				join(FIXTURES_DIR, "duplicate-ids", "process-a.bpmn"),
+				"utf-8",
+			),
+		);
+		writeFileSync(
+			join(externalDir, ".bpmnlintrc"),
+			JSON.stringify({
+				extends: ["bpmnlint:recommended"],
+				rules: { "label-required": "warn" },
+			}),
+		);
+		try {
+			const result = await asyncSpawn(
+				"node",
+				[
+					"--experimental-strip-types",
+					join(REPO_ROOT, CLI),
+					"bpmn",
+					"lint",
+					file,
+				],
+				{
+					cwd: externalDir,
+					env: { ...process.env, FORCE_COLOR: "1" },
+				},
+			);
+			assert.strictEqual(result.status, 1, `stderr: ${result.stderr}`);
+			const out = result.stdout;
+			const summary = out.split("\n").find((l) => l.includes("problem"));
+			if (!summary) {
+				assert.fail(`no summary line in output: ${out.slice(0, 300)}`);
+			}
+			// styleText(["bold", "red"], ...) emits \x1b[1m \x1b[31m around
+			// the summary text. Build the regex from char codes so biome's
+			// noControlCharactersInRegex doesn't flag a literal ESC.
+			const redEsc = `${String.fromCharCode(0x1b)}\\[31m`;
+			assert.ok(
+				new RegExp(redEsc).test(summary),
+				`summary should carry the red ANSI escape. Got: ${JSON.stringify(summary)}`,
+			);
+			assert.ok(
+				/\d+ errors?, \d+ warnings?/.test(summary),
+				"summary should report both error and warning counts",
+			);
+		} finally {
+			rmSync(externalDir, { recursive: true, force: true });
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
 // bpmn lint — --dry-run
 // ---------------------------------------------------------------------------
 

--- a/tests/unit/bpmn-plugin.test.ts
+++ b/tests/unit/bpmn-plugin.test.ts
@@ -472,6 +472,80 @@ describe("CLI behavioural: bpmn lint --dry-run", () => {
 // ---------------------------------------------------------------------------
 
 describe("CLI behavioural: bpmn lint .bpmnlintrc override", () => {
+	test("warnings-only override surfaces 'warning' in JSON and text", async () => {
+		// Pin the contract that bpmnlint's raw "warn" category is
+		// normalised to "warning" everywhere — JSON output, the text
+		// severity column, and the summary row.
+		const externalDir = mkdtempSync(join(tmpdir(), "c8ctl-bpmn-warn-"));
+		const file = join(externalDir, "test.bpmn");
+		writeFileSync(
+			file,
+			readFileSync(
+				join(FIXTURES_DIR, "simple-will-create-incident.bpmn"),
+				"utf-8",
+			),
+		);
+		writeFileSync(
+			join(externalDir, ".bpmnlintrc"),
+			JSON.stringify({
+				extends: ["bpmnlint:recommended"],
+				rules: { "label-required": "warn" },
+			}),
+		);
+		try {
+			// JSON mode — category must be "warning", not "warn".
+			const jsonRun = await asyncSpawn(
+				"node",
+				[
+					"--experimental-strip-types",
+					join(REPO_ROOT, CLI),
+					"--json",
+					"bpmn",
+					"lint",
+					file,
+				],
+				{ cwd: externalDir, env: process.env },
+			);
+			assert.strictEqual(jsonRun.status, 0, `stderr: ${jsonRun.stderr}`);
+			const parsed = JSON.parse(jsonRun.stdout);
+			assert.ok(parsed.issues.length > 0, "should have warning-level issues");
+			for (const issue of parsed.issues) {
+				assert.strictEqual(
+					issue.category,
+					"warning",
+					`category should be 'warning', got '${issue.category}'`,
+				);
+			}
+			assert.strictEqual(parsed.errorCount, 0);
+			assert.ok(parsed.warningCount > 0);
+
+			// Text mode — severity column should read "warning" and the
+			// summary line should mention warnings, not errors.
+			const textRun = await asyncSpawn(
+				"node",
+				[
+					"--experimental-strip-types",
+					join(REPO_ROOT, CLI),
+					"bpmn",
+					"lint",
+					file,
+				],
+				{ cwd: externalDir, env: process.env },
+			);
+			assert.strictEqual(textRun.status, 0, `stderr: ${textRun.stderr}`);
+			assert.ok(
+				/\swarning\s/.test(textRun.stdout),
+				`text output should include 'warning' as severity. Got: ${textRun.stdout.slice(0, 400)}`,
+			);
+			assert.ok(
+				/0 errors, \d+ warnings?/.test(textRun.stdout),
+				"summary should report 0 errors and >=1 warning",
+			);
+		} finally {
+			rmSync(externalDir, { recursive: true, force: true });
+		}
+	});
+
 	test("respects user .bpmnlintrc that disables a rule", async () => {
 		const externalDir = mkdtempSync(join(tmpdir(), "c8ctl-bpmn-rc-"));
 		const file = join(externalDir, "test.bpmn");

--- a/tests/unit/bpmn-plugin.test.ts
+++ b/tests/unit/bpmn-plugin.test.ts
@@ -342,6 +342,132 @@ describe("CLI behavioural: bpmn lint output formatting", () => {
 });
 
 // ---------------------------------------------------------------------------
+// bpmn lint — --dry-run
+// ---------------------------------------------------------------------------
+
+describe("CLI behavioural: bpmn lint --dry-run", () => {
+	test("Cloud file: prints platform, source, and resolved camunda-compat config", async () => {
+		const file = join(FIXTURES_DIR, "simple.bpmn");
+		const result = await c8text("bpmn", "lint", "--dry-run", file);
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const out = result.stdout;
+		assert.ok(
+			out.includes("Dry run — no lint performed."),
+			`dry-run banner missing. Got: ${out}`,
+		);
+		assert.ok(
+			out.includes(`Source: ${file}`),
+			"source line should be absolute",
+		);
+		assert.ok(
+			out.includes("Camunda Cloud 8.8.0"),
+			"platform line should reflect fixture's executionPlatform + version",
+		);
+		assert.ok(
+			out.includes("bpmnlint:recommended"),
+			"extends should include bpmnlint:recommended",
+		);
+		assert.ok(
+			out.includes("plugin:camunda-compat/camunda-cloud-8-8"),
+			"extends should include the resolved camunda-compat config",
+		);
+		assert.ok(
+			!out.includes("No issues found"),
+			"linter must not run under --dry-run",
+		);
+	});
+
+	test("Cloud file: JSON mode emits structured dry-run envelope", async () => {
+		const file = join(FIXTURES_DIR, "simple.bpmn");
+		const result = await c8("bpmn", "lint", "--dry-run", file);
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const parsed = JSON.parse(result.stdout);
+		assert.strictEqual(parsed.dryRun, true);
+		assert.strictEqual(parsed.command, "bpmn lint");
+		assert.strictEqual(parsed.source, file);
+		assert.deepStrictEqual(parsed.platform, {
+			executionPlatform: "Camunda Cloud",
+			version: "8.8.0",
+		});
+		assert.ok(Array.isArray(parsed.config.extends));
+		assert.ok(parsed.config.extends.includes("bpmnlint:recommended"));
+	});
+
+	test("non-Cloud file: platform reported, no camunda-compat in extends", async () => {
+		const tempDir = mkdtempSync(join(tmpdir(), "c8ctl-bpmn-dryrun-"));
+		const file = join(tempDir, "no-platform.bpmn");
+		writeFileSync(
+			file,
+			`<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <bpmn:process id="p1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" />
+  </bpmn:process>
+</bpmn:definitions>`,
+		);
+		try {
+			const result = await c8text("bpmn", "lint", "--dry-run", file);
+			assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+			const out = result.stdout;
+			assert.ok(
+				out.includes("Platform: not declared"),
+				`expected 'not declared'. Got: ${out}`,
+			);
+			assert.ok(out.includes("bpmnlint:recommended"));
+			assert.ok(
+				!out.includes("camunda-compat"),
+				"no camunda-compat config should appear for non-Cloud files",
+			);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+
+	test(".bpmnlintrc override: dry-run reflects the user's config", async () => {
+		const externalDir = mkdtempSync(join(tmpdir(), "c8ctl-bpmn-dryrun-rc-"));
+		const file = join(externalDir, "test.bpmn");
+		writeFileSync(
+			file,
+			readFileSync(join(FIXTURES_DIR, "simple.bpmn"), "utf-8"),
+		);
+		writeFileSync(
+			join(externalDir, ".bpmnlintrc"),
+			JSON.stringify({
+				extends: ["bpmnlint:recommended"],
+				rules: { "label-required": "off" },
+			}),
+		);
+		try {
+			const result = await asyncSpawn(
+				"node",
+				[
+					"--experimental-strip-types",
+					join(REPO_ROOT, CLI),
+					"bpmn",
+					"lint",
+					"--dry-run",
+					file,
+				],
+				{ cwd: externalDir, env: process.env },
+			);
+			assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+			const out = result.stdout;
+			assert.ok(out.includes("Dry run — no lint performed."));
+			assert.ok(
+				out.includes('"label-required": "off"'),
+				"override rule should appear in printed config",
+			);
+			assert.ok(
+				!out.includes("camunda-compat"),
+				".bpmnlintrc takes precedence; no auto-detected compat config",
+			);
+		} finally {
+			rmSync(externalDir, { recursive: true, force: true });
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
 // bpmn lint — .bpmnlintrc override
 // ---------------------------------------------------------------------------
 

--- a/tests/unit/bpmn-plugin.test.ts
+++ b/tests/unit/bpmn-plugin.test.ts
@@ -546,6 +546,75 @@ describe("CLI behavioural: bpmn lint .bpmnlintrc override", () => {
 		}
 	});
 
+	test("non-JSON .bpmnlintrc reports the JSON-only constraint clearly", async () => {
+		const externalDir = mkdtempSync(join(tmpdir(), "c8ctl-bpmn-yaml-"));
+		const file = join(externalDir, "test.bpmn");
+		writeFileSync(
+			file,
+			readFileSync(join(FIXTURES_DIR, "simple.bpmn"), "utf-8"),
+		);
+		writeFileSync(
+			join(externalDir, ".bpmnlintrc"),
+			"extends: bpmnlint:recommended\n",
+		);
+		try {
+			const result = await asyncSpawn(
+				"node",
+				[
+					"--experimental-strip-types",
+					join(REPO_ROOT, CLI),
+					"bpmn",
+					"lint",
+					file,
+				],
+				{ cwd: externalDir, env: process.env },
+			);
+			assert.strictEqual(result.status, 1);
+			const output = result.stdout + result.stderr;
+			assert.ok(
+				output.includes("only JSON is supported"),
+				`expected JSON-only message. Got: ${output.slice(0, 400)}`,
+			);
+			assert.ok(
+				output.includes("standalone `bpmnlint` CLI"),
+				"should point users at the upstream CLI for YAML/JS configs",
+			);
+		} finally {
+			rmSync(externalDir, { recursive: true, force: true });
+		}
+	});
+
+	test("JSON array .bpmnlintrc reports 'must contain a JSON object'", async () => {
+		const externalDir = mkdtempSync(join(tmpdir(), "c8ctl-bpmn-arr-"));
+		const file = join(externalDir, "test.bpmn");
+		writeFileSync(
+			file,
+			readFileSync(join(FIXTURES_DIR, "simple.bpmn"), "utf-8"),
+		);
+		writeFileSync(join(externalDir, ".bpmnlintrc"), JSON.stringify(["foo"]));
+		try {
+			const result = await asyncSpawn(
+				"node",
+				[
+					"--experimental-strip-types",
+					join(REPO_ROOT, CLI),
+					"bpmn",
+					"lint",
+					file,
+				],
+				{ cwd: externalDir, env: process.env },
+			);
+			assert.strictEqual(result.status, 1);
+			const output = result.stdout + result.stderr;
+			assert.ok(
+				output.includes("must contain a JSON object"),
+				`expected object-shape message. Got: ${output.slice(0, 400)}`,
+			);
+		} finally {
+			rmSync(externalDir, { recursive: true, force: true });
+		}
+	});
+
 	test("respects user .bpmnlintrc that disables a rule", async () => {
 		const externalDir = mkdtempSync(join(tmpdir(), "c8ctl-bpmn-rc-"));
 		const file = join(externalDir, "test.bpmn");


### PR DESCRIPTION
## Description

- `--dry-run` now prints the resolved ruleset (source, declared platform, full `extends` list) and exits 0 without running the linter — useful for debugging "why did c8ctl pick this ruleset?".
- `.bpmnlintrc` parse failures emit a self-explanatory error pointing at the upstream `bpmnlint` CLI for YAML/JS configs; constraint is now documented in the README.
- camunda-compat fallback is bracketed: pre-1.0 Cloud versions fall through to `bpmnlint:recommended` only; versions newer than any shipped config use the highest available config and emit a one-line warning suggesting a c8ctl update.
- Lint category is normalised once so JSON `category` and text `severity` can never drift.
- Test coverage filled out for ruleset routing, non-Cloud platform attributes, mixed error+warning summaries, and both fallback branches.