### PR TITLE
feat(deploy): add actionable hint for HTTP 413 payload-too-large

### DIFF
--- a/src/commands/helpers/deploy-helpers.ts
+++ b/src/commands/helpers/deploy-helpers.ts
@@ -859,8 +859,17 @@ function handleDeploymentError(
 	const detail = typeof raw.detail === "string" ? raw.detail : undefined;
 	const status = typeof raw.status === "number" ? raw.status : undefined;
 
+	// HTTP 413 is raised by the cluster ingress (body-size limit), not the
+	// engine — it arrives as a bare "HTTP 413" with no Problem-Detail body.
+	// Give it a self-explanatory title so the "Deployment failed" line and
+	// the rethrown SilentError both read clearly. The actionable detail
+	// (payload size, largest file, how to split) is added by
+	// `printDeploymentHints`, keyed off `status === 413`.
+	const effectiveTitle =
+		status === 413 ? "Payload too large (HTTP 413)" : title;
+
 	// Display the main error
-	logger.error("Deployment failed", new Error(title));
+	logger.error("Deployment failed", new Error(effectiveTitle));
 
 	// Display the detailed error message if available
 	if (detail) {
@@ -878,7 +887,24 @@ function handleDeploymentError(
 	// Pre-rendered the rich error context above; throw a SilentError so
 	// `handleCommandError` exits non-zero without re-rendering a
 	// duplicate "Failed to deploy: <message>" summary line.
-	throw new SilentError(title);
+	throw new SilentError(effectiveTitle);
+}
+
+/**
+ * Format a byte count as a human-readable size (e.g. "1.5 MB").
+ * Used by the HTTP 413 hint so the user sees roughly how large the
+ * rejected payload was.
+ */
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	const units = ["KB", "MB", "GB", "TB"];
+	let value = bytes / 1024;
+	let unitIndex = 0;
+	while (value >= 1024 && unitIndex < units.length - 1) {
+		value /= 1024;
+		unitIndex++;
+	}
+	return `${value.toFixed(1)} ${units[unitIndex]}`;
 }
 
 /**
@@ -948,6 +974,28 @@ function printDeploymentHints(
 	} else if (title === "RESOURCE_EXHAUSTED") {
 		hints.push("💡 The server is under heavy load (backpressure).");
 		hints.push("   Wait a moment and retry the deployment.");
+	} else if (status === 413) {
+		const totalBytes = resources.reduce(
+			(sum, r) => sum + r.content.byteLength,
+			0,
+		);
+		hints.push(
+			`💡 The deployment payload (~${formatBytes(totalBytes)} across ${resources.length} resource(s)) exceeded the cluster's request body-size limit.`,
+		);
+		hints.push(
+			"   This limit is enforced by the cluster ingress, not the engine, so the whole deployment was rejected before reaching Camunda — nothing was deployed.",
+		);
+		if (resources.length > 0) {
+			const largest = resources.reduce((max, r) =>
+				r.content.byteLength > max.content.byteLength ? r : max,
+			);
+			hints.push(
+				`   Largest single resource: ${largest.relativePath || largest.name} (~${formatBytes(largest.content.byteLength)}).`,
+			);
+		}
+		hints.push(
+			"   Split the resources across multiple `c8 deploy` runs so each request stays under the limit.",
+		);
 	} else if (title === "NOT_FOUND" || status === 404) {
 		hints.push(
 			"💡 The Camunda server could not be reached or the endpoint was not found.",

--- a/tests/unit/deploy-413.test.ts
+++ b/tests/unit/deploy-413.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Behavioural guard for the HTTP 413 (Payload Too Large) deploy hint.
+ *
+ * When a `POST /deployments` payload exceeds the cluster ingress's
+ * body-size limit the request is rejected with HTTP 413 *before* it
+ * reaches the engine, so there is no RFC 9457 Problem-Detail body. The
+ * deploy error handler must still produce a clear, actionable message:
+ *   - a "Payload too large (HTTP 413)" title, and
+ *   - 413-specific guidance (payload size / largest resource / split).
+ *
+ * This drives the real CLI as a subprocess against a local `node:http`
+ * server that returns 413 for the deployment POST — no live cluster and
+ * no internal exports required. Pins the diagnostic introduced for
+ * https://github.com/camunda/c8ctl/issues/446 so it cannot regress
+ * unnoticed.
+ */
+
+import assert from "node:assert";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, test } from "node:test";
+import { c8WithEnv } from "../utils/cli.ts";
+
+const SIMPLE_BPMN = `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="proc-413" isExecutable="true">
+    <bpmn:startEvent id="start"/>
+  </bpmn:process>
+</bpmn:definitions>`;
+
+/** Start a stub HTTP server that answers every request with HTTP 413. */
+function start413Server(): Promise<{ server: Server; baseUrl: string }> {
+	return new Promise((resolve) => {
+		const server = createServer((req, res) => {
+			// Drain the request body, then reject — mirroring an ingress that
+			// returns 413 with a plain-text (non Problem-Detail) body.
+			req.resume();
+			req.on("end", () => {
+				res.writeHead(413, { "Content-Type": "text/plain" });
+				res.end("Payload Too Large");
+			});
+		});
+		server.listen(0, "127.0.0.1", () => {
+			const address = server.address();
+			const port = typeof address === "object" && address ? address.port : 0;
+			resolve({ server, baseUrl: `http://127.0.0.1:${port}/v2` });
+		});
+	});
+}
+
+describe("deploy: HTTP 413 produces an actionable payload-too-large hint", () => {
+	let tempDir: string;
+	let server: Server | undefined;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "c8ctl-deploy-413-"));
+	});
+
+	afterEach(() => {
+		rmSync(tempDir, { recursive: true, force: true });
+		server?.close();
+		server = undefined;
+	});
+
+	test("413 response: clear title + payload-size guidance, exit 1", async () => {
+		const started = await start413Server();
+		server = started.server;
+
+		const bpmnPath = join(tempDir, "proc-413.bpmn");
+		writeFileSync(bpmnPath, SIMPLE_BPMN);
+
+		const result = await c8WithEnv(
+			{ CAMUNDA_BASE_URL: started.baseUrl },
+			"deploy",
+			bpmnPath,
+		);
+
+		assert.strictEqual(
+			result.status,
+			1,
+			`expected exit 1, got ${result.status}. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("Payload too large (HTTP 413)"),
+			`expected the clearer 413 title in stderr. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("exceeded the cluster's request body-size limit"),
+			`expected the 413-specific payload-size hint in stderr. stderr:\n${result.stderr}`,
+		);
+		assert.ok(
+			result.stderr.includes("Split the resources across multiple"),
+			`expected the split-deploys guidance in stderr. stderr:\n${result.stderr}`,
+		);
+	});
+});

--- a/tests/utils/cli.ts
+++ b/tests/utils/cli.ts
@@ -70,6 +70,22 @@ export async function c8(...args: string[]): Promise<SpawnResult> {
 }
 
 /**
+ * Like `c8()`, but merges `extraEnv` over the deterministic test env.
+ * Use this to point the CLI at a local stub server (override
+ * `CAMUNDA_BASE_URL`) so error paths that need a real HTTP response —
+ * e.g. an HTTP 413 from the cluster ingress — can be exercised without a
+ * live cluster.
+ */
+export async function c8WithEnv(
+	extraEnv: Record<string, string>,
+	...args: string[]
+): Promise<SpawnResult> {
+	return asyncSpawn("node", ["--experimental-strip-types", CLI, ...args], {
+		env: { ...buildChildEnv(), ...extraEnv },
+	});
+}
+
+/**
  * Like `c8()`, but accepts a `timeout` (and any future options). Use this
  * for invocations that could hang under regression so the test fails fast
  * instead of stalling the suite (e.g. long-running verbs against the --help


### PR DESCRIPTION
## What

When a single `POST /deployments` payload exceeds the cluster ingress's body-size limit, the request is rejected with **HTTP 413** *before it reaches the engine*. There's no RFC 9457 Problem-Detail body, so the failure currently falls through to the generic "review the error message above" hint — which tells the user nothing about what went wrong.

This adds a dedicated `status === 413` branch to `printDeploymentHints` that surfaces the diagnostics the issue asked for: **which limit was hit, and how many bytes were sent.**

## Changes

- **New 413 hint** reports:
  - total payload size + resource count that were rejected (`~X MB across N resource(s)`)
  - that the limit is enforced by the **cluster ingress, not the engine**, so the deployment is atomic-rejected and *nothing* was deployed
  - the **largest single resource** and its size — so the user can tell whether splitting will help, or whether one file alone is over the limit
  - the fix: split across multiple `c8 deploy` runs
- **Clearer title** — maps the bare `HTTP 413` to `Payload too large (HTTP 413)` for the `Deployment failed` line and the rethrown `SilentError`.
- Small `formatBytes` helper for human-readable sizes.

## Scope

This is the **diagnostic** half of [#446](https://github.com/camunda/c8ctl/issues/446) — low-risk, no behavior change to successful deploys. The larger ask in the issue (client-side size-aware **batching**) is a separate behavior change with an atomicity trade-off and is intentionally **not** included here; it warrants its own design discussion.

## Verification

- `npm run typecheck` — clean
- `biome check` — clean
- deploy error-path + logging unit tests — 9/9 pass

Refs #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)