### PR TITLE
refactor: thread per-invocation flags through ctx, not the global runtime (#424)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ Key components:
 
 - `src/framework/command-registry.ts` — single source of truth: all commands are declared here with flags, resources, help text, validation, and shell completions
 - `src/command-dispatch.ts` — maps `"verb:resource"` keys to handler functions (composition root, top-level)
-- `src/framework/command-framework.ts` — provides `defineCommand()` and the `dryRun()` helper
+- `src/framework/command-framework.ts` — provides `defineCommand()`, the `CommandContext` type, and the `createDryRun()` factory behind `ctx.dryRun()`
 - `src/index.ts` — CLI entry point; parses arguments, resolves profiles, routes to handlers (composition root, top-level)
 - `src/core/config.ts` — profile and session state: stores credentials, active profile, active tenant, output mode
 - `src/core/logger.ts` — text/JSON output rendering; `isRecord()` type guard lives here
@@ -95,6 +95,18 @@ Two conventions worth internalising:
 
 - **`utils/shared/` vs `utils/command-local/`** — the split axis is "command-agnostic reusable leaf" vs "the guts of one command". `command-local` helpers stay test-visible (not moved into `commands/**`) deliberately: their logic is pure and cross-platform and is better covered by direct unit tests than by coarser `c8()` subprocess tests.
 - **`utils/command-local/` vs `commands/helpers/`** — both hold command-specific support code, but `command-local` is test-visible (tests import it directly) while `commands/helpers/` is command-private and test-invisible (driven only through the `c8()` subprocess helper, per #291).
+
+##### Per-invocation flags come from `ctx`, not the global runtime (#424)
+
+The `c8ctl` runtime singleton (`src/core/runtime.ts`) stays — it is the irreducible plugin SDK exposed on `globalThis.c8ctl` (every default plugin and the scaffold template read it via `globalThis.c8ctl`), and `src/core/**` legitimately owns and wraps it (the core error handler and SDK client read `c8ctl.verbose`/`c8ctl.dryRun` directly; the composition root writes them). What shrank is its *mutable surface as seen from the layers above core*.
+
+Per-invocation request state — whether `--dry-run` / `--verbose` were passed — is resolved once at the composition root (`src/index.ts`) and threaded into handlers through the typed `CommandContext`:
+
+- **`ctx.dryRun({ command, method, endpoint, profile, body? })`** — the bound dry-run helper. Returns a `DryRunResult` when dry-run is active (return it to short-circuit), else `null`. Built by `createDryRun(isDryRun)` at the composition root. This replaces the old free `dryRun()` helper that read the global.
+- **`ctx.isDryRun`** — the raw boolean, for the handful of handlers that emit a *custom* dry-run payload (`deploy`, `identity`) rather than the framework's standard `DryRunResult`.
+- **`ctx.verbose`** — whether `--verbose` was passed.
+
+`src/commands/**` and `src/framework/**` must obtain these from `ctx` (handlers) or an explicit parameter (non-handler framework entry points such as `installCompletion`/`refreshCompletionsIfStale`), and must **not** read `c8ctl.dryRun` or `c8ctl.verbose` back off the global. This is guarded by [`tests/unit/no-runtime-global-reads-in-handlers.test.ts`](tests/unit/no-runtime-global-reads-in-handlers.test.ts) (AST-based, so the field names are safe to mention in comments and strings). `c8ctl.outputMode` is *session display state*, not a per-invocation request flag — read it via `logger.mode` where a logger is in scope; the `session` command reads it directly because managing session state is its job.
 
 ### Commit message guidelines
 
@@ -341,14 +353,16 @@ Every command handler in `src/commands/**` follows the same shape. Pattern-match
 #### Canonical shape
 
 ```ts
-import { defineCommand, dryRun } from "../framework/index.ts";
+import { defineCommand } from "../framework/index.ts";
 
 export const myCommand = defineCommand("myverb", "my-resource", async (ctx, flags, args) => {
   const { client, profile, logger } = ctx;
 
   // 1. Dry-run check — must come BEFORE any I/O. Returns a DryRunResult
-  //    if `--dry-run` was passed, or `null` to continue.
-  const dr = dryRun({
+  //    if `--dry-run` was passed, or `null` to continue. The helper is
+  //    bound to this invocation's flag and lives on `ctx`, so handlers
+  //    never read dry-run state off the global runtime.
+  const dr = ctx.dryRun({
     command: "myverb my-resource",
     method: "POST",
     endpoint: "/my-resources",
@@ -401,10 +415,10 @@ export const deployCommand = defineCommand("deploy", "", async (ctx, flags) => {
 ```
 
 ```ts
-// ✅ Canonical shape — body inline, dryRun() helper, throws on failure,
+// ✅ Canonical shape — body inline, ctx.dryRun() helper, throws on failure,
 //    returns a CommandResult.
 export const deployCommand = defineCommand("deploy", "", async (ctx, flags) => {
-  const dr = dryRun({ command: "deploy", method: "POST", endpoint: "/deployments", profile: ctx.profile });
+  const dr = ctx.dryRun({ command: "deploy", method: "POST", endpoint: "/deployments", profile: ctx.profile });
   if (dr) return dr;
 
   if (ctx.positionals.length === 0) {
@@ -526,7 +540,7 @@ Create a handler file in `src/commands/`:
 
 ```typescript
 // src/commands/my-resource.ts
-import { defineCommand, dryRun } from "../framework/index.ts";
+import { defineCommand } from "../framework/index.ts";
 
 export const myverbMyResourceCommand = defineCommand(
   "myverb",
@@ -539,7 +553,7 @@ export const myverbMyResourceCommand = defineCommand(
     // args.key     → MyBrandedKey (required positional, branded)
 
     // Dry-run support (required for all commands)
-    const dr = dryRun({
+    const dr = ctx.dryRun({
       command: "myverb my-resource",
       method: "POST",
       endpoint: "/my-resources",
@@ -567,7 +581,7 @@ export const myverbMyResourceCommand = defineCommand(
 | `success` | Mutation confirmation | `{ message }` |
 | `no-result` | Nothing to display | — |
 
-The `dryRun()` helper checks the `--dry-run` flag and returns a `DryRunResult` if set, or `undefined` to continue.
+The `ctx.dryRun()` helper checks the `--dry-run` flag (captured once at the composition root) and returns a `DryRunResult` if set, or `null` to continue. The raw boolean is also available as `ctx.isDryRun` for handlers that emit a custom dry-run payload (`deploy`, `identity`).
 
 ##### 5. Register in `COMMAND_DISPATCH`
 
@@ -600,7 +614,7 @@ By adding the registry entry and dispatch wiring, these features are automatical
 - `c8ctl completion bash/zsh/fish` includes the verb, resource, and all flags
 - `parseArgs` accepts the declared flags with correct types
 - Flag validation runs at the boundary (branded types enforced)
-- `--dry-run` support (via `dryRun()` helper)
+- `--dry-run` support (via the `ctx.dryRun()` helper)
 - Output rendering (JSON, table, fields filtering) handled by the framework
 - Resource alias resolution (`mr` → `my-resource`) works everywhere
 

--- a/src/commands/completion.ts
+++ b/src/commands/completion.ts
@@ -44,7 +44,10 @@ export const completionCommand = defineCommand(
 		const resource = ctx.resource;
 		if (resource === "install") {
 			const shellFlag = flags.shell;
-			installCompletion(typeof shellFlag === "string" ? shellFlag : undefined);
+			installCompletion(
+				typeof shellFlag === "string" ? shellFlag : undefined,
+				ctx.isDryRun,
+			);
 			return undefined;
 		}
 		// Non-install resource → render the requested shell's completion

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -5,12 +5,12 @@
  * table output.
  *
  * The body lives directly in the handler (per #288): argument-shape
- * resolution, dry-run preview via the framework's `dryRun()` helper,
+ * resolution, dry-run preview via the context's `ctx.dryRun()` helper,
  * and the call into the shared `deployResources` helper that watch also
  * uses for change-triggered re-deploys.
  */
 
-import { defineCommand, dryRun } from "../framework/index.ts";
+import { defineCommand } from "../framework/index.ts";
 import {
 	ALL_DEPLOYABLE_EXTENSIONS,
 	DEPLOYABLE_EXTENSIONS,
@@ -76,15 +76,15 @@ export const deployCommand = defineCommand("deploy", "", async (ctx, flags) => {
 	// Dry-run preview. Collect resources first so the preview body
 	// reflects what would actually be sent — and so the empty-paths /
 	// no-files guards still surface as thrown errors before we emit.
-	// Uses `ctx.dryRun` and `ctx.tenantId` from the framework rather
+	// Uses `ctx.isDryRun` and `ctx.tenantId` from the framework rather
 	// than reaching into the global runtime/config layer.
-	if (ctx.dryRun) {
+	if (ctx.isDryRun) {
 		const { resources: previewResources, skippedExtensions } =
 			collectResourcesForPaths(paths, flags.force, extensionList);
 
 		logSkippedExtensions(skippedExtensions);
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "deploy",
 			method: "POST",
 			endpoint: "/deployments",
@@ -107,6 +107,7 @@ export const deployCommand = defineCommand("deploy", "", async (ctx, flags) => {
 		profile: ctx.profile,
 		force: flags.force,
 		extensionList,
+		verbose: ctx.verbose,
 	});
 	return { kind: "none" };
 });

--- a/src/commands/forms.ts
+++ b/src/commands/forms.ts
@@ -10,8 +10,8 @@ import {
 import { isRecord } from "../core/index.ts";
 import {
 	type CommandResult,
+	type DryRunFn,
 	defineCommand,
-	dryRun,
 } from "../framework/index.ts";
 
 /** Extract HTTP status code from an unknown error (SDK errors expose statusCode or status). */
@@ -45,12 +45,12 @@ export const getFormCommand = defineCommand(
 		}
 
 		if (isUserTask) {
-			return handleUserTaskForm(key, profile, client);
+			return handleUserTaskForm(key, profile, client, ctx.dryRun);
 		}
 		if (isProcessDefinition) {
-			return handleStartForm(key, profile, client);
+			return handleStartForm(key, profile, client, ctx.dryRun);
 		}
-		return handleFormBoth(key, profile, client);
+		return handleFormBoth(key, profile, client, ctx.dryRun);
 	},
 );
 
@@ -58,6 +58,7 @@ async function handleUserTaskForm(
 	userTaskKey: string,
 	profile: string | undefined,
 	client: CamundaClient,
+	dryRun: DryRunFn,
 ): Promise<CommandResult> {
 	const dr = dryRun({
 		command: "get form --userTask",
@@ -94,6 +95,7 @@ async function handleStartForm(
 	processDefinitionKey: string,
 	profile: string | undefined,
 	client: CamundaClient,
+	dryRun: DryRunFn,
 ): Promise<CommandResult> {
 	const dr = dryRun({
 		command: "get form --processDefinition",
@@ -133,6 +135,7 @@ async function handleFormBoth(
 	key: string,
 	profile: string | undefined,
 	client: CamundaClient,
+	dryRun: DryRunFn,
 ): Promise<CommandResult> {
 	const dr = dryRun({
 		command: "get form",

--- a/src/commands/helpers/deploy-helpers.ts
+++ b/src/commands/helpers/deploy-helpers.ts
@@ -17,7 +17,6 @@ import {
 import { basename, dirname, extname, join, relative, resolve } from "node:path";
 import { TenantId } from "@camunda8/orchestration-cluster-api";
 import {
-	c8ctl,
 	createClient,
 	getLogger,
 	isRecord,
@@ -39,7 +38,7 @@ const PROCESS_APPLICATION_FILE = ".process-application";
  * Helper to output messages that respect JSON mode for Unix pipe compatibility
  */
 function logMessage(message: string): void {
-	if (c8ctl.outputMode === "json") {
+	if (getLogger().mode === "json") {
 		console.error(JSON.stringify({ type: "message", message }));
 	} else {
 		console.error(message);
@@ -493,8 +492,8 @@ export function collectResourcesForPaths(
  * result table. Used by `deployCommand` (the standard CLI entry point)
  * and by `watchCommand` (for change-triggered re-deploys).
  *
- * Does NOT consult `c8ctl.dryRun` — dry-run handling lives in the
- * `deployCommand` handler so the framework's `dryRun()` helper owns
+ * Does NOT consult dry-run state — dry-run handling lives in the
+ * `deployCommand` handler so the context's `ctx.dryRun()` helper owns
  * preview emission. Watch never triggers a dry-run, so this split also
  * removes a footgun where a stale dry-run flag could suppress a watch
  * deploy.
@@ -517,6 +516,8 @@ export async function deployResources(
 		 * Callers do not need their own try/catch to suppress aborts.
 		 */
 		signal?: AbortSignal;
+		/** Whether --verbose was set (surfaces raw errors with stack traces). */
+		verbose?: boolean;
 	},
 ): Promise<void> {
 	const logger = getLogger();
@@ -689,6 +690,7 @@ export async function deployResources(
 			logger,
 			options.continueOnError,
 			options.continueOnUserError,
+			options.verbose === true,
 		);
 		// `handleDeploymentError` either throws (terminal) or returns
 		// (continue-on-error). On the continue path, skip the success
@@ -790,6 +792,7 @@ function handleDeploymentError(
 	logger: ReturnType<typeof getLogger>,
 	continueOnError?: boolean,
 	continueOnUserError?: boolean,
+	verbose?: boolean,
 ): void {
 	// Extract problem title early to determine whether this is a user-fixable error
 	const raw: Record<string, unknown> = isRecord(error) ? error : {};
@@ -798,7 +801,7 @@ function handleDeploymentError(
 	const shouldContinue =
 		continueOnError || (continueOnUserError && isUserFixable);
 
-	if (c8ctl.verbose) {
+	if (verbose) {
 		if (shouldContinue) {
 			throw error;
 		}

--- a/src/commands/identity-authorizations.ts
+++ b/src/commands/identity-authorizations.ts
@@ -13,7 +13,6 @@ import {
 import { fetchAllPages, sortTableData } from "../core/index.ts";
 import {
 	defineCommand,
-	dryRun,
 	requireCsvEnum,
 	requireEnum,
 	requireOption,
@@ -28,7 +27,7 @@ export const listAuthorizationsCommand = defineCommand(
 	async (ctx) => {
 		const { client, profile, limit } = ctx;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "list authorizations",
 			method: "POST",
 			endpoint: "/authorizations/search",
@@ -77,7 +76,7 @@ export const searchIdentityAuthorizationsCommand = defineCommand(
 
 		const searchFilter = Object.keys(filter).length > 0 ? { filter } : {};
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "search authorizations",
 			method: "POST",
 			endpoint: "/authorizations/search",
@@ -123,7 +122,7 @@ export const getIdentityAuthorizationCommand = defineCommand(
 		const { client, profile } = ctx;
 		const authorizationKey = args.authorizationKey;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "get authorization",
 			method: "GET",
 			endpoint: `/authorizations/${authorizationKey}`,
@@ -214,7 +213,7 @@ export const createIdentityAuthorizationCommand = defineCommand(
 			permissionTypes: validated.permissionTypes,
 		};
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "create authorization",
 			method: "POST",
 			endpoint: "/authorizations",
@@ -238,7 +237,7 @@ export const deleteIdentityAuthorizationCommand = defineCommand(
 		const { client, profile } = ctx;
 		const authorizationKey = args.authorizationKey;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "delete authorization",
 			method: "DELETE",
 			endpoint: `/authorizations/${encodeURIComponent(String(authorizationKey))}`,

--- a/src/commands/identity-groups.ts
+++ b/src/commands/identity-groups.ts
@@ -3,7 +3,7 @@
  */
 
 import { fetchAllPages, sortTableData } from "../core/index.ts";
-import { defineCommand, dryRun } from "../framework/index.ts";
+import { defineCommand } from "../framework/index.ts";
 import { toStringFilter } from "./search.ts";
 
 /**
@@ -12,7 +12,7 @@ import { toStringFilter } from "./search.ts";
 export const listGroupsCommand = defineCommand("list", "group", async (ctx) => {
 	const { client, profile, limit } = ctx;
 
-	const dr = dryRun({
+	const dr = ctx.dryRun({
 		command: "list groups",
 		method: "POST",
 		endpoint: "/groups/search",
@@ -53,7 +53,7 @@ export const searchIdentityGroupsCommand = defineCommand(
 
 		const searchFilter = Object.keys(filter).length > 0 ? { filter } : {};
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "search groups",
 			method: "POST",
 			endpoint: "/groups/search",
@@ -94,7 +94,7 @@ export const getIdentityGroupCommand = defineCommand(
 		const { client, profile } = ctx;
 		const groupId = args.groupId;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "get group",
 			method: "GET",
 			endpoint: `/groups/${groupId}`,
@@ -128,7 +128,7 @@ export const createIdentityGroupCommand = defineCommand(
 
 		const body = { groupId: flags.groupId, name: flags.name };
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "create group",
 			method: "POST",
 			endpoint: "/groups",
@@ -152,7 +152,7 @@ export const deleteIdentityGroupCommand = defineCommand(
 		const { client, profile } = ctx;
 		const groupId = args.groupId;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "delete group",
 			method: "DELETE",
 			endpoint: `/groups/${encodeURIComponent(groupId)}`,

--- a/src/commands/identity-mapping-rules.ts
+++ b/src/commands/identity-mapping-rules.ts
@@ -3,7 +3,7 @@
  */
 
 import { fetchAllPages, sortTableData } from "../core/index.ts";
-import { defineCommand, dryRun } from "../framework/index.ts";
+import { defineCommand } from "../framework/index.ts";
 
 /**
  * List all mapping rules
@@ -14,7 +14,7 @@ export const listMappingRulesCommand = defineCommand(
 	async (ctx) => {
 		const { client, profile, limit } = ctx;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "list mapping-rules",
 			method: "POST",
 			endpoint: "/mapping-rules/search",
@@ -59,7 +59,7 @@ export const searchIdentityMappingRulesCommand = defineCommand(
 
 		const searchFilter = Object.keys(filter).length > 0 ? { filter } : {};
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "search mapping-rules",
 			method: "POST",
 			endpoint: "/mapping-rules/search",
@@ -101,7 +101,7 @@ export const getIdentityMappingRuleCommand = defineCommand(
 		const { client, profile } = ctx;
 		const mappingRuleId = args.mappingRuleId;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "get mapping-rule",
 			method: "GET",
 			endpoint: `/mapping-rules/${mappingRuleId}`,
@@ -146,7 +146,7 @@ export const createIdentityMappingRuleCommand = defineCommand(
 			claimValue: flags.claimValue,
 		};
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "create mapping-rule",
 			method: "POST",
 			endpoint: "/mapping-rules",
@@ -170,7 +170,7 @@ export const deleteIdentityMappingRuleCommand = defineCommand(
 		const { client, profile } = ctx;
 		const mappingRuleId = args.mappingRuleId;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "delete mapping-rule",
 			method: "DELETE",
 			endpoint: `/mapping-rules/${encodeURIComponent(mappingRuleId)}`,

--- a/src/commands/identity-roles.ts
+++ b/src/commands/identity-roles.ts
@@ -3,7 +3,7 @@
  */
 
 import { fetchAllPages, sortTableData } from "../core/index.ts";
-import { defineCommand, dryRun } from "../framework/index.ts";
+import { defineCommand } from "../framework/index.ts";
 
 /**
  * List all roles
@@ -11,7 +11,7 @@ import { defineCommand, dryRun } from "../framework/index.ts";
 export const listRolesCommand = defineCommand("list", "role", async (ctx) => {
 	const { client, profile, limit } = ctx;
 
-	const dr = dryRun({
+	const dr = ctx.dryRun({
 		command: "list roles",
 		method: "POST",
 		endpoint: "/roles/search",
@@ -52,7 +52,7 @@ export const searchIdentityRolesCommand = defineCommand(
 
 		const searchFilter = Object.keys(filter).length > 0 ? { filter } : {};
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "search roles",
 			method: "POST",
 			endpoint: "/roles/search",
@@ -93,7 +93,7 @@ export const getIdentityRoleCommand = defineCommand(
 		const { client, profile } = ctx;
 		const roleId = args.roleId;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "get role",
 			method: "GET",
 			endpoint: `/roles/${roleId}`,
@@ -127,7 +127,7 @@ export const createIdentityRoleCommand = defineCommand(
 
 		const body = { roleId: flags.roleId, name: flags.name };
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "create role",
 			method: "POST",
 			endpoint: "/roles",
@@ -151,7 +151,7 @@ export const deleteIdentityRoleCommand = defineCommand(
 		const { client, profile } = ctx;
 		const roleId = args.roleId;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "delete role",
 			method: "DELETE",
 			endpoint: `/roles/${encodeURIComponent(roleId)}`,

--- a/src/commands/identity-tenants.ts
+++ b/src/commands/identity-tenants.ts
@@ -3,7 +3,7 @@
  */
 
 import { fetchAllPages, sortTableData } from "../core/index.ts";
-import { defineCommand, dryRun } from "../framework/index.ts";
+import { defineCommand } from "../framework/index.ts";
 
 /**
  * List all tenants
@@ -14,7 +14,7 @@ export const listTenantsCommand = defineCommand(
 	async (ctx) => {
 		const { client, profile, limit } = ctx;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "list tenants",
 			method: "POST",
 			endpoint: "/tenants/search",
@@ -56,7 +56,7 @@ export const searchIdentityTenantsCommand = defineCommand(
 
 		const searchFilter = Object.keys(filter).length > 0 ? { filter } : {};
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "search tenants",
 			method: "POST",
 			endpoint: "/tenants/search",
@@ -97,7 +97,7 @@ export const getIdentityTenantCommand = defineCommand(
 		const { client, profile } = ctx;
 		const tenantId = args.tenantId;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "get tenant",
 			method: "GET",
 			endpoint: `/tenants/${tenantId}`,
@@ -134,7 +134,7 @@ export const createIdentityTenantCommand = defineCommand(
 			name: flags.name,
 		};
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "create tenant",
 			method: "POST",
 			endpoint: "/tenants",
@@ -158,7 +158,7 @@ export const deleteIdentityTenantCommand = defineCommand(
 		const { client, profile } = ctx;
 		const tenantId = args.tenantId;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "delete tenant",
 			method: "DELETE",
 			endpoint: `/tenants/${encodeURIComponent(String(tenantId))}`,

--- a/src/commands/identity-users.ts
+++ b/src/commands/identity-users.ts
@@ -3,7 +3,7 @@
  */
 
 import { fetchAllPages, sortTableData } from "../core/index.ts";
-import { defineCommand, dryRun } from "../framework/index.ts";
+import { defineCommand } from "../framework/index.ts";
 import { toStringFilter } from "./search.ts";
 
 /**
@@ -12,7 +12,7 @@ import { toStringFilter } from "./search.ts";
 export const listUsersCommand = defineCommand("list", "user", async (ctx) => {
 	const { client, profile, limit } = ctx;
 
-	const dr = dryRun({
+	const dr = ctx.dryRun({
 		command: "list users",
 		method: "POST",
 		endpoint: "/users/search",
@@ -55,7 +55,7 @@ export const searchIdentityUsersCommand = defineCommand(
 
 		const searchFilter = Object.keys(filter).length > 0 ? { filter } : {};
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "search users",
 			method: "POST",
 			endpoint: "/users/search",
@@ -96,7 +96,7 @@ export const getIdentityUserCommand = defineCommand(
 		const { client, profile } = ctx;
 		const username = args.username;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "get user",
 			method: "GET",
 			endpoint: `/users/${username}`,
@@ -135,7 +135,7 @@ export const createIdentityUserCommand = defineCommand(
 			...(flags.email ? { email: flags.email } : {}),
 		};
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "create user",
 			method: "POST",
 			endpoint: "/users",
@@ -159,7 +159,7 @@ export const deleteIdentityUserCommand = defineCommand(
 		const { client, profile } = ctx;
 		const username = args.username;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "delete user",
 			method: "DELETE",
 			endpoint: `/users/${encodeURIComponent(String(username))}`,

--- a/src/commands/identity.ts
+++ b/src/commands/identity.ts
@@ -4,7 +4,6 @@
 
 import { TenantId, Username } from "@camunda8/orchestration-cluster-api";
 import {
-	c8ctl,
 	createClient,
 	getLogger,
 	resolveClusterConfig,
@@ -122,7 +121,7 @@ async function handleAssign(
 	resource: string,
 	id: string,
 	values: Record<string, unknown>,
-	options: { profile?: string },
+	options: { profile?: string; isDryRun: boolean },
 ): Promise<void> {
 	const logger = getLogger();
 	const allowedTargets = ALLOWED_ASSIGN_TARGETS[resource];
@@ -154,7 +153,7 @@ async function handleAssign(
 	const resourcePath = RESOURCE_PATHS[resource];
 	const targetPath = `${targetFlag.replace(/^to-/, "")}s`;
 
-	if (c8ctl.dryRun) {
+	if (options.isDryRun) {
 		const config = resolveClusterConfig(options.profile);
 		logger.json({
 			dryRun: true,
@@ -280,7 +279,7 @@ async function handleUnassign(
 	resource: string,
 	id: string,
 	values: Record<string, unknown>,
-	options: { profile?: string },
+	options: { profile?: string; isDryRun: boolean },
 ): Promise<void> {
 	const logger = getLogger();
 	const allowedSources = ALLOWED_UNASSIGN_SOURCES[resource];
@@ -312,7 +311,7 @@ async function handleUnassign(
 	const resourcePath = RESOURCE_PATHS[resource];
 	const sourcePath = `${sourceFlag.replace(/^from-/, "")}s`;
 
-	if (c8ctl.dryRun) {
+	if (options.isDryRun) {
 		const config = resolveClusterConfig(options.profile);
 		logger.json({
 			dryRun: true,
@@ -461,6 +460,7 @@ function makeAssignCommand<
 			{ ...flags },
 			{
 				profile: ctx.profile,
+				isDryRun: ctx.isDryRun,
 			},
 		);
 		return undefined;
@@ -478,6 +478,7 @@ function makeUnassignCommand<
 			{ ...flags },
 			{
 				profile: ctx.profile,
+				isDryRun: ctx.isDryRun,
 			},
 		);
 		return undefined;
@@ -517,6 +518,7 @@ export const assignFallbackCommand = defineCommand(
 			{ ...flags },
 			{
 				profile: ctx.profile,
+				isDryRun: ctx.isDryRun,
 			},
 		);
 		return undefined;
@@ -538,6 +540,7 @@ export const unassignFallbackCommand = defineCommand(
 			{ ...flags },
 			{
 				profile: ctx.profile,
+				isDryRun: ctx.isDryRun,
 			},
 		);
 		return undefined;

--- a/src/commands/incidents.ts
+++ b/src/commands/incidents.ts
@@ -3,7 +3,7 @@
  */
 
 import { fetchAllPages } from "../core/index.ts";
-import { defineCommand, dryRun } from "../framework/index.ts";
+import { defineCommand } from "../framework/index.ts";
 import { buildDateFilter, parseBetween } from "../utils/index.ts";
 
 /**
@@ -40,7 +40,7 @@ export const listIncidentsCommand = defineCommand(
 			}
 		}
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "list incidents",
 			method: "POST",
 			endpoint: "/incidents/search",
@@ -82,7 +82,7 @@ export const getIncidentCommand = defineCommand(
 		const { client, profile } = ctx;
 		const key = args.key;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "get incident",
 			method: "GET",
 			endpoint: `/incidents/${key}`,
@@ -108,7 +108,7 @@ export const resolveIncidentCommand = defineCommand(
 		const { client, profile } = ctx;
 		const key = args.key;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "resolve incident",
 			method: "POST",
 			endpoint: `/incidents/${key}/resolution`,

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -4,7 +4,7 @@
 
 import { TenantId } from "@camunda8/orchestration-cluster-api";
 import { fetchAllPages } from "../core/index.ts";
-import { defineCommand, dryRun } from "../framework/index.ts";
+import { defineCommand } from "../framework/index.ts";
 import { buildDateFilter, parseBetween } from "../utils/index.ts";
 
 /**
@@ -42,7 +42,7 @@ export const listJobsCommand = defineCommand(
 			}
 		}
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "list jobs",
 			method: "POST",
 			endpoint: "/jobs/search",
@@ -96,7 +96,7 @@ export const activateJobsCommand = defineCommand(
 			throw new Error("--timeout must be a positive integer (milliseconds)");
 		}
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "activate jobs",
 			method: "POST",
 			endpoint: "/jobs/activation",
@@ -157,7 +157,7 @@ export const completeJobCommand = defineCommand(
 			body.variables = variables;
 		}
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "complete job",
 			method: "POST",
 			endpoint: `/jobs/${key}/completion`,
@@ -190,7 +190,7 @@ export const failJobCommand = defineCommand(
 			throw new Error("--retries must be a non-negative integer");
 		}
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "fail job",
 			method: "POST",
 			endpoint: `/jobs/${key}/failure`,

--- a/src/commands/mcp-proxy.ts
+++ b/src/commands/mcp-proxy.ts
@@ -11,7 +11,6 @@ import {
 	ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import {
-	c8ctl,
 	createClient,
 	Logger,
 	type LogWriter,
@@ -267,9 +266,9 @@ export const mcpProxyCommand = defineCommand("mcp-proxy", "", async (ctx) => {
 
 		// In verbose mode users want the full stack trace, so re-throw and
 		// let Node print it to stderr. The framework's default error handler
-		// short-circuits to a plain rethrow when `c8ctl.verbose` is set
+		// short-circuits to a plain rethrow when verbose is set
 		// (see src/errors.ts), so no stdout hint is emitted in that path.
-		if (c8ctl.verbose) {
+		if (ctx.verbose) {
 			throw normalizedError;
 		}
 

--- a/src/commands/messages.ts
+++ b/src/commands/messages.ts
@@ -4,7 +4,7 @@
 
 import { TenantId } from "@camunda8/orchestration-cluster-api";
 import { resolveTenantId } from "../core/index.ts";
-import { defineCommand, dryRun } from "../framework/index.ts";
+import { defineCommand } from "../framework/index.ts";
 
 /**
  * Publish message
@@ -39,7 +39,7 @@ export const publishMessageCommand = defineCommand(
 			body.timeToLive = timeToLive;
 		}
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "publish message",
 			method: "POST",
 			endpoint: "/messages/publication",
@@ -94,7 +94,7 @@ export const correlateMessageCommand = defineCommand(
 			body.timeToLive = timeToLive;
 		}
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "correlate message",
 			method: "POST",
 			endpoint: "/messages/correlation",

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -26,7 +26,7 @@ import {
 export const openAppCommand = defineCommand("open", "", async (ctx) => {
 	const { app, profile, dryRun } = validateOpenAppOptions(ctx.resource, {
 		profile: ctx.profile,
-		dryRun: ctx.dryRun,
+		dryRun: ctx.isDryRun,
 	});
 
 	const config = resolveClusterConfig(profile);

--- a/src/commands/process-definitions.ts
+++ b/src/commands/process-definitions.ts
@@ -3,7 +3,7 @@
  */
 
 import { fetchAllPages } from "../core/index.ts";
-import { defineCommand, dryRun } from "../framework/index.ts";
+import { defineCommand } from "../framework/index.ts";
 
 // ─── get pd ──────────────────────────────────────────────────────────────────
 
@@ -15,7 +15,7 @@ export const getProcessDefinitionCommand = defineCommand(
 		const key = args.key;
 
 		if (flags.xml) {
-			const dr = dryRun({
+			const dr = ctx.dryRun({
 				command: "get process-definition xml",
 				method: "GET",
 				endpoint: `/process-definitions/${key}/xml`,
@@ -30,7 +30,7 @@ export const getProcessDefinitionCommand = defineCommand(
 			return { kind: "raw", content: result };
 		}
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "get process-definition",
 			method: "GET",
 			endpoint: `/process-definitions/${key}`,
@@ -61,7 +61,7 @@ export const listProcessDefinitionsCommand = defineCommand(
 			},
 		};
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "list process-definitions",
 			method: "POST",
 			endpoint: "/process-definitions/search",

--- a/src/commands/process-instances.ts
+++ b/src/commands/process-instances.ts
@@ -8,7 +8,7 @@ import {
 	TenantId,
 } from "@camunda8/orchestration-cluster-api";
 import { fetchAllPages, handleCommandError } from "../core/index.ts";
-import { defineCommand, dryRun } from "../framework/index.ts";
+import { defineCommand } from "../framework/index.ts";
 import { buildDateFilter, parseBetween } from "../utils/index.ts";
 
 /**
@@ -66,7 +66,7 @@ export const listProcessInstancesCommand = defineCommand(
 			}
 		}
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "list process-instances",
 			method: "POST",
 			endpoint: "/process-instances/search",
@@ -111,7 +111,7 @@ export const getProcessInstanceCommand = defineCommand(
 		// but used as a boolean toggle for get pi. Check argv directly.
 		const includeVariables = process.argv.includes("--variables");
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "get process-instance",
 			method: "GET",
 			endpoint: `/process-instances/${key}`,
@@ -183,7 +183,7 @@ export const createProcessInstanceCommand = defineCommand(
 		if (awaitCompletion) body.awaitCompletion = true;
 		if (requestTimeout !== undefined) body.requestTimeout = requestTimeout;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "create process-instance",
 			method: "POST",
 			endpoint: "/process-instances",
@@ -286,7 +286,7 @@ export const awaitProcessInstanceCommand = defineCommand(
 		if (flags.variables) body.variables = JSON.parse(flags.variables);
 		if (requestTimeout !== undefined) body.requestTimeout = requestTimeout;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "await process-instance",
 			method: "POST",
 			endpoint: "/process-instances",
@@ -348,7 +348,7 @@ export const cancelProcessInstanceCommand = defineCommand(
 		const { client, profile } = ctx;
 		const key = args.key;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "cancel process-instance",
 			method: "POST",
 			endpoint: `/process-instances/${key}/cancellation`,

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -2,7 +2,7 @@
  * Run command — deploy a BPMN file and start a process instance in one step.
  *
  * Per #288, the body lives directly in the `defineCommand` handler:
- * dry-run preview via the framework's `dryRun()` helper, validation
+ * dry-run preview via the context's `ctx.dryRun()` helper, validation
  * up-front, and `throw` on every error path so the framework's
  * `handleCommandError` wrapper owns process termination.
  */
@@ -14,7 +14,7 @@ import {
 	TenantId,
 } from "@camunda8/orchestration-cluster-api";
 import { resolveTenantId } from "../core/index.ts";
-import { defineCommand, dryRun } from "../framework/index.ts";
+import { defineCommand } from "../framework/index.ts";
 
 /**
  * Extract process ID from BPMN file content.
@@ -36,7 +36,7 @@ export const runCommand = defineCommand("run", "", async (ctx, flags) => {
 	// Dry-run preview comes first, mirroring the pre-#288 order pinned by
 	// `tests/unit/form-topology-run-behaviour.test.ts`. The body shape
 	// `{ path, variables }` is part of that contract.
-	const dr = dryRun({
+	const dr = ctx.dryRun({
 		command: "run",
 		method: "POST",
 		endpoint: "/deployments + /process-instances",

--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -8,7 +8,7 @@ import {
 	type Logger,
 	sortTableData,
 } from "../core/index.ts";
-import { defineCommand, dryRun } from "../framework/index.ts";
+import { defineCommand } from "../framework/index.ts";
 import {
 	API_DEFAULT_PAGE_SIZE,
 	buildDateFilter,
@@ -160,7 +160,7 @@ export const searchProcessDefinitionsCommand = defineCommand(
 			filter.filter.processDefinitionKey = flags.key;
 		}
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "search process-definitions",
 			method: "POST",
 			endpoint: "/process-definitions/search",
@@ -319,7 +319,7 @@ export const searchProcessInstancesCommand = defineCommand(
 			}
 		}
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "search process-instances",
 			method: "POST",
 			endpoint: "/process-instances/search",
@@ -448,7 +448,7 @@ export const searchUserTasksCommand = defineCommand(
 			}
 		}
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "search user-tasks",
 			method: "POST",
 			endpoint: "/user-tasks/search",
@@ -600,7 +600,7 @@ export const searchIncidentsCommand = defineCommand(
 			}
 		}
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "search incidents",
 			method: "POST",
 			endpoint: "/incidents/search",
@@ -737,7 +737,7 @@ export const searchJobsCommand = defineCommand(
 			}
 		}
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "search jobs",
 			method: "POST",
 			endpoint: "/jobs/search",
@@ -848,7 +848,7 @@ export const searchVariablesCommand = defineCommand(
 		// By default, truncate values unless --fullValue is specified
 		const truncateValues = !flags.fullValue;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "search variables",
 			method: "POST",
 			endpoint: "/variables/search",

--- a/src/commands/topology.ts
+++ b/src/commands/topology.ts
@@ -2,7 +2,7 @@
  * Topology commands
  */
 
-import { defineCommand, dryRun } from "../framework/index.ts";
+import { defineCommand } from "../framework/index.ts";
 
 /**
  * Get cluster topology
@@ -13,7 +13,7 @@ export const getTopologyCommand = defineCommand(
 	async (ctx) => {
 		const { client, profile } = ctx;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "get topology",
 			method: "GET",
 			endpoint: "/topology",

--- a/src/commands/user-tasks.ts
+++ b/src/commands/user-tasks.ts
@@ -3,7 +3,7 @@
  */
 
 import { fetchAllPages } from "../core/index.ts";
-import { defineCommand, dryRun } from "../framework/index.ts";
+import { defineCommand } from "../framework/index.ts";
 import { buildDateFilter, parseBetween } from "../utils/index.ts";
 
 /**
@@ -44,7 +44,7 @@ export const listUserTasksCommand = defineCommand(
 			}
 		}
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "list user-tasks",
 			method: "POST",
 			endpoint: "/user-tasks/search",
@@ -93,7 +93,7 @@ export const completeUserTaskCommand = defineCommand(
 			body.variables = variables;
 		}
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "complete user-task",
 			method: "POST",
 			endpoint: `/user-tasks/${key}/completion`,

--- a/src/commands/variables.ts
+++ b/src/commands/variables.ts
@@ -3,7 +3,7 @@
  */
 
 import { isRecord } from "../core/index.ts";
-import { defineCommand, dryRun } from "../framework/index.ts";
+import { defineCommand } from "../framework/index.ts";
 
 /**
  * Set variables on an element instance (process instance or flow element).
@@ -40,7 +40,7 @@ export const setVariableCommand = defineCommand(
 
 		const local = flags.local === true;
 
-		const dr = dryRun({
+		const dr = ctx.dryRun({
 			command: "set variable",
 			method: "PUT",
 			endpoint: `/element-instances/${key}/variables`,

--- a/src/commands/watch.ts
+++ b/src/commands/watch.ts
@@ -202,6 +202,7 @@ export const watchCommand = defineCommand("watch", "", async (ctx, flags) => {
 								continueOnError: flags.force,
 								continueOnUserError: true,
 								signal: ac.signal,
+								verbose: ctx.verbose,
 							});
 						} catch (error) {
 							// `deployResources()` normally returns early when its signal

--- a/src/framework/command-framework.ts
+++ b/src/framework/command-framework.ts
@@ -15,7 +15,6 @@
 
 import type { CamundaClient } from "@camunda8/orchestration-cluster-api";
 import {
-	c8ctl,
 	getLogger,
 	handleCommandError,
 	type Logger,
@@ -242,8 +241,16 @@ export interface CommandContext {
 	dateField: string | undefined;
 	/** Version filter (parsed from --version flag). */
 	version?: number | undefined;
-	/** Whether --dry-run was set. */
-	dryRun: boolean | undefined;
+	/** Whether --dry-run was set (for handlers that emit a custom dry-run payload). */
+	isDryRun: boolean;
+	/**
+	 * Dry-run helper bound to this invocation: returns a `DryRunResult` when
+	 * --dry-run is active, else null. Captures the flag at construction, so
+	 * handlers never read dry-run state off the global runtime.
+	 */
+	dryRun: DryRunFn;
+	/** Whether --verbose was set. */
+	verbose: boolean;
 	/** Active profile name (for client/tenant resolution). */
 	profile: string | undefined;
 }
@@ -556,33 +563,40 @@ function renderResult(result: CommandResult, ctx: CommandContext): void {
 // ─── dryRun ──────────────────────────────────────────────────────────────────
 
 /**
- * Check if dry-run mode is active and return a `DryRunResult` if so.
+ * Build the `ctx.dryRun()` helper bound to this invocation's --dry-run state.
+ *
+ * When dry-run is active it returns a `DryRunResult` describing the request
+ * that *would* be sent; otherwise it returns null so the handler proceeds. The
+ * dry-run flag is captured once at context construction (the composition root),
+ * so handlers obtain it from `ctx` and never read it off the global runtime.
  *
  * Usage in handlers:
  * ```ts
- * const dr = dryRun({ command: "list pi", method: "POST", endpoint: "/process-instances/search", profile, body: filter });
+ * const dr = ctx.dryRun({ command: "list pi", method: "POST", endpoint: "/process-instances/search", profile: ctx.profile, body: filter });
  * if (dr) return dr;
  * ```
- *
- * Replaces the old `emitDryRun()` side-effecting pattern.
  */
-export function dryRun(opts: {
+export type DryRunFn = (opts: {
 	command: string;
 	method: string;
 	endpoint: string;
 	profile?: string;
 	body?: unknown;
-}): DryRunResult | null {
-	if (!c8ctl.dryRun) return null;
-	const config = resolveClusterConfig(opts.profile);
-	return {
-		kind: "dryRun",
-		info: {
-			dryRun: true,
-			command: opts.command,
-			method: opts.method,
-			url: `${config.baseUrl}${opts.endpoint}`,
-			...(opts.body !== undefined && { body: opts.body }),
-		},
+}) => DryRunResult | null;
+
+export function createDryRun(isDryRun: boolean): DryRunFn {
+	return (opts) => {
+		if (!isDryRun) return null;
+		const config = resolveClusterConfig(opts.profile);
+		return {
+			kind: "dryRun",
+			info: {
+				dryRun: true,
+				command: opts.command,
+				method: opts.method,
+				url: `${config.baseUrl}${opts.endpoint}`,
+				...(opts.body !== undefined && { body: opts.body }),
+			},
+		};
 	};
 }

--- a/src/framework/ui/completion.ts
+++ b/src/framework/ui/completion.ts
@@ -897,7 +897,10 @@ export function extractCompletionVersion(filePath: string): string | undefined {
  *
  * Supports --dry-run via the c8ctl runtime flag.
  */
-export function installCompletion(shellOverride?: string): void {
+export function installCompletion(
+	shellOverride?: string,
+	isDryRun = false,
+): void {
 	const logger = getLogger();
 	const shell = shellOverride?.toLowerCase() ?? detectShell();
 
@@ -920,7 +923,7 @@ export function installCompletion(shellOverride?: string): void {
 		: true;
 
 	// Dry-run support
-	if (c8ctl.dryRun) {
+	if (isDryRun) {
 		const result: Record<string, unknown> = {
 			dryRun: true,
 			detectedShell: shell,
@@ -990,9 +993,9 @@ export function installCompletion(shellOverride?: string): void {
  * or if the embedded version matches the running CLI version.
  * Synchronous write (~1ms for a few KB).
  */
-export function refreshCompletionsIfStale(): void {
+export function refreshCompletionsIfStale(isDryRun = false): void {
 	// Skip in dry-run mode — refresh is a side effect
-	if (c8ctl.dryRun) return;
+	if (isDryRun) return;
 
 	// Use the same source of truth as generateForShell() for version headers
 	const currentVersion = c8ctl.version;

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
 	COMMAND_REGISTRY,
 	type CommandContext,
 	type CommandDef,
+	createDryRun,
 	deriveParseArgsOptions,
 	detectUnknownFlags,
 	executePluginCommand,
@@ -390,7 +391,7 @@ async function main() {
 	await loadInstalledPlugins();
 
 	// Auto-refresh installed completions if CLI version changed
-	refreshCompletionsIfStale();
+	refreshCompletionsIfStale(c8ctl.dryRun ?? false);
 
 	// Extract command and resource
 	const [rawVerb, resource, ...args] = positionals;
@@ -732,7 +733,9 @@ async function main() {
 			between: str(values.between),
 			dateField: str(values.dateField),
 			version: parseVersionFlag(values),
-			dryRun: c8ctl.dryRun,
+			isDryRun: c8ctl.dryRun ?? false,
+			dryRun: createDryRun(c8ctl.dryRun ?? false),
+			verbose: c8ctl.verbose ?? false,
 			profile,
 		};
 		await handler.execute(ctx, values, args);

--- a/tests/unit/command-framework.test.ts
+++ b/tests/unit/command-framework.test.ts
@@ -18,6 +18,7 @@ import {
 import {
 	type CommandContext,
 	type CommandResult,
+	createDryRun,
 	defineCommand,
 	deserializeFlags,
 	type InferFlags,
@@ -305,7 +306,10 @@ describe("defineCommand", () => {
 			all: undefined,
 			between: undefined,
 			dateField: undefined,
-			dryRun: undefined,
+			version: undefined,
+			isDryRun: false,
+			dryRun: createDryRun(false),
+			verbose: false,
 			profile: undefined,
 		};
 

--- a/tests/unit/no-runtime-global-reads-in-handlers.test.ts
+++ b/tests/unit/no-runtime-global-reads-in-handlers.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Architectural class-of-defect guard for issue #424, finding #3.
+ *
+ * Per-invocation request flags (`--dry-run`, `--verbose`) are resolved once
+ * at the composition root (`src/index.ts`) and threaded into command handlers
+ * through the typed `CommandContext`:
+ *
+ *   - `ctx.dryRun({ ... })` — the bound dry-run helper (returns a
+ *     `DryRunResult` when active, else null).
+ *   - `ctx.isDryRun` — the boolean, for handlers that emit a custom dry-run
+ *     payload (deploy, identity).
+ *   - `ctx.verbose` — whether `--verbose` was passed.
+ *
+ * The command (`src/commands/**`) and framework (`src/framework/**`) layers
+ * must obtain these from `ctx` (or, for non-handler framework entry points,
+ * an explicit parameter) and must NOT read them back off the mutable global
+ * `c8ctl` runtime singleton. Doing so re-introduces hidden coupling to the
+ * singleton and bypasses the DI channel.
+ *
+ * The global itself stays — it is the irreducible plugin SDK exposed on
+ * `globalThis.c8ctl`, and `src/core/**` legitimately owns/wraps it (the
+ * core error handler and SDK client read it directly, and the composition
+ * root writes it). This guard is scoped to the two layers that receive a
+ * `CommandContext` instead.
+ *
+ * AST-based (not regex) so field names in comments, doc strings, and string
+ * literals cannot produce false positives or false negatives. See
+ * `tests/utils/no-runtime-global-reads.ts`.
+ */
+
+import assert from "node:assert";
+import { readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, test } from "node:test";
+import { findRuntimeGlobalReads } from "../utils/no-runtime-global-reads.ts";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
+
+/** Per-invocation request flags that must come from `ctx`, not the global. */
+const FORBIDDEN_FIELDS = ["dryRun", "verbose"] as const;
+
+/** Layers that receive a CommandContext and must not read the mutable global. */
+const GUARDED_DIRS = [
+	join(PROJECT_ROOT, "src", "commands"),
+	join(PROJECT_ROOT, "src", "framework"),
+];
+
+function listTsFilesRecursive(dir: string): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(dir, { withFileTypes: true })) {
+		const abs = join(dir, entry.name);
+		if (entry.isDirectory()) {
+			out.push(...listTsFilesRecursive(abs));
+		} else if (entry.name.endsWith(".ts")) {
+			out.push(abs);
+		}
+	}
+	return out;
+}
+
+/** Convert an absolute path under PROJECT_ROOT to a workspace-relative
+ * POSIX path for stable diagnostic output. */
+function toRelative(absPath: string): string {
+	const rel = absPath.slice(PROJECT_ROOT.length + 1);
+	return rel.split(/[\\/]/).join("/");
+}
+
+describe("architectural guard: ctx, not the global runtime, carries per-invocation flags (#424)", () => {
+	const files = GUARDED_DIRS.flatMap(listTsFilesRecursive);
+
+	test("no command/framework file reads `c8ctl.dryRun` or `c8ctl.verbose`", () => {
+		const violations: { file: string; line: number; text: string }[] = [];
+		for (const abs of files) {
+			for (const read of findRuntimeGlobalReads(abs, FORBIDDEN_FIELDS)) {
+				violations.push({
+					file: toRelative(abs),
+					line: read.line,
+					text: read.text,
+				});
+			}
+		}
+		assert.strictEqual(
+			violations.length,
+			0,
+			`Command and framework files must read per-invocation flags from the ` +
+				`CommandContext (\`ctx.dryRun()\`, \`ctx.isDryRun\`, \`ctx.verbose\`), ` +
+				`not from the global \`c8ctl\` runtime. Found ${violations.length}:\n` +
+				violations
+					.map((v) => `  - ${v.file}:${v.line} — ${v.text}`)
+					.join("\n") +
+				`\n\nThread the flag through \`ctx\` (handlers) or an explicit ` +
+				`parameter (non-handler framework entry points) instead.`,
+		);
+	});
+});

--- a/tests/utils/no-runtime-global-reads.ts
+++ b/tests/utils/no-runtime-global-reads.ts
@@ -1,0 +1,85 @@
+/**
+ * AST-based scanner that finds reads of per-invocation request flags off
+ * the global `c8ctl` runtime singleton (e.g. `c8ctl.dryRun`, `c8ctl.verbose`).
+ *
+ * Why this guard exists (issue #424, finding #3): per-invocation request
+ * state — whether `--dry-run` / `--verbose` were passed — is resolved once
+ * at the composition root (`src/index.ts`) and threaded into command
+ * handlers through the typed `CommandContext` (`ctx.dryRun()`, `ctx.isDryRun`,
+ * `ctx.verbose`). Reaching back into the mutable global from the command or
+ * framework layers re-introduces hidden coupling to the singleton and
+ * bypasses the DI channel, so it is forbidden there.
+ *
+ * Why AST and not regex: a regex over file text would flag the same field
+ * names inside comments, doc strings, and string literals (false positives)
+ * and can miss real reads when naive comment-stripping interacts with
+ * strings/templates (false negatives). The TypeScript parser distinguishes
+ * code from comments and literals, so a PropertyAccessExpression walk is the
+ * only durable shape. See `tests/utils/no-process-exit.ts` for the same
+ * rationale.
+ *
+ * Matches the plain form `c8ctl.<field>` only (object identifier `c8ctl`,
+ * property name in the configured set). It intentionally does NOT match
+ * `globalThis.c8ctl.<field>`, element access (`c8ctl["dryRun"]`), or aliased
+ * destructures — those idioms do not appear in this codebase and flagging
+ * them would cost more in false positives than they catch.
+ */
+
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+
+export interface RuntimeGlobalRead {
+	/** 1-based line number of the read. */
+	line: number;
+	/** 1-based column number of the read. */
+	column: number;
+	/** The field that was read, e.g. `dryRun`. */
+	field: string;
+	/** The full property-access text, e.g. `c8ctl.dryRun`. */
+	text: string;
+}
+
+/**
+ * Parse a TypeScript file and return every `c8ctl.<field>` property access
+ * whose field is in `forbiddenFields`. Comments and string/template literals
+ * are ignored (the parser correctly distinguishes them from real code).
+ */
+export function findRuntimeGlobalReads(
+	filePath: string,
+	forbiddenFields: readonly string[],
+): RuntimeGlobalRead[] {
+	const source = readFileSync(filePath, "utf8");
+	const sf = ts.createSourceFile(
+		filePath,
+		source,
+		ts.ScriptTarget.Latest,
+		/* setParentNodes */ true,
+		ts.ScriptKind.TS,
+	);
+
+	const forbidden = new Set(forbiddenFields);
+	const hits: RuntimeGlobalRead[] = [];
+
+	const visit = (node: ts.Node): void => {
+		if (
+			ts.isPropertyAccessExpression(node) &&
+			ts.isIdentifier(node.expression) &&
+			node.expression.text === "c8ctl" &&
+			forbidden.has(node.name.text)
+		) {
+			const { line, character } = sf.getLineAndCharacterOfPosition(
+				node.getStart(sf),
+			);
+			hits.push({
+				line: line + 1,
+				column: character + 1,
+				field: node.name.text,
+				text: node.getText(sf),
+			});
+		}
+		ts.forEachChild(node, visit);
+	};
+	visit(sf);
+
+	return hits;
+}


### PR DESCRIPTION
## What

Decouples the command and framework layers from the mutable surface of the global `c8ctl` runtime singleton, for the per-invocation request flags `--dry-run` and `--verbose` (issue #424, finding #3 — the "(Optional, larger)" item).

Per-invocation request state is now resolved **once** at the composition root (`src/index.ts`) and threaded into handlers through the typed `CommandContext`, instead of being read back off the global from the layers above `core`.

## Why

`CommandContext` already declared `dryRun` and `index.ts` already populated it — but the free `dryRun()` helper bypassed `ctx` and re-read `c8ctl.dryRun` directly, and a handful of handlers/helpers reached into `c8ctl.verbose` / `c8ctl.dryRun`. That re-introduced hidden coupling to the singleton around an existing DI channel. This PR closes those bypasses and adds a guard so they can't backslide.

The `c8ctl` global **stays** — it is the irreducible plugin SDK exposed on `globalThis.c8ctl` (every default plugin + the scaffold template read it), and `src/core/**` legitimately owns/wraps it. Only its *mutable surface as seen from above core* shrinks.

## Changes

- **`command-framework.ts`**: replace the free `dryRun()` helper (read `c8ctl.dryRun`) with a `createDryRun(isDryRun)` factory + exported `DryRunFn` type. `CommandContext` now carries:
  - `dryRun(opts)` — the bound dry-run helper (returns `DryRunResult` or `null`)
  - `isDryRun` — the boolean, for handlers that emit a *custom* dry-run payload (`deploy`, `identity`)
  - `verbose`
- **`index.ts`**: build `isDryRun` / `dryRun` / `verbose` from the resolved flags at ctx construction.
- Migrated all command handlers to `ctx.dryRun({ ... })` (63 sites); `deploy`/`identity` to `ctx.isDryRun`; `mcp-proxy`/`deploy` to `ctx.verbose`.
- Non-handler helpers (`forms`, `identity` assign/unassign, `completion` install/refresh) receive the flag via an explicit parameter instead of reading the global.
- `deploy-helpers` reads output mode via `logger.mode` instead of `c8ctl.outputMode`.

## Guard

New AST-based architectural guard `tests/unit/no-runtime-global-reads-in-handlers.test.ts` (+ `tests/utils/no-runtime-global-reads.ts`) forbids `c8ctl.dryRun` / `c8ctl.verbose` reads in `src/commands/**` and `src/framework/**`. Proven to detect a violation (file:line) before landing. `c8ctl.outputMode` is session display state (read via `logger.mode`) and is out of scope.

Documented the convention in **AGENTS.md**.

## Verification

- `npm run typecheck` ✅
- `npx biome check src tests` ✅
- `npm run check:layering` ✅
- `npm run test:unit` ✅ (1816 pass, incl. the new guard)
- `npm run build` ✅
- Smoke-tested `--dry-run` for standard (`list pi`), custom-payload (`deploy`, `assign role`), and `completion install` paths.

Refs #424

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
