### PR TITLE
ci: add Slack notifications for release failures and community issues

### DIFF
--- a/.github/workflows/community-notify.yml
+++ b/.github/workflows/community-notify.yml
@@ -1,0 +1,18 @@
+name: Community & Dependabot Notifications
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions: {}
+
+jobs:
+  notify:
+    uses: camunda/sdk-infra/.github/workflows/sdk-slack-community-notify.yml@v1
+    with:
+      repo-name: c8ctl
+      mention-group: ${{ vars.SLACK_MENTION_GROUP }}
+    secrets:
+      slack-webhook-url: ${{ secrets.SLACK_SDK_ALERTS }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,7 @@ jobs:
   notify-release-failure:
     needs: [test, release]
     if: ${{ always() && contains(needs.*.result, 'failure') }}
+    permissions: {}
     uses: camunda/sdk-infra/.github/workflows/sdk-slack-notify.yml@v1
     with:
       repo-name: c8ctl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,3 +131,14 @@ jobs:
           # Disabled while repo is private. See: https://github.com/camunda/c8ctl/issues/12
           NPM_CONFIG_PROVENANCE: 'false' 
         run: NODE_AUTH_TOKEN="" npx semantic-release
+
+  notify-release-failure:
+    needs: [test, release]
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    uses: camunda/sdk-infra/.github/workflows/sdk-slack-notify.yml@v1
+    with:
+      repo-name: c8ctl
+      workflow-name: Release
+      mention-group: ${{ vars.SLACK_MENTION_GROUP }}
+    secrets:
+      slack-webhook-url: ${{ secrets.SLACK_SDK_ALERTS }}


### PR DESCRIPTION
Adds Slack notifications to c8ctl via the shared `sdk-infra` reusable workflows.

## Changes

### Release failure notifications (`release.yml`)
- Added `notify-release-failure` job that fires when any pipeline stage (`test` or `release`) fails
- Uses `camunda/sdk-infra/.github/workflows/sdk-slack-notify.yml@v1`
- Includes `@group` mention via `SLACK_MENTION_GROUP` variable

### Community & Dependabot notifications (`community-notify.yml`)
- New workflow triggered on `issues: [opened]` and `pull_request_target: [opened]`
- Uses `camunda/sdk-infra/.github/workflows/sdk-slack-community-notify.yml@v1`
- Community issues/PRs: urgent notification with `@group` mention
- Dependabot PRs: non-urgent notification (no mention)
- Maintainer activity: skipped (no notification)

## Setup
- `SLACK_SDK_ALERTS` secret (webhook URL) ✅
- `SLACK_MENTION_GROUP` variable (Slack group ID) ✅