### PR TITLE
fix(search): remove unsupported tenantId from ws

### DIFF
--- a/src/commands/search.ts
+++ b/src/commands/search.ts
@@ -942,7 +942,7 @@ export const searchWaitStatesCommand = defineCommand(
 	"search",
 	"wait-state",
 	async (ctx, flags, _args) => {
-		const { client, logger, tenantId, profile } = ctx;
+		const { client, logger, profile } = ctx;
 
 		const criteria: string[] = [];
 		if (flags.processInstanceKey) {
@@ -974,7 +974,7 @@ export const searchWaitStatesCommand = defineCommand(
 		}
 
 		const filter: { filter: Record<string, unknown> } = {
-			filter: { tenantId },
+			filter: {},
 		};
 
 		if (flags.processInstanceKey) {


### PR DESCRIPTION
Removes the tenantId filter criterion from the wait-states search. The API doesn't support this filter field.