### PR TITLE
feat(activate): add --fetchVariable flag to fetch job variables server-side

### DIFF
--- a/README.md
+++ b/README.md
@@ -1351,6 +1351,7 @@ Activate jobs of a specific type for processing
 | `--timeout` | string |  | Job timeout in milliseconds |
 | `--worker` | string |  | Worker name |
 | `--customHeaders` | boolean |  | Include custom headers in output |
+| `--variables` | boolean |  | Include variables in output |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1351,7 +1351,7 @@ Activate jobs of a specific type for processing
 | `--timeout` | string |  | Job timeout in milliseconds |
 | `--worker` | string |  | Worker name |
 | `--customHeaders` | boolean |  | Include custom headers in output |
-| `--variables` | boolean |  | Include variables in output |
+| `--fetchVariable` | string |  | Comma-separated variable names to fetch from the server and include in output |
 
 ---
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -691,7 +691,7 @@ Activate jobs of a specific type for processing
 | `--timeout` | string |  | Job timeout in milliseconds |
 | `--worker` | string |  | Worker name |
 | `--customHeaders` | boolean |  | Include custom headers in output |
-| `--variables` | boolean |  | Include variables in output |
+| `--fetchVariable` | string |  | Comma-separated variable names to fetch from the server and include in output |
 
 ---
 

--- a/docs/command-reference.md
+++ b/docs/command-reference.md
@@ -691,6 +691,7 @@ Activate jobs of a specific type for processing
 | `--timeout` | string |  | Job timeout in milliseconds |
 | `--worker` | string |  | Worker name |
 | `--customHeaders` | boolean |  | Include custom headers in output |
+| `--variables` | boolean |  | Include variables in output |
 
 ---
 

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -88,11 +88,6 @@ export const activateJobsCommand = defineCommand(
 			: 10;
 		const timeout = flags.timeout ? parseInt(flags.timeout, 10) : 60000;
 		const worker = flags.worker || "c8ctl";
-		// `--fetchVariable` maps to the Activate Jobs API's `fetchVariable`
-		// field: a list of variable names the server should return for each
-		// activated job (empty ⇒ all). Passing it filters the payload
-		// server-side rather than merely trimming the display. When present,
-		// the requested variables are also surfaced in the output.
 		const fetchVariableNames = flags.fetchVariable
 			?.split(",")
 			.map((name) => name.trim())

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -88,14 +88,21 @@ export const activateJobsCommand = defineCommand(
 			: 10;
 		const timeout = flags.timeout ? parseInt(flags.timeout, 10) : 60000;
 		const worker = flags.worker || "c8ctl";
-		const fetchVariableNames = flags.fetchVariable
-			?.split(",")
-			.map((name) => name.trim())
-			.filter(Boolean);
-		const fetchVariable =
-			fetchVariableNames && fetchVariableNames.length > 0
-				? fetchVariableNames
-				: undefined;
+		// --fetchVariable restricts which variables the server returns. Per the
+		// REST spec an *empty* list means "return all visible variables", which
+		// defeats the point of the flag, so if the flag is provided but resolves
+		// to no usable names we reject it rather than silently fetching all.
+		let fetchVariable: string[] | undefined;
+		if (flags.fetchVariable !== undefined) {
+			const fetchVariableNames = flags.fetchVariable
+				.split(",")
+				.map((name) => name.trim())
+				.filter(Boolean);
+			if (fetchVariableNames.length === 0) {
+				throw new Error("--fetchVariable was given no valid variable names");
+			}
+			fetchVariable = fetchVariableNames;
+		}
 
 		if (Number.isNaN(maxJobsToActivate) || maxJobsToActivate < 1) {
 			throw new Error("--maxJobsToActivate must be a positive integer");

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -88,12 +88,19 @@ export const activateJobsCommand = defineCommand(
 			: 10;
 		const timeout = flags.timeout ? parseInt(flags.timeout, 10) : 60000;
 		const worker = flags.worker || "c8ctl";
-		// `--variables` is registered as a string type in parseArgs (for
-		// `complete`/`fail`/`publish job --variables '{...}'`, which
-		// `deriveParseArgsOptions` promotes globally) but is used here as a
-		// boolean display toggle. Read argv directly so detection is
-		// position-independent (mirrors `get pi --variables`).
-		const includeVariables = process.argv.includes("--variables");
+		// `--fetchVariable` maps to the Activate Jobs API's `fetchVariable`
+		// field: a list of variable names the server should return for each
+		// activated job (empty ⇒ all). Passing it filters the payload
+		// server-side rather than merely trimming the display. When present,
+		// the requested variables are also surfaced in the output.
+		const fetchVariableNames = flags.fetchVariable
+			?.split(",")
+			.map((name) => name.trim())
+			.filter(Boolean);
+		const fetchVariable =
+			fetchVariableNames && fetchVariableNames.length > 0
+				? fetchVariableNames
+				: undefined;
 
 		if (Number.isNaN(maxJobsToActivate) || maxJobsToActivate < 1) {
 			throw new Error("--maxJobsToActivate must be a positive integer");
@@ -113,6 +120,7 @@ export const activateJobsCommand = defineCommand(
 				maxJobsToActivate,
 				timeout,
 				worker,
+				...(fetchVariable && { fetchVariable }),
 			},
 		});
 		if (dr) return dr;
@@ -125,6 +133,7 @@ export const activateJobsCommand = defineCommand(
 			maxJobsToActivate,
 			timeout,
 			worker,
+			...(fetchVariable && { fetchVariable }),
 		});
 
 		if (result.jobs && result.jobs.length > 0) {
@@ -139,7 +148,7 @@ export const activateJobsCommand = defineCommand(
 					...(flags.customHeaders && {
 						"Custom Headers": job.customHeaders,
 					}),
-					...(includeVariables && {
+					...(fetchVariable && {
 						Variables: job.variables,
 					}),
 				})),

--- a/src/commands/jobs.ts
+++ b/src/commands/jobs.ts
@@ -88,6 +88,12 @@ export const activateJobsCommand = defineCommand(
 			: 10;
 		const timeout = flags.timeout ? parseInt(flags.timeout, 10) : 60000;
 		const worker = flags.worker || "c8ctl";
+		// `--variables` is registered as a string type in parseArgs (for
+		// `complete`/`fail`/`publish job --variables '{...}'`, which
+		// `deriveParseArgsOptions` promotes globally) but is used here as a
+		// boolean display toggle. Read argv directly so detection is
+		// position-independent (mirrors `get pi --variables`).
+		const includeVariables = process.argv.includes("--variables");
 
 		if (Number.isNaN(maxJobsToActivate) || maxJobsToActivate < 1) {
 			throw new Error("--maxJobsToActivate must be a positive integer");
@@ -132,6 +138,9 @@ export const activateJobsCommand = defineCommand(
 					"Element Instance": job.elementInstanceKey,
 					...(flags.customHeaders && {
 						"Custom Headers": job.customHeaders,
+					}),
+					...(includeVariables && {
+						Variables: job.variables,
 					}),
 				})),
 				emptyMessage: "",

--- a/src/framework/command-registry.ts
+++ b/src/framework/command-registry.ts
@@ -1248,9 +1248,10 @@ export const COMMAND_REGISTRY = {
 				type: "boolean",
 				description: "Include custom headers in output",
 			},
-			variables: {
-				type: "boolean",
-				description: "Include variables in output",
+			fetchVariable: {
+				type: "string",
+				description:
+					"Comma-separated variable names to fetch from the server and include in output",
 			},
 		},
 		resourcePositionals: {

--- a/src/framework/command-registry.ts
+++ b/src/framework/command-registry.ts
@@ -1248,6 +1248,10 @@ export const COMMAND_REGISTRY = {
 				type: "boolean",
 				description: "Include custom headers in output",
 			},
+			variables: {
+				type: "boolean",
+				description: "Include variables in output",
+			},
 		},
 		resourcePositionals: {
 			jobs: [

--- a/tests/unit/help.test.ts
+++ b/tests/unit/help.test.ts
@@ -503,6 +503,8 @@ describe("Help Module", () => {
 		assert.ok(output.includes("--maxJobsToActivate"));
 		assert.ok(output.includes("--timeout"));
 		assert.ok(output.includes("--worker"));
+		assert.ok(output.includes("--customHeaders"));
+		assert.ok(output.includes("--variables"));
 	});
 
 	test("showCommandHelp shows publish help", () => {

--- a/tests/unit/help.test.ts
+++ b/tests/unit/help.test.ts
@@ -504,7 +504,7 @@ describe("Help Module", () => {
 		assert.ok(output.includes("--timeout"));
 		assert.ok(output.includes("--worker"));
 		assert.ok(output.includes("--customHeaders"));
-		assert.ok(output.includes("--variables"));
+		assert.ok(output.includes("--fetchVariable"));
 	});
 
 	test("showCommandHelp shows publish help", () => {

--- a/tests/unit/jobs-behaviour.test.ts
+++ b/tests/unit/jobs-behaviour.test.ts
@@ -222,7 +222,21 @@ describe("CLI behavioural: activate jobs", () => {
 		assert.deepStrictEqual(body.fetchVariable, ["scopeInput", "projectName"]);
 	});
 
-	test("--dry-run omits fetchVariable when the value is an empty string", async () => {
+	test("--dry-run accepts --fetchVariable=value (equals form)", async () => {
+		const result = await c8(
+			"activate",
+			"jobs",
+			"--dry-run",
+			"my-job-type",
+			"--fetchVariable=scopeInput",
+		);
+
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const body = asRecord(parseJson(result).body, "dry-run body");
+		assert.deepStrictEqual(body.fetchVariable, ["scopeInput"]);
+	});
+
+	test("--fetchVariable with an empty string is treated as unset (framework normalizes it away)", async () => {
 		const result = await c8(
 			"activate",
 			"jobs",
@@ -232,12 +246,17 @@ describe("CLI behavioural: activate jobs", () => {
 			"",
 		);
 
+		// The framework's deserializeFlags normalizes an empty-string flag value
+		// to `undefined` before the handler runs, so `--fetchVariable ""` is
+		// indistinguishable from omitting the flag: no filter, field absent. A
+		// non-empty-but-empty-after-parse value (e.g. " , , ") does reach the
+		// handler and is rejected — see the next test.
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const body = asRecord(parseJson(result).body, "dry-run body");
 		assert.strictEqual(body.fetchVariable, undefined);
 	});
 
-	test("--dry-run omits fetchVariable when the value is only whitespace and commas", async () => {
+	test("--fetchVariable errors when the value is only whitespace and commas", async () => {
 		const result = await c8(
 			"activate",
 			"jobs",
@@ -247,10 +266,13 @@ describe("CLI behavioural: activate jobs", () => {
 			" , , ",
 		);
 
-		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const body = asRecord(parseJson(result).body, "dry-run body");
-		// Every token trims to empty, so nothing survives filtering.
-		assert.strictEqual(body.fetchVariable, undefined);
+		// Every token trims to empty, so nothing survives filtering: providing the
+		// flag with no usable names is rejected rather than fetching all variables.
+		assert.notStrictEqual(result.status, 0, "expected a non-zero exit");
+		assert.match(
+			result.stderr,
+			/--fetchVariable was given no valid variable names/,
+		);
 	});
 
 	test("--dry-run drops empty tokens from --fetchVariable and keeps the rest", async () => {

--- a/tests/unit/jobs-behaviour.test.ts
+++ b/tests/unit/jobs-behaviour.test.ts
@@ -199,19 +199,29 @@ describe("CLI behavioural: activate jobs", () => {
 		assert.strictEqual(body.customHeaders, undefined);
 	});
 
-	test("--variables flag is accepted without error", async () => {
+	test("--dry-run does not include fetchVariable by default", async () => {
+		const result = await c8("activate", "jobs", "--dry-run", "my-job-type");
+
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const body = asRecord(parseJson(result).body, "dry-run body");
+		assert.strictEqual(body.fetchVariable, undefined);
+	});
+
+	test("--dry-run sends --fetchVariable as a trimmed name array in the body", async () => {
 		const result = await c8(
 			"activate",
 			"jobs",
 			"--dry-run",
 			"my-job-type",
-			"--variables",
+			"--fetchVariable",
+			"scopeInput, projectName",
 		);
 
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const body = asRecord(parseJson(result).body, "dry-run body");
-		// --variables is a display flag only; it must not appear in the API body
-		assert.strictEqual(body.variables, undefined);
+		// --fetchVariable is a real API parameter (server-side variable filter),
+		// so it MUST appear in the request body, split into a trimmed array.
+		assert.deepStrictEqual(body.fetchVariable, ["scopeInput", "projectName"]);
 	});
 });
 
@@ -312,13 +322,13 @@ describe("CLI behavioural: activate jobs --customHeaders rendering", () => {
 	});
 });
 
-// ─── activate jobs with variables response ────────────────────────────────────
+// ─── activate jobs with fetchVariable ─────────────────────────────────────────
 //
-// --variables comes from the API response, so these tests require a mock
-// HTTP server: --dry-run exits before the API call and cannot exercise the
-// rendering path.
+// --fetchVariable filters variables server-side and surfaces the returned
+// values in the output, so these tests require a mock HTTP server: --dry-run
+// exits before the API call and cannot exercise the request/rendering path.
 
-describe("CLI behavioural: activate jobs --variables rendering", () => {
+describe("CLI behavioural: activate jobs --fetchVariable rendering", () => {
 	let server: { url: string; close: () => Promise<void> } | null = null;
 
 	afterEach(async () => {
@@ -328,7 +338,7 @@ describe("CLI behavioural: activate jobs --variables rendering", () => {
 		}
 	});
 
-	test("--variables includes variables as an object in JSON output", async () => {
+	test("--fetchVariable includes the returned variables as an object in JSON output", async () => {
 		const mockJob = {
 			jobKey: "123456",
 			type: "my-job-type",
@@ -357,7 +367,8 @@ describe("CLI behavioural: activate jobs --variables rendering", () => {
 			"activate",
 			"jobs",
 			"my-job-type",
-			"--variables",
+			"--fetchVariable",
+			"scopeInput,projectName",
 		);
 
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
@@ -371,7 +382,50 @@ describe("CLI behavioural: activate jobs --variables rendering", () => {
 		});
 	});
 
-	test("without --variables the field is absent from output", async () => {
+	test("--fetchVariable is sent to the server in the request body", async () => {
+		let receivedBody = "";
+		const mockJob = {
+			jobKey: "123456",
+			type: "my-job-type",
+			retries: 3,
+			processInstanceKey: "789",
+			customHeaders: {},
+			worker: "c8ctl",
+			deadline: Date.now() + 60000,
+			elementId: "task1",
+			processDefinitionId: "process1",
+			processDefinitionVersion: 1,
+			processDefinitionKey: "pd1",
+			tenantId: "<default>",
+			variables: { scopeInput: { processName: "Loan Approval" } },
+		};
+		server = await startMockServer((req, res) => {
+			const chunks: Buffer[] = [];
+			req.on("data", (chunk: Buffer) => chunks.push(chunk));
+			req.on("end", () => {
+				receivedBody = Buffer.concat(chunks).toString("utf8");
+				res.setHeader("content-type", "application/json");
+				res.end(JSON.stringify({ jobs: [mockJob] }));
+			});
+		});
+
+		const result = await c8WithMockServer(
+			server.url,
+			"activate",
+			"jobs",
+			"my-job-type",
+			"--fetchVariable",
+			"scopeInput",
+		);
+
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		// The server-side filter must reach the wire: the request body carries
+		// fetchVariable so the server only returns the requested variables.
+		const sent = asRecord(JSON.parse(receivedBody), "request body");
+		assert.deepStrictEqual(sent.fetchVariable, ["scopeInput"]);
+	});
+
+	test("without --fetchVariable the field is absent from output", async () => {
 		const mockJob = {
 			jobKey: "123456",
 			type: "my-job-type",
@@ -406,62 +460,7 @@ describe("CLI behavioural: activate jobs --variables rendering", () => {
 		assert.strictEqual(
 			row.Variables,
 			undefined,
-			"Variables should be absent when --variables flag is not passed",
-		);
-	});
-
-	test("--variables is detected even when not the final argument", async () => {
-		// `variables` is globally promoted to a `string` flag by
-		// `deriveParseArgsOptions` (for `complete`/`fail`/`publish job
-		// --variables '{...}'`), so parseArgs assigns the following token as
-		// its value rather than returning a boolean. Detection therefore reads
-		// `process.argv` directly (mirroring `get pi --variables`) so the flag
-		// works regardless of position. (Note: the following token is still
-		// consumed by parseArgs — a shared framework limitation — so
-		// `--variables` should be placed last in practice.)
-		const mockJob = {
-			jobKey: "123456",
-			type: "my-job-type",
-			retries: 3,
-			processInstanceKey: "789",
-			customHeaders: {},
-			worker: "c8ctl",
-			deadline: Date.now() + 60000,
-			elementId: "task1",
-			processDefinitionId: "process1",
-			processDefinitionVersion: 1,
-			processDefinitionKey: "pd1",
-			tenantId: "<default>",
-			variables: { scopeInput: { processName: "Loan Approval" } },
-		};
-		server = await startMockServer((_req, res) => {
-			res.setHeader("content-type", "application/json");
-			res.end(JSON.stringify({ jobs: [mockJob] }));
-		});
-
-		const result = await c8WithMockServer(
-			server.url,
-			"activate",
-			"jobs",
-			"my-job-type",
-			"--variables",
-			"--customHeaders",
-		);
-
-		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
-		const rows = asRecordArray(JSON.parse(result.stdout), "output rows");
-		assert.ok(rows.length > 0, "expected at least one row");
-		const row = asRecord(rows[0], "first row");
-		assert.deepStrictEqual(row.Variables, {
-			scopeInput: { processName: "Loan Approval" },
-		});
-		// parseArgs treats `--variables` as a string option, so the following
-		// `--customHeaders` token is swallowed as its value rather than parsed
-		// as a boolean flag — the documented "place --variables last" caveat.
-		assert.strictEqual(
-			row["Custom Headers"],
-			undefined,
-			"--customHeaders is swallowed as --variables' value when not placed last",
+			"Variables should be absent when --fetchVariable flag is not passed",
 		);
 	});
 });

--- a/tests/unit/jobs-behaviour.test.ts
+++ b/tests/unit/jobs-behaviour.test.ts
@@ -198,6 +198,21 @@ describe("CLI behavioural: activate jobs", () => {
 		// --customHeaders is a display flag only; it must not appear in the API body
 		assert.strictEqual(body.customHeaders, undefined);
 	});
+
+	test("--variables flag is accepted without error", async () => {
+		const result = await c8(
+			"activate",
+			"jobs",
+			"--dry-run",
+			"my-job-type",
+			"--variables",
+		);
+
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const body = asRecord(parseJson(result).body, "dry-run body");
+		// --variables is a display flag only; it must not appear in the API body
+		assert.strictEqual(body.variables, undefined);
+	});
 });
 
 // ─── activate jobs with customHeaders response ───────────────────────────────
@@ -293,6 +308,160 @@ describe("CLI behavioural: activate jobs --customHeaders rendering", () => {
 			row["Custom Headers"],
 			undefined,
 			"Custom Headers should be absent when --customHeaders flag is not passed",
+		);
+	});
+});
+
+// ─── activate jobs with variables response ────────────────────────────────────
+//
+// --variables comes from the API response, so these tests require a mock
+// HTTP server: --dry-run exits before the API call and cannot exercise the
+// rendering path.
+
+describe("CLI behavioural: activate jobs --variables rendering", () => {
+	let server: { url: string; close: () => Promise<void> } | null = null;
+
+	afterEach(async () => {
+		if (server) {
+			await server.close();
+			server = null;
+		}
+	});
+
+	test("--variables includes variables as an object in JSON output", async () => {
+		const mockJob = {
+			jobKey: "123456",
+			type: "my-job-type",
+			retries: 3,
+			processInstanceKey: "789",
+			customHeaders: {},
+			worker: "c8ctl",
+			deadline: Date.now() + 60000,
+			elementId: "task1",
+			processDefinitionId: "process1",
+			processDefinitionVersion: 1,
+			processDefinitionKey: "pd1",
+			tenantId: "<default>",
+			variables: {
+				scopeInput: { processName: "Loan Approval" },
+				projectName: "loan",
+			},
+		};
+		server = await startMockServer((_req, res) => {
+			res.setHeader("content-type", "application/json");
+			res.end(JSON.stringify({ jobs: [mockJob] }));
+		});
+
+		const result = await c8WithMockServer(
+			server.url,
+			"activate",
+			"jobs",
+			"my-job-type",
+			"--variables",
+		);
+
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const rows = asRecordArray(JSON.parse(result.stdout), "output rows");
+		assert.ok(rows.length > 0, "expected at least one row");
+		const row = asRecord(rows[0], "first row");
+		// "Variables" must be a plain object, not a JSON string
+		assert.deepStrictEqual(row.Variables, {
+			scopeInput: { processName: "Loan Approval" },
+			projectName: "loan",
+		});
+	});
+
+	test("without --variables the field is absent from output", async () => {
+		const mockJob = {
+			jobKey: "123456",
+			type: "my-job-type",
+			retries: 3,
+			processInstanceKey: "789",
+			customHeaders: {},
+			worker: "c8ctl",
+			deadline: Date.now() + 60000,
+			elementId: "task1",
+			processDefinitionId: "process1",
+			processDefinitionVersion: 1,
+			processDefinitionKey: "pd1",
+			tenantId: "<default>",
+			variables: { scopeInput: { processName: "Loan Approval" } },
+		};
+		server = await startMockServer((_req, res) => {
+			res.setHeader("content-type", "application/json");
+			res.end(JSON.stringify({ jobs: [mockJob] }));
+		});
+
+		const result = await c8WithMockServer(
+			server.url,
+			"activate",
+			"jobs",
+			"my-job-type",
+		);
+
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const rows = asRecordArray(JSON.parse(result.stdout), "output rows");
+		assert.ok(rows.length > 0, "expected at least one row");
+		const row = asRecord(rows[0], "first row");
+		assert.strictEqual(
+			row.Variables,
+			undefined,
+			"Variables should be absent when --variables flag is not passed",
+		);
+	});
+
+	test("--variables is detected even when not the final argument", async () => {
+		// `variables` is globally promoted to a `string` flag by
+		// `deriveParseArgsOptions` (for `complete`/`fail`/`publish job
+		// --variables '{...}'`), so parseArgs assigns the following token as
+		// its value rather than returning a boolean. Detection therefore reads
+		// `process.argv` directly (mirroring `get pi --variables`) so the flag
+		// works regardless of position. (Note: the following token is still
+		// consumed by parseArgs — a shared framework limitation — so
+		// `--variables` should be placed last in practice.)
+		const mockJob = {
+			jobKey: "123456",
+			type: "my-job-type",
+			retries: 3,
+			processInstanceKey: "789",
+			customHeaders: {},
+			worker: "c8ctl",
+			deadline: Date.now() + 60000,
+			elementId: "task1",
+			processDefinitionId: "process1",
+			processDefinitionVersion: 1,
+			processDefinitionKey: "pd1",
+			tenantId: "<default>",
+			variables: { scopeInput: { processName: "Loan Approval" } },
+		};
+		server = await startMockServer((_req, res) => {
+			res.setHeader("content-type", "application/json");
+			res.end(JSON.stringify({ jobs: [mockJob] }));
+		});
+
+		const result = await c8WithMockServer(
+			server.url,
+			"activate",
+			"jobs",
+			"my-job-type",
+			"--variables",
+			"--customHeaders",
+		);
+
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const rows = asRecordArray(JSON.parse(result.stdout), "output rows");
+		assert.ok(rows.length > 0, "expected at least one row");
+		const row = asRecord(rows[0], "first row");
+		assert.deepStrictEqual(row.Variables, {
+			scopeInput: { processName: "Loan Approval" },
+		});
+		// parseArgs treats `--variables` as a string option, so the following
+		// `--customHeaders` token is swallowed as its value rather than parsed
+		// as a boolean flag — the documented "place --variables last" caveat.
+		assert.strictEqual(
+			row["Custom Headers"],
+			undefined,
+			"--customHeaders is swallowed as --variables' value when not placed last",
 		);
 	});
 });

--- a/tests/unit/jobs-behaviour.test.ts
+++ b/tests/unit/jobs-behaviour.test.ts
@@ -219,8 +219,52 @@ describe("CLI behavioural: activate jobs", () => {
 
 		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
 		const body = asRecord(parseJson(result).body, "dry-run body");
-		// --fetchVariable is a real API parameter (server-side variable filter),
-		// so it MUST appear in the request body, split into a trimmed array.
+		assert.deepStrictEqual(body.fetchVariable, ["scopeInput", "projectName"]);
+	});
+
+	test("--dry-run omits fetchVariable when the value is an empty string", async () => {
+		const result = await c8(
+			"activate",
+			"jobs",
+			"--dry-run",
+			"my-job-type",
+			"--fetchVariable",
+			"",
+		);
+
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const body = asRecord(parseJson(result).body, "dry-run body");
+		assert.strictEqual(body.fetchVariable, undefined);
+	});
+
+	test("--dry-run omits fetchVariable when the value is only whitespace and commas", async () => {
+		const result = await c8(
+			"activate",
+			"jobs",
+			"--dry-run",
+			"my-job-type",
+			"--fetchVariable",
+			" , , ",
+		);
+
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const body = asRecord(parseJson(result).body, "dry-run body");
+		// Every token trims to empty, so nothing survives filtering.
+		assert.strictEqual(body.fetchVariable, undefined);
+	});
+
+	test("--dry-run drops empty tokens from --fetchVariable and keeps the rest", async () => {
+		const result = await c8(
+			"activate",
+			"jobs",
+			"--dry-run",
+			"my-job-type",
+			"--fetchVariable",
+			"scopeInput,,projectName, ,",
+		);
+
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		const body = asRecord(parseJson(result).body, "dry-run body");
 		assert.deepStrictEqual(body.fetchVariable, ["scopeInput", "projectName"]);
 	});
 });
@@ -753,6 +797,66 @@ describe("CLI behavioural: activate jobs --customHeaders text-mode rendering", (
 			`Expected JSON-stringified customHeaders in text output, got:\n${result.stdout}`,
 		);
 		// Ensure the old broken rendering is gone
+		assert.ok(
+			!result.stdout.includes("[object Object]"),
+			`Expected no [object Object] in text output, got:\n${result.stdout}`,
+		);
+	});
+});
+
+// ─── activate jobs --fetchVariable text-mode rendering ───────────────────────
+//
+// Verifies that the object-valued Variables cell is JSON-stringified in text
+// mode rather than rendered as "[object Object]", matching the customHeaders
+// behaviour above.
+
+describe("CLI behavioural: activate jobs --fetchVariable text-mode rendering", () => {
+	let server: { url: string; close: () => Promise<void> } | null = null;
+
+	afterEach(async () => {
+		if (server) {
+			await server.close();
+			server = null;
+		}
+	});
+
+	test("Variables column contains JSON-stringified object in text output", async () => {
+		const mockJob = {
+			jobKey: "123456",
+			type: "my-job-type",
+			retries: 3,
+			processInstanceKey: "789",
+			customHeaders: {},
+			worker: "c8ctl",
+			deadline: Date.now() + 60000,
+			elementId: "task1",
+			processDefinitionId: "process1",
+			processDefinitionVersion: 1,
+			processDefinitionKey: "pd1",
+			tenantId: "<default>",
+			variables: { scopeInput: { processName: "Loan Approval" } },
+		};
+		server = await startMockServer((_req, res) => {
+			res.setHeader("content-type", "application/json");
+			res.end(JSON.stringify({ jobs: [mockJob] }));
+		});
+
+		const result = await c8WithMockServerText(
+			server.url,
+			"activate",
+			"jobs",
+			"my-job-type",
+			"--fetchVariable",
+			"scopeInput",
+		);
+
+		assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+		// Text mode: look for the JSON-stringified value in stdout lines
+		assert.ok(
+			result.stdout.includes('{"scopeInput":{"processName":"Loan Approval"}}'),
+			`Expected JSON-stringified variables in text output, got:\n${result.stdout}`,
+		);
+		// Ensure objects are not rendered as "[object Object]"
 		assert.ok(
 			!result.stdout.includes("[object Object]"),
 			`Expected no [object Object] in text output, got:\n${result.stdout}`,


### PR DESCRIPTION
## Summary

- Adds a `--fetchVariable` flag to `c8ctl activate jobs` that takes a comma-separated list of variable names (e.g. `--fetchVariable scopeInput,projectName`)
- The names are sent in the Activate Jobs request body as the API's `fetchVariable` field, so the server returns **only** the requested variables for each activated job instead of the full payload
- The requested variables are also surfaced in the command output
- Rejects a provided-but-empty `--fetchVariable` (see [Empty-value handling](#empty-value-handling) below) so users can't unknowingly fetch the full variable set

## Context

Required by `governance-phase-activation` in `process-os` as part of the variable→file bridge described in the scope capture spec (in https://github.com/camunda/process-os/pull/278 see `2026-07-07-scope-capture-and-discovery-config-rework.md`, §4.1.1). The bridge needs to read the `scopeInput` variable from activated `camunda-init` jobs without raw REST calls; `c8ctl` handles auth transparently.

Fetching every variable on job activation is a real cost in agent workflows — full-value variables (e.g. `scopeInput` blobs) are fetched and paid for even when only one is needed. The API's `fetchVariable` field is the correct lever to filter **server-side**, which is what this flag exposes.

## Empty-value handling

Per the [Activate Jobs REST spec](https://docs.camunda.io/docs/apis-tools/orchestration-cluster-api-rest/specifications/activate-jobs/), an *empty* `fetchVariable` list means "return all visible variables". Silently sending an empty list would defeat the purpose of the flag: the user would think they were reducing the payload while still fetching everything.

So when `--fetchVariable` is provided but resolves to no usable names after splitting/trimming (e.g. `--fetchVariable " , , "`), the command now fails with a clear error and a non-zero exit, consistent with the other flag guards in this handler and the `--fetchVariables` guard in `process-instances.ts`.

Note: a literal empty string (`--fetchVariable ""`) is normalized to `undefined` by the framework's `deserializeFlags` before the handler runs, so it stays indistinguishable from omitting the flag (no filter applied). Only non-empty values that collapse to an empty list are rejected. Not passing the flag at all remains the legitimate "no filtering" path.

## Naming

The flag is `--fetchVariable` (singular), matching the Activate Jobs API spec exactly. It is intentionally distinct from the existing `--fetchVariables` (plural) on `create process-instance`, which maps to a different API.

## Test plan

- [x] `npm run build` — clean (0 lint/type/tsc errors)
- [x] `npm run test:unit` — new/updated behavioural tests pass:
  - dry-run omits `fetchVariable` by default
  - dry-run sends trimmed name array; drops empty tokens and keeps the rest
  - provided-but-empty value (`" , , "`) fails with a non-zero exit and actionable error
  - empty string is treated as unset (framework normalizes it away)
  - filter reaches the wire (asserted against a mock server); variables rendered in JSON and text modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
