### PR TITLE
test: isolate spawned CLI from ambient color-forcing env vars

### DIFF
--- a/tests/unit/bpmn-plugin.test.ts
+++ b/tests/unit/bpmn-plugin.test.ts
@@ -473,6 +473,7 @@ describe("CLI behavioural: bpmn lint output formatting", () => {
 				["--experimental-strip-types", CLI, "bpmn", "lint", file],
 				{
 					cwd: REPO_ROOT,
+					color: true,
 					env: { ...process.env, FORCE_COLOR: "1", C8CTL_DATA_DIR: dataDir },
 				},
 			);
@@ -599,6 +600,7 @@ describe("CLI behavioural: bpmn lint ruleset routing", () => {
 				],
 				{
 					cwd: externalDir,
+					color: true,
 					env: { ...process.env, FORCE_COLOR: "1" },
 				},
 			);

--- a/tests/unit/spawn-color-isolation.test.ts
+++ b/tests/unit/spawn-color-isolation.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Guard for the test spawn helpers' color isolation.
+ *
+ * Regression context: a developer who exports `FORCE_COLOR` in their shell
+ * used to break ~11 unit tests (bpmn-plugin, element-template). Those tests
+ * spawn the CLI and match plain-text output (e.g. `/\swarning\s/`,
+ * `^\s+ID\s+…`). With `FORCE_COLOR` inherited via `{ ...process.env }`,
+ * `node:util`'s `styleText` wrapped the values in ANSI escapes and the
+ * matches failed. CI never sets `FORCE_COLOR`, so it stayed green and the
+ * failure only ever surfaced locally.
+ *
+ * The fix neutralises color-forcing variables at the spawn layer
+ * (`resolveSpawnEnv` in tests/utils/spawn.ts) unless a caller explicitly opts
+ * in with `color: true`. These tests pin that contract for the whole class of
+ * spawn-based assertions, not just the original instances. The probe is a
+ * tiny `node -e` script using `styleText` directly, so the guard does not
+ * depend on any particular CLI command's formatting.
+ */
+
+import assert from "node:assert";
+import { afterEach, beforeEach, describe, test } from "node:test";
+import { asyncSpawn } from "../utils/spawn.ts";
+
+// `node -e` probe: emit a styled string. styleText only adds ANSI escapes when
+// the child stream reports color support, which is governed by the child's
+// FORCE_COLOR / NO_COLOR environment.
+const PROBE = [
+	"-e",
+	"const { styleText } = require('node:util');" +
+		"process.stdout.write(styleText('red', 'PROBE'));",
+];
+
+// Build the ESC-sequence matcher from char codes so biome's
+// noControlCharactersInRegex rule doesn't flag a literal control character.
+const ansiRegex = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]+m`);
+
+describe("spawn helpers: color isolation (regression guard)", () => {
+	const saved = {
+		FORCE_COLOR: process.env.FORCE_COLOR,
+		CLICOLOR_FORCE: process.env.CLICOLOR_FORCE,
+		CLICOLOR: process.env.CLICOLOR,
+		NO_COLOR: process.env.NO_COLOR,
+	};
+
+	beforeEach(() => {
+		// Simulate a developer shell that forces color on.
+		process.env.FORCE_COLOR = "1";
+		process.env.CLICOLOR_FORCE = "1";
+		delete process.env.NO_COLOR;
+	});
+
+	afterEach(() => {
+		for (const [key, value] of Object.entries(saved)) {
+			if (value === undefined) {
+				delete process.env[key];
+			} else {
+				process.env[key] = value;
+			}
+		}
+	});
+
+	test("default spawn strips ambient FORCE_COLOR — output is plain", async () => {
+		const result = await asyncSpawn("node", PROBE);
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		assert.ok(
+			!ansiRegex.test(result.stdout),
+			`output should contain no ANSI escapes, got: ${JSON.stringify(result.stdout)}`,
+		);
+		assert.ok(
+			result.stdout.includes("PROBE"),
+			`output should still contain the plain text, got: ${JSON.stringify(result.stdout)}`,
+		);
+	});
+
+	test("default spawn strips FORCE_COLOR even when caller spreads process.env", async () => {
+		// This is the exact shape the previously-failing tests used.
+		const result = await asyncSpawn("node", PROBE, { env: { ...process.env } });
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		assert.ok(
+			!ansiRegex.test(result.stdout),
+			`output should contain no ANSI escapes, got: ${JSON.stringify(result.stdout)}`,
+		);
+	});
+
+	test("color: true preserves caller's FORCE_COLOR — escapes are emitted", async () => {
+		const result = await asyncSpawn("node", PROBE, {
+			color: true,
+			env: { ...process.env, FORCE_COLOR: "1" },
+		});
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		assert.ok(
+			ansiRegex.test(result.stdout),
+			`output should carry ANSI escapes when color is opted in, got: ${JSON.stringify(result.stdout)}`,
+		);
+	});
+});

--- a/tests/utils/spawn.ts
+++ b/tests/utils/spawn.ts
@@ -54,6 +54,48 @@ function assertNoControlChars(value: string, fieldName: string): void {
 	}
 }
 
+/**
+ * Options accepted by the spawn helpers.
+ *
+ * `color` opts the child *in* to colored output. By default the helpers
+ * neutralise color-forcing environment variables (see {@link resolveSpawnEnv})
+ * so output is deterministic regardless of the developer's shell. Set
+ * `color: true` only for the rare test that asserts ANSI escapes are present.
+ */
+export interface SpawnOptions {
+	cwd?: string;
+	env?: NodeJS.ProcessEnv;
+	timeout?: number;
+	color?: boolean;
+}
+
+/**
+ * Build the environment passed to a spawned child.
+ *
+ * Unless `color: true` is requested, this strips the color-forcing variables
+ * (`FORCE_COLOR`, `CLICOLOR_FORCE`, `CLICOLOR`) inherited from the caller's
+ * shell and sets `NO_COLOR=1`. `node:util`'s `styleText` (and the CLI's
+ * formatters built on it) only emit ANSI escapes when the stream reports color
+ * support; a developer who exports `FORCE_COLOR` would otherwise force color
+ * into the piped child and break assertions that match plain text (e.g.
+ * `/\swarning\s/` or `^\s+ID\s+…`). CI doesn't set those variables, so this
+ * keeps local runs deterministic and aligned with CI.
+ *
+ * When `color: true`, the caller's env is passed through untouched so tests
+ * that explicitly set `FORCE_COLOR` can assert on the escapes.
+ */
+function resolveSpawnEnv(options?: SpawnOptions): NodeJS.ProcessEnv {
+	const base = options?.env ?? process.env;
+	if (options?.color) {
+		return { ...base };
+	}
+	const env: NodeJS.ProcessEnv = { ...base, NO_COLOR: "1" };
+	delete env.FORCE_COLOR;
+	delete env.CLICOLOR_FORCE;
+	delete env.CLICOLOR;
+	return env;
+}
+
 function validateSpawnInputs(
 	command: string,
 	args: string[],
@@ -104,12 +146,14 @@ export interface SpawnResult {
 export async function asyncSpawn(
 	command: string,
 	args: string[],
-	options?: { cwd?: string; env?: NodeJS.ProcessEnv; timeout?: number },
+	options?: SpawnOptions,
 ): Promise<SpawnResult> {
-	validateSpawnInputs(command, args, options);
+	const env = resolveSpawnEnv(options);
+	validateSpawnInputs(command, args, { ...options, env });
 	try {
 		const { stdout, stderr } = await execFile(command, args, {
-			...options,
+			cwd: options?.cwd,
+			env,
 			maxBuffer: 10 * 1024 * 1024,
 			...(options?.timeout !== undefined ? { timeout: options.timeout } : {}),
 		});
@@ -135,13 +179,14 @@ export async function asyncSpawnWithStdin(
 	command: string,
 	args: string[],
 	writeStdin: (stdin: NodeJS.WritableStream) => void | Promise<void>,
-	options?: { cwd?: string; env?: NodeJS.ProcessEnv; timeout?: number },
+	options?: SpawnOptions,
 ): Promise<SpawnResult> {
-	validateSpawnInputs(command, args, options);
+	const env = resolveSpawnEnv(options);
+	validateSpawnInputs(command, args, { ...options, env });
 	const child = spawn(command, args, {
 		stdio: ["pipe", "pipe", "pipe"],
 		cwd: options?.cwd,
-		env: options?.env,
+		env,
 		...(options?.timeout !== undefined ? { timeout: options.timeout } : {}),
 	});
 


### PR DESCRIPTION
Pinned diagnosis of the local-only `npm test` failures (~11 tests in `bpmn-plugin` / `element-template`) and the durable fix.

## Root cause

Spawn-based unit tests assert against **plain-text** CLI output:

- `bpmn-plugin.test.ts` → `/\swarning\s/` (whitespace must hug `warning`)
- `element-template.test.ts` → `^\s+ID\s+io\.camunda…`, `.includes("HTTP endpoint (endpoint)")`, etc.

The test helpers forward the full environment to the spawned CLI via `{ ...process.env }` / `env: process.env`. `node:util`'s `styleText` emits ANSI escapes whenever the child stream reports color support — which it does when `FORCE_COLOR` (or `CLICOLOR_FORCE`) is exported in the developer's shell. With color on, e.g. the severity cell becomes `ESC[33mwarning ESC[39m`, so `\swarning\s` no longer matches and the label/regex assertions fail.

## Why CI did not gate it

CI never sets `FORCE_COLOR`/`CLICOLOR_FORCE`; the child stdout is piped → `styleText` emits plain text → assertions pass. The failure only surfaces in shells that force color on, which is purely local. Nothing actually regressed on `main`.

**Reproduction:** `FORCE_COLOR=1 npm run test:unit` reproduces exactly 1 bpmn + 10 element-template failures; unset, the suite is green.

## Fix

Neutralise color-forcing variables at the spawn layer (`resolveSpawnEnv` in `tests/utils/spawn.ts`): by default strip `FORCE_COLOR`/`CLICOLOR_FORCE`/`CLICOLOR` and set `NO_COLOR=1`, so spawned-CLI output is deterministic regardless of the developer's shell and aligned with CI. A new `color: true` opt-in preserves the caller's color env for the two tests that intentionally assert ANSI escapes (`bpmn-plugin.test.ts`).

This closes the whole **class** of spawn-based plain-text assertions, not just the original instances.

## Guard

`tests/unit/spawn-color-isolation.test.ts` pins the contract:

- ambient `FORCE_COLOR` cannot leak color into a default spawn (incl. the `{ ...process.env }` shape the failing tests used);
- `color: true` still preserves the escapes.

## Verification

- `FORCE_COLOR=1 npm run test:unit` → **1776 pass, 0 fail** (was 11 failing)
- `npm run test:unit` (no color) → green
- `npm run typecheck` → clean
- `npx biome check` on changed files → clean
