### PR TITLE
feat(process-instances): make empty "list" message reflect the applied filters

### DIFF
--- a/src/commands/process-instances.ts
+++ b/src/commands/process-instances.ts
@@ -9,7 +9,11 @@ import {
 } from "@camunda8/orchestration-cluster-api";
 import { fetchAllPages, handleCommandError } from "../core/index.ts";
 import { defineCommand } from "../framework/index.ts";
-import { buildDateFilter, parseBetween } from "../utils/index.ts";
+import {
+	buildDateFilter,
+	parseBetween,
+	processInstancesEmptyMessage,
+} from "../utils/index.ts";
 
 /**
  * List process instances
@@ -92,7 +96,7 @@ export const listProcessInstancesCommand = defineCommand(
 				"Start Date": pi.startDate || "-",
 				"Tenant ID": pi.tenantId,
 			})),
-			emptyMessage: "No process instances found",
+			emptyMessage: processInstancesEmptyMessage(filter.filter),
 		};
 	},
 );

--- a/src/utils/command-local/process-instance-helpers.ts
+++ b/src/utils/command-local/process-instance-helpers.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure helpers that are the guts of the `process-instance` commands, kept
+ * test-visible in the `utils` layer.
+ */
+
+/**
+ * Builds an explicit empty-result message for `c8ctl list process-instance`,
+ * naming the filters that were actually applied so the user understands the
+ * scope of the query that returned nothing.
+ *
+ * In particular the default `state = ACTIVE` filter — applied unless `--state`
+ * or `--all` is given — is otherwise invisible, so a bare `list pi` that hides
+ * completed/terminated instances looks like "no instances at all". Rendering the
+ * state as an adjective on the resource noun ("No ACTIVE process instances
+ * found") makes the constraint obvious.
+ *
+ * @param filter The `filter` object sent to `searchProcessInstances` (i.e.
+ *   `body.filter`), so the message reflects exactly what was queried.
+ */
+export function processInstancesEmptyMessage(
+	filter: Record<string, unknown>,
+): string {
+	const state = typeof filter.state === "string" ? filter.state : undefined;
+	const noun = `${state ? `${state} ` : ""}process instances`;
+
+	const qualifiers: string[] = [];
+
+	const definitionId = filter.processDefinitionId;
+	if (typeof definitionId === "string" && definitionId.length > 0) {
+		qualifiers.push(`process "${definitionId}"`);
+	}
+
+	const version = filter.processDefinitionVersion;
+	if (version !== undefined && version !== null) {
+		qualifiers.push(`version ${version}`);
+	}
+
+	const tenantId = filter.tenantId;
+	if (
+		typeof tenantId === "string" &&
+		tenantId.length > 0 &&
+		tenantId !== "<default>"
+	) {
+		qualifiers.push(`tenant "${tenantId}"`);
+	}
+
+	for (const field of ["startDate", "endDate"] as const) {
+		if (filter[field] !== undefined) {
+			qualifiers.push(`${field} within the given range`);
+		}
+	}
+
+	const base = `No ${noun} found`;
+	return qualifiers.length > 0 ? `${base} for ${qualifiers.join(", ")}` : base;
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,6 +7,7 @@
 export * from "./command-local/deploy-version.ts";
 export * from "./command-local/mcp-proxy-helpers.ts";
 export * from "./command-local/open-helpers.ts";
+export * from "./command-local/process-instance-helpers.ts";
 export * from "./command-local/search-helpers.ts";
 export * from "./command-local/watch-constants.ts";
 export * from "./shared/date-filter.ts";

--- a/tests/unit/process-instances.test.ts
+++ b/tests/unit/process-instances.test.ts
@@ -4,6 +4,7 @@
 
 import assert from "node:assert";
 import { describe, test } from "node:test";
+import { processInstancesEmptyMessage } from "../../src/utils/index.ts";
 
 describe("Process Instances Table Formatting", () => {
 	/**
@@ -82,5 +83,60 @@ describe("Process Instances Table Formatting", () => {
 			state: "ACTIVE",
 		});
 		assert.strictEqual(row.Key, "⚠ 444555666");
+	});
+});
+
+describe("processInstancesEmptyMessage", () => {
+	test("surfaces the default ACTIVE state filter", () => {
+		assert.strictEqual(
+			processInstancesEmptyMessage({ tenantId: "<default>", state: "ACTIVE" }),
+			"No ACTIVE process instances found",
+		);
+	});
+
+	test("surfaces an explicit state filter (e.g. COMPLETED)", () => {
+		assert.strictEqual(
+			processInstancesEmptyMessage({ state: "COMPLETED" }),
+			"No COMPLETED process instances found",
+		);
+	});
+
+	test("omits the state adjective when no state filter is applied (--all)", () => {
+		assert.strictEqual(
+			processInstancesEmptyMessage({ tenantId: "<default>" }),
+			"No process instances found",
+		);
+	});
+
+	test("appends process id and version qualifiers", () => {
+		assert.strictEqual(
+			processInstancesEmptyMessage({
+				state: "ACTIVE",
+				processDefinitionId: "order-process",
+				processDefinitionVersion: 2,
+			}),
+			'No ACTIVE process instances found for process "order-process", version 2',
+		);
+	});
+
+	test("includes a non-default tenant but not the default tenant", () => {
+		assert.strictEqual(
+			processInstancesEmptyMessage({ state: "ACTIVE", tenantId: "acme" }),
+			'No ACTIVE process instances found for tenant "acme"',
+		);
+		assert.strictEqual(
+			processInstancesEmptyMessage({ state: "ACTIVE", tenantId: "<default>" }),
+			"No ACTIVE process instances found",
+		);
+	});
+
+	test("notes an applied date range", () => {
+		assert.strictEqual(
+			processInstancesEmptyMessage({
+				state: "ACTIVE",
+				startDate: { $gt: "2024-01-01" },
+			}),
+			"No ACTIVE process instances found for startDate within the given range",
+		);
 	});
 });


### PR DESCRIPTION
## Problem

`c8ctl list process-instance` (`list pi`) silently defaults to filtering `state = ACTIVE` unless `--state <X>` or `--all` is passed (`src/commands/process-instances.ts:51-55`). When a user has only completed/terminated instances, the command prints a flat **"No process instances found"** — giving no indication that an ACTIVE-only filter was applied. This is confusing, especially against engines (e.g. Nano BPM) that retain history: the instances exist, but the default filter hides them.

## Change

Build the empty-result message from the `filter` object actually sent to `searchProcessInstances`, so the constraint is explicit:

- `c8ctl list pi` → **`No ACTIVE process instances found`**
- `c8ctl list pi --state COMPLETED` → **`No COMPLETED process instances found`**
- `c8ctl list pi --all` → **`No process instances found`** (no state filter)
- with more filters → e.g. `No ACTIVE process instances found for process "order", version 2`

The state renders as an adjective on the resource noun; process id, version, non-default tenant, and an applied date range are appended as qualifiers — so the message is explicit for **all** filters that were applied, not just state.

## Implementation

- New pure, test-visible command-local helper `processInstancesEmptyMessage(filter)` in `src/utils/command-local/process-instance-helpers.ts` (exported via the utils barrel, consistent with the layered architecture).
- `listProcessInstancesCommand` now uses it for `emptyMessage`.

## Tests

- Added unit coverage for each filter combination (default ACTIVE, explicit state, `--all`, process id + version, non-default vs default tenant, date range).
- `npm run typecheck`, `biome check` (full tree), the layering import-boundary guard, and the new tests all pass.

> Note: 26 pre-existing `.c8ignore`/deploy unit-test failures on this machine are environmental ("Multiple profiles configured but no profile specified") and reproduce on `main` without these changes; the `docs/command-reference.md` sync drift is also pre-existing and unrelated.