### PR TITLE
Fix/cluster start stable alias issue 431

### DIFF
--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -179,8 +179,12 @@ function readLocalAliasMapping(cacheDir, alias) {
     // "8.9.5"). This prevents re-downloading a rolling alias when a compatible
     // pinned version is already installed locally (#431).
     if (isMinorVersionPattern(value)) {
-      const installedVersions = getInstalledVersionsList(cacheDir);
-      const match = installedVersions.find((v) => v.startsWith(value + '.'));
+      const installedVersions = getInstalledVersionsList(cacheDir)
+        .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+      const match = installedVersions
+        .filter((v) => v.startsWith(value + '.'))
+        .reverse()
+        .find((v) => isC8RunInstalled({ cacheDir, version: v }));
       if (match) return match;
     }
 

--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -172,7 +172,19 @@ function readLocalAliasMapping(cacheDir, alias) {
     const value = readFileSync(filePath, 'utf-8').trim();
     // Only use the cached mapping if the version is actually installed
     const config = { cacheDir, version: value };
-    return isC8RunInstalled(config) ? value : null;
+    if (isC8RunInstalled(config)) return value;
+
+    // For rolling versions (minor version patterns like "8.9"), check if any
+    // installed version matches the minor version prefix (e.g. "8.9" matches
+    // "8.9.5"). This prevents re-downloading a rolling alias when a compatible
+    // pinned version is already installed locally (#431).
+    if (isMinorVersionPattern(value)) {
+      const installedVersions = getInstalledVersionsList(cacheDir);
+      const match = installedVersions.find((v) => v.startsWith(value + '.'));
+      if (match) return match;
+    }
+
+    return null;
   } catch {
     return null;
   }

--- a/tests/unit/cluster-plugin.test.ts
+++ b/tests/unit/cluster-plugin.test.ts
@@ -1058,6 +1058,38 @@ describe("Cluster Plugin – resolveVersion", () => {
 		});
 		assert.strictEqual(resolved, "8.8.5", "non-alias should pass through");
 	});
+
+	test("preferLocal matches installed minor prefix when alias resolves to rolling version (#431)", async () => {
+		// Simulate: alias "stable" → "8.9" (minor/rolling), but installed version is "8.9.5".
+		// The cache dir has c8run-8.9.5, NOT c8run-8.9.
+		// Current bug: readLocalAliasMapping does an exact match on "8.9" → not found → re-downloads.
+		// Fix: should find c8run-8.9.5 because it starts with "8.9."
+		const cacheDir = mkdtempSync(join(tmpdir(), "c8ctl-test-"));
+		try {
+			// Simulate installed version 8.9.5 (full semver directory)
+			const installDir = join(cacheDir, "c8run-8.9.5", "c8run-8.9.5");
+			mkdirSync(installDir, { recursive: true });
+			writeFileSync(join(installDir, "c8run"), "fake");
+
+			// Simulate the alias cache: stable → 8.9 (minor version pattern)
+			plugin.storeLocalAliasMapping(cacheDir, "stable", "8.9");
+
+			// Remote is unreachable — preferLocal should still find the installed version
+			mockFetchOffline();
+
+			const resolved = await plugin.resolveVersion("stable", {
+				preferLocal: true,
+				cacheDir,
+			});
+			assert.strictEqual(
+				resolved,
+				"8.9.5",
+				"should find installed 8.9.5 when alias maps to rolling 8.9",
+			);
+		} finally {
+			rmSync(cacheDir, { recursive: true, force: true });
+		}
+	});
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #431 


This PR causes `c8 cluster start stable` to use the latest locally installed server in the stable release line when available, rather than forcing the rolling install. 