### PR TITLE
refactor(src): per-layer barrels + module encapsulation guard (#424)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,6 +5,9 @@
 #    no-unsafe-type-assertion plugin applies to both.
 # 2. Run tsc --noEmit -p tsconfig.check.json to catch type/parse errors in
 #    both src/ and tests/ before they hit CI.
+# 3. When src/ files are staged, run the architectural layering guard so
+#    cross-/intra-layer import violations (issue #414/#424) are caught at
+#    commit time rather than in CI.
 
 # --- Collect staged src files ---
 staged_src=()
@@ -87,6 +90,26 @@ EOF
   [ $TSC_EXIT -ne 0 ] && EXIT_CODE=$TSC_EXIT
 elif [ ${#all_staged[@]} -gt 0 ]; then
   echo "pre-commit: Skipping tsc — not installed locally. Run npm install first."
+fi
+
+# --- Architectural layering guard ---
+# When any src/ file is staged, verify the layered-architecture import
+# boundaries (issues #414 / #424) before the change can leak into CI. The guard
+# is a fast (~1s) whole-tree structural scan, so — unlike the scoped tsc step
+# above — it inspects the working-tree src/, not just the staged set. The
+# dirty-file check above guarantees staged files match disk; only unstaged WIP
+# in *other* src files could surface here, which is an acceptable trade for
+# catching layering regressions at commit time instead of in CI. Needs the
+# TypeScript compiler API, so it shares the tsc availability gate.
+if [ ${#staged_src[@]} -gt 0 ] && npx --no-install tsc --version >/dev/null 2>&1; then
+  guard_output=$(node --experimental-strip-types --test tests/unit/layering-import-boundary.test.ts 2>&1)
+  if [ $? -ne 0 ]; then
+    echo "pre-commit: architectural layering guard failed (npm run check:layering):"
+    echo "$guard_output"
+    EXIT_CODE=1
+  fi
+elif [ ${#staged_src[@]} -gt 0 ]; then
+  echo "pre-commit: Skipping layering guard — tsc not installed locally. Run npm install first."
 fi
 
 exit $EXIT_CODE

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,15 @@ composition root (src/index.ts, src/command-dispatch.ts)  →  commands  →  fr
 
 This is guarded by [`tests/unit/layering-import-boundary.test.ts`](tests/unit/layering-import-boundary.test.ts). The guard classifies a file by its **first** path segment, so sub-directories (`framework/plugins/`, `framework/ui/`, `utils/shared/`, `utils/command-local/`) inherit their parent layer — sub-grouping is free w.r.t. the guard. The composition root is pinned to an explicit allow-list (`src/index.ts`, `src/command-dispatch.ts`); any *new* top-level `src/*.ts` file fails the guard until it is deliberately classified.
 
+##### Per-layer barrels (module encapsulation, #424)
+
+The three barreled layers — `core`, `utils`, `framework` — each expose a single public entry point, `<layer>/index.ts` (`export *` over their internal files). The same guard enforces two further rules:
+
+- **Rule A — cross-layer imports go through the barrel.** A file importing *into* a barreled layer must target `../core/index.ts`, never a deep file like `../core/logger.ts`. This holds for `commands/**` and the composition root alike.
+- **Rule B — intra-layer imports stay direct.** A file *within* a barreled layer imports its siblings by direct path (`./logger.ts`), never via its own barrel — this keeps module-eval order obvious and avoids self-referential cycles. (The barrel file re-exporting siblings via `./file.ts` is itself an intra-layer direct import, so it is allowed.)
+
+`commands/` is deliberately **not** barreled: nothing imports it cross-layer except the composition root, which is allowed to reach deep command files (it eager-loads every handler in `command-dispatch.ts`). To widen a barreled layer's public surface, add the symbol's source file to that layer's `index.ts`.
+
 Two conventions worth internalising:
 
 - **`utils/shared/` vs `utils/command-local/`** — the split axis is "command-agnostic reusable leaf" vs "the guts of one command". `command-local` helpers stay test-visible (not moved into `commands/**`) deliberately: their logic is pure and cross-platform and is better covered by direct unit tests than by coarser `c8()` subprocess tests.
@@ -331,7 +340,7 @@ Every command handler in `src/commands/**` follows the same shape. Pattern-match
 #### Canonical shape
 
 ```ts
-import { defineCommand, dryRun } from "../framework/command-framework.ts";
+import { defineCommand, dryRun } from "../framework/index.ts";
 
 export const myCommand = defineCommand("myverb", "my-resource", async (ctx, flags, args) => {
   const { client, profile, logger } = ctx;
@@ -516,7 +525,7 @@ Create a handler file in `src/commands/`:
 
 ```typescript
 // src/commands/my-resource.ts
-import { defineCommand, dryRun } from "../framework/command-framework.ts";
+import { defineCommand, dryRun } from "../framework/index.ts";
 
 export const myverbMyResourceCommand = defineCommand(
   "myverb",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,8 +193,9 @@ Never skip the lint and type-check steps before pushing.
 
 - `npm run typecheck` — runs `tsc --noEmit -p tsconfig.check.json` over `src/` and `tests/`
 - `npx biome check --fix` — lints and formats `src/` and `tests/` per `biome.json` (includes the `no-unsafe-type-assertion` plugin)
+- `npm run check:layering` — runs the architectural layering guard (`tests/unit/layering-import-boundary.test.ts`) in isolation: layer-direction rules plus the per-layer barrel rules (#414/#424). Fast (~1s); use it to check import boundaries without running the whole unit suite.
 - `npm run test:unit` — fast unit tests (no live Camunda required)
-- `.githooks/pre-commit` — on commit, runs biome on staged files and typechecks a temporary tsconfig scoped to the staged set (transitive imports are still resolved). Skips biome or tsc individually if not installed locally.
+- `.githooks/pre-commit` — on commit, runs biome on staged files and typechecks a temporary tsconfig scoped to the staged set (transitive imports are still resolved). When any `src/` file is staged it also runs the layering guard (`check:layering`) against the working tree, so import-boundary regressions are caught at commit time instead of in CI. Skips biome, tsc, or the guard individually if the toolchain is not installed locally.
 
 #### Test process isolation — `--experimental-test-isolation=none` for integration tests
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "lint": "biome check src/ tests/ scripts/ default-plugins/",
     "lint:src": "biome check src/ scripts/",
     "typecheck": "tsc --noEmit -p tsconfig.check.json",
+  "check:layering": "node --experimental-strip-types --test tests/unit/layering-import-boundary.test.ts",
     "clean": "node -e \"require('fs').rmSync('dist',{recursive:true,force:true})\"",
     "copy-plugins": "node -e \"const fs=require('fs');const src='default-plugins';const dest='dist/default-plugins';if(fs.existsSync(src)){fs.cpSync(src,dest,{recursive:true,filter:(s)=>!s.endsWith('.ts')})}\"",
     "copy-templates": "node -e \"const fs=require('fs');const src='src/templates';const dest='dist/templates';if(fs.existsSync(src)){fs.cpSync(src,dest,{recursive:true})}\"",

--- a/src/command-dispatch.ts
+++ b/src/command-dispatch.ts
@@ -119,7 +119,7 @@ import {
 } from "./commands/user-tasks.ts";
 import { setVariableCommand } from "./commands/variables.ts";
 import { watchCommand } from "./commands/watch.ts";
-import type { AnyCommandHandler } from "./framework/command-framework.ts";
+import type { AnyCommandHandler } from "./framework/index.ts";
 
 /**
  * Dispatch map keyed by "verb:resource".

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -8,11 +8,11 @@
  * verb at runtime.
  */
 
-import { defineCommand } from "../framework/command-framework.ts";
 import {
+	defineCommand,
 	installCompletion,
 	showCompletion,
-} from "../framework/ui/completion.ts";
+} from "../framework/index.ts";
 
 /**
  * `completion` verb dispatcher.

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -10,11 +10,11 @@
  * uses for change-triggered re-deploys.
  */
 
-import { defineCommand, dryRun } from "../framework/command-framework.ts";
+import { defineCommand, dryRun } from "../framework/index.ts";
 import {
 	ALL_DEPLOYABLE_EXTENSIONS,
 	DEPLOYABLE_EXTENSIONS,
-} from "../utils/shared/resource-extensions.ts";
+} from "../utils/index.ts";
 import {
 	collectResourcesForPaths,
 	deployResources,

--- a/src/commands/forms.ts
+++ b/src/commands/forms.ts
@@ -7,12 +7,12 @@ import {
 	ProcessDefinitionKey,
 	UserTaskKey,
 } from "@camunda8/orchestration-cluster-api";
-import { isRecord } from "../core/logger.ts";
+import { isRecord } from "../core/index.ts";
 import {
 	type CommandResult,
 	defineCommand,
 	dryRun,
-} from "../framework/command-framework.ts";
+} from "../framework/index.ts";
 
 /** Extract HTTP status code from an unknown error (SDK errors expose statusCode or status). */
 function getErrorStatus(error: unknown): number | undefined {

--- a/src/commands/helpers/deploy-helpers.ts
+++ b/src/commands/helpers/deploy-helpers.ts
@@ -16,18 +16,22 @@ import {
 } from "node:fs";
 import { basename, dirname, extname, join, relative, resolve } from "node:path";
 import { TenantId } from "@camunda8/orchestration-cluster-api";
-import { createClient } from "../../core/client.ts";
-import { resolveTenantId } from "../../core/config.ts";
-import { normalizeToError, SilentError } from "../../core/errors.ts";
-import { getLogger, isRecord } from "../../core/logger.ts";
-import { c8ctl } from "../../core/runtime.ts";
 import {
+	c8ctl,
+	createClient,
+	getLogger,
+	isRecord,
+	normalizeToError,
+	resolveTenantId,
+	SilentError,
+} from "../../core/index.ts";
+import {
+	DEPLOYABLE_EXTENSIONS,
 	type Ignore,
 	isIgnored,
 	loadIgnoreRules,
 	resolveIgnoreBaseDir,
-} from "../../utils/shared/ignore.ts";
-import { DEPLOYABLE_EXTENSIONS } from "../../utils/shared/resource-extensions.ts";
+} from "../../utils/index.ts";
 
 const PROCESS_APPLICATION_FILE = ".process-application";
 

--- a/src/commands/identity-authorizations.ts
+++ b/src/commands/identity-authorizations.ts
@@ -10,14 +10,14 @@ import {
 	type ResourceTypeEnum,
 	ResourceTypeEnum as ResourceTypeValues,
 } from "@camunda8/orchestration-cluster-api";
-import { fetchAllPages } from "../core/client.ts";
-import { sortTableData } from "../core/logger.ts";
-import { defineCommand, dryRun } from "../framework/command-framework.ts";
+import { fetchAllPages, sortTableData } from "../core/index.ts";
 import {
+	defineCommand,
+	dryRun,
 	requireCsvEnum,
 	requireEnum,
 	requireOption,
-} from "../framework/command-validation.ts";
+} from "../framework/index.ts";
 
 /**
  * List all authorizations

--- a/src/commands/identity-groups.ts
+++ b/src/commands/identity-groups.ts
@@ -2,9 +2,8 @@
  * Identity group commands
  */
 
-import { fetchAllPages } from "../core/client.ts";
-import { sortTableData } from "../core/logger.ts";
-import { defineCommand, dryRun } from "../framework/command-framework.ts";
+import { fetchAllPages, sortTableData } from "../core/index.ts";
+import { defineCommand, dryRun } from "../framework/index.ts";
 import { toStringFilter } from "./search.ts";
 
 /**

--- a/src/commands/identity-mapping-rules.ts
+++ b/src/commands/identity-mapping-rules.ts
@@ -2,9 +2,8 @@
  * Identity mapping rule commands
  */
 
-import { fetchAllPages } from "../core/client.ts";
-import { sortTableData } from "../core/logger.ts";
-import { defineCommand, dryRun } from "../framework/command-framework.ts";
+import { fetchAllPages, sortTableData } from "../core/index.ts";
+import { defineCommand, dryRun } from "../framework/index.ts";
 
 /**
  * List all mapping rules

--- a/src/commands/identity-roles.ts
+++ b/src/commands/identity-roles.ts
@@ -2,9 +2,8 @@
  * Identity role commands
  */
 
-import { fetchAllPages } from "../core/client.ts";
-import { sortTableData } from "../core/logger.ts";
-import { defineCommand, dryRun } from "../framework/command-framework.ts";
+import { fetchAllPages, sortTableData } from "../core/index.ts";
+import { defineCommand, dryRun } from "../framework/index.ts";
 
 /**
  * List all roles

--- a/src/commands/identity-tenants.ts
+++ b/src/commands/identity-tenants.ts
@@ -2,9 +2,8 @@
  * Identity tenant commands
  */
 
-import { fetchAllPages } from "../core/client.ts";
-import { sortTableData } from "../core/logger.ts";
-import { defineCommand, dryRun } from "../framework/command-framework.ts";
+import { fetchAllPages, sortTableData } from "../core/index.ts";
+import { defineCommand, dryRun } from "../framework/index.ts";
 
 /**
  * List all tenants

--- a/src/commands/identity-users.ts
+++ b/src/commands/identity-users.ts
@@ -2,9 +2,8 @@
  * Identity user commands
  */
 
-import { fetchAllPages } from "../core/client.ts";
-import { sortTableData } from "../core/logger.ts";
-import { defineCommand, dryRun } from "../framework/command-framework.ts";
+import { fetchAllPages, sortTableData } from "../core/index.ts";
+import { defineCommand, dryRun } from "../framework/index.ts";
 import { toStringFilter } from "./search.ts";
 
 /**

--- a/src/commands/identity.ts
+++ b/src/commands/identity.ts
@@ -3,11 +3,13 @@
  */
 
 import { TenantId, Username } from "@camunda8/orchestration-cluster-api";
-import { createClient } from "../core/client.ts";
-import { resolveClusterConfig } from "../core/config.ts";
-import { getLogger } from "../core/logger.ts";
-import { c8ctl } from "../core/runtime.ts";
-import { defineCommand } from "../framework/command-framework.ts";
+import {
+	c8ctl,
+	createClient,
+	getLogger,
+	resolveClusterConfig,
+} from "../core/index.ts";
+import { defineCommand } from "../framework/index.ts";
 
 export {
 	createIdentityAuthorizationCommand,

--- a/src/commands/incidents.ts
+++ b/src/commands/incidents.ts
@@ -2,9 +2,9 @@
  * Incident commands
  */
 
-import { fetchAllPages } from "../core/client.ts";
-import { defineCommand, dryRun } from "../framework/command-framework.ts";
-import { buildDateFilter, parseBetween } from "../utils/shared/date-filter.ts";
+import { fetchAllPages } from "../core/index.ts";
+import { defineCommand, dryRun } from "../framework/index.ts";
+import { buildDateFilter, parseBetween } from "../utils/index.ts";
 
 /**
  * List incidents

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -3,9 +3,9 @@
  */
 
 import { TenantId } from "@camunda8/orchestration-cluster-api";
-import { fetchAllPages } from "../core/client.ts";
-import { defineCommand, dryRun } from "../framework/command-framework.ts";
-import { buildDateFilter, parseBetween } from "../utils/shared/date-filter.ts";
+import { fetchAllPages } from "../core/index.ts";
+import { defineCommand, dryRun } from "../framework/index.ts";
+import { buildDateFilter, parseBetween } from "../utils/index.ts";
 
 /**
  * List jobs

--- a/src/commands/mcp-proxy.ts
+++ b/src/commands/mcp-proxy.ts
@@ -10,16 +10,15 @@ import {
 	CallToolRequestSchema,
 	ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { createClient } from "../core/client.ts";
-import { normalizeToError } from "../core/errors.ts";
-import { Logger, type LogWriter } from "../core/logger.ts";
-import { c8ctl } from "../core/runtime.ts";
-import { defineCommand } from "../framework/command-framework.ts";
-import { getVersion } from "../framework/ui/help.ts";
 import {
-	createCamundaFetch,
-	normalizeRemoteMcpUrl,
-} from "../utils/command-local/mcp-proxy-helpers.ts";
+	c8ctl,
+	createClient,
+	Logger,
+	type LogWriter,
+	normalizeToError,
+} from "../core/index.ts";
+import { defineCommand, getVersion } from "../framework/index.ts";
+import { createCamundaFetch, normalizeRemoteMcpUrl } from "../utils/index.ts";
 
 /**
  * MCP Proxy that bridges STDIO (local) to HTTP (remote) with Camunda authentication.

--- a/src/commands/messages.ts
+++ b/src/commands/messages.ts
@@ -3,8 +3,8 @@
  */
 
 import { TenantId } from "@camunda8/orchestration-cluster-api";
-import { resolveTenantId } from "../core/config.ts";
-import { defineCommand, dryRun } from "../framework/command-framework.ts";
+import { resolveTenantId } from "../core/index.ts";
+import { defineCommand, dryRun } from "../framework/index.ts";
 
 /**
  * Publish message

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -6,13 +6,13 @@
  * unit-tested without violating the test→commands import boundary (#291).
  */
 
-import { resolveClusterConfig } from "../core/config.ts";
-import { defineCommand } from "../framework/command-framework.ts";
+import { resolveClusterConfig } from "../core/index.ts";
+import { defineCommand } from "../framework/index.ts";
 import {
 	deriveAppUrl,
 	openUrl,
 	validateOpenAppOptions,
-} from "../utils/command-local/open-helpers.ts";
+} from "../utils/index.ts";
 
 // ─── defineCommand ───────────────────────────────────────────────────────────
 

--- a/src/commands/plugins.ts
+++ b/src/commands/plugins.ts
@@ -6,26 +6,24 @@ import { execFileSync } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { ensurePluginsDir } from "../core/config.ts";
-import { handleCommandError } from "../core/errors.ts";
-import { getLogger } from "../core/logger.ts";
-import { defineCommand } from "../framework/command-framework.ts";
 import {
-	clearLoadedPlugins,
-	getLoadedPluginSummaries,
-	getPluginCollisions,
-} from "../framework/plugins/plugin-loader.ts";
+	ensurePluginsDir,
+	getLogger,
+	handleCommandError,
+} from "../core/index.ts";
 import {
 	addPluginToRegistry,
+	clearLoadedPlugins,
+	defineCommand,
+	getInstalledPluginVersion,
+	getLoadedPluginSummaries,
+	getPluginCollisions,
 	getPluginEntry,
 	getRegisteredPlugins,
+	getVersionFromSource,
 	isPluginRegistered,
 	removePluginFromRegistry,
-} from "../framework/plugins/plugin-registry.ts";
-import {
-	getInstalledPluginVersion,
-	getVersionFromSource,
-} from "../framework/plugins/plugin-version.ts";
+} from "../framework/index.ts";
 
 export { getInstalledPluginVersion, getVersionFromSource };
 

--- a/src/commands/process-definitions.ts
+++ b/src/commands/process-definitions.ts
@@ -2,8 +2,8 @@
  * Process definition commands
  */
 
-import { fetchAllPages } from "../core/client.ts";
-import { defineCommand, dryRun } from "../framework/command-framework.ts";
+import { fetchAllPages } from "../core/index.ts";
+import { defineCommand, dryRun } from "../framework/index.ts";
 
 // ─── get pd ──────────────────────────────────────────────────────────────────
 

--- a/src/commands/process-instances.ts
+++ b/src/commands/process-instances.ts
@@ -7,10 +7,9 @@ import {
 	ProcessDefinitionId,
 	TenantId,
 } from "@camunda8/orchestration-cluster-api";
-import { fetchAllPages } from "../core/client.ts";
-import { handleCommandError } from "../core/errors.ts";
-import { defineCommand, dryRun } from "../framework/command-framework.ts";
-import { buildDateFilter, parseBetween } from "../utils/shared/date-filter.ts";
+import { fetchAllPages, handleCommandError } from "../core/index.ts";
+import { defineCommand, dryRun } from "../framework/index.ts";
+import { buildDateFilter, parseBetween } from "../utils/index.ts";
 
 /**
  * List process instances

--- a/src/commands/profiles.ts
+++ b/src/commands/profiles.ts
@@ -7,18 +7,18 @@
 import { existsSync, readFileSync } from "node:fs";
 import {
 	addProfile as addProfileConfig,
+	c8ctl,
 	DEFAULT_PROFILE,
 	envVarsToProfile,
 	getAllProfiles,
+	getLogger,
 	hasCamundaEnvVars,
 	MODELER_PREFIX,
 	type Profile,
 	parseEnvFile,
 	removeProfile as removeProfileConfig,
-} from "../core/config.ts";
-import { getLogger } from "../core/logger.ts";
-import { c8ctl } from "../core/runtime.ts";
-import { defineCommand } from "../framework/command-framework.ts";
+} from "../core/index.ts";
+import { defineCommand } from "../framework/index.ts";
 
 /**
  * List all profiles (c8ctl + Modeler)

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -13,8 +13,8 @@ import {
 	ProcessDefinitionId,
 	TenantId,
 } from "@camunda8/orchestration-cluster-api";
-import { resolveTenantId } from "../core/config.ts";
-import { defineCommand, dryRun } from "../framework/command-framework.ts";
+import { resolveTenantId } from "../core/index.ts";
+import { defineCommand, dryRun } from "../framework/index.ts";
 
 /**
  * Extract process ID from BPMN file content.

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -2,20 +2,25 @@
  * Search commands
  */
 
-import { DEFAULT_PAGE_SIZE, fetchAllPages } from "../core/client.ts";
-import { type Logger, sortTableData } from "../core/logger.ts";
-import { defineCommand, dryRun } from "../framework/command-framework.ts";
+import {
+	DEFAULT_PAGE_SIZE,
+	fetchAllPages,
+	type Logger,
+	sortTableData,
+} from "../core/index.ts";
+import { defineCommand, dryRun } from "../framework/index.ts";
 import {
 	API_DEFAULT_PAGE_SIZE,
+	buildDateFilter,
 	hasUnescapedWildcard,
 	logNoResults,
 	logResultCount,
 	matchesCaseInsensitive,
 	matchesCaseSensitive,
+	parseBetween,
 	toStringFilter,
 	wildcardToRegex,
-} from "../utils/command-local/search-helpers.ts";
-import { buildDateFilter, parseBetween } from "../utils/shared/date-filter.ts";
+} from "../utils/index.ts";
 
 export {
 	API_DEFAULT_PAGE_SIZE,

--- a/src/commands/session.ts
+++ b/src/commands/session.ts
@@ -3,15 +3,15 @@
  */
 
 import {
+	c8ctl,
 	clearActiveProfile,
+	getLogger,
 	getProfileOrModeler,
 	setActiveProfile,
 	setActiveTenant,
 	setOutputMode,
-} from "../core/config.ts";
-import { getLogger } from "../core/logger.ts";
-import { c8ctl } from "../core/runtime.ts";
-import { defineCommand } from "../framework/command-framework.ts";
+} from "../core/index.ts";
+import { defineCommand } from "../framework/index.ts";
 
 /**
  * Set active profile

--- a/src/commands/topology.ts
+++ b/src/commands/topology.ts
@@ -2,7 +2,7 @@
  * Topology commands
  */
 
-import { defineCommand, dryRun } from "../framework/command-framework.ts";
+import { defineCommand, dryRun } from "../framework/index.ts";
 
 /**
  * Get cluster topology

--- a/src/commands/user-tasks.ts
+++ b/src/commands/user-tasks.ts
@@ -2,9 +2,9 @@
  * User task commands
  */
 
-import { fetchAllPages } from "../core/client.ts";
-import { defineCommand, dryRun } from "../framework/command-framework.ts";
-import { buildDateFilter, parseBetween } from "../utils/shared/date-filter.ts";
+import { fetchAllPages } from "../core/index.ts";
+import { defineCommand, dryRun } from "../framework/index.ts";
+import { buildDateFilter, parseBetween } from "../utils/index.ts";
 
 /**
  * List user tasks

--- a/src/commands/variables.ts
+++ b/src/commands/variables.ts
@@ -2,8 +2,8 @@
  * Variable commands
  */
 
-import { isRecord } from "../core/logger.ts";
-import { defineCommand, dryRun } from "../framework/command-framework.ts";
+import { isRecord } from "../core/index.ts";
+import { defineCommand, dryRun } from "../framework/index.ts";
 
 /**
  * Set variables on an element instance (process instance or flow element).

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -4,18 +4,16 @@
 
 import { existsSync, realpathSync, statSync, watch } from "node:fs";
 import { basename, extname, resolve } from "node:path";
-import { normalizeToError } from "../core/errors.ts";
-import { defineCommand } from "../framework/command-framework.ts";
-import { DEPLOY_COOLDOWN } from "../utils/command-local/watch-constants.ts";
+import { normalizeToError } from "../core/index.ts";
+import { defineCommand } from "../framework/index.ts";
 import {
+	ALL_DEPLOYABLE_EXTENSIONS,
+	DEPLOY_COOLDOWN,
+	DEPLOYABLE_EXTENSIONS,
 	isIgnored,
 	loadIgnoreRules,
 	resolveIgnoreBaseDir,
-} from "../utils/shared/ignore.ts";
-import {
-	ALL_DEPLOYABLE_EXTENSIONS,
-	DEPLOYABLE_EXTENSIONS,
-} from "../utils/shared/resource-extensions.ts";
+} from "../utils/index.ts";
 import {
 	deployResources,
 	findProcessApplicationRoot,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,12 @@
+// Public barrel for the `core` layer.
+//
+// Other layers (commands, framework, utils) and the composition root MUST import
+// core symbols through this barrel (`../core/index.ts`), never from deep core
+// files. Intra-core imports use direct sibling paths. This contract is enforced
+// by tests/unit/layering-import-boundary.test.ts (Rules A and B).
+export * from "./client.ts";
+export * from "./config.ts";
+export * from "./errors.ts";
+export * from "./logger.ts";
+export * from "./runtime.ts";
+export * from "./update-check.ts";

--- a/src/framework/command-framework.ts
+++ b/src/framework/command-framework.ts
@@ -14,15 +14,15 @@
  */
 
 import type { CamundaClient } from "@camunda8/orchestration-cluster-api";
-import { resolveClusterConfig } from "../core/config.ts";
-import { handleCommandError } from "../core/errors.ts";
 import {
+	c8ctl,
 	getLogger,
+	handleCommandError,
 	type Logger,
+	resolveClusterConfig,
 	type SortOrder,
 	sortTableData,
-} from "../core/logger.ts";
-import { c8ctl } from "../core/runtime.ts";
+} from "../core/index.ts";
 import {
 	COMMAND_REGISTRY,
 	type CommandDef,

--- a/src/framework/command-validation.ts
+++ b/src/framework/command-validation.ts
@@ -9,7 +9,7 @@
  * handlers receive already-validated types and need no internal guards.
  */
 
-import { getLogger } from "../core/logger.ts";
+import { getLogger } from "../core/index.ts";
 import {
 	type FlagDef,
 	GLOBAL_FLAGS,

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -1,0 +1,14 @@
+// Public barrel for the `framework` layer.
+//
+// Other layers (commands, utils) and the composition root MUST import framework
+// symbols through this barrel (`../framework/index.ts`), never from deep
+// framework files. Intra-framework imports use direct sibling paths. Enforced by
+// tests/unit/layering-import-boundary.test.ts (Rules A and B).
+export * from "./command-framework.ts";
+export * from "./command-registry.ts";
+export * from "./command-validation.ts";
+export * from "./plugins/plugin-loader.ts";
+export * from "./plugins/plugin-registry.ts";
+export * from "./plugins/plugin-version.ts";
+export * from "./ui/completion.ts";
+export * from "./ui/help.ts";

--- a/src/framework/plugins/plugin-loader.ts
+++ b/src/framework/plugins/plugin-loader.ts
@@ -5,9 +5,13 @@
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import type { CamundaClient } from "@camunda8/orchestration-cluster-api";
-import { ensurePluginsDir } from "../../core/config.ts";
-import { getLogger, type Logger, type OutputMode } from "../../core/logger.ts";
-import { c8ctl } from "../../core/runtime.ts";
+import {
+	c8ctl,
+	ensurePluginsDir,
+	getLogger,
+	type Logger,
+	type OutputMode,
+} from "../../core/index.ts";
 import type { FlagDef } from "../command-registry.ts";
 
 /**
@@ -52,7 +56,7 @@ export interface PluginCtx {
 	readonly client: CamundaClient;
 }
 
-export type CommandHandler = (
+export type PluginCommandHandler = (
 	args: string[],
 	flags?: Record<string, unknown>,
 	ctx?: PluginCtx,
@@ -60,10 +64,10 @@ export type CommandHandler = (
 
 export interface CommandWithFlags {
 	flags: Record<string, FlagDef>;
-	handler: CommandHandler;
+	handler: PluginCommandHandler;
 }
 
-export type PluginCommand = CommandHandler | CommandWithFlags;
+export type PluginCommand = PluginCommandHandler | CommandWithFlags;
 
 export interface PluginCommands {
 	[commandName: string]: PluginCommand;

--- a/src/framework/plugins/plugin-registry.ts
+++ b/src/framework/plugins/plugin-registry.ts
@@ -4,7 +4,7 @@
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
-import { getUserDataDir } from "../../core/config.ts";
+import { getUserDataDir } from "../../core/index.ts";
 
 export interface PluginEntry {
 	name: string;

--- a/src/framework/ui/completion.ts
+++ b/src/framework/ui/completion.ts
@@ -5,9 +5,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir, platform } from "node:os";
 import { join } from "node:path";
-import { getUserDataDir } from "../../core/config.ts";
-import { getLogger } from "../../core/logger.ts";
-import { c8ctl } from "../../core/runtime.ts";
+import { c8ctl, getLogger, getUserDataDir } from "../../core/index.ts";
 import {
 	COMMAND_REGISTRY,
 	type CommandDef,

--- a/src/framework/ui/help.ts
+++ b/src/framework/ui/help.ts
@@ -5,7 +5,7 @@
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { getLogger } from "../../core/logger.ts";
+import { getLogger } from "../../core/index.ts";
 import {
 	COMMAND_REGISTRY,
 	type CommandDef,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,47 +8,40 @@ import { realpathSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 import { COMMAND_DISPATCH } from "./command-dispatch.ts";
-import { createClient } from "./core/client.ts";
 import {
+	c8ctl,
+	createClient,
+	getLogger,
 	getUserDataDir,
 	loadSessionState,
-	resolveTenantId,
-} from "./core/config.ts";
-import { getLogger, type SortOrder } from "./core/logger.ts";
-import { c8ctl } from "./core/runtime.ts";
-import {
 	printUpdateNotification,
+	resolveTenantId,
+	type SortOrder,
 	startUpdateCheck,
-} from "./core/update-check.ts";
-import type { CommandContext } from "./framework/command-framework.ts";
+} from "./core/index.ts";
 import {
 	COMMAND_REGISTRY,
+	type CommandContext,
 	type CommandDef,
 	deriveParseArgsOptions,
+	detectUnknownFlags,
+	executePluginCommand,
 	GLOBAL_FLAGS,
 	getCommandDef,
-	resolveAlias,
-	resolveVerbAlias,
-} from "./framework/command-registry.ts";
-import {
-	detectUnknownFlags,
-	validateFlags,
-} from "./framework/command-validation.ts";
-import {
-	executePluginCommand,
 	getPluginCommands,
 	getPluginVersionForCommand,
 	isPassthroughPluginCommand,
 	loadInstalledPlugins,
 	type PluginCtx,
-} from "./framework/plugins/plugin-loader.ts";
-import { refreshCompletionsIfStale } from "./framework/ui/completion.ts";
-import {
+	refreshCompletionsIfStale,
+	resolveAlias,
+	resolveVerbAlias,
 	showCommandHelp,
 	showHelp,
 	showVerbResources,
 	showVersion,
-} from "./framework/ui/help.ts";
+	validateFlags,
+} from "./framework/index.ts";
 
 /**
  * Type guard: extract a string value from parseArgs values, or undefined.

--- a/src/utils/command-local/mcp-proxy-helpers.ts
+++ b/src/utils/command-local/mcp-proxy-helpers.ts
@@ -5,7 +5,7 @@
  */
 
 import type { CamundaClient } from "@camunda8/orchestration-cluster-api";
-import { isRecord, type Logger } from "../../core/logger.ts";
+import { isRecord, type Logger } from "../../core/index.ts";
 
 /**
  * Creates a custom fetch function that injects Camunda authentication headers

--- a/src/utils/command-local/open-helpers.ts
+++ b/src/utils/command-local/open-helpers.ts
@@ -7,7 +7,7 @@
 
 import { spawn } from "node:child_process";
 import { platform } from "node:os";
-import { getLogger } from "../../core/logger.ts";
+import { getLogger } from "../../core/index.ts";
 import { requireOneOf, requirePositional } from "../shared/validation.ts";
 
 export const OPEN_APPS = [

--- a/src/utils/command-local/search-helpers.ts
+++ b/src/utils/command-local/search-helpers.ts
@@ -5,7 +5,7 @@
  * these.
  */
 
-import type { Logger } from "../../core/logger.ts";
+import type { Logger } from "../../core/index.ts";
 
 /** Default page size the Camunda REST API uses when no explicit limit is set */
 export const API_DEFAULT_PAGE_SIZE = 100;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,14 @@
+// Public barrel for the `utils` layer.
+//
+// Other layers and the composition root MUST import utils symbols through this
+// barrel (`../utils/index.ts`), never from deep utils files. Intra-utils imports
+// use direct sibling paths. Enforced by
+// tests/unit/layering-import-boundary.test.ts (Rules A and B).
+export * from "./command-local/mcp-proxy-helpers.ts";
+export * from "./command-local/open-helpers.ts";
+export * from "./command-local/search-helpers.ts";
+export * from "./command-local/watch-constants.ts";
+export * from "./shared/date-filter.ts";
+export * from "./shared/ignore.ts";
+export * from "./shared/resource-extensions.ts";
+export * from "./shared/validation.ts";

--- a/src/utils/shared/validation.ts
+++ b/src/utils/shared/validation.ts
@@ -7,7 +7,7 @@
  * them without importing the `framework/` layer.
  */
 
-import { getLogger } from "../../core/logger.ts";
+import { getLogger } from "../../core/index.ts";
 
 /**
  * Validate that a positional argument is present and non-empty.

--- a/tests/unit/layering-import-boundary.test.ts
+++ b/tests/unit/layering-import-boundary.test.ts
@@ -35,6 +35,22 @@
  * violation, the fix is almost always to move the shared code *down*
  * to the lowest layer that needs it — not to widen the rule.
  *
+ * Module encapsulation (issue #424)
+ * ---------------------------------
+ *
+ * The barreled layers (`core`, `utils`, `framework`) each expose a single
+ * public entry point, `<layer>/index.ts`. Two further rules keep that
+ * encapsulation honest:
+ *
+ *   - Rule A — a *cross-layer* import into a barreled layer MUST target the
+ *     barrel (`../core/index.ts`), never a deep file (`../core/logger.ts`).
+ *   - Rule B — an *intra-layer* import within a barreled layer MUST target a
+ *     sibling file directly (`./logger.ts`), never the layer's own barrel
+ *     (avoids self-referential cycles and keeps module-eval order obvious).
+ *
+ * `commands` is deliberately NOT barreled: it is consumed only by the
+ * composition root, which is allowed to reach deep command files.
+ *
  * Detection
  * ---------
  *
@@ -129,6 +145,81 @@ function toRelative(absPath: string): string {
 	return relative(PROJECT_ROOT, absPath).split(/[\\/]/).join("/");
 }
 
+// Barreled layers expose a single public entry point (`<layer>/index.ts`).
+// Cross-layer imports must go through the barrel; intra-layer imports must not
+// (issue #424). `commands` is intentionally NOT barreled: nothing imports it
+// cross-layer except the composition root, which may reach deep command files.
+const BARRELED_LAYERS: ReadonlySet<string> = new Set<string>([
+	"core",
+	"utils",
+	"framework",
+]);
+
+interface Edge {
+	line: number;
+	specifier: string;
+	/** Resolved absolute path of the import target inside src/. */
+	target: string;
+	toLayer: Layer | "unknown";
+}
+
+/** Collect every relative import/export edge that resolves inside src/. */
+function collectEdges(absPath: string, sf: ts.SourceFile): Edge[] {
+	const edges: Edge[] = [];
+
+	const record = (specNode: ts.Node, spec: string): void => {
+		// Only relative specifiers point inside src/.
+		if (!spec.startsWith(".")) return;
+		const target = resolve(dirname(absPath), spec);
+		// Ignore imports that resolve outside src/ (e.g. into tests/ — none
+		// today — or sibling roots). Those are not layer edges.
+		const rel = relative(SRC_DIR, target);
+		if (rel.startsWith("..")) return;
+		const { line } = sf.getLineAndCharacterOfPosition(specNode.getStart(sf));
+		edges.push({
+			line: line + 1,
+			specifier: spec,
+			target,
+			toLayer: layerOf(target),
+		});
+	};
+
+	const visit = (node: ts.Node): void => {
+		if (
+			ts.isImportDeclaration(node) &&
+			ts.isStringLiteral(node.moduleSpecifier)
+		) {
+			record(node.moduleSpecifier, node.moduleSpecifier.text);
+		} else if (
+			ts.isExportDeclaration(node) &&
+			node.moduleSpecifier &&
+			ts.isStringLiteral(node.moduleSpecifier)
+		) {
+			record(node.moduleSpecifier, node.moduleSpecifier.text);
+		} else if (ts.isCallExpression(node)) {
+			const arg0 = node.arguments[0];
+			if (arg0 && ts.isStringLiteral(arg0)) {
+				const isDynamic = node.expression.kind === ts.SyntaxKind.ImportKeyword;
+				const isRequire =
+					ts.isIdentifier(node.expression) &&
+					node.expression.text === "require";
+				if (isDynamic || isRequire) record(arg0, arg0.text);
+			}
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(sf);
+
+	return edges;
+}
+
+/** True when an edge resolves to a barreled layer's `index.ts` entry point. */
+function isBarrelTarget(target: string): boolean {
+	const rel = relative(SRC_DIR, target).split(/[\\/]/).join("/");
+	const segment = rel.includes("/") ? rel.slice(0, rel.indexOf("/")) : "";
+	return BARRELED_LAYERS.has(layerOf(target)) && rel === `${segment}/index.ts`;
+}
+
 interface Violation {
 	file: string;
 	fromLayer: Layer;
@@ -151,54 +242,71 @@ function findViolations(absPath: string): Violation[] {
 		ts.ScriptKind.TS,
 	);
 	const out: Violation[] = [];
-
-	const check = (specNode: ts.Node, spec: string): void => {
-		// Only relative specifiers point inside src/.
-		if (!spec.startsWith(".")) return;
-		const target = resolve(dirname(absPath), spec);
-		// Ignore imports that resolve outside src/ (e.g. into tests/ — none
-		// today — or sibling roots). Those are not layer edges.
-		const rel = relative(SRC_DIR, target);
-		if (rel.startsWith("..")) return;
-		const toLayer = layerOf(target);
-		if (toLayer === "unknown" || !allowed.has(toLayer)) {
-			const { line } = sf.getLineAndCharacterOfPosition(specNode.getStart(sf));
+	for (const edge of collectEdges(absPath, sf)) {
+		if (edge.toLayer === "unknown" || !allowed.has(edge.toLayer)) {
 			out.push({
 				file: toRelative(absPath),
 				fromLayer,
-				line: line + 1,
-				specifier: spec,
-				toLayer,
+				line: edge.line,
+				specifier: edge.specifier,
+				toLayer: edge.toLayer,
 			});
 		}
-	};
+	}
+	return out;
+}
 
-	const visit = (node: ts.Node): void => {
-		if (
-			ts.isImportDeclaration(node) &&
-			ts.isStringLiteral(node.moduleSpecifier)
-		) {
-			check(node.moduleSpecifier, node.moduleSpecifier.text);
-		} else if (
-			ts.isExportDeclaration(node) &&
-			node.moduleSpecifier &&
-			ts.isStringLiteral(node.moduleSpecifier)
-		) {
-			check(node.moduleSpecifier, node.moduleSpecifier.text);
-		} else if (ts.isCallExpression(node)) {
-			const arg0 = node.arguments[0];
-			if (arg0 && ts.isStringLiteral(arg0)) {
-				const isDynamic = node.expression.kind === ts.SyntaxKind.ImportKeyword;
-				const isRequire =
-					ts.isIdentifier(node.expression) &&
-					node.expression.text === "require";
-				if (isDynamic || isRequire) check(arg0, arg0.text);
-			}
+interface BarrelViolation {
+	file: string;
+	line: number;
+	rule: "cross-layer-must-use-barrel" | "intra-layer-must-be-direct";
+	specifier: string;
+	message: string;
+}
+
+/**
+ * Enforce per-layer module encapsulation (issue #424):
+ *
+ *   Rule A — a cross-layer import into a barreled layer MUST target the
+ *            layer's `index.ts` barrel, never a deep file.
+ *   Rule B — an intra-layer import within a barreled layer MUST target a
+ *            sibling file directly, never the layer's own barrel (keeps the
+ *            module-eval order obvious and avoids self-referential cycles).
+ */
+function findBarrelViolations(absPath: string): BarrelViolation[] {
+	const fromLayer = layerOf(absPath);
+	if (fromLayer === "unknown") return [];
+	const source = readFileSync(absPath, "utf8");
+	const sf = ts.createSourceFile(
+		absPath,
+		source,
+		ts.ScriptTarget.Latest,
+		true,
+		ts.ScriptKind.TS,
+	);
+	const out: BarrelViolation[] = [];
+	for (const edge of collectEdges(absPath, sf)) {
+		if (edge.toLayer === "unknown") continue;
+		if (!BARRELED_LAYERS.has(edge.toLayer)) continue;
+		const barrel = isBarrelTarget(edge.target);
+		if (edge.toLayer !== fromLayer && !barrel) {
+			out.push({
+				file: toRelative(absPath),
+				line: edge.line,
+				rule: "cross-layer-must-use-barrel",
+				specifier: edge.specifier,
+				message: `cross-layer import into '${edge.toLayer}' must go through '${edge.toLayer}/index.ts', not a deep file`,
+			});
+		} else if (edge.toLayer === fromLayer && barrel) {
+			out.push({
+				file: toRelative(absPath),
+				line: edge.line,
+				rule: "intra-layer-must-be-direct",
+				specifier: edge.specifier,
+				message: `intra-'${fromLayer}' import must target a sibling file directly, not the '${fromLayer}/index.ts' barrel`,
+			});
 		}
-		ts.forEachChild(node, visit);
-	};
-	visit(sf);
-
+	}
 	return out;
 }
 
@@ -238,6 +346,26 @@ describe("architectural guard: src/ layered architecture (#414)", () => {
 				.join(
 					"\n",
 				)}\n\nFix by moving the shared code down to the lowest layer that needs it, not by widening the rule.`,
+		);
+	});
+
+	test("barreled layers are imported through their barrel (#424)", () => {
+		const violations: BarrelViolation[] = [];
+		for (const abs of files) {
+			violations.push(...findBarrelViolations(abs));
+		}
+
+		assert.strictEqual(
+			violations.length,
+			0,
+			`Found ${violations.length} module-encapsulation violation(s):\n${violations
+				.map(
+					(v) =>
+						`  ${v.file}:${v.line}  [${v.rule}]  ${v.specifier}\n      ${v.message}`,
+				)
+				.join(
+					"\n",
+				)}\n\nBarreled layers (${[...BARRELED_LAYERS].join(", ")}) expose a single public entry point '<layer>/index.ts'. Import across layers via the barrel; import within a layer via direct sibling paths.`,
 		);
 	});
 });


### PR DESCRIPTION
## What

Introduces guarded **per-layer barrels** for the three barreled layers (`core`, `utils`, `framework`) and rewrites all cross-layer import sites to go through them. Addresses **finding #4** of #424 (within-layer coupling follow-ups to the #414 layered-architecture refactor).

Each barreled layer now exposes a single public entry point `<layer>/index.ts` (`export *` over its internal files). The ~111 cross-layer import statements collapse into 73 barrel imports; intra-layer imports keep direct sibling paths.

## Two new guard rules

Added to `tests/unit/layering-import-boundary.test.ts`:

- **Rule A** — a cross-layer import *into* a barreled layer must target the layer's `index.ts` barrel, never a deep file (`../core/index.ts`, not `../core/logger.ts`).
- **Rule B** — an intra-layer import *within* a barreled layer must target a sibling file directly, never the layer's own barrel (keeps module-eval order obvious, avoids self-referential cycles).

`commands/` is intentionally **not** barreled — it is consumed only by the composition root, which is allowed to reach deep command files.

## Notable

- Renames plugin-loader's internal `CommandHandler` type to `PluginCommandHandler` to remove a latent `export *` name collision in the framework barrel. It was only ever used inside `plugin-loader.ts`; not part of any public/plugin API surface.
- The actual cross-layer surface was verified collision-free before choosing `export *` (core 35, utils 22, framework 41 names; no name imported from two files).
- No startup-perf regression: `command-dispatch.ts` already eager-loads every handler, so the CLI already loads the full graph at startup.
- `AGENTS.md` documents the barrel convention + both rules; stale `defineCommand` import examples repointed to the barrel.

## Verification

- `npm run typecheck` passes
- `npx biome check src tests` passes (0 diagnostics)
- `npm run test:unit` passes (1815 tests, incl. the new Rule A/B guard test)
- `npm run build` passes + smoke-tested `node dist/index.js help`

Refs #424
