### PR TITLE
fix: show argument placeholder for run when resources list is empty (#441)

### DIFF
--- a/src/framework/ui/help.ts
+++ b/src/framework/ui/help.ts
@@ -607,7 +607,7 @@ export function showVerbResources(verb: string): void {
 		return;
 	}
 
-	if (resources.length === 0 && !def.requiresResource) {
+	if (resources.length === 0) {
 		const placeholder = deriveResourcePlaceholder(resolvedVerb, def);
 		console.log(`\nUsage: c8ctl ${resolvedVerb} ${placeholder}\n`);
 		console.log(`Argument:\n  ${placeholder || "(none)"}`);

--- a/tests/unit/help.test.ts
+++ b/tests/unit/help.test.ts
@@ -231,6 +231,33 @@ describe("Help Module", () => {
 		assert.ok(output.includes("fish"));
 	});
 
+	test("showVerbResources shows argument placeholder for run (resources: [], requiresResource: true)", () => {
+		showVerbResources("run");
+
+		const output = consoleLogSpy.join("\n");
+		assert.ok(output.includes("c8ctl run"), "should show usage line");
+		assert.ok(
+			output.includes("Argument:"),
+			"should show Argument section, not empty Available resources",
+		);
+		assert.ok(
+			!output.includes("Available resources:"),
+			"should not show empty Available resources list",
+		);
+	});
+
+	test("showVerbResources shows argument placeholder for deploy (resources: [], requiresResource: false)", () => {
+		showVerbResources("deploy");
+
+		const output = consoleLogSpy.join("\n");
+		assert.ok(output.includes("c8ctl deploy"), "should show usage line");
+		assert.ok(output.includes("Argument:"), "should show Argument section");
+		assert.ok(
+			!output.includes("Available resources:"),
+			"should not show empty Available resources list",
+		);
+	});
+
 	test("showHelp includes completion command", () => {
 		showHelp();
 

--- a/tests/unit/help.test.ts
+++ b/tests/unit/help.test.ts
@@ -241,6 +241,10 @@ describe("Help Module", () => {
 			"should show Argument section, not empty Available resources",
 		);
 		assert.ok(
+			output.includes("<path>"),
+			"should show <path> placeholder from helpResource",
+		);
+		assert.ok(
 			!output.includes("Available resources:"),
 			"should not show empty Available resources list",
 		);
@@ -252,6 +256,10 @@ describe("Help Module", () => {
 		const output = consoleLogSpy.join("\n");
 		assert.ok(output.includes("c8ctl deploy"), "should show usage line");
 		assert.ok(output.includes("Argument:"), "should show Argument section");
+		assert.ok(
+			output.includes("[path...]"),
+			"should show [path...] placeholder from helpResource",
+		);
 		assert.ok(
 			!output.includes("Available resources:"),
 			"should not show empty Available resources list",


### PR DESCRIPTION
## Summary

- Fixes #441
- `showVerbResources` now shows `Argument: <path>` for `c8ctl run` instead of an empty `Available resources:` list
- One-line fix: dropped the `!requiresResource` guard that incorrectly gated the argument-placeholder branch

## Root cause

`src/framework/ui/help.ts` entered the "show argument placeholder" branch only when `resources.length === 0 && !requiresResource`. The `run` verb has `resources: []` but `requiresResource: true`, causing it to fall through to the generic path and render an empty list.

## Test plan

- [ ] `showVerbResources("run")` — new test asserts `Argument:` section present, `Available resources:` absent
- [ ] `showVerbResources("deploy")` — new test asserts same (was already working, now explicitly guarded)
- [ ] `npm run test:unit` passes (101 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)