### PR TITLE
fix(cluster): avoid false-positive update hint for same-minor pins

### DIFF
--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -79,7 +79,7 @@ export function majorMinorOf(version) {
 export function isRemoteMinorNewer(remoteVersion, resolvedVersion) {
   const remote = majorMinorOf(remoteVersion);
   const resolved = majorMinorOf(resolvedVersion);
-  // If either side is unparseable, fall back to a conservative string compare.
+  // If either side is unparseable, fall back to the previous behavior (string inequality).
   if (!remote || !resolved) return remoteVersion !== resolvedVersion;
   return (
     remote.major > resolved.major ||

--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -58,6 +58,36 @@ export function isRollingVersion(versionSpec) {
 }
 
 /**
+ * Extract the leading major.minor pair from a version string.
+ * Accepts minor patterns ("8.10") and concrete versions ("8.10.0-alpha1").
+ * Returns { major, minor } or null if the string has no major.minor prefix.
+ */
+export function majorMinorOf(version) {
+  const match = /^(\d+)\.(\d+)/.exec(version);
+  if (!match) return null;
+  return { major: Number(match[1]), minor: Number(match[2]) };
+}
+
+/**
+ * True when the remote alias target is a strictly newer minor line than the
+ * locally resolved version. The remote alias always resolves to a major.minor
+ * pattern (e.g. "8.10"), whereas the resolved version may be a concrete pin
+ * (e.g. "8.10.0-alpha1") within that same minor line. Comparing the raw
+ * strings produces false positives (#434): "8.10" !== "8.10.0-alpha1" even
+ * though no newer release exists. Compare at the major.minor level instead.
+ */
+export function isRemoteMinorNewer(remoteVersion, resolvedVersion) {
+  const remote = majorMinorOf(remoteVersion);
+  const resolved = majorMinorOf(resolvedVersion);
+  // If either side is unparseable, fall back to a conservative string compare.
+  if (!remote || !resolved) return remoteVersion !== resolvedVersion;
+  return (
+    remote.major > resolved.major ||
+    (remote.major === resolved.major && remote.minor > resolved.minor)
+  );
+}
+
+/**
  * Fetch the c8run download directory listing and discover the latest
  * stable and alpha minor versions.
  *
@@ -244,7 +274,7 @@ export function checkBackgroundAliasFreshness(versionSpec, resolvedVersion) {
         if (html) {
           const remote = parseVersionsFromHtml(html);
           const remoteVersion = remote?.[versionSpec];
-          if (remoteVersion && remoteVersion !== resolvedVersion) {
+          if (remoteVersion && isRemoteMinorNewer(remoteVersion, resolvedVersion)) {
             logger.info(
               `A newer "${versionSpec}" release is available (${remoteVersion}). ` +
               `Install it with: c8ctl cluster install ${versionSpec}`,

--- a/tests/unit/cluster-plugin.test.ts
+++ b/tests/unit/cluster-plugin.test.ts
@@ -1146,6 +1146,27 @@ describe("Cluster Plugin – checkBackgroundAliasFreshness", () => {
 		);
 	});
 
+	test("does not print hint when resolved version is a concrete pin in the same minor (#434)", async () => {
+		// Remote alpha train: 8.10 has alpha dirs but no GA yet → alpha alias = 8.10.
+		// Local alpha resolved to the concrete pin 8.10.0-alpha1 (same minor line).
+		// @ts-expect-error — mock fetch
+		globalThis.fetch = async () => ({
+			ok: true,
+			text: async () => `
+        <a href="8.9/">8.9</a><a href="8.9.0/">8.9.0</a>
+        <a href="8.10/">8.10</a><a href="8.10.0-alpha1/">8.10.0-alpha1</a>
+      `,
+		});
+
+		await plugin.checkBackgroundAliasFreshness("alpha", "8.10.0-alpha1");
+
+		assert.strictEqual(
+			loggedMessages.filter((m: string) => m.includes("newer")).length,
+			0,
+			"Should not print upgrade hint when the resolved pin is in the same minor line",
+		);
+	});
+
 	test("does not print hint when remote alias matches resolved version", async () => {
 		// @ts-expect-error — mock fetch
 		globalThis.fetch = async () => ({
@@ -1980,6 +2001,31 @@ describe("Cluster Plugin – isRollingVersion", () => {
 		assert.strictEqual(plugin.isRollingVersion("8.9.0-alpha5"), false);
 		assert.strictEqual(plugin.isRollingVersion("8.8.1"), false);
 		assert.strictEqual(plugin.isRollingVersion("latest"), false);
+	});
+});
+
+describe("Cluster Plugin – isRemoteMinorNewer", () => {
+	test("true when remote minor is strictly newer", () => {
+		assert.strictEqual(plugin.isRemoteMinorNewer("8.9", "8.8"), true);
+		assert.strictEqual(plugin.isRemoteMinorNewer("8.10", "8.9"), true);
+		assert.strictEqual(plugin.isRemoteMinorNewer("9.0", "8.99"), true);
+	});
+
+	test("false when remote minor matches resolved minor line (#434)", () => {
+		assert.strictEqual(
+			plugin.isRemoteMinorNewer("8.10", "8.10.0-alpha1"),
+			false,
+		);
+		assert.strictEqual(plugin.isRemoteMinorNewer("8.9", "8.9"), false);
+		assert.strictEqual(plugin.isRemoteMinorNewer("8.9", "8.9.0"), false);
+	});
+
+	test("false when remote minor is older", () => {
+		assert.strictEqual(plugin.isRemoteMinorNewer("8.8", "8.9"), false);
+		assert.strictEqual(
+			plugin.isRemoteMinorNewer("8.9", "8.10.0-alpha1"),
+			false,
+		);
 	});
 });
 


### PR DESCRIPTION
 `c8ctl cluster start` printed a false-positive "A newer 'alpha' release is available (8.10)" hint even when no newer version existed.

**Root cause**: In `default-plugins/cluster/c8ctl-plugin.js`, `checkBackgroundAliasFreshness` compared the remote alias target against the resolved version using a raw string `!==`. The remote alias always resolves to a major.minor pattern (8.10), while the locally resolved version can be a concrete pin (8.10.0-alpha1) within that same minor line. `"8.10" !== "8.10.0-alpha1"` → false positive.

**Fix**: Added `majorMinorOf()` and `isRemoteMinorNewer()` helpers and compare at the major.minor level — the hint only fires when the remote minor line is strictly newer. Falls back to the old string compare if either side is unparseable.

**Tests (red/green verified):**

 - A regression test in the `checkBackgroundAliasFreshness` suite reproducing the exact issue scenario — confirmed it fails against the old code and passes with the fix.
 - Direct unit tests for `isRemoteMinorNewer `covering newer / same-minor / older cases.

All 126 cluster-plugin tests pass; typecheck and biome are clean.
