### PR TITLE
feat: add deploy confirmation guard for multi-profile safety

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -667,7 +667,7 @@ to prevent deploying to the wrong cluster:
 
 ```bash
 # Shows: Deploying to profile "production" (https://prod.zeebe.camunda.io)
-#        Continue? [y/N]
+#        Continue? [y/N/a] (a = always, don't prompt again)
 c8 deploy ./process.bpmn
 
 # Skip confirmation with --yes / -y
@@ -677,6 +677,10 @@ c8 deploy ./process.bpmn -y
 # Explicit --profile also skips confirmation (target is unambiguous)
 c8 deploy ./process.bpmn --profile=staging
 ```
+
+Answering `a` (always) persists the preference in your session so future
+deploys proceed without prompting. To re-enable prompts, remove the
+`skipConfirmation` key from your `session.json`.
 
 In non-interactive environments (CI, piped input), the confirmation is
 skipped automatically and the target is logged to stderr.

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -660,6 +660,27 @@ c8 deploy
 c8 watch
 ```
 
+### Deploy Confirmation
+
+When multiple profiles are configured, `c8 deploy` prompts for confirmation
+to prevent deploying to the wrong cluster:
+
+```bash
+# Shows: Deploying to profile "production" (https://prod.zeebe.camunda.io)
+#        Continue? [y/N]
+c8 deploy ./process.bpmn
+
+# Skip confirmation with --yes / -y
+c8 deploy ./process.bpmn --yes
+c8 deploy ./process.bpmn -y
+
+# Explicit --profile also skips confirmation (target is unambiguous)
+c8 deploy ./process.bpmn --profile=staging
+```
+
+In non-interactive environments (CI, piped input), the confirmation is
+skipped automatically and the target is logged to stderr.
+
 ### Run (Deploy + Start)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -796,7 +796,7 @@ These flags are accepted by every command.
 | `--verbose` | boolean |  | Show verbose output |
 | `--fields` | string |  | Comma-separated list of fields to display |
 | `--json` | boolean |  | Force JSON output for this invocation (does not persist; overrides session state and C8CTL_OUTPUT_MODE) |
-| `--yes` / `-y` | boolean |  | Skip confirmation prompts (e.g. deploy target) |
+| `--yes` / `-y` | boolean |  | Skip confirmation prompts |
 
 ### Resource Aliases
 

--- a/README.md
+++ b/README.md
@@ -796,6 +796,7 @@ These flags are accepted by every command.
 | `--verbose` | boolean |  | Show verbose output |
 | `--fields` | string |  | Comma-separated list of fields to display |
 | `--json` | boolean |  | Force JSON output for this invocation (does not persist; overrides session state and C8CTL_OUTPUT_MODE) |
+| `--yes` / `-y` | boolean |  | Skip confirmation prompts (e.g. deploy target) |
 
 ### Resource Aliases
 

--- a/src/command-framework.ts
+++ b/src/command-framework.ts
@@ -247,6 +247,8 @@ export interface CommandContext {
 	dryRun: boolean | undefined;
 	/** Active profile name (for client/tenant resolution). */
 	profile: string | undefined;
+	/** Whether --yes / -y was set (skip confirmation prompts). */
+	yes: boolean | undefined;
 }
 
 // ─── CommandHandler ──────────────────────────────────────────────────────────

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -220,7 +220,7 @@ export const GLOBAL_FLAGS = {
 	},
 	yes: {
 		type: "boolean",
-		description: "Skip confirmation prompts (e.g. deploy target)",
+		description: "Skip confirmation prompts",
 		short: "y",
 		agentDescription:
 			"Skip interactive confirmation prompts. When multiple profiles are configured, " +

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -218,6 +218,16 @@ export const GLOBAL_FLAGS = {
 			"Per-invocation JSON output. Equivalent to setting outputMode=json for one command without mutating session.json.\nPrecedence: --json > C8CTL_OUTPUT_MODE > persisted session state.",
 		agentAppliesTo: "all commands",
 	},
+	yes: {
+		type: "boolean",
+		description: "Skip confirmation prompts (e.g. deploy target)",
+		short: "y",
+		agentDescription:
+			"Skip interactive confirmation prompts. When multiple profiles are configured, " +
+			"mutating commands like deploy prompt for confirmation before proceeding. " +
+			"Pass --yes to skip the prompt (useful for scripts and CI).",
+		agentAppliesTo: "mutating commands (deploy)",
+	},
 } as const satisfies Record<string, FlagDef>;
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -97,6 +97,7 @@ export interface SessionState {
 	activeProfile?: string;
 	activeTenant?: string;
 	outputMode: OutputMode;
+	skipConfirmation?: boolean;
 }
 
 /**
@@ -648,11 +649,16 @@ export function loadSessionState(): SessionState {
 			typeof state.activeTenant === "string" ? state.activeTenant : undefined;
 		c8ctl.outputMode = state.outputMode === "json" ? "json" : "text";
 		persistedOutputMode = c8ctl.outputMode;
+		c8ctl.skipConfirmation =
+			typeof state.skipConfirmation === "boolean"
+				? state.skipConfirmation
+				: undefined;
 
 		return {
 			activeProfile: c8ctl.activeProfile,
 			activeTenant: c8ctl.activeTenant,
 			outputMode: c8ctl.outputMode,
+			skipConfirmation: c8ctl.skipConfirmation,
 		};
 	} catch {
 		return {
@@ -674,6 +680,7 @@ export function saveSessionState(state?: SessionState): void {
 		activeProfile: state?.activeProfile ?? c8ctl.activeProfile,
 		activeTenant: state?.activeTenant ?? c8ctl.activeTenant,
 		outputMode: state?.outputMode ?? persistedOutputMode,
+		skipConfirmation: state?.skipConfirmation ?? c8ctl.skipConfirmation,
 	};
 
 	if (state) {
@@ -681,6 +688,7 @@ export function saveSessionState(state?: SessionState): void {
 		c8ctl.activeTenant = state.activeTenant;
 		c8ctl.outputMode = state.outputMode;
 		persistedOutputMode = state.outputMode;
+		c8ctl.skipConfirmation = state.skipConfirmation;
 	}
 
 	const path = getSessionStatePath();
@@ -717,6 +725,14 @@ export function setActiveTenant(tenantId: string): void {
 export function setOutputMode(mode: OutputMode): void {
 	c8ctl.outputMode = mode;
 	persistedOutputMode = mode;
+	saveSessionState();
+}
+
+/**
+ * Set skipConfirmation preference in session and persist to disk
+ */
+export function setSkipConfirmation(skip: boolean): void {
+	c8ctl.skipConfirmation = skip;
 	saveSessionState();
 }
 

--- a/src/confirm.ts
+++ b/src/confirm.ts
@@ -12,16 +12,16 @@ import { createInterface } from "node:readline";
 import { c8ctl } from "./runtime.ts";
 
 /**
- * Prompt the user to confirm a deploy target when multiple profiles exist.
+ * Prompt the user to confirm a deploy target.
  *
- * Conditions for prompting (all must be true):
- * - `--yes` / `-y` was NOT passed
- * - `--profile` was NOT explicitly passed
- * - More than one profile is configured
- * - `CAMUNDA_BASE_URL` is NOT set (env-based config)
- * - stdin and stderr are both a TTY (interactive terminal)
+ * The caller decides *when* to call this (e.g. based on `--yes`,
+ * `--profile`, profile count, env vars). This helper handles only
+ * the TTY check and the actual prompting/logging:
  *
- * When stdin or stderr is not a TTY, logs the target and proceeds.
+ * - **Interactive** (stdin + stderr are TTY): asks `Continue? [y/N]`
+ *   and returns the user's answer.
+ * - **Non-interactive** (piped/redirected): logs the target to stderr
+ *   and returns `true` (auto-approve).
  */
 export async function confirmDeployTarget(options: {
 	profileName: string;

--- a/src/confirm.ts
+++ b/src/confirm.ts
@@ -2,14 +2,16 @@
  * Interactive confirmation prompt for mutating commands.
  *
  * Uses Node's built-in `readline` — no external dependencies.
- * Returns `true` if the user confirms, `false` otherwise.
- * Automatically skips (returns `true`) when stdin or stderr is not
+ * Returns `"yes"`, `"no"`, or `"always"`.
+ * Automatically skips (returns `"yes"`) when stdin or stderr is not
  * a TTY (e.g. piped input, CI, redirected stderr), logging the
  * target to stderr instead.
  */
 
 import { createInterface } from "node:readline";
 import { c8ctl } from "./runtime.ts";
+
+export type ConfirmResult = "yes" | "no" | "always";
 
 /**
  * Prompt the user to confirm a deploy target.
@@ -18,15 +20,15 @@ import { c8ctl } from "./runtime.ts";
  * `--profile`, profile count, env vars). This helper handles only
  * the TTY check and the actual prompting/logging:
  *
- * - **Interactive** (stdin + stderr are TTY): asks `Continue? [y/N]`
+ * - **Interactive** (stdin + stderr are TTY): asks `Continue? [y/N/a]`
  *   and returns the user's answer.
  * - **Non-interactive** (piped/redirected): logs the target to stderr
- *   and returns `true` (auto-approve).
+ *   and returns `"yes"` (auto-approve).
  */
 export async function confirmDeployTarget(options: {
 	profileName: string;
 	baseUrl: string;
-}): Promise<boolean> {
+}): Promise<ConfirmResult> {
 	const { profileName, baseUrl } = options;
 	const message = `Deploying to profile "${profileName}" (${baseUrl})`;
 
@@ -39,21 +41,27 @@ export async function confirmDeployTarget(options: {
 		} else {
 			console.error(message);
 		}
-		return true;
+		return "yes";
 	}
 
-	return new Promise<boolean>((resolve) => {
+	return new Promise<ConfirmResult>((resolve) => {
 		const rl = createInterface({
 			input: process.stdin,
 			output: process.stderr,
 		});
 
 		rl.question(
-			`Deploying to profile "${profileName}" (${baseUrl})\nContinue? [y/N] `,
+			`Deploying to profile "${profileName}" (${baseUrl})\nContinue? [y/N/a] (a = always, don't prompt again) `,
 			(answer) => {
 				rl.close();
 				const normalized = answer.trim().toLowerCase();
-				resolve(normalized === "y" || normalized === "yes");
+				if (normalized === "a" || normalized === "always") {
+					resolve("always");
+				} else if (normalized === "y" || normalized === "yes") {
+					resolve("yes");
+				} else {
+					resolve("no");
+				}
 			},
 		);
 	});

--- a/src/confirm.ts
+++ b/src/confirm.ts
@@ -3,8 +3,9 @@
  *
  * Uses Node's built-in `readline` — no external dependencies.
  * Returns `true` if the user confirms, `false` otherwise.
- * Automatically skips (returns `true`) when stdin is not a TTY
- * (e.g. piped input, CI), logging the target to stderr instead.
+ * Automatically skips (returns `true`) when stdin or stderr is not
+ * a TTY (e.g. piped input, CI, redirected stderr), logging the
+ * target to stderr instead.
  */
 
 import { createInterface } from "node:readline";
@@ -17,9 +18,10 @@ import { c8ctl } from "./runtime.ts";
  * - `--yes` / `-y` was NOT passed
  * - `--profile` was NOT explicitly passed
  * - More than one profile is configured
- * - stdin is a TTY (interactive terminal)
+ * - `CAMUNDA_BASE_URL` is NOT set (env-based config)
+ * - stdin and stderr are both a TTY (interactive terminal)
  *
- * When stdin is not a TTY, logs the target to stderr and proceeds.
+ * When stdin or stderr is not a TTY, logs the target and proceeds.
  */
 export async function confirmDeployTarget(options: {
 	profileName: string;

--- a/src/confirm.ts
+++ b/src/confirm.ts
@@ -28,8 +28,10 @@ export async function confirmDeployTarget(options: {
 	const { profileName, baseUrl } = options;
 	const message = `Deploying to profile "${profileName}" (${baseUrl})`;
 
-	// Non-interactive: log target and proceed
-	if (!process.stdin.isTTY) {
+	// Non-interactive: log target and proceed.
+	// Treat the session as non-interactive unless both stdin AND stderr
+	// are TTY — if stderr is redirected the prompt would be invisible.
+	if (!process.stdin.isTTY || !process.stderr.isTTY) {
 		if (c8ctl.outputMode === "json") {
 			console.error(JSON.stringify({ type: "message", message }));
 		} else {

--- a/src/confirm.ts
+++ b/src/confirm.ts
@@ -42,8 +42,8 @@ export async function confirmDeployTarget(options: {
 			`Deploying to profile "${profileName}" (${baseUrl})\nContinue? [y/N] `,
 			(answer) => {
 				rl.close();
-				const normalised = answer.trim().toLowerCase();
-				resolve(normalised === "y" || normalised === "yes");
+				const normalized = answer.trim().toLowerCase();
+				resolve(normalized === "y" || normalized === "yes");
 			},
 		);
 	});

--- a/src/confirm.ts
+++ b/src/confirm.ts
@@ -8,6 +8,7 @@
  */
 
 import { createInterface } from "node:readline";
+import { c8ctl } from "./runtime.ts";
 
 /**
  * Prompt the user to confirm a deploy target when multiple profiles exist.
@@ -25,10 +26,15 @@ export async function confirmDeployTarget(options: {
 	baseUrl: string;
 }): Promise<boolean> {
 	const { profileName, baseUrl } = options;
+	const message = `Deploying to profile "${profileName}" (${baseUrl})`;
 
 	// Non-interactive: log target and proceed
 	if (!process.stdin.isTTY) {
-		console.error(`Deploying to profile "${profileName}" (${baseUrl})`);
+		if (c8ctl.outputMode === "json") {
+			console.error(JSON.stringify({ type: "message", message }));
+		} else {
+			console.error(message);
+		}
 		return true;
 	}
 

--- a/src/confirm.ts
+++ b/src/confirm.ts
@@ -62,7 +62,7 @@ export async function confirmDeployTarget(options: {
 		});
 
 		rl.question(
-			`Deploying to profile "${profileName}" (${baseUrl})\nContinue? [y/N/a] (a = always, don't prompt again) `,
+			`${message}\nContinue? [y/N/a] (a = always, don't prompt again) `,
 			(answer) => {
 				answered = true;
 				rl.close();

--- a/src/confirm.ts
+++ b/src/confirm.ts
@@ -1,0 +1,50 @@
+/**
+ * Interactive confirmation prompt for mutating commands.
+ *
+ * Uses Node's built-in `readline` — no external dependencies.
+ * Returns `true` if the user confirms, `false` otherwise.
+ * Automatically skips (returns `true`) when stdin is not a TTY
+ * (e.g. piped input, CI), logging the target to stderr instead.
+ */
+
+import { createInterface } from "node:readline";
+
+/**
+ * Prompt the user to confirm a deploy target when multiple profiles exist.
+ *
+ * Conditions for prompting (all must be true):
+ * - `--yes` / `-y` was NOT passed
+ * - `--profile` was NOT explicitly passed
+ * - More than one profile is configured
+ * - stdin is a TTY (interactive terminal)
+ *
+ * When stdin is not a TTY, logs the target to stderr and proceeds.
+ */
+export async function confirmDeployTarget(options: {
+	profileName: string;
+	baseUrl: string;
+}): Promise<boolean> {
+	const { profileName, baseUrl } = options;
+
+	// Non-interactive: log target and proceed
+	if (!process.stdin.isTTY) {
+		console.error(`Deploying to profile "${profileName}" (${baseUrl})`);
+		return true;
+	}
+
+	return new Promise<boolean>((resolve) => {
+		const rl = createInterface({
+			input: process.stdin,
+			output: process.stderr,
+		});
+
+		rl.question(
+			`Deploying to profile "${profileName}" (${baseUrl})\nContinue? [y/N] `,
+			(answer) => {
+				rl.close();
+				const normalised = answer.trim().toLowerCase();
+				resolve(normalised === "y" || normalised === "yes");
+			},
+		);
+	});
+}

--- a/src/confirm.ts
+++ b/src/confirm.ts
@@ -9,7 +9,7 @@
  */
 
 import { createInterface } from "node:readline";
-import { c8ctl } from "./runtime.ts";
+import { logStderrMessage } from "./logger.ts";
 
 export type ConfirmResult = "yes" | "no" | "always";
 
@@ -36,11 +36,7 @@ export async function confirmDeployTarget(options: {
 	// Treat the session as non-interactive unless both stdin AND stderr
 	// are TTY — if stderr is redirected the prompt would be invisible.
 	if (!process.stdin.isTTY || !process.stderr.isTTY) {
-		if (c8ctl.outputMode === "json") {
-			console.error(JSON.stringify({ type: "message", message }));
-		} else {
-			console.error(message);
-		}
+		logStderrMessage(message);
 		return "yes";
 	}
 

--- a/src/confirm.ts
+++ b/src/confirm.ts
@@ -45,14 +45,26 @@ export async function confirmDeployTarget(options: {
 	}
 
 	return new Promise<ConfirmResult>((resolve) => {
+		let answered = false;
 		const rl = createInterface({
 			input: process.stdin,
 			output: process.stderr,
 		});
 
+		// Safety net: if stdin closes (Ctrl+D / EOF) or SIGINT fires
+		// before a line is submitted, the question callback never runs.
+		// Treat that as "no" so the promise always resolves.
+		rl.on("close", () => {
+			if (!answered) {
+				answered = true;
+				resolve("no");
+			}
+		});
+
 		rl.question(
 			`Deploying to profile "${profileName}" (${baseUrl})\nContinue? [y/N/a] (a = always, don't prompt again) `,
 			(answer) => {
+				answered = true;
 				rl.close();
 				const normalized = answer.trim().toLowerCase();
 				if (normalized === "a" || normalized === "always") {

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -968,9 +968,15 @@ export const deployCommand = defineCommand("deploy", "", async (ctx, flags) => {
 	// When multiple profiles are configured and the user did not
 	// explicitly pass --profile or --yes, prompt for confirmation so
 	// they see exactly which cluster they are deploying to.
-	// Skip the guard when env-based config (CAMUNDA_BASE_URL) is in use
-	// — the user has already chosen their target via the environment.
-	if (!ctx.yes && !ctx.profile && !process.env.CAMUNDA_BASE_URL) {
+	// Skip the guard when env-based config (CAMUNDA_BASE_URL) is the
+	// *effective* target — i.e. no active session profile overrides it.
+	// When an active session profile exists, it takes priority over
+	// env vars in resolveClusterConfig(), so the guard must still run.
+	const envIsEffectiveTarget =
+		!!process.env.CAMUNDA_BASE_URL &&
+		(c8ctl.activeProfile == null ||
+			getProfileOrModeler(c8ctl.activeProfile) == null);
+	if (!ctx.yes && !ctx.profile && !envIsEffectiveTarget) {
 		const profiles = getAllProfiles();
 		if (profiles.length > 1) {
 			// Resolve the effective profile and URL for the confirmation message.

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -972,18 +972,18 @@ export const deployCommand = defineCommand("deploy", "", async (ctx, flags) => {
 	// *effective* target — i.e. no active session profile overrides it.
 	// When an active session profile exists, it takes priority over
 	// env vars in resolveClusterConfig(), so the guard must still run.
+	const { activeProfile } = c8ctl;
+	const activeProfileConfig =
+		activeProfile != null ? getProfileOrModeler(activeProfile) : undefined;
 	const envIsEffectiveTarget =
-		!!process.env.CAMUNDA_BASE_URL &&
-		(c8ctl.activeProfile == null ||
-			getProfileOrModeler(c8ctl.activeProfile) == null);
+		!!process.env.CAMUNDA_BASE_URL && activeProfileConfig == null;
 	if (!ctx.yes && !ctx.profile && !envIsEffectiveTarget) {
 		const profiles = getAllProfiles();
 		if (profiles.length > 1) {
 			// Resolve the effective profile and URL for the confirmation message.
 			const config = resolveClusterConfig();
-			const { activeProfile } = c8ctl;
 			const profileName =
-				activeProfile != null && getProfileOrModeler(activeProfile) != null
+				activeProfile != null && activeProfileConfig != null
 					? activeProfile
 					: DEFAULT_PROFILE;
 

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -15,6 +15,7 @@ import {
 import {
 	DEFAULT_PROFILE,
 	getAllProfiles,
+	getProfileOrModeler,
 	resolveClusterConfig,
 	resolveTenantId,
 } from "./config.ts";
@@ -972,9 +973,13 @@ export const deployCommand = defineCommand("deploy", "", async (ctx, flags) => {
 		if (profiles.length > 1) {
 			// Resolve the effective profile and URL for the confirmation message.
 			const config = resolveClusterConfig();
+			const { activeProfile } = c8ctl;
 			const profileName =
-				c8ctl.activeProfile ??
-				(process.env.CAMUNDA_BASE_URL ? "(env)" : DEFAULT_PROFILE);
+				activeProfile != null && getProfileOrModeler(activeProfile) != null
+					? activeProfile
+					: process.env.CAMUNDA_BASE_URL
+						? "(env)"
+						: DEFAULT_PROFILE;
 
 			const confirmed = await confirmDeployTarget({
 				profileName,

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -18,6 +18,7 @@ import {
 	getProfileOrModeler,
 	resolveClusterConfig,
 	resolveTenantId,
+	setSkipConfirmation,
 } from "./config.ts";
 import { confirmDeployTarget } from "./confirm.ts";
 import { normalizeToError, SilentError } from "./errors.ts";
@@ -972,12 +973,19 @@ export const deployCommand = defineCommand("deploy", "", async (ctx, flags) => {
 	// *effective* target — i.e. no active session profile overrides it.
 	// When an active session profile exists, it takes priority over
 	// env vars in resolveClusterConfig(), so the guard must still run.
+	// Also skip when the user has persisted skipConfirmation (via the
+	// "always" prompt option or equivalent).
 	const { activeProfile } = c8ctl;
 	const activeProfileConfig =
 		activeProfile != null ? getProfileOrModeler(activeProfile) : undefined;
 	const envIsEffectiveTarget =
 		!!process.env.CAMUNDA_BASE_URL && activeProfileConfig == null;
-	if (!ctx.yes && !ctx.profile && !envIsEffectiveTarget) {
+	if (
+		!ctx.yes &&
+		!c8ctl.skipConfirmation &&
+		!ctx.profile &&
+		!envIsEffectiveTarget
+	) {
 		const profiles = getAllProfiles();
 		if (profiles.length > 1) {
 			// Resolve the effective profile and URL for the confirmation message.
@@ -987,11 +995,13 @@ export const deployCommand = defineCommand("deploy", "", async (ctx, flags) => {
 					? activeProfile
 					: DEFAULT_PROFILE;
 
-			const confirmed = await confirmDeployTarget({
+			const result = await confirmDeployTarget({
 				profileName,
 				baseUrl: config.baseUrl,
 			});
-			if (!confirmed) {
+			if (result === "always") {
+				setSkipConfirmation(true);
+			} else if (result === "no") {
 				logMessage("Deploy cancelled.");
 				logMessage(
 					"Hint: use --profile=<name> to target a specific cluster, or --yes to skip this prompt.",

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -968,7 +968,9 @@ export const deployCommand = defineCommand("deploy", "", async (ctx, flags) => {
 	// When multiple profiles are configured and the user did not
 	// explicitly pass --profile or --yes, prompt for confirmation so
 	// they see exactly which cluster they are deploying to.
-	if (!ctx.yes && !ctx.profile) {
+	// Skip the guard when env-based config (CAMUNDA_BASE_URL) is in use
+	// — the user has already chosen their target via the environment.
+	if (!ctx.yes && !ctx.profile && !process.env.CAMUNDA_BASE_URL) {
 		const profiles = getAllProfiles();
 		if (profiles.length > 1) {
 			// Resolve the effective profile and URL for the confirmation message.

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -23,7 +23,7 @@ import {
 import { confirmDeployTarget } from "./confirm.ts";
 import { normalizeToError, SilentError } from "./errors.ts";
 import { isIgnored, loadIgnoreRules, resolveIgnoreBaseDir } from "./ignore.ts";
-import { getLogger, isRecord } from "./logger.ts";
+import { getLogger, isRecord, logStderrMessage } from "./logger.ts";
 import { c8ctl } from "./runtime.ts";
 
 const PROCESS_APPLICATION_FILE = ".process-application";
@@ -32,11 +32,7 @@ const PROCESS_APPLICATION_FILE = ".process-application";
  * Helper to output messages that respect JSON mode for Unix pipe compatibility
  */
 function logMessage(message: string): void {
-	if (c8ctl.outputMode === "json") {
-		console.error(JSON.stringify({ type: "message", message }));
-	} else {
-		console.error(message);
-	}
+	logStderrMessage(message);
 }
 
 /**

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -979,9 +979,7 @@ export const deployCommand = defineCommand("deploy", "", async (ctx, flags) => {
 			const profileName =
 				activeProfile != null && getProfileOrModeler(activeProfile) != null
 					? activeProfile
-					: process.env.CAMUNDA_BASE_URL
-						? "(env)"
-						: DEFAULT_PROFILE;
+					: DEFAULT_PROFILE;
 
 			const confirmed = await confirmDeployTarget({
 				profileName,

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -971,7 +971,8 @@ export const deployCommand = defineCommand("deploy", "", async (ctx, flags) => {
 		if (profiles.length > 1) {
 			// Resolve the effective profile and URL for the confirmation message.
 			const config = resolveClusterConfig(ctx.profile);
-			const profileName = c8ctl.activeProfile ?? "(env / default)";
+			const profileName = c8ctl.activeProfile
+				?? (process.env.CAMUNDA_BASE_URL ? "(env)" : "local");
 
 			const confirmed = await confirmDeployTarget({
 				profileName,

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -13,6 +13,7 @@ import {
 	DEPLOYABLE_EXTENSIONS,
 } from "./commands/resource-extensions.ts";
 import {
+	DEFAULT_PROFILE,
 	getAllProfiles,
 	resolveClusterConfig,
 	resolveTenantId,
@@ -970,10 +971,10 @@ export const deployCommand = defineCommand("deploy", "", async (ctx, flags) => {
 		const profiles = getAllProfiles();
 		if (profiles.length > 1) {
 			// Resolve the effective profile and URL for the confirmation message.
-			const config = resolveClusterConfig(ctx.profile);
+			const config = resolveClusterConfig();
 			const profileName =
 				c8ctl.activeProfile ??
-				(process.env.CAMUNDA_BASE_URL ? "(env)" : "local");
+				(process.env.CAMUNDA_BASE_URL ? "(env)" : DEFAULT_PROFILE);
 
 			const confirmed = await confirmDeployTarget({
 				profileName,

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -12,7 +12,8 @@ import {
 	ALL_DEPLOYABLE_EXTENSIONS,
 	DEPLOYABLE_EXTENSIONS,
 } from "./commands/resource-extensions.ts";
-import { resolveTenantId } from "./config.ts";
+import { getAllProfiles, resolveClusterConfig, resolveTenantId } from "./config.ts";
+import { confirmDeployTarget } from "./confirm.ts";
 import { normalizeToError, SilentError } from "./errors.ts";
 import { isIgnored, loadIgnoreRules, resolveIgnoreBaseDir } from "./ignore.ts";
 import { getLogger, isRecord } from "./logger.ts";
@@ -956,6 +957,33 @@ export const deployCommand = defineCommand("deploy", "", async (ctx, flags) => {
 	// table. Keeping the helper self-contained avoids threading
 	// pre-collected state between the handler and the shared helper
 	// used by `watch`.
+
+	// ── Deploy confirmation guard (#393) ──────────────────────────────
+	// When multiple profiles are configured and the user did not
+	// explicitly pass --profile or --yes, prompt for confirmation so
+	// they see exactly which cluster they are deploying to.
+	if (!ctx.yes && !ctx.profile) {
+		const profiles = getAllProfiles();
+		if (profiles.length > 1) {
+			// Resolve the effective profile and URL for the confirmation message.
+			const config = resolveClusterConfig(ctx.profile);
+			const profileName =
+				c8ctl.activeProfile ?? "(env / default)";
+
+			const confirmed = await confirmDeployTarget({
+				profileName,
+				baseUrl: config.baseUrl,
+			});
+			if (!confirmed) {
+				logMessage("Deploy cancelled.");
+				logMessage(
+					'Hint: use --profile=<name> to target a specific cluster, or --yes to skip this prompt.',
+				);
+				return { kind: "none" };
+			}
+		}
+	}
+
 	await deployResources(paths, {
 		profile: ctx.profile,
 		force: flags.force,

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -971,8 +971,9 @@ export const deployCommand = defineCommand("deploy", "", async (ctx, flags) => {
 		if (profiles.length > 1) {
 			// Resolve the effective profile and URL for the confirmation message.
 			const config = resolveClusterConfig(ctx.profile);
-			const profileName = c8ctl.activeProfile
-				?? (process.env.CAMUNDA_BASE_URL ? "(env)" : "local");
+			const profileName =
+				c8ctl.activeProfile ??
+				(process.env.CAMUNDA_BASE_URL ? "(env)" : "local");
 
 			const confirmed = await confirmDeployTarget({
 				profileName,

--- a/src/deployments.ts
+++ b/src/deployments.ts
@@ -12,7 +12,11 @@ import {
 	ALL_DEPLOYABLE_EXTENSIONS,
 	DEPLOYABLE_EXTENSIONS,
 } from "./commands/resource-extensions.ts";
-import { getAllProfiles, resolveClusterConfig, resolveTenantId } from "./config.ts";
+import {
+	getAllProfiles,
+	resolveClusterConfig,
+	resolveTenantId,
+} from "./config.ts";
 import { confirmDeployTarget } from "./confirm.ts";
 import { normalizeToError, SilentError } from "./errors.ts";
 import { isIgnored, loadIgnoreRules, resolveIgnoreBaseDir } from "./ignore.ts";
@@ -967,8 +971,7 @@ export const deployCommand = defineCommand("deploy", "", async (ctx, flags) => {
 		if (profiles.length > 1) {
 			// Resolve the effective profile and URL for the confirmation message.
 			const config = resolveClusterConfig(ctx.profile);
-			const profileName =
-				c8ctl.activeProfile ?? "(env / default)";
+			const profileName = c8ctl.activeProfile ?? "(env / default)";
 
 			const confirmed = await confirmDeployTarget({
 				profileName,
@@ -977,7 +980,7 @@ export const deployCommand = defineCommand("deploy", "", async (ctx, flags) => {
 			if (!confirmed) {
 				logMessage("Deploy cancelled.");
 				logMessage(
-					'Hint: use --profile=<name> to target a specific cluster, or --yes to skip this prompt.',
+					"Hint: use --profile=<name> to target a specific cluster, or --yes to skip this prompt.",
 				);
 				return { kind: "none" };
 			}

--- a/src/index.ts
+++ b/src/index.ts
@@ -722,6 +722,7 @@ async function main() {
 			version: parseVersionFlag(values),
 			dryRun: c8ctl.dryRun,
 			profile,
+			yes: bool(values.yes),
 		};
 		await handler.execute(ctx, values, args);
 		return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -476,6 +476,7 @@ async function main() {
 			profile: pluginProfile,
 			dryRun: c8ctl.dryRun === true,
 			verbose: c8ctl.verbose === true,
+			yes: bool(values.yes) === true,
 			outputMode: c8ctl.outputMode,
 			fields: c8ctl.fields,
 			logger,

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -433,3 +433,19 @@ export function getLogger(mode?: OutputMode): Logger {
 	}
 	return loggerInstance;
 }
+
+/**
+ * Log a message to stderr, respecting the current output mode.
+ * In JSON mode, emits a structured `{ type: "message", message }` record.
+ * In text mode, emits the plain message string.
+ *
+ * Use this for informational messages that should not appear in stdout
+ * (e.g. confirmation prompts, deploy progress).
+ */
+export function logStderrMessage(message: string): void {
+	if (c8ctl.outputMode === "json") {
+		console.error(JSON.stringify({ type: "message", message }));
+	} else {
+		console.error(message);
+	}
+}

--- a/src/plugin-loader.ts
+++ b/src/plugin-loader.ts
@@ -44,6 +44,8 @@ export interface PluginCtx {
 	verbose: boolean;
 	/** Effective output mode (`--json` toggles to `json`). */
 	outputMode: OutputMode;
+	/** True when `--yes` is set. Skips interactive confirmation prompts. */
+	yes: boolean;
 	/** Parsed `--fields a,b,c` list, or undefined when not set. */
 	fields?: string[];
 	/** Host logger — use `logger.json(...)` for structured output. */

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -55,6 +55,8 @@ export interface C8ctlPluginRuntime {
 	dryRun?: boolean;
 	/** When true, enables SDK trace logging and surfaces raw errors instead of user-friendly messages */
 	verbose?: boolean;
+	/** When true, skip confirmation prompts without asking (persisted preference). */
+	skipConfirmation?: boolean;
 	createClient(
 		profileFlag?: string,
 		additionalSdkConfig?: Partial<CamundaOptions>,
@@ -102,6 +104,7 @@ class C8ctl implements C8ctlPluginRuntime {
 	private _dryRun?: boolean;
 	private _verbose?: boolean;
 	private _resolvedBaseUrl?: string;
+	private _skipConfirmation?: boolean;
 	private _deps?: C8ctlDeps;
 
 	readonly env: C8ctlEnv = {
@@ -231,6 +234,14 @@ class C8ctl implements C8ctlPluginRuntime {
 
 	set resolvedBaseUrl(value: string | undefined) {
 		this._resolvedBaseUrl = value;
+	}
+
+	get skipConfirmation(): boolean | undefined {
+		return this._skipConfirmation;
+	}
+
+	set skipConfirmation(value: boolean | undefined) {
+		this._skipConfirmation = value;
 	}
 }
 

--- a/tests/fixtures/confirm-interactive-helper.ts
+++ b/tests/fixtures/confirm-interactive-helper.ts
@@ -1,0 +1,21 @@
+/**
+ * Helper script for confirm-interactive.test.ts.
+ *
+ * Forces the interactive (TTY) branch of confirmDeployTarget() by
+ * stubbing isTTY on stdin and stderr, then prints the result to
+ * stdout so the test can assert on it.
+ */
+
+// Stub isTTY before importing confirmDeployTarget so the readline
+// branch fires even though we are running in a piped subprocess.
+Object.defineProperty(process.stdin, "isTTY", { value: true });
+Object.defineProperty(process.stderr, "isTTY", { value: true });
+
+const { confirmDeployTarget } = await import("../../src/confirm.ts");
+
+const result = await confirmDeployTarget({
+	profileName: "production",
+	baseUrl: "https://prod.zeebe.camunda.io",
+});
+
+process.stdout.write(result);

--- a/tests/fixtures/plugins/plugin-with-host-context/c8ctl-plugin.js
+++ b/tests/fixtures/plugins/plugin-with-host-context/c8ctl-plugin.js
@@ -23,6 +23,7 @@ export const commands = {
         ? {
             dryRun: ctx.dryRun,
             verbose: ctx.verbose,
+            yes: ctx.yes,
             outputMode: ctx.outputMode,
             fields: ctx.fields ?? null,
             profile: ctx.profile,

--- a/tests/unit/command-framework.test.ts
+++ b/tests/unit/command-framework.test.ts
@@ -307,6 +307,7 @@ describe("defineCommand", () => {
 			dateField: undefined,
 			dryRun: undefined,
 			profile: undefined,
+			yes: undefined,
 		};
 
 		await cmd.execute(mockCtx, { xml: true }, ["12345"]);

--- a/tests/unit/confirm-interactive.test.ts
+++ b/tests/unit/confirm-interactive.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for the interactive (TTY) branch of confirmDeployTarget().
+ *
+ * These tests exercise the readline prompt directly by spawning a
+ * small script that imports confirmDeployTarget and writes input via
+ * stdin. The script overrides process.stdin.isTTY / process.stderr.isTTY
+ * so the interactive branch fires even from a non-TTY subprocess.
+ */
+
+import assert from "node:assert";
+import { resolve } from "node:path";
+import { describe, test } from "node:test";
+import { asyncSpawnWithStdin } from "../utils/spawn.ts";
+
+const HELPER = resolve(
+	import.meta.dirname,
+	"..",
+	"fixtures",
+	"confirm-interactive-helper.ts",
+);
+
+async function runConfirmHelper(
+	input: string,
+): Promise<{ stdout: string; stderr: string; status: number | null }> {
+	return asyncSpawnWithStdin(
+		"node",
+		["--experimental-strip-types", HELPER],
+		(stdin) => {
+			stdin.write(`${input}\n`);
+		},
+		{ timeout: 10_000 },
+	);
+}
+
+describe("confirmDeployTarget — interactive branch", () => {
+	test("'y' resolves to 'yes'", async () => {
+		const result = await runConfirmHelper("y");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		assert.strictEqual(result.stdout.trim(), "yes");
+	});
+
+	test("'yes' resolves to 'yes'", async () => {
+		const result = await runConfirmHelper("yes");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		assert.strictEqual(result.stdout.trim(), "yes");
+	});
+
+	test("'Y' (uppercase) resolves to 'yes'", async () => {
+		const result = await runConfirmHelper("Y");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		assert.strictEqual(result.stdout.trim(), "yes");
+	});
+
+	test("'n' resolves to 'no'", async () => {
+		const result = await runConfirmHelper("n");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		assert.strictEqual(result.stdout.trim(), "no");
+	});
+
+	test("empty input (just Enter) resolves to 'no'", async () => {
+		const result = await runConfirmHelper("");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		assert.strictEqual(result.stdout.trim(), "no");
+	});
+
+	test("'a' resolves to 'always'", async () => {
+		const result = await runConfirmHelper("a");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		assert.strictEqual(result.stdout.trim(), "always");
+	});
+
+	test("'always' resolves to 'always'", async () => {
+		const result = await runConfirmHelper("always");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		assert.strictEqual(result.stdout.trim(), "always");
+	});
+
+	test("'A' (uppercase) resolves to 'always'", async () => {
+		const result = await runConfirmHelper("A");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		assert.strictEqual(result.stdout.trim(), "always");
+	});
+
+	test("EOF (Ctrl+D) without input resolves to 'no'", async () => {
+		// Send nothing and let stdin close immediately (EOF).
+		const result = await asyncSpawnWithStdin(
+			"node",
+			["--experimental-strip-types", HELPER],
+			(stdin) => {
+				// Close stdin without writing anything — simulates Ctrl+D.
+				stdin.end();
+			},
+			{ timeout: 10_000 },
+		);
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		assert.strictEqual(result.stdout.trim(), "no");
+	});
+
+	test("prompt text appears on stderr", async () => {
+		const result = await runConfirmHelper("y");
+		assert.ok(
+			result.stderr.includes("Deploying to profile"),
+			`prompt should appear on stderr, got: ${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("[y/N/a]"),
+			`prompt should include [y/N/a], got: ${result.stderr}`,
+		);
+	});
+});

--- a/tests/unit/deploy-confirm.test.ts
+++ b/tests/unit/deploy-confirm.test.ts
@@ -45,10 +45,11 @@ let tempDir: string;
  * extraArgs are appended after `deploy <dir>`.
  */
 async function c8Deploy(
-	cwd: string,
+	deployPath: string,
 	profiles: Array<{ name: string; baseUrl: string }>,
 	extraArgs: string[] = [],
 	sessionOverrides: Record<string, unknown> = {},
+	envOverrides: Record<string, string> = {},
 ): Promise<SpawnResult> {
 	const dir = mkdtempSync(join(tempDir, ".c8ctl-data-"));
 	writeFileSync(
@@ -59,12 +60,14 @@ async function c8Deploy(
 
 	return asyncSpawn(
 		"node",
-		["--experimental-strip-types", CLI, "deploy", cwd, ...extraArgs],
+		["--experimental-strip-types", CLI, "deploy", deployPath, ...extraArgs],
 		{
 			env: {
 				PATH: process.env.PATH,
 				HOME: "/tmp/c8ctl-test-nonexistent-home",
 				C8CTL_DATA_DIR: dir,
+				C8CTL_MODELER_DIR: join(dir, "no-modeler"),
+				...envOverrides,
 			},
 		},
 	);
@@ -93,6 +96,39 @@ describe("deploy confirmation guard (#393)", () => {
 		assert.ok(
 			!result.stderr.includes("Deploying to profile"),
 			`should not show confirmation for single profile, got: ${result.stderr}`,
+		);
+	});
+
+	test("single profile without --dry-run: no confirmation message", async () => {
+		// Non-dry-run variant: deploy fails (unreachable) but the guard
+		// should not fire for a single profile.
+		const result = await c8Deploy(tempDir, [
+			{ name: "local", baseUrl: "http://127.0.0.1:1/v2" },
+		]);
+
+		assert.ok(
+			!result.stderr.includes("Deploying to profile"),
+			`should not show confirmation for single profile, got: ${result.stderr}`,
+		);
+	});
+
+	test("multiple profiles with CAMUNDA_BASE_URL: no confirmation message", async () => {
+		// Env-based config means the user has chosen their target via the
+		// environment — the guard should not fire.
+		const result = await c8Deploy(
+			tempDir,
+			[
+				{ name: "local", baseUrl: "http://127.0.0.1:1/v2" },
+				{ name: "production", baseUrl: "http://127.0.0.1:2/v2" },
+			],
+			[],
+			{},
+			{ CAMUNDA_BASE_URL: "http://127.0.0.1:3/v2" },
+		);
+
+		assert.ok(
+			!result.stderr.includes("Deploying to profile"),
+			`CAMUNDA_BASE_URL should skip confirmation, got: ${result.stderr}`,
 		);
 	});
 

--- a/tests/unit/deploy-confirm.test.ts
+++ b/tests/unit/deploy-confirm.test.ts
@@ -115,17 +115,17 @@ describe("deploy confirmation guard (#393)", () => {
 	});
 
 	test("multiple profiles with --yes: no confirmation message", async () => {
-		// --yes skips confirmation. Uses --dry-run for clean exit.
+		// --yes skips confirmation. Deploy will fail (no cluster) but
+		// the confirmation guard is exercised before the failure.
 		const result = await c8Deploy(
 			tempDir,
 			[
 				{ name: "local", baseUrl: "http://localhost:8080/v2" },
 				{ name: "production", baseUrl: "https://prod.zeebe.camunda.io" },
 			],
-			["--dry-run", "--yes"],
+			["--yes"],
 		);
 
-		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		assert.ok(
 			!result.stderr.includes("Deploying to profile"),
 			`--yes should skip confirmation, got: ${result.stderr}`,
@@ -139,10 +139,9 @@ describe("deploy confirmation guard (#393)", () => {
 				{ name: "local", baseUrl: "http://localhost:8080/v2" },
 				{ name: "production", baseUrl: "https://prod.zeebe.camunda.io" },
 			],
-			["--dry-run", "-y"],
+			["-y"],
 		);
 
-		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		assert.ok(
 			!result.stderr.includes("Deploying to profile"),
 			`-y should skip confirmation, got: ${result.stderr}`,
@@ -150,17 +149,16 @@ describe("deploy confirmation guard (#393)", () => {
 	});
 
 	test("multiple profiles with explicit --profile: no confirmation message", async () => {
-		// Explicit --profile means the user knows the target. Uses --dry-run.
+		// Explicit --profile means the user knows the target.
 		const result = await c8Deploy(
 			tempDir,
 			[
 				{ name: "local", baseUrl: "http://localhost:8080/v2" },
 				{ name: "production", baseUrl: "https://prod.zeebe.camunda.io" },
 			],
-			["--dry-run", "--profile=local"],
+			["--profile=local"],
 		);
 
-		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		assert.ok(
 			!result.stderr.includes("Deploying to profile"),
 			`explicit --profile should skip confirmation, got: ${result.stderr}`,
@@ -176,7 +174,7 @@ describe("deploy confirmation guard (#393)", () => {
 				{ name: "staging", baseUrl: "https://staging.zeebe.camunda.io" },
 			],
 			[],
-			{ activeProfile: "staging" },
+			{ activeProfile: "staging", outputMode: "text" },
 		);
 
 		assert.ok(

--- a/tests/unit/deploy-confirm.test.ts
+++ b/tests/unit/deploy-confirm.test.ts
@@ -241,4 +241,23 @@ describe("deploy confirmation guard (#393)", () => {
 			`should show session profile name, not env, got: ${result.stderr}`,
 		);
 	});
+
+	test("multiple profiles with skipConfirmation persisted: no confirmation message", async () => {
+		// When skipConfirmation is persisted in session.json, the guard
+		// should not fire — equivalent to always passing --yes.
+		const result = await c8Deploy(
+			tempDir,
+			[
+				{ name: "local", baseUrl: "http://127.0.0.1:1/v2" },
+				{ name: "production", baseUrl: "http://127.0.0.1:2/v2" },
+			],
+			[],
+			{ skipConfirmation: true },
+		);
+
+		assert.ok(
+			!result.stderr.includes("Deploying to profile"),
+			`skipConfirmation should skip confirmation, got: ${result.stderr}`,
+		);
+	});
 });

--- a/tests/unit/deploy-confirm.test.ts
+++ b/tests/unit/deploy-confirm.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for deploy confirmation guard (#393).
+ *
+ * Verifies that `c8 deploy` prompts for confirmation when multiple
+ * profiles are configured and the user did not explicitly pass
+ * --profile or --yes. Since test subprocesses are not a TTY, the
+ * confirmation auto-approves but logs the target to stderr.
+ *
+ * Tests that verify confirmation IS shown do NOT use --dry-run
+ * (the guard runs after the dry-run exit). The deploy will fail
+ * (no real cluster), but the confirmation message in stderr is
+ * what we assert on.
+ *
+ * Tests that verify confirmation is SKIPPED use --dry-run so the
+ * CLI exits cleanly (confirmation never fires either way).
+ */
+
+import assert from "node:assert";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, test } from "node:test";
+import { asyncSpawn, type SpawnResult } from "../utils/spawn.ts";
+
+const CLI = resolve(import.meta.dirname, "..", "..", "src", "index.ts");
+
+const MINIMAL_BPMN = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="test-process" isExecutable="true">
+    <bpmn:startEvent id="start"/>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="test-process">
+      <bpmndi:BPMNShape id="start_di" bpmnElement="start">
+        <dc:Bounds x="173" y="102" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>`;
+
+let tempDir: string;
+
+/**
+ * Spawn the CLI with a custom data dir containing the given profiles.
+ * extraArgs are appended after `deploy <dir>`.
+ */
+async function c8Deploy(
+	cwd: string,
+	profiles: Array<{ name: string; baseUrl: string }>,
+	extraArgs: string[] = [],
+	sessionOverrides: Record<string, unknown> = {},
+): Promise<SpawnResult> {
+	const dir = mkdtempSync(join(tempDir, ".c8ctl-data-"));
+	writeFileSync(
+		join(dir, "session.json"),
+		JSON.stringify({ outputMode: "json", ...sessionOverrides }),
+	);
+	writeFileSync(
+		join(dir, "profiles.json"),
+		JSON.stringify({ profiles }),
+	);
+
+	return asyncSpawn(
+		"node",
+		["--experimental-strip-types", CLI, "deploy", cwd, ...extraArgs],
+		{
+			env: {
+				PATH: process.env.PATH,
+				HOME: "/tmp/c8ctl-test-nonexistent-home",
+				C8CTL_DATA_DIR: dir,
+			},
+		},
+	);
+}
+
+describe("deploy confirmation guard (#393)", () => {
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "c8ctl-confirm-"));
+		writeFileSync(join(tempDir, "test.bpmn"), MINIMAL_BPMN);
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	test("single profile: no confirmation message in stderr", async () => {
+		// With only one profile, deploy should proceed without confirmation.
+		// Uses --dry-run for a clean exit (confirmation never fires either way).
+		const result = await c8Deploy(
+			tempDir,
+			[{ name: "local", baseUrl: "http://localhost:8080/v2" }],
+			["--dry-run"],
+		);
+
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		assert.ok(
+			!result.stderr.includes("Deploying to profile"),
+			`should not show confirmation for single profile, got: ${result.stderr}`,
+		);
+	});
+
+	test("multiple profiles without --yes: shows target in stderr (non-TTY auto-approve)", async () => {
+		// No --dry-run: the confirmation guard runs, then deploy fails (no cluster).
+		// We only assert on the confirmation message in stderr.
+		const result = await c8Deploy(
+			tempDir,
+			[
+				{ name: "local", baseUrl: "http://localhost:8080/v2" },
+				{ name: "production", baseUrl: "https://prod.zeebe.camunda.io" },
+			],
+		);
+
+		// Deploy will fail (no real cluster) — that's expected.
+		assert.ok(
+			result.stderr.includes("Deploying to profile"),
+			`should show deploy target when multiple profiles exist, got: ${result.stderr}`,
+		);
+	});
+
+	test("multiple profiles with --yes: no confirmation message", async () => {
+		// --yes skips confirmation. Uses --dry-run for clean exit.
+		const result = await c8Deploy(
+			tempDir,
+			[
+				{ name: "local", baseUrl: "http://localhost:8080/v2" },
+				{ name: "production", baseUrl: "https://prod.zeebe.camunda.io" },
+			],
+			["--dry-run", "--yes"],
+		);
+
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		assert.ok(
+			!result.stderr.includes("Deploying to profile"),
+			`--yes should skip confirmation, got: ${result.stderr}`,
+		);
+	});
+
+	test("multiple profiles with -y: no confirmation message", async () => {
+		const result = await c8Deploy(
+			tempDir,
+			[
+				{ name: "local", baseUrl: "http://localhost:8080/v2" },
+				{ name: "production", baseUrl: "https://prod.zeebe.camunda.io" },
+			],
+			["--dry-run", "-y"],
+		);
+
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		assert.ok(
+			!result.stderr.includes("Deploying to profile"),
+			`-y should skip confirmation, got: ${result.stderr}`,
+		);
+	});
+
+	test("multiple profiles with explicit --profile: no confirmation message", async () => {
+		// Explicit --profile means the user knows the target. Uses --dry-run.
+		const result = await c8Deploy(
+			tempDir,
+			[
+				{ name: "local", baseUrl: "http://localhost:8080/v2" },
+				{ name: "production", baseUrl: "https://prod.zeebe.camunda.io" },
+			],
+			["--dry-run", "--profile=local"],
+		);
+
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		assert.ok(
+			!result.stderr.includes("Deploying to profile"),
+			`explicit --profile should skip confirmation, got: ${result.stderr}`,
+		);
+	});
+
+	test("multiple profiles with active session profile: shows profile name in confirmation", async () => {
+		// No --dry-run: confirmation runs and shows the active profile name.
+		const result = await c8Deploy(
+			tempDir,
+			[
+				{ name: "local", baseUrl: "http://localhost:8080/v2" },
+				{ name: "staging", baseUrl: "https://staging.zeebe.camunda.io" },
+			],
+			[],
+			{ activeProfile: "staging" },
+		);
+
+		assert.ok(
+			result.stderr.includes('"staging"'),
+			`should show active profile name in confirmation, got: ${result.stderr}`,
+		);
+	});
+});

--- a/tests/unit/deploy-confirm.test.ts
+++ b/tests/unit/deploy-confirm.test.ts
@@ -69,6 +69,7 @@ async function c8Deploy(
 				C8CTL_MODELER_DIR: join(dir, "no-modeler"),
 				...envOverrides,
 			},
+			timeout: 15_000,
 		},
 	);
 }

--- a/tests/unit/deploy-confirm.test.ts
+++ b/tests/unit/deploy-confirm.test.ts
@@ -58,10 +58,7 @@ async function c8Deploy(
 		join(dir, "session.json"),
 		JSON.stringify({ outputMode: "json", ...sessionOverrides }),
 	);
-	writeFileSync(
-		join(dir, "profiles.json"),
-		JSON.stringify({ profiles }),
-	);
+	writeFileSync(join(dir, "profiles.json"), JSON.stringify({ profiles }));
 
 	return asyncSpawn(
 		"node",
@@ -105,13 +102,10 @@ describe("deploy confirmation guard (#393)", () => {
 	test("multiple profiles without --yes: shows target in stderr (non-TTY auto-approve)", async () => {
 		// No --dry-run: the confirmation guard runs, then deploy fails (no cluster).
 		// We only assert on the confirmation message in stderr.
-		const result = await c8Deploy(
-			tempDir,
-			[
-				{ name: "local", baseUrl: "http://localhost:8080/v2" },
-				{ name: "production", baseUrl: "https://prod.zeebe.camunda.io" },
-			],
-		);
+		const result = await c8Deploy(tempDir, [
+			{ name: "local", baseUrl: "http://localhost:8080/v2" },
+			{ name: "production", baseUrl: "https://prod.zeebe.camunda.io" },
+		]);
 
 		// Deploy will fail (no real cluster) — that's expected.
 		assert.ok(

--- a/tests/unit/deploy-confirm.test.ts
+++ b/tests/unit/deploy-confirm.test.ts
@@ -216,4 +216,29 @@ describe("deploy confirmation guard (#393)", () => {
 			`should show active profile name in confirmation, got: ${result.stderr}`,
 		);
 	});
+
+	test("active session profile + CAMUNDA_BASE_URL: guard still runs (profile overrides env)", async () => {
+		// When both an active session profile and CAMUNDA_BASE_URL are set,
+		// resolveClusterConfig() prefers the session profile. The guard must
+		// still run because CAMUNDA_BASE_URL is NOT the effective target.
+		const result = await c8Deploy(
+			tempDir,
+			[
+				{ name: "local", baseUrl: "http://127.0.0.1:1/v2" },
+				{ name: "staging", baseUrl: "http://127.0.0.1:2/v2" },
+			],
+			[],
+			{ activeProfile: "staging", outputMode: "text" },
+			{ CAMUNDA_BASE_URL: "http://127.0.0.1:3/v2" },
+		);
+
+		assert.ok(
+			result.stderr.includes("Deploying to profile"),
+			`guard should still run when active profile overrides CAMUNDA_BASE_URL, got: ${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes('"staging"'),
+			`should show session profile name, not env, got: ${result.stderr}`,
+		);
+	});
 });

--- a/tests/unit/deploy-confirm.test.ts
+++ b/tests/unit/deploy-confirm.test.ts
@@ -88,7 +88,7 @@ describe("deploy confirmation guard (#393)", () => {
 		// Uses --dry-run for a clean exit (confirmation never fires either way).
 		const result = await c8Deploy(
 			tempDir,
-			[{ name: "local", baseUrl: "http://localhost:8080/v2" }],
+			[{ name: "local", baseUrl: "http://127.0.0.1:1/v2" }],
 			["--dry-run"],
 		);
 
@@ -103,8 +103,8 @@ describe("deploy confirmation guard (#393)", () => {
 		// No --dry-run: the confirmation guard runs, then deploy fails (no cluster).
 		// We only assert on the confirmation message in stderr.
 		const result = await c8Deploy(tempDir, [
-			{ name: "local", baseUrl: "http://localhost:8080/v2" },
-			{ name: "production", baseUrl: "https://prod.zeebe.camunda.io" },
+			{ name: "local", baseUrl: "http://127.0.0.1:1/v2" },
+			{ name: "production", baseUrl: "http://127.0.0.1:2/v2" },
 		]);
 
 		// Deploy will fail (no real cluster) — that's expected.
@@ -120,8 +120,8 @@ describe("deploy confirmation guard (#393)", () => {
 		const result = await c8Deploy(
 			tempDir,
 			[
-				{ name: "local", baseUrl: "http://localhost:8080/v2" },
-				{ name: "production", baseUrl: "https://prod.zeebe.camunda.io" },
+				{ name: "local", baseUrl: "http://127.0.0.1:1/v2" },
+				{ name: "production", baseUrl: "http://127.0.0.1:2/v2" },
 			],
 			["--yes"],
 		);
@@ -136,8 +136,8 @@ describe("deploy confirmation guard (#393)", () => {
 		const result = await c8Deploy(
 			tempDir,
 			[
-				{ name: "local", baseUrl: "http://localhost:8080/v2" },
-				{ name: "production", baseUrl: "https://prod.zeebe.camunda.io" },
+				{ name: "local", baseUrl: "http://127.0.0.1:1/v2" },
+				{ name: "production", baseUrl: "http://127.0.0.1:2/v2" },
 			],
 			["-y"],
 		);
@@ -153,8 +153,8 @@ describe("deploy confirmation guard (#393)", () => {
 		const result = await c8Deploy(
 			tempDir,
 			[
-				{ name: "local", baseUrl: "http://localhost:8080/v2" },
-				{ name: "production", baseUrl: "https://prod.zeebe.camunda.io" },
+				{ name: "local", baseUrl: "http://127.0.0.1:1/v2" },
+				{ name: "production", baseUrl: "http://127.0.0.1:2/v2" },
 			],
 			["--profile=local"],
 		);
@@ -170,8 +170,8 @@ describe("deploy confirmation guard (#393)", () => {
 		const result = await c8Deploy(
 			tempDir,
 			[
-				{ name: "local", baseUrl: "http://localhost:8080/v2" },
-				{ name: "staging", baseUrl: "https://staging.zeebe.camunda.io" },
+				{ name: "local", baseUrl: "http://127.0.0.1:1/v2" },
+				{ name: "staging", baseUrl: "http://127.0.0.1:2/v2" },
 			],
 			[],
 			{ activeProfile: "staging", outputMode: "text" },

--- a/tests/unit/deploy-confirm.test.ts
+++ b/tests/unit/deploy-confirm.test.ts
@@ -6,13 +6,10 @@
  * --profile or --yes. Since test subprocesses are not a TTY, the
  * confirmation auto-approves but logs the target to stderr.
  *
- * Tests that verify confirmation IS shown do NOT use --dry-run
- * (the guard runs after the dry-run exit). The deploy will fail
- * (no real cluster), but the confirmation message in stderr is
- * what we assert on.
- *
- * Tests that verify confirmation is SKIPPED use --dry-run so the
- * CLI exits cleanly (confirmation never fires either way).
+ * Most tests run without --dry-run so the confirmation guard is
+ * actually exercised (it runs after the dry-run exit). The deploy
+ * will fail (no real cluster / unreachable address), but the
+ * confirmation message in stderr is what we assert on.
  */
 
 import assert from "node:assert";

--- a/tests/unit/plugin-host-context-contract.test.ts
+++ b/tests/unit/plugin-host-context-contract.test.ts
@@ -179,6 +179,23 @@ describe("plugin host context: ctx is passed as the third handler argument", () 
 		assert.strictEqual(parsed.ctx.profile, undefined);
 	});
 
+	test("ctx.yes reflects --yes", async () => {
+		const result = await c8Plugin("echo-ctx", "--yes");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const parsed = lastJsonRecord(result.stdout);
+		assert.ok(isRecord(parsed.ctx));
+		assert.strictEqual(parsed.ctx.yes, true);
+	});
+
+	test("ctx.yes is false when --yes is omitted", async () => {
+		const result = await c8Plugin("echo-ctx");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const parsed = lastJsonRecord(result.stdout);
+		assert.ok(isRecord(parsed.ctx));
+		assert.strictEqual(parsed.ctx.yes, false);
+	});
+	});
+
 	test("ctx.outputMode is 'json' when --json is set", async () => {
 		const result = await c8Plugin("echo-ctx", "--json");
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);

--- a/tests/unit/plugin-host-context-contract.test.ts
+++ b/tests/unit/plugin-host-context-contract.test.ts
@@ -194,7 +194,6 @@ describe("plugin host context: ctx is passed as the third handler argument", () 
 		assert.ok(isRecord(parsed.ctx));
 		assert.strictEqual(parsed.ctx.yes, false);
 	});
-	});
 
 	test("ctx.outputMode is 'json' when --json is set", async () => {
 		const result = await c8Plugin("echo-ctx", "--json");

--- a/tests/unit/plugin-host-context-contract.test.ts
+++ b/tests/unit/plugin-host-context-contract.test.ts
@@ -234,6 +234,7 @@ describe("plugin host context: ctx is passed as the third handler argument", () 
 			["verbose", "verbose"],
 			["fields", "fields"],
 			["json", "outputMode"], // --json toggles outputMode
+			["yes", "yes"],
 		]);
 		const missing: string[] = [];
 		for (const name of Object.keys(GLOBAL_FLAGS)) {


### PR DESCRIPTION
## Summary

When multiple profiles are configured, `c8 deploy` now prompts for confirmation showing the target cluster URL before proceeding. This prevents accidental deployments to the wrong cluster.

Closes #393

## Changes

- **`--yes` / `-y` global flag**: Skip confirmation prompts (added to `GLOBAL_FLAGS`)
- **`src/confirm.ts`**: New confirmation prompt utility using Node's built-in `readline`
- **Deploy guard in `src/deployments.ts`**: Checks profile count and prompts before deploying
- **6 new tests** in `tests/unit/deploy-confirm.test.ts`
- **Documentation** updated in `EXAMPLES.md` and `README.md`

## Behavior

| Condition | Result |
|---|---|
| 1 profile (or env-based config) | Deploy immediately |
| Multiple profiles + `--yes` / `-y` | Deploy immediately |
| Multiple profiles + explicit `--profile` | Deploy immediately |
| Multiple profiles, interactive TTY | Prompt: `Deploying to profile \"X\" (url). Continue? [y/N]` |
| Multiple profiles, non-TTY (CI/pipe) | Log target to stderr, proceed automatically |

## Testing

```
node --test tests/unit/deploy-confirm.test.ts      # 6/6 pass
node --test tests/unit/deploy-behaviour.test.ts     # passes
node --test tests/unit/deploy-error-paths.test.ts   # passes
npm run typecheck                                    # 0 errors
```