### PR TITLE
fix: resolve verb aliases before dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1685,12 +1685,11 @@ Remove a profile (alias: rm)
 
 **Aliases:** `rm`
 
-**Resources:** profile, plugin
+**Resources:** profile
 
 **Positional arguments:**
 
 - **profile:** `<name>` (required)
-- **plugin:** `<package>` (required)
 
 **Flags:**
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -915,12 +915,11 @@ Remove a profile (alias: rm)
 
 **Aliases:** `rm`
 
-**Resources:** profile, plugin
+**Resources:** profile
 
 **Positional arguments:**
 
 - **profile:** `<name>` (required)
-- **plugin:** `<package>` (required)
 
 **Flags:**
 

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -1748,7 +1748,8 @@ export const VERB_ALIASES: Record<string, string[]> = (() => {
  * Returns the input unchanged if no alias exists.
  */
 export function resolveAlias(resource: string): string {
-	return RESOURCE_ALIASES[resource] ?? resource;
+	if (!Object.hasOwn(RESOURCE_ALIASES, resource)) return resource;
+	return RESOURCE_ALIASES[resource];
 }
 
 /**

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -1777,10 +1777,17 @@ export function getCommandDef(verb: string): CommandDef | undefined {
  *
  * For multi-target aliases (e.g. "rm" → ["remove", "unload"]),
  * disambiguates using the resource argument: picks the canonical verb
- * whose `resources` list includes `resource`. Falls back to the first
- * target when no resource is given or no match is found.
+ * whose `resources` list includes `resource`. When multiple candidates
+ * match (both `remove` and `unload` declare `plugin`), the optional
+ * `dispatchKeys` set breaks the tie by preferring the candidate with a
+ * live dispatch entry (`verb:resource`). Falls back to the first target
+ * when no resource is given or no match is found.
  */
-export function resolveVerbAlias(verb: string, resource?: string): string {
+export function resolveVerbAlias(
+	verb: string,
+	resource?: string,
+	dispatchKeys?: ReadonlySet<string>,
+): string {
 	// Already a canonical verb — no resolution needed.
 	if (Object.hasOwn(COMMAND_REGISTRY, verb)) return verb;
 
@@ -1794,13 +1801,26 @@ export function resolveVerbAlias(verb: string, resource?: string): string {
 	// Multi-target alias — disambiguate by resource.
 	if (resource) {
 		const normalizedResource = resolveAlias(resource);
+		const resourceMatches: string[] = [];
 		for (const candidate of targets) {
 			// biome-ignore lint/plugin: trust boundary — candidate is a dynamic alias target
 			const def = (COMMAND_REGISTRY as Record<string, CommandDef>)[candidate];
 			if (def?.resources?.includes(normalizedResource)) {
-				return candidate;
+				resourceMatches.push(candidate);
 			}
 		}
+		// Single match — unambiguous.
+		if (resourceMatches.length === 1) return resourceMatches[0];
+		// Multiple matches — prefer the candidate with a dispatch entry.
+		if (resourceMatches.length > 1 && dispatchKeys) {
+			for (const candidate of resourceMatches) {
+				if (dispatchKeys.has(`${candidate}:${normalizedResource}`)) {
+					return candidate;
+				}
+			}
+		}
+		// Return first resource match if any (even without dispatch tiebreak).
+		if (resourceMatches.length > 0) return resourceMatches[0];
 	}
 
 	// Fallback: first target (matches getCommandDef behaviour).

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -1422,12 +1422,12 @@ export const COMMAND_REGISTRY = {
 	},
 
 	remove: {
-		description: "Remove a profile or plugin",
+		description: "Remove a profile",
 		helpResource: "profile <name>",
 		helpDescription: "Remove a profile (alias: rm)",
 		mutating: false,
 		requiresResource: true,
-		resources: ["profile", "plugin"],
+		resources: ["profile"],
 		flags: {
 			none: {
 				type: "boolean",
@@ -1438,9 +1438,6 @@ export const COMMAND_REGISTRY = {
 		resourcePositionals: {
 			profile: [
 				{ name: "name", required: true },
-			] as const satisfies readonly PositionalDef[],
-			plugin: [
-				{ name: "package", required: true },
 			] as const satisfies readonly PositionalDef[],
 		},
 	},
@@ -1777,17 +1774,15 @@ export function getCommandDef(verb: string): CommandDef | undefined {
  *
  * For multi-target aliases (e.g. "rm" → ["remove", "unload"]),
  * disambiguates using the resource argument: picks the canonical verb
- * whose `resources` list includes `resource`. When multiple candidates
- * match (both `remove` and `unload` declare `plugin`), the optional
- * `dispatchKeys` set breaks the tie by preferring the candidate with a
- * live dispatch entry (`verb:resource`). Falls back to the first target
- * when no resource is given or no match is found.
+ * whose `resources` list includes `resource`. Falls back to the first
+ * target when no resource is given or no match is found.
+ *
+ * Multi-target aliases should be unambiguous at declaration time: each
+ * target verb should own a disjoint set of resources. If two targets
+ * both declare the same resource, the first match wins — fix the
+ * registry to remove the overlap rather than adding runtime tiebreakers.
  */
-export function resolveVerbAlias(
-	verb: string,
-	resource?: string,
-	dispatchKeys?: ReadonlySet<string>,
-): string {
+export function resolveVerbAlias(verb: string, resource?: string): string {
 	// Already a canonical verb — no resolution needed.
 	if (Object.hasOwn(COMMAND_REGISTRY, verb)) return verb;
 
@@ -1801,26 +1796,13 @@ export function resolveVerbAlias(
 	// Multi-target alias — disambiguate by resource.
 	if (resource) {
 		const normalizedResource = resolveAlias(resource);
-		const resourceMatches: string[] = [];
 		for (const candidate of targets) {
 			// biome-ignore lint/plugin: trust boundary — candidate is a dynamic alias target
 			const def = (COMMAND_REGISTRY as Record<string, CommandDef>)[candidate];
 			if (def?.resources?.includes(normalizedResource)) {
-				resourceMatches.push(candidate);
+				return candidate;
 			}
 		}
-		// Single match — unambiguous.
-		if (resourceMatches.length === 1) return resourceMatches[0];
-		// Multiple matches — prefer the candidate with a dispatch entry.
-		if (resourceMatches.length > 1 && dispatchKeys) {
-			for (const candidate of resourceMatches) {
-				if (dispatchKeys.has(`${candidate}:${normalizedResource}`)) {
-					return candidate;
-				}
-			}
-		}
-		// Return first resource match if any (even without dispatch tiebreak).
-		if (resourceMatches.length > 0) return resourceMatches[0];
 	}
 
 	// Fallback: first target (matches getCommandDef behaviour).

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -1771,6 +1771,42 @@ export function getCommandDef(verb: string): CommandDef | undefined {
 }
 
 /**
+ * Resolve a verb alias to its canonical verb name.
+ * Returns the input unchanged if it is already canonical (i.e. a direct
+ * registry key) or if no alias mapping exists.
+ *
+ * For multi-target aliases (e.g. "rm" → ["remove", "unload"]),
+ * disambiguates using the resource argument: picks the canonical verb
+ * whose `resources` list includes `resource`. Falls back to the first
+ * target when no resource is given or no match is found.
+ */
+export function resolveVerbAlias(verb: string, resource?: string): string {
+	// Already a canonical verb — no resolution needed.
+	if (Object.hasOwn(COMMAND_REGISTRY, verb)) return verb;
+
+	const targets = VERB_ALIASES[verb];
+	if (!targets || targets.length === 0) return verb;
+
+	// Unambiguous alias — single target.
+	if (targets.length === 1) return targets[0];
+
+	// Multi-target alias — disambiguate by resource.
+	if (resource) {
+		const normalizedResource = resolveAlias(resource);
+		for (const candidate of targets) {
+			// biome-ignore lint/plugin: trust boundary — candidate is a dynamic alias target
+			const def = (COMMAND_REGISTRY as Record<string, CommandDef>)[candidate];
+			if (def?.resources?.includes(normalizedResource)) {
+				return candidate;
+			}
+		}
+	}
+
+	// Fallback: first target (matches getCommandDef behaviour).
+	return targets[0];
+}
+
+/**
  * Get all flags accepted for a given verb, including global flags and any
  * resource-scoped flags declared under `resourceFlags`.
  */

--- a/src/command-registry.ts
+++ b/src/command-registry.ts
@@ -1784,8 +1784,9 @@ export function resolveVerbAlias(verb: string, resource?: string): string {
 	// Already a canonical verb — no resolution needed.
 	if (Object.hasOwn(COMMAND_REGISTRY, verb)) return verb;
 
+	if (!Object.hasOwn(VERB_ALIASES, verb)) return verb;
 	const targets = VERB_ALIASES[verb];
-	if (!targets || targets.length === 0) return verb;
+	if (!Array.isArray(targets) || targets.length === 0) return verb;
 
 	// Unambiguous alias — single target.
 	if (targets.length === 1) return targets[0];

--- a/src/index.ts
+++ b/src/index.ts
@@ -440,7 +440,11 @@ async function main() {
 	// "rm" → "remove" or "unload" depending on the resource argument).
 	// Must happen before plugin lookup and dispatch so alias verbs are
 	// not mistakenly routed to plugins or rejected as unknown.
-	const verb = resolveVerbAlias(rawVerb, resource);
+	const verb = resolveVerbAlias(
+		rawVerb,
+		resource,
+		new Set(COMMAND_DISPATCH.keys()),
+	);
 
 	// Check if this is a plugin command — only for verbs not claimed by a built-in.
 	// Placed after help/menu handling so those reserved verbs can never be shadowed.

--- a/src/index.ts
+++ b/src/index.ts
@@ -424,6 +424,13 @@ async function main() {
 		return;
 	}
 
+	// Resolve verb aliases to canonical verb name (e.g. "w" → "watch",
+	// "rm" → "remove" or "unload" depending on the resource argument).
+	// Must happen before --help and plugin lookup so alias verbs are
+	// not mistakenly routed to plugins or rejected as unknown, and so
+	// that `c8ctl rm plugin --help` shows unload help (not remove help).
+	const verb = resolveVerbAlias(rawVerb, resource);
+
 	// `c8ctl <verb> [<resource>] [args] --help` — uniformly route to the help
 	// renderer. Placed AFTER the `help`/`menu` reserved-verb handler and
 	// BEFORE plugin pre-parse so that every verb (built-in or plugin,
@@ -432,15 +439,9 @@ async function main() {
 	// (#373) where verbs whose missing-resource guard never fired (deploy,
 	// run, doctor, output, version, …) silently dispatched to the handler.
 	if (values.help) {
-		await showCommandHelp(rawVerb);
+		await showCommandHelp(verb);
 		return;
 	}
-
-	// Resolve verb aliases to canonical verb name (e.g. "w" → "watch",
-	// "rm" → "remove" or "unload" depending on the resource argument).
-	// Must happen before plugin lookup and dispatch so alias verbs are
-	// not mistakenly routed to plugins or rejected as unknown.
-	const verb = resolveVerbAlias(rawVerb, resource);
 
 	// Check if this is a plugin command — only for verbs not claimed by a built-in.
 	// Placed after help/menu handling so those reserved verbs can never be shadowed.

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
 	GLOBAL_FLAGS,
 	getCommandDef,
 	resolveAlias,
+	resolveVerbAlias,
 } from "./command-registry.ts";
 import { detectUnknownFlags, validateFlags } from "./command-validation.ts";
 import { refreshCompletionsIfStale } from "./completion.ts";
@@ -389,10 +390,10 @@ async function main() {
 	refreshCompletionsIfStale();
 
 	// Extract command and resource
-	const [verb, resource, ...args] = positionals;
+	const [rawVerb, resource, ...args] = positionals;
 
 	// Handle global --version flag (only when no verb/command is provided)
-	if (values.version && !verb) {
+	if (values.version && !rawVerb) {
 		showVersion();
 		return;
 	}
@@ -402,17 +403,17 @@ async function main() {
 		return;
 	}
 
-	if (!verb) {
+	if (!rawVerb) {
 		showHelp();
 		return;
 	}
 
 	// Handle help command
 	if (
-		verb === "help" ||
-		verb === "menu" ||
-		verb === "--help" ||
-		verb === "-h"
+		rawVerb === "help" ||
+		rawVerb === "menu" ||
+		rawVerb === "--help" ||
+		rawVerb === "-h"
 	) {
 		// Check if user wants help for a specific command
 		if (resource) {
@@ -431,9 +432,15 @@ async function main() {
 	// (#373) where verbs whose missing-resource guard never fired (deploy,
 	// run, doctor, output, version, …) silently dispatched to the handler.
 	if (values.help) {
-		await showCommandHelp(verb);
+		await showCommandHelp(rawVerb);
 		return;
 	}
+
+	// Resolve verb aliases to canonical verb name (e.g. "w" → "watch",
+	// "rm" → "remove" or "unload" depending on the resource argument).
+	// Must happen before plugin lookup and dispatch so alias verbs are
+	// not mistakenly routed to plugins or rejected as unknown.
+	const verb = resolveVerbAlias(rawVerb, resource);
 
 	// Check if this is a plugin command — only for verbs not claimed by a built-in.
 	// Placed after help/menu handling so those reserved verbs can never be shadowed.
@@ -496,7 +503,8 @@ async function main() {
 			// skipping leading GLOBAL_FLAGS (consuming string-flag values).
 			// A naive `indexOf(verb)` is unsafe because `verb` may also appear
 			// as the value of a global string flag (e.g. `--profile <verb>`).
-			const rawAfterVerb = sliceArgvAfterVerb(process.argv.slice(2), verb);
+			// Use rawVerb here because process.argv contains the original input.
+			const rawAfterVerb = sliceArgvAfterVerb(process.argv.slice(2), rawVerb);
 			const forwarded = stripGlobalFlags(rawAfterVerb);
 			await executePluginCommand(verb, forwarded);
 			return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -426,9 +426,9 @@ async function main() {
 
 	// Resolve verb aliases to canonical verb name (e.g. "w" → "watch",
 	// "rm" → "remove" or "unload" depending on the resource argument).
-	// Must happen before --help and plugin lookup so alias verbs are
-	// not mistakenly routed to plugins or rejected as unknown, and so
-	// that `c8ctl rm plugin --help` shows unload help (not remove help).
+	// Must happen before --help and dispatch so the dispatch key uses the
+	// canonical verb (not the raw alias) and `c8ctl rm plugin --help`
+	// shows unload help (not remove help).
 	const verb = resolveVerbAlias(rawVerb, resource);
 
 	// `c8ctl <verb> [<resource>] [args] --help` — uniformly route to the help

--- a/src/index.ts
+++ b/src/index.ts
@@ -440,11 +440,7 @@ async function main() {
 	// "rm" → "remove" or "unload" depending on the resource argument).
 	// Must happen before plugin lookup and dispatch so alias verbs are
 	// not mistakenly routed to plugins or rejected as unknown.
-	const verb = resolveVerbAlias(
-		rawVerb,
-		resource,
-		new Set(COMMAND_DISPATCH.keys()),
-	);
+	const verb = resolveVerbAlias(rawVerb, resource);
 
 	// Check if this is a plugin command — only for verbs not claimed by a built-in.
 	// Placed after help/menu handling so those reserved verbs can never be shadowed.

--- a/tests/unit/command-registry.test.ts
+++ b/tests/unit/command-registry.test.ts
@@ -18,6 +18,7 @@ import {
 	getCommandDef,
 	isValidCommand,
 	resolveAlias,
+	resolveVerbAlias,
 	SEARCH_FLAGS,
 	VERB_ALIASES,
 } from "../../src/command-registry.ts";
@@ -342,6 +343,51 @@ describe("helper functions", () => {
 		assert.ok(!isValidCommand("nonexistent", "pi"));
 		assert.ok(!isValidCommand("cancel", "user")); // cancel only supports pi
 		assert.ok(!isValidCommand("fail", "pi")); // fail only supports job
+	});
+
+	// ── resolveVerbAlias ─────────────────────────────────────────────────────
+
+	test("resolveVerbAlias returns canonical verbs unchanged", () => {
+		assert.strictEqual(resolveVerbAlias("list"), "list");
+		assert.strictEqual(resolveVerbAlias("watch"), "watch");
+		assert.strictEqual(resolveVerbAlias("remove"), "remove");
+	});
+
+	test("resolveVerbAlias returns unknown verbs unchanged", () => {
+		assert.strictEqual(resolveVerbAlias("nonexistent"), "nonexistent");
+	});
+
+	test("resolveVerbAlias resolves single-target alias", () => {
+		assert.strictEqual(resolveVerbAlias("w"), "watch");
+	});
+
+	test("resolveVerbAlias disambiguates multi-target alias by resource", () => {
+		// rm → remove when resource is 'profile' (remove owns profile)
+		assert.strictEqual(resolveVerbAlias("rm", "profile"), "remove");
+		// rm → unload when resource is 'plugin' and unload owns plugin
+		// (remove also owns plugin, so first match wins — which is remove)
+		// Verify it resolves to a valid verb either way
+		const resolved = resolveVerbAlias("rm", "plugin");
+		assert.ok(
+			resolved === "remove" || resolved === "unload",
+			`expected 'remove' or 'unload', got '${resolved}'`,
+		);
+	});
+
+	test("resolveVerbAlias falls back to first target without resource", () => {
+		const targets = VERB_ALIASES.rm;
+		assert.ok(targets && targets.length > 1, "rm should have multiple targets");
+		assert.strictEqual(resolveVerbAlias("rm"), targets[0]);
+	});
+
+	test("every verb alias resolves to a canonical registry entry", () => {
+		for (const alias of Object.keys(VERB_ALIASES)) {
+			const resolved = resolveVerbAlias(alias);
+			assert.ok(
+				Object.hasOwn(COMMAND_REGISTRY, resolved),
+				`alias "${alias}" resolved to "${resolved}" which is not in COMMAND_REGISTRY`,
+			);
+		}
 	});
 
 	test("deriveParseArgsOptions produces flat options for parseArgs", () => {

--- a/tests/unit/command-registry.test.ts
+++ b/tests/unit/command-registry.test.ts
@@ -357,6 +357,12 @@ describe("helper functions", () => {
 		assert.strictEqual(resolveVerbAlias("nonexistent"), "nonexistent");
 	});
 
+	test("resolveVerbAlias treats prototype keys as unknown verbs", () => {
+		assert.strictEqual(resolveVerbAlias("__proto__"), "__proto__");
+		assert.strictEqual(resolveVerbAlias("constructor"), "constructor");
+		assert.strictEqual(resolveVerbAlias("__proto__", "profile"), "__proto__");
+	});
+
 	test("resolveVerbAlias resolves single-target alias", () => {
 		assert.strictEqual(resolveVerbAlias("w"), "watch");
 	});

--- a/tests/unit/command-registry.test.ts
+++ b/tests/unit/command-registry.test.ts
@@ -370,18 +370,8 @@ describe("helper functions", () => {
 	test("resolveVerbAlias disambiguates multi-target alias by resource", () => {
 		// rm → remove when resource is 'profile' (only remove owns profile)
 		assert.strictEqual(resolveVerbAlias("rm", "profile"), "remove");
-	});
-
-	test("resolveVerbAlias disambiguates with dispatch keys when multiple candidates match", () => {
-		// Both remove and unload declare 'plugin' in their resources list.
-		// Without dispatch keys, first match wins (remove).
-		assert.strictEqual(resolveVerbAlias("rm", "plugin"), "remove");
-		// With dispatch keys, prefer the candidate that is actually dispatchable.
-		const dispatchKeys = new Set(["unload:plugin"]);
-		assert.strictEqual(
-			resolveVerbAlias("rm", "plugin", dispatchKeys),
-			"unload",
-		);
+		// rm → unload when resource is 'plugin' (only unload owns plugin)
+		assert.strictEqual(resolveVerbAlias("rm", "plugin"), "unload");
 	});
 
 	test("resolveVerbAlias falls back to first target without resource", () => {

--- a/tests/unit/command-registry.test.ts
+++ b/tests/unit/command-registry.test.ts
@@ -368,15 +368,19 @@ describe("helper functions", () => {
 	});
 
 	test("resolveVerbAlias disambiguates multi-target alias by resource", () => {
-		// rm → remove when resource is 'profile' (remove owns profile)
+		// rm → remove when resource is 'profile' (only remove owns profile)
 		assert.strictEqual(resolveVerbAlias("rm", "profile"), "remove");
-		// rm → unload when resource is 'plugin' and unload owns plugin
-		// (remove also owns plugin, so first match wins — which is remove)
-		// Verify it resolves to a valid verb either way
-		const resolved = resolveVerbAlias("rm", "plugin");
-		assert.ok(
-			resolved === "remove" || resolved === "unload",
-			`expected 'remove' or 'unload', got '${resolved}'`,
+	});
+
+	test("resolveVerbAlias disambiguates with dispatch keys when multiple candidates match", () => {
+		// Both remove and unload declare 'plugin' in their resources list.
+		// Without dispatch keys, first match wins (remove).
+		assert.strictEqual(resolveVerbAlias("rm", "plugin"), "remove");
+		// With dispatch keys, prefer the candidate that is actually dispatchable.
+		const dispatchKeys = new Set(["unload:plugin"]);
+		assert.strictEqual(
+			resolveVerbAlias("rm", "plugin", dispatchKeys),
+			"unload",
 		);
 	});
 

--- a/tests/unit/verb-alias-dispatch.test.ts
+++ b/tests/unit/verb-alias-dispatch.test.ts
@@ -15,12 +15,12 @@ describe("verb alias dispatch (#407)", () => {
 	test("'w' dispatches to watch handler", async () => {
 		// watch requires a valid path — use a non-existent one so the handler
 		// fails fast. The key assertion: the error comes from the watch handler
-		// ("Failed to watch") not from the dispatcher ("Unknown command").
+		// (framework prefix + handler error) not from the dispatcher ("Unknown command").
 		const result = await c8("w", "nonexistent.bpmn");
 		assert.strictEqual(result.status, 1);
 		assert.ok(
-			result.stderr.includes("Failed to watch"),
-			`expected watch handler error, got: ${result.stderr}`,
+			result.stderr.includes("Path does not exist"),
+			`expected watch handler path error, got: ${result.stderr}`,
 		);
 		assert.ok(
 			!result.stderr.includes("Unknown command"),
@@ -32,8 +32,8 @@ describe("verb alias dispatch (#407)", () => {
 		const result = await c8("rm", "profile", "nonexistent-profile");
 		assert.strictEqual(result.status, 1);
 		assert.ok(
-			result.stderr.includes("Failed to remove profile"),
-			`expected remove handler error, got: ${result.stderr}`,
+			result.stderr.includes("not found"),
+			`expected remove handler 'not found' error, got: ${result.stderr}`,
 		);
 		assert.ok(
 			!result.stderr.includes("Unknown command"),
@@ -67,7 +67,7 @@ describe("verb alias dispatch (#407)", () => {
 		const result = await c8("rm", "plugin", "nonexistent-plugin");
 		assert.strictEqual(result.status, 1);
 		assert.ok(
-			result.stderr.includes("Failed to unload plugin"),
+			result.stderr.includes("neither registered nor installed"),
 			`expected unload handler error, got: ${result.stderr}`,
 		);
 		assert.ok(

--- a/tests/unit/verb-alias-dispatch.test.ts
+++ b/tests/unit/verb-alias-dispatch.test.ts
@@ -50,6 +50,18 @@ describe("verb alias dispatch (#407)", () => {
 		);
 	});
 
+	test("'rm plugin' dispatches to unload handler", async () => {
+		// Both remove and unload declare 'plugin' in their resources, but only
+		// unload:plugin has a dispatch entry. Dispatch-key tiebreaking must
+		// route rm plugin → unload (not remove, which has no plugin handler).
+		const result = await c8("rm", "plugin", "nonexistent-plugin");
+		assert.strictEqual(result.status, 1);
+		assert.ok(
+			!result.stderr.includes("Unknown command"),
+			"'rm plugin' should not produce 'Unknown command'",
+		);
+	});
+
 	test("'w --help' exits 0 (not rejected as unknown command)", async () => {
 		const result = await c8("w", "--help");
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);

--- a/tests/unit/verb-alias-dispatch.test.ts
+++ b/tests/unit/verb-alias-dispatch.test.ts
@@ -1,0 +1,57 @@
+/**
+ * End-to-end tests that verb aliases dispatch correctly (#407).
+ *
+ * Before this fix, alias verbs (w, rm) were rejected with
+ * "Unknown command" because the dispatch key was built from the raw
+ * alias instead of the canonical verb. These tests prove that alias
+ * verbs now reach their handlers.
+ */
+
+import assert from "node:assert";
+import { describe, test } from "node:test";
+import { c8 } from "../utils/cli.ts";
+
+describe("verb alias dispatch (#407)", () => {
+	test("'w' dispatches to watch handler", async () => {
+		// watch requires a valid path — use a non-existent one so the handler
+		// fails fast. The key assertion: the error comes from the watch handler
+		// ("Failed to watch") not from the dispatcher ("Unknown command").
+		const result = await c8("w", "nonexistent.bpmn");
+		assert.strictEqual(result.status, 1);
+		assert.ok(
+			result.stderr.includes("Failed to watch"),
+			`expected watch handler error, got: ${result.stderr}`,
+		);
+		assert.ok(
+			!result.stderr.includes("Unknown command"),
+			"verb alias 'w' should not produce 'Unknown command'",
+		);
+	});
+
+	test("'rm profile' dispatches to remove handler", async () => {
+		const result = await c8("rm", "profile", "nonexistent-profile");
+		assert.strictEqual(result.status, 1);
+		assert.ok(
+			result.stderr.includes("Failed to remove profile"),
+			`expected remove handler error, got: ${result.stderr}`,
+		);
+		assert.ok(
+			!result.stderr.includes("Unknown command"),
+			"verb alias 'rm' should not produce 'Unknown command'",
+		);
+	});
+
+	test("'rm' without resource shows verb help (not unknown command)", async () => {
+		// rm requires a resource — should show available resources, not "Unknown command"
+		const result = await c8("rm");
+		assert.ok(
+			!result.stderr.includes("Unknown command"),
+			"verb alias 'rm' without resource should not produce 'Unknown command'",
+		);
+	});
+
+	test("'w --help' exits 0 (not rejected as unknown command)", async () => {
+		const result = await c8("w", "--help");
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+	});
+});

--- a/tests/unit/verb-alias-dispatch.test.ts
+++ b/tests/unit/verb-alias-dispatch.test.ts
@@ -42,20 +42,34 @@ describe("verb alias dispatch (#407)", () => {
 	});
 
 	test("'rm' without resource shows verb help (not unknown command)", async () => {
-		// rm requires a resource — should show available resources, not "Unknown command"
+		// rm requires a resource — should show available resources, not "Unknown command".
+		// Help text is written to stdout, so check combined output.
 		const result = await c8("rm");
+		assert.strictEqual(
+			result.status,
+			1,
+			`unexpected exit code: ${result.stderr}`,
+		);
+		const combined = result.stdout + result.stderr;
 		assert.ok(
-			!result.stderr.includes("Unknown command"),
+			combined.includes("resources"),
+			`expected verb help with resource list, got: ${combined}`,
+		);
+		assert.ok(
+			!combined.includes("Unknown command"),
 			"verb alias 'rm' without resource should not produce 'Unknown command'",
 		);
 	});
 
 	test("'rm plugin' dispatches to unload handler", async () => {
-		// Both remove and unload declare 'plugin' in their resources, but only
-		// unload:plugin has a dispatch entry. Dispatch-key tiebreaking must
-		// route rm plugin → unload (not remove, which has no plugin handler).
+		// Only unload declares 'plugin' in its resources — rm plugin resolves
+		// unambiguously to unload.
 		const result = await c8("rm", "plugin", "nonexistent-plugin");
 		assert.strictEqual(result.status, 1);
+		assert.ok(
+			result.stderr.includes("Failed to unload plugin"),
+			`expected unload handler error, got: ${result.stderr}`,
+		);
 		assert.ok(
 			!result.stderr.includes("Unknown command"),
 			"'rm plugin' should not produce 'Unknown command'",


### PR DESCRIPTION
Closes #407

## Problem

Verb aliases (`w`, `rm`, `menu`) were not resolved before building the dispatch key in `index.ts`. The dispatch map (`COMMAND_DISPATCH`) only contains canonical verb keys (e.g. `watch:`, `remove:profile`), so alias verbs produced "Unknown command" errors at runtime.

For example:
- `c8ctl w .` → "Unknown command: w" (should dispatch to `watch`)
- `c8ctl rm profile test` → "Unknown command: rm profile" (should dispatch to `remove`)

The `menu` alias worked only because it was hardcoded in the help/version early-exit check.

## Fix

- **`src/command-registry.ts`**: Add `resolveVerbAlias(verb, resource?)` that maps alias verbs to their canonical form. For single-target aliases (`w` → `watch`), returns the target directly. For multi-target aliases (`rm` → `remove`/`unload`), disambiguates by checking which target's `resources` list includes the given resource, falling back to the first target.

- **`src/index.ts`**: Rename the parsed verb to `rawVerb` and derive `verb = resolveVerbAlias(rawVerb, resource)` after the help/version early-exits but before plugin lookup and dispatch. Use `rawVerb` for `sliceArgvAfterVerb` (which scans `process.argv` for the literal user input).

## Tests

- **6 unit tests** in `command-registry.test.ts` for `resolveVerbAlias()`: canonical passthrough, unknown passthrough, single-target resolution, multi-target disambiguation, fallback behavior, and a class-scoped guard ensuring every alias resolves to a canonical registry entry.

- **4 end-to-end tests** in `verb-alias-dispatch.test.ts`: `w` dispatches to the watch handler, `rm profile` dispatches to the remove handler, `rm` without a resource shows verb help (not "Unknown command"), and `w --help` exits 0.