### PR TITLE
feat(cluster): add cluster purge subcommand and stop --purge flag

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1233,6 +1233,26 @@ c8 cluster install alpha
 c8 cluster delete 8.8
 ```
 
+### Purge Cluster Data
+
+Wipe history and journal data while keeping the downloaded binary intact.
+The next `cluster start` begins with a fresh empty state without re-downloading anything.
+
+```bash
+# Purge data for a specific version (version required, like delete)
+c8 cluster purge 8.9
+c8 cluster purge 8.9.0-alpha5
+
+# Stop the running cluster and purge its data in one step
+c8 cluster stop --purge
+```
+
+If the target version is currently running, stop it first with `cluster stop`
+(or use `cluster stop --purge` to stop and purge in one step).
+
+`cluster stop --purge` is the recommended way to reset a running cluster:
+it captures the running version, stops it, then purges the data atomically.
+
 ### Typical Local Development Workflow
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -517,6 +517,12 @@ c8ctl cluster install 8.9
 
 # Remove a cached version
 c8ctl cluster delete 8.9
+
+# Purge history and journal data for a version (binary stays intact)
+c8ctl cluster purge 8.9
+
+# Stop cluster and purge its runtime data in one step
+c8ctl cluster stop --purge
 ```
 
 #### Version Aliases

--- a/default-plugins/cluster/c8ctl-plugin.js
+++ b/default-plugins/cluster/c8ctl-plugin.js
@@ -320,6 +320,7 @@ export const metadata = {
         { name: 'delete', description: 'Remove a cached version' },
         { name: 'log', description: 'Stream cluster logs' },
         { name: 'logs', description: 'Stream cluster logs' },
+        { name: 'purge', description: 'Delete runtime data (keeps binary) so the next start is fresh' },
       ],
       examples: [
         { command: 'c8ctl cluster start', description: 'Start a local Camunda 8 cluster (latest stable)' },
@@ -332,6 +333,8 @@ export const metadata = {
         { command: 'c8ctl cluster list-remote', description: 'List all versions available on the remote download server' },
         { command: 'c8ctl cluster install 8.8', description: 'Download a version without starting it' },
         { command: 'c8ctl cluster delete 8.8', description: 'Remove a locally cached version' },
+        { command: 'c8ctl cluster purge 8.8', description: 'Delete runtime data for a version (binary stays intact)' },
+        { command: 'c8ctl cluster stop --purge', description: 'Stop the running cluster and delete its runtime data' },
       ],
     },
   },
@@ -1043,13 +1046,16 @@ export async function stopC8Run(config, debug = false) {
     logger.warn(
       'Cluster marker file found, but no running cluster processes detected. Cleaning up stale marker.',
     );
+    let staleVersion = null;
+    if (existsSync(versionFile)) {
+      const v = readFileSync(versionFile, 'utf-8').trim();
+      if (v) staleVersion = v;
+      rmSync(versionFile);
+    }
     if (existsSync(markerFile)) {
       rmSync(markerFile);
     }
-    if (existsSync(versionFile)) {
-      rmSync(versionFile);
-    }
-    return;
+    return staleVersion;
   }
 
   if (!markerExists && clusterAppearsRunning) {
@@ -1069,10 +1075,12 @@ export async function stopC8Run(config, debug = false) {
     : [];
 
   const versionsToTry = [];
+  let stoppedVersion = null;
 
   if (existsSync(versionFile)) {
     const markerVersion = readFileSync(versionFile, 'utf-8').trim();
     if (markerVersion) {
+      stoppedVersion = markerVersion;
       versionsToTry.push(markerVersion);
     }
   }
@@ -1186,6 +1194,7 @@ export async function stopC8Run(config, debug = false) {
   }
 
   logger.info('Cluster stopped.');
+  return stoppedVersion;
 }
 
 // ---------------------------------------------------------------------------
@@ -1370,6 +1379,37 @@ export async function listRemoteVersions() {
 }
 
 // ---------------------------------------------------------------------------
+// Shared helpers for delete / purge
+// ---------------------------------------------------------------------------
+
+// Validate and resolve a version spec to the locally installed version name.
+// Aliases (stable, alpha) are resolved preferring the local cache so that
+// delete/purge operate on what is actually installed.
+async function resolveVersionArg(cacheDir, versionSpec) {
+  validateVersionSpec(versionSpec);
+  return isVersionAlias(versionSpec)
+    ? await resolveVersion(versionSpec, { preferLocal: true, cacheDir })
+    : versionSpec;
+}
+
+// Return true if the given version appears to be currently running.
+// Requires both marker files to identify the running version, then confirms
+// with live .process pidfiles. Without markers we cannot attribute any
+// running process to a specific version, so we return false — consistent
+// with stopC8Run treating marker absence as "not running".
+function isVersionRunning(cacheDir, version) {
+  const markerFile = join(cacheDir, ACTIVE_MARKER_FILE);
+  const versionFile = join(cacheDir, VERSION_MARKER_FILE);
+
+  if (!existsSync(markerFile) || !existsSync(versionFile)) return false;
+
+  const markerVersion = readFileSync(versionFile, 'utf-8').trim();
+  if (markerVersion !== version) return false;
+
+  return hasRunningClusterPidfiles(cacheDir);
+}
+
+// ---------------------------------------------------------------------------
 // Delete cached version
 // ---------------------------------------------------------------------------
 
@@ -1381,28 +1421,28 @@ export async function deleteVersion(cacheDir, versionSpec) {
     process.exit(1);
   }
 
-  validateVersionSpec(versionSpec);
-
-  // Resolve named aliases (stable/alpha) to the actual cached version name.
-  // Use preferLocal so we delete the version that's actually installed,
-  // not whatever the remote currently resolves the alias to.
   // Major.minor patterns like 8.8 are used as-is since the cache dir is named c8run-8.8.
-  const resolvedVersion = isVersionAlias(versionSpec)
-    ? await resolveVersion(versionSpec, { preferLocal: true, cacheDir })
-    : versionSpec;
+  const resolvedVersion = await resolveVersionArg(cacheDir, versionSpec);
 
   // Prevent deleting a currently running version
-  const versionFile = join(cacheDir, VERSION_MARKER_FILE);
-  const markerFile = join(cacheDir, ACTIVE_MARKER_FILE);
+  if (isVersionRunning(cacheDir, resolvedVersion)) {
+    logger.error(
+      `Version ${resolvedVersion} is currently running. Stop it first with: c8ctl cluster stop`
+    );
+    process.exit(1);
+  }
 
-  if (existsSync(markerFile) && existsSync(versionFile)) {
-    const runningVersion = readFileSync(versionFile, 'utf-8').trim();
-    if (runningVersion === resolvedVersion) {
-      logger.error(
-        `Version ${resolvedVersion} is currently running. Stop it first with: c8ctl cluster stop`
-      );
-      process.exit(1);
-    }
+  // Safety backstop: if processes are running but either marker is absent we
+  // cannot confirm the version, so refuse rather than risk deleting a live install.
+  if (
+    (!existsSync(join(cacheDir, ACTIVE_MARKER_FILE)) || !existsSync(join(cacheDir, VERSION_MARKER_FILE))) &&
+    hasRunningClusterPidfiles(cacheDir)
+  ) {
+    logger.error(
+      'A cluster appears to be running (processes detected) but the cluster marker is missing. ' +
+      'Run c8ctl cluster stop first.'
+    );
+    process.exit(1);
   }
 
   const config = { cacheDir, version: resolvedVersion };
@@ -1414,6 +1454,79 @@ export async function deleteVersion(cacheDir, versionSpec) {
 
   purgeInstalledVersion(config, { reason: 'as requested' });
   logger.info(`Version ${versionSpec} has been deleted.`);
+}
+
+// ---------------------------------------------------------------------------
+// Purge cluster data
+// ---------------------------------------------------------------------------
+
+export async function purgeClusterData(cacheDir, versionSpec) {
+  const logger = getLogger();
+
+  const resolvedVersion = await resolveVersionArg(cacheDir, versionSpec);
+
+  // Prevent purging a currently running version
+  if (isVersionRunning(cacheDir, resolvedVersion)) {
+    logger.error(
+      `Version ${resolvedVersion} is currently running. ` +
+      'Stop it first with: c8ctl cluster stop\n' +
+      `Or stop and purge in one step: c8ctl cluster stop --purge`
+    );
+    process.exit(1);
+  }
+
+  // Safety backstop: if processes are running but either marker is absent we
+  // cannot confirm the version, so refuse rather than risk purging a live cluster.
+  if (
+    (!existsSync(join(cacheDir, ACTIVE_MARKER_FILE)) || !existsSync(join(cacheDir, VERSION_MARKER_FILE))) &&
+    hasRunningClusterPidfiles(cacheDir)
+  ) {
+    logger.error(
+      'A cluster appears to be running (processes detected) but the cluster marker is missing. ' +
+      'Run c8ctl cluster stop first.'
+    );
+    process.exit(1);
+  }
+
+  const config = { cacheDir, version: resolvedVersion };
+  if (!isC8RunInstalled(config)) {
+    logger.error(`Version ${resolvedVersion} is not installed locally.`);
+    process.exit(1);
+  }
+
+  const binaryPath = getC8RunBinaryPath(config);
+  const binaryDir = dirname(binaryPath);
+
+  const deleted = [];
+
+  // Delete camunda-data (history data + application state)
+  const camundaDataDir = join(binaryDir, 'camunda-data');
+  if (existsSync(camundaDataDir)) {
+    rmSync(camundaDataDir, { recursive: true });
+    deleted.push('camunda-data');
+  }
+
+  // Delete Zeebe journal data inside camunda-zeebe-* subdirectory
+  if (existsSync(binaryDir)) {
+    for (const entry of readdirSync(binaryDir, { withFileTypes: true })) {
+      if (!entry.isDirectory() || !entry.name.startsWith('camunda-zeebe-')) continue;
+      const dataDir = join(binaryDir, entry.name, 'data');
+      if (existsSync(dataDir)) {
+        rmSync(dataDir, { recursive: true });
+        deleted.push(join(entry.name, 'data'));
+      }
+    }
+  }
+
+  if (deleted.length > 0) {
+    logger.info(`Purged runtime data for ${resolvedVersion}:`);
+    for (const d of deleted) {
+      logger.info(`  deleted: ${d}`);
+    }
+  } else {
+    logger.info(`No runtime data found for ${resolvedVersion} — nothing to delete.`);
+  }
+  logger.info(`Binary and installed files preserved. Start fresh with: c8ctl cluster start ${resolvedVersion}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -1499,7 +1612,7 @@ export async function streamLogs(cacheDir) {
 // ---------------------------------------------------------------------------
 
 export function parsePluginArgs(args) {
-  const result = { subcommand: null, version: null, debug: false };
+  const result = { subcommand: null, version: null, debug: false, purge: false };
 
   let i = 0;
   while (i < args.length) {
@@ -1519,6 +1632,12 @@ export function parsePluginArgs(args) {
 
     if (arg === '--debug') {
       result.debug = true;
+      i += 1;
+      continue;
+    }
+
+    if (arg === '--purge') {
+      result.purge = true;
       i += 1;
       continue;
     }
@@ -1546,7 +1665,7 @@ export function parsePluginArgs(args) {
 // Plugin commands export
 // ---------------------------------------------------------------------------
 
-const VALID_SUBCOMMANDS = ['start', 'stop', 'status', 'list', 'list-remote', 'install', 'delete', 'log', 'logs'];
+const VALID_SUBCOMMANDS = ['start', 'stop', 'status', 'list', 'list-remote', 'install', 'delete', 'purge', 'log', 'logs'];
 
 export const commands = {
   'cluster': async (args) => {
@@ -1556,28 +1675,31 @@ export const commands = {
     if (!parsed.subcommand || !VALID_SUBCOMMANDS.includes(parsed.subcommand)) {
       console.log('Usage:');
       console.log('  c8ctl cluster start [<version>] [--debug]');
-      console.log('  c8ctl cluster stop');
+      console.log('  c8ctl cluster stop [--purge]');
       console.log('  c8ctl cluster status');
       console.log('  c8ctl cluster logs              (alias: log)');
       console.log('  c8ctl cluster list');
       console.log('  c8ctl cluster list-remote');
       console.log('  c8ctl cluster install <version>');
       console.log('  c8ctl cluster delete <version>');
+      console.log('  c8ctl cluster purge <version>');
       console.log('');
       console.log('Subcommands:');
       console.log('  start        Download (if needed) and start a local Camunda 8 cluster');
-      console.log('  stop         Stop the running local Camunda 8 cluster');
+      console.log('  stop         Stop the running local Camunda 8 cluster (--purge also deletes runtime data)');
       console.log('  status       Show whether a cluster is running and connection details');
       console.log('  logs         Stream log output from the running cluster');
       console.log('  list         List locally cached versions and available version aliases');
       console.log('  list-remote  List all versions available on the remote download server');
       console.log('  install      Download a version without starting it');
       console.log('  delete       Remove a locally cached version to reclaim disk space');
+      console.log('  purge        Delete runtime data for a version (binary stays intact, next start is fresh)');
       console.log('');
       console.log('Options:');
       console.log('  <version>              Camunda version, alias, or major.minor (default: stable)');
       console.log('  --c8-version <version> Alternative flag form for version');
       console.log('  --debug                Stream raw c8run output during start');
+      console.log('  --purge                (stop only) also delete runtime data after stopping');
       console.log('');
       console.log('A <version> can be:');
       console.log('  stable / alpha         Named aliases');
@@ -1604,7 +1726,14 @@ export const commands = {
       console.log('  c8ctl cluster list-remote');
       console.log('  c8ctl cluster install 8.8');
       console.log('  c8ctl cluster delete 8.8');
+      console.log('  c8ctl cluster purge 8.8          # Delete runtime data, keep binary');
+      console.log('  c8ctl cluster stop --purge        # Stop cluster and delete its runtime data');
       return;
+    }
+
+    if (parsed.purge && parsed.subcommand !== 'stop') {
+      logger.error('--purge can only be used with the stop subcommand. Example: c8ctl cluster stop --purge');
+      process.exit(1);
     }
 
     if (parsed.subcommand === 'status') {
@@ -1647,11 +1776,14 @@ export const commands = {
       return;
     }
 
-    // install and delete require an explicit version argument
-    if (!parsed.version && (parsed.subcommand === 'install' || parsed.subcommand === 'delete')) {
-      const example = parsed.subcommand === 'delete'
-        ? 'c8ctl cluster delete 8.8'
-        : 'c8ctl cluster install stable';
+    // install, delete, and purge require an explicit version argument
+    if (!parsed.version && (parsed.subcommand === 'install' || parsed.subcommand === 'delete' || parsed.subcommand === 'purge')) {
+      const example =
+        parsed.subcommand === 'delete'
+          ? 'c8ctl cluster delete 8.8'
+          : parsed.subcommand === 'purge'
+            ? 'c8ctl cluster purge 8.8'
+            : 'c8ctl cluster install stable';
       logger.error(`Please specify a version. Example: ${example}`);
       process.exit(1);
     }
@@ -1661,6 +1793,16 @@ export const commands = {
         await deleteVersion(getCacheDir(), parsed.version);
       } catch (error) {
         logger.error(`Failed to delete version: ${error}`);
+        process.exit(1);
+      }
+      return;
+    }
+
+    if (parsed.subcommand === 'purge') {
+      try {
+        await purgeClusterData(getCacheDir(), parsed.version);
+      } catch (error) {
+        logger.error(`Failed to purge cluster data: ${error}`);
         process.exit(1);
       }
       return;
@@ -1713,7 +1855,15 @@ export const commands = {
       }
     } else if (parsed.subcommand === 'stop') {
       try {
-        await stopC8Run(config, parsed.debug);
+        const stoppedVersion = await stopC8Run(config, parsed.debug);
+        if (parsed.purge) {
+          if (!stoppedVersion) {
+            logger.warn('Cannot determine which version to purge (version marker is missing). ' +
+                'To purge manually, run: c8ctl cluster purge <version>');
+          } else {
+            await purgeClusterData(theCacheDir, stoppedVersion);
+          }
+        }
       } catch (error) {
         logger.error(`Failed to stop cluster: ${error}`);
         process.exit(1);

--- a/tests/unit/cluster-plugin.test.ts
+++ b/tests/unit/cluster-plugin.test.ts
@@ -68,7 +68,7 @@ describe("Cluster Plugin – metadata", () => {
 		}
 	});
 
-	test("examples include start, stop, status, list, logs, list-remote, install, and delete commands", () => {
+	test("examples include start, stop, status, list, logs, list-remote, install, delete, and purge commands", () => {
 		const examples = plugin.metadata.commands.cluster.examples;
 		const cmds = examples.map((e: { command: string }) => e.command);
 		assert.ok(
@@ -104,6 +104,10 @@ describe("Cluster Plugin – metadata", () => {
 		assert.ok(
 			cmds.some((c: string) => c.includes("delete")),
 			"Should have a delete example",
+		);
+		assert.ok(
+			cmds.some((c: string) => c.includes("purge")),
+			"Should have a purge example",
 		);
 	});
 });
@@ -301,6 +305,17 @@ describe("Cluster Plugin – parsePluginArgs", () => {
 	test("parses --debug flag", () => {
 		const result = plugin.parsePluginArgs(["start", "--debug"]);
 		assert.strictEqual(result.debug, true);
+	});
+
+	test("parses --purge flag", () => {
+		const result = plugin.parsePluginArgs(["stop", "--purge"]);
+		assert.strictEqual(result.subcommand, "stop");
+		assert.strictEqual(result.purge, true);
+	});
+
+	test("purge defaults to false when flag absent", () => {
+		const result = plugin.parsePluginArgs(["stop"]);
+		assert.strictEqual(result.purge, false);
 	});
 
 	test("throws when --c8-version has no value (end of args)", () => {
@@ -1577,6 +1592,7 @@ describe("Cluster Plugin – deleteVersion", () => {
 	let captured: string[];
 	let originalLog: typeof console.log;
 	let originalWarn: typeof console.warn;
+	let originalError: typeof console.error;
 	let originalExit: typeof process.exit;
 
 	beforeEach(() => {
@@ -1584,11 +1600,15 @@ describe("Cluster Plugin – deleteVersion", () => {
 		captured = [];
 		originalLog = console.log;
 		originalWarn = console.warn;
+		originalError = console.error;
 		originalExit = process.exit;
 		console.log = (...args: unknown[]) => {
 			captured.push(args.map(String).join(" "));
 		};
 		console.warn = (...args: unknown[]) => {
+			captured.push(args.map(String).join(" "));
+		};
+		console.error = (...args: unknown[]) => {
 			captured.push(args.map(String).join(" "));
 		};
 	});
@@ -1597,6 +1617,7 @@ describe("Cluster Plugin – deleteVersion", () => {
 		if (existsSync(tempDir)) rmSync(tempDir, { recursive: true, force: true });
 		console.log = originalLog;
 		console.warn = originalWarn;
+		console.error = originalError;
 		process.exit = originalExit;
 	});
 
@@ -1630,6 +1651,8 @@ describe("Cluster Plugin – deleteVersion", () => {
 		writeFileSync(join(binaryDir, "c8run"), "");
 		writeFileSync(join(tempDir, "cluster.active"), "running");
 		writeFileSync(join(tempDir, "cluster.version"), "8.8");
+		// Live pidfile so isVersionRunning() returns true
+		writeFileSync(join(binaryDir, "camunda.process"), String(process.pid));
 
 		let exitCalled = false;
 		const restoreExit = mockProcessExit(() => {
@@ -1645,6 +1668,345 @@ describe("Cluster Plugin – deleteVersion", () => {
 		} finally {
 			restoreExit();
 		}
+	});
+
+	test("prevents deleting when pidfiles indicate a running cluster but marker is missing", async () => {
+		const binaryDir = join(tempDir, "c8run-8.8", "c8run-8.8.1");
+		mkdirSync(binaryDir, { recursive: true });
+		writeFileSync(join(binaryDir, "c8run"), "");
+		// No marker files — only a live pidfile
+		writeFileSync(join(binaryDir, "camunda.process"), String(process.pid));
+
+		const restoreExit = mockProcessExit(() => {});
+
+		try {
+			await plugin.deleteVersion(tempDir, "8.8").catch(() => {});
+			const output = captured.join("\n");
+			assert.ok(
+				output.includes("marker is missing"),
+				"Should error about missing marker when processes are detected",
+			);
+		} finally {
+			restoreExit();
+		}
+	});
+
+	test("prevents deleting when cluster.active exists but cluster.version is missing and pidfiles present", async () => {
+		const binaryDir = join(tempDir, "c8run-8.8", "c8run-8.8.1");
+		mkdirSync(binaryDir, { recursive: true });
+		writeFileSync(join(binaryDir, "c8run"), "");
+		// Partial marker state: active exists but version file is absent
+		writeFileSync(join(tempDir, "cluster.active"), "");
+		writeFileSync(join(binaryDir, "camunda.process"), String(process.pid));
+
+		const restoreExit = mockProcessExit(() => {});
+
+		try {
+			await plugin.deleteVersion(tempDir, "8.8").catch(() => {});
+			const output = captured.join("\n");
+			assert.ok(
+				output.includes("marker is missing"),
+				"Should error about missing marker when cluster.version is absent",
+			);
+		} finally {
+			restoreExit();
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// purgeClusterData
+// ---------------------------------------------------------------------------
+
+describe("Cluster Plugin – purgeClusterData", () => {
+	let tempDir: string;
+	let captured: string[];
+	let originalLog: typeof console.log;
+	let originalWarn: typeof console.warn;
+	let originalError: typeof console.error;
+	let originalExit: typeof process.exit;
+
+	function makeFakeInstall(
+		cacheDir: string,
+		version: string,
+		versionDir: string,
+	) {
+		const binaryDir = join(cacheDir, `c8run-${version}`, versionDir);
+		mkdirSync(binaryDir, { recursive: true });
+		writeFileSync(join(binaryDir, "c8run"), "");
+		// camunda-data dir (history data + app state)
+		mkdirSync(join(binaryDir, "camunda-data"), { recursive: true });
+		writeFileSync(join(binaryDir, "camunda-data", "elasticsearch.db"), "data");
+		// camunda-zeebe-* dir with data subdir (Zeebe journal)
+		const zeebeDir = join(binaryDir, `camunda-zeebe-${versionDir}`);
+		mkdirSync(join(zeebeDir, "data"), { recursive: true });
+		writeFileSync(join(zeebeDir, "data", "raft.log"), "journal");
+		mkdirSync(join(zeebeDir, "lib"), { recursive: true });
+		writeFileSync(join(zeebeDir, "lib", "zeebe.jar"), "binary");
+		return binaryDir;
+	}
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "c8ctl-test-"));
+		captured = [];
+		originalLog = console.log;
+		originalWarn = console.warn;
+		originalError = console.error;
+		originalExit = process.exit;
+		console.log = (...args: unknown[]) =>
+			captured.push(args.map(String).join(" "));
+		console.warn = (...args: unknown[]) =>
+			captured.push(args.map(String).join(" "));
+		console.error = (...args: unknown[]) =>
+			captured.push(args.map(String).join(" "));
+	});
+
+	afterEach(() => {
+		if (existsSync(tempDir)) rmSync(tempDir, { recursive: true, force: true });
+		console.log = originalLog;
+		console.warn = originalWarn;
+		console.error = originalError;
+		process.exit = originalExit;
+	});
+
+	test("deletes camunda-data and zeebe data dirs, preserves binary and zeebe lib", async () => {
+		const binaryDir = makeFakeInstall(tempDir, "8.9", "c8run-8.9.9");
+
+		await plugin.purgeClusterData(tempDir, "8.9");
+
+		assert.strictEqual(
+			existsSync(join(binaryDir, "camunda-data")),
+			false,
+			"camunda-data should be removed",
+		);
+		const zeebeDataDir = join(binaryDir, "camunda-zeebe-c8run-8.9.9", "data");
+		assert.strictEqual(
+			existsSync(zeebeDataDir),
+			false,
+			"zeebe data dir should be removed",
+		);
+		assert.ok(
+			existsSync(join(binaryDir, "c8run")),
+			"binary should be preserved",
+		);
+		assert.ok(
+			existsSync(join(binaryDir, "camunda-zeebe-c8run-8.9.9", "lib")),
+			"zeebe lib should be preserved",
+		);
+	});
+
+	test("logs what was deleted and what was preserved", async () => {
+		makeFakeInstall(tempDir, "8.9", "c8run-8.9.9");
+
+		await plugin.purgeClusterData(tempDir, "8.9");
+
+		const output = captured.join("\n");
+		assert.ok(
+			output.includes("purged") ||
+				output.includes("deleted") ||
+				output.includes("Purged") ||
+				output.includes("Deleted"),
+			"Should log what was deleted",
+		);
+		assert.ok(
+			output.includes("preserved") ||
+				output.includes("intact") ||
+				output.includes("binary"),
+			"Should mention what was preserved",
+		);
+	});
+
+	test("errors and exits when version is not installed", async () => {
+		const restoreExit = mockProcessExit(() => {});
+		try {
+			await assert.rejects(
+				() => plugin.purgeClusterData(tempDir, "9.9"),
+				/exit/,
+			);
+			const output = captured.join("\n");
+			assert.ok(
+				output.includes("not installed") || output.includes("9.9"),
+				"Should report version not found",
+			);
+		} finally {
+			restoreExit();
+		}
+	});
+
+	test("works when camunda-data does not exist (e.g. never started)", async () => {
+		const binaryDir = join(tempDir, "c8run-8.9", "c8run-8.9.9");
+		mkdirSync(binaryDir, { recursive: true });
+		writeFileSync(join(binaryDir, "c8run"), "");
+
+		// Should not throw even with no data dirs to delete
+		await plugin.purgeClusterData(tempDir, "8.9");
+
+		const output = captured.join("\n");
+		assert.ok(output.length > 0, "Should produce some output");
+	});
+
+	test("rejects invalid version spec (path traversal attempt)", async () => {
+		await assert.rejects(
+			() => plugin.purgeClusterData(tempDir, "../evil"),
+			/Invalid version/,
+		);
+	});
+
+	test("rejects version spec with double-dot sequence", async () => {
+		await assert.rejects(
+			() => plugin.purgeClusterData(tempDir, "8..9"),
+			/Invalid version/,
+		);
+	});
+
+	test("purges successfully even when a different version is currently running", async () => {
+		const binaryDir = makeFakeInstall(tempDir, "8.9", "c8run-8.9.9");
+		// Simulate version 8.10 running (different from the 8.9 we are purging)
+		writeFileSync(join(tempDir, "cluster.active"), "");
+		writeFileSync(join(tempDir, "cluster.version"), "8.10");
+		const runningVersionDir = join(tempDir, "c8run-8.10");
+		mkdirSync(runningVersionDir, { recursive: true });
+		writeFileSync(
+			join(runningVersionDir, "camunda.process"),
+			String(process.pid),
+		);
+
+		// 8.9's data dirs should be deleted without error
+		await plugin.purgeClusterData(tempDir, "8.9");
+
+		assert.strictEqual(
+			existsSync(join(binaryDir, "camunda-data")),
+			false,
+			"8.9 camunda-data should be purged regardless of 8.10 running",
+		);
+		// 8.10's directory should be untouched
+		assert.ok(
+			existsSync(runningVersionDir),
+			"Running version directory should be untouched",
+		);
+	});
+
+	test("errors and exits when the target version is currently running", async () => {
+		const binaryDir = makeFakeInstall(tempDir, "8.9", "c8run-8.9.9");
+		writeFileSync(join(tempDir, "cluster.active"), "");
+		writeFileSync(join(tempDir, "cluster.version"), "8.9");
+		// Live pidfile so isVersionRunning() returns true
+		writeFileSync(join(binaryDir, "camunda.process"), String(process.pid));
+
+		const restoreExit = mockProcessExit(() => {});
+		try {
+			await assert.rejects(
+				() => plugin.purgeClusterData(tempDir, "8.9"),
+				/exit/,
+			);
+			const output = captured.join("\n");
+			assert.ok(
+				output.includes("running") || output.includes("Stop"),
+				"Should tell the user to stop the cluster first",
+			);
+			assert.ok(
+				output.includes("--purge"),
+				"Should hint at cluster stop --purge",
+			);
+		} finally {
+			restoreExit();
+		}
+	});
+
+	test("purges successfully when marker is stale (no live process)", async () => {
+		const binaryDir = makeFakeInstall(tempDir, "8.9", "c8run-8.9.9");
+		// Marker files exist but no .process file → cluster is not actually running
+		writeFileSync(join(tempDir, "cluster.active"), "");
+		writeFileSync(join(tempDir, "cluster.version"), "8.9");
+
+		await plugin.purgeClusterData(tempDir, "8.9");
+
+		assert.strictEqual(
+			existsSync(join(binaryDir, "camunda-data")),
+			false,
+			"camunda-data should be deleted despite stale marker",
+		);
+	});
+
+	test("prevents purge when pidfiles indicate a running cluster but marker is missing", async () => {
+		const binaryDir = makeFakeInstall(tempDir, "8.9", "c8run-8.9.9");
+		// No marker files — only a live pidfile
+		writeFileSync(join(binaryDir, "camunda.process"), String(process.pid));
+
+		const restoreExit = mockProcessExit(() => {});
+		try {
+			await plugin.purgeClusterData(tempDir, "8.9").catch(() => {});
+			const output = captured.join("\n");
+			assert.ok(
+				output.includes("marker is missing"),
+				"Should error about missing marker when processes are detected",
+			);
+		} finally {
+			restoreExit();
+		}
+	});
+
+	test("prevents purge when cluster.active exists but cluster.version is missing and pidfiles present", async () => {
+		const binaryDir = makeFakeInstall(tempDir, "8.9", "c8run-8.9.9");
+		// Partial marker state: active exists but version file is absent
+		writeFileSync(join(tempDir, "cluster.active"), "");
+		writeFileSync(join(binaryDir, "camunda.process"), String(process.pid));
+
+		const restoreExit = mockProcessExit(() => {});
+		try {
+			await plugin.purgeClusterData(tempDir, "8.9").catch(() => {});
+			const output = captured.join("\n");
+			assert.ok(
+				output.includes("marker is missing"),
+				"Should error about missing marker when cluster.version is absent",
+			);
+		} finally {
+			restoreExit();
+		}
+	});
+
+	test("deletes data dirs from multiple camunda-zeebe-* subdirectories", async () => {
+		const binaryDir = makeFakeInstall(tempDir, "8.9", "c8run-8.9.9");
+		// Add a second zeebe distribution dir
+		const zeebeDir2 = join(binaryDir, "camunda-zeebe-connector-8.9.9");
+		mkdirSync(join(zeebeDir2, "data"), { recursive: true });
+		writeFileSync(join(zeebeDir2, "data", "raft.log"), "journal");
+		mkdirSync(join(zeebeDir2, "lib"), { recursive: true });
+		writeFileSync(join(zeebeDir2, "lib", "connector.jar"), "binary");
+
+		await plugin.purgeClusterData(tempDir, "8.9");
+
+		assert.strictEqual(
+			existsSync(join(binaryDir, "camunda-zeebe-c8run-8.9.9", "data")),
+			false,
+			"First zeebe data dir should be deleted",
+		);
+		assert.strictEqual(
+			existsSync(join(zeebeDir2, "data")),
+			false,
+			"Second zeebe data dir should also be deleted",
+		);
+		assert.ok(
+			existsSync(join(zeebeDir2, "lib")),
+			"Second zeebe lib dir should be preserved",
+		);
+	});
+
+	test("handles camunda-zeebe-* dir that has no data subdir (lib-only)", async () => {
+		const binaryDir = join(tempDir, "c8run-8.9", "c8run-8.9.9");
+		mkdirSync(binaryDir, { recursive: true });
+		writeFileSync(join(binaryDir, "c8run"), "");
+		const zeebeDir = join(binaryDir, "camunda-zeebe-8.9.9");
+		mkdirSync(join(zeebeDir, "lib"), { recursive: true });
+		writeFileSync(join(zeebeDir, "lib", "zeebe.jar"), "binary");
+		// No data subdir created
+
+		await plugin.purgeClusterData(tempDir, "8.9");
+
+		assert.ok(
+			existsSync(join(zeebeDir, "lib")),
+			"zeebe lib should remain untouched",
+		);
 	});
 });
 
@@ -1962,6 +2324,21 @@ describe("Cluster Plugin – logs, list-remote, install, delete subcommands", ()
 			"delete without version should prompt for one",
 		);
 	});
+
+	test("--purge on non-stop subcommand exits with error", async () => {
+		const restoreExit = mockProcessExit();
+
+		try {
+			await plugin.commands.cluster(["start", "--purge"]).catch(() => {});
+		} finally {
+			restoreExit();
+		}
+		const output = captured.join("\n");
+		assert.ok(
+			output.includes("--purge can only be used with the stop subcommand"),
+			"--purge on start should error",
+		);
+	});
 });
 
 // ---------------------------------------------------------------------------
@@ -2239,7 +2616,7 @@ describe("Cluster Plugin – stopC8Run", () => {
 		writeFileSync(join(tempDir, "cluster.version"), "8.8.1");
 
 		const config = { cacheDir: tempDir, version: "8.8" };
-		await plugin.stopC8Run(config);
+		const result = await plugin.stopC8Run(config);
 
 		const output = captured.join("\n");
 		assert.ok(
@@ -2255,6 +2632,12 @@ describe("Cluster Plugin – stopC8Run", () => {
 		assert.ok(
 			!existsSync(join(tempDir, "cluster.version")),
 			"Version marker should be removed",
+		);
+		// Return value should carry the version so stop --purge can proceed
+		assert.strictEqual(
+			result,
+			"8.8.1",
+			"Should return the stale version so stop --purge can purge it",
 		);
 	});
 });


### PR DESCRIPTION
## Summary

Adds two ways to wipe history and journal data while keeping the downloaded binary intact so the next start begins with a fresh empty state without re-downloading.

- **`c8ctl cluster purge <version>`** — deletes `camunda-data/` (history data + application state) and `camunda-zeebe-*/data/` (Zeebe journal) for the specified version. Mirrors the `delete` command: explicit version required, errors if the version is currently running.
- **`c8ctl cluster stop --purge`** — stops the running cluster and purges its data atomically. Captures the running version from the marker file before stop removes it, including the stale-marker case (crash recovery).

Behavior:
- Errors if the target version is currently running — hint suggests `cluster stop --purge`
- Errors with `--purge` on any subcommand other than `stop`
- A different version running is fine — each version's data is isolated in its own directory
- Both `delete` and `purge` refuse when pidfiles indicate a live cluster but the active marker is absent, to guard against crashes that leave processes running without marker files
- Errors if the specified version is not installed locally
- Resolves named aliases (`stable`, `alpha`) to the locally installed version
- Binary, JRE, configuration, and Zeebe libs are preserved

## Test plan

- [ ] `c8ctl cluster purge` without a version prints a clear error with an example
- [ ] `c8ctl cluster purge 8.9` deletes history and journal data, leaves binary intact
- [ ] `c8ctl cluster purge 8.9` while 8.9 is running prints error with `stop --purge` hint
- [ ] `c8ctl cluster purge 8.9` while a different version is running succeeds
- [ ] `c8ctl cluster stop --purge` stops and purges in one step
- [ ] `c8ctl cluster stop --purge` works when the cluster left a stale marker (crash recovery)
- [ ] `c8ctl cluster start --purge` prints a clear error
- [ ] `c8ctl cluster --help` shows updated usage, `--purge` option, and examples
- [ ] All 142 cluster plugin unit tests pass (`node --test tests/unit/cluster-plugin.test.ts`)

closes #451.