### PR TITLE
feat(element-template): add edit subcommand to fix apply --set data loss

### DIFF
--- a/default-plugins/element-template/AGENTS.md
+++ b/default-plugins/element-template/AGENTS.md
@@ -10,10 +10,12 @@ version resolution.
 | File | Purpose |
 | --- | --- |
 | `c8ctl-plugin.ts` | Plugin API (metadata + commands export), subcommand dispatch table |
-| `commands/<name>.ts` | One file per subcommand: `apply`, `get`, `get-properties`, `info`, `search`, `sync` |
+| `commands/<name>.ts` | One file per subcommand: `apply`, `edit`, `get`, `get-properties`, `info`, `search`, `sync` |
 | `template-ref.ts` | `parseTemplateRef`, `readBpmnInput`, `getExecutionPlatformVersion`, `resolveOotbTemplate`, `loadTemplate` |
 | `marketplace.ts` | Cache I/O, `/ootb-connectors` fetch, sync, search, version resolution |
-| `helpers.ts` | `--set` parsing, file/URL fetch, glob → regex, multi-binding lookup, condition warnings |
+| `helpers.ts` | `--set` parsing, file/URL fetch, glob → regex, multi-binding lookup, condition warnings, `atomicOverwriteFile` |
+| `binding.ts` | Binding-target resolution shared by `apply`/`edit` — which moddle child + property a `zeebe:input`/etc. binding writes to. Hand-rolled stand-in for bpmn-js-element-templates' internal `setPropertyValue`; see the note at the top of the file about replacing it once bpmn-io/bpmn-js-element-templates#236 ships. |
+| `vendor.ts` | `resolveVendorBundle()` + the minimal bpmn-js `Modeler`/`modeling` type surface shared by `apply`/`edit` |
 | `vendor-src/bundle-entry.js` | esbuild entry — re-exports `Modeler`, `CloudElementTemplatesCoreModule`, `ZeebeModdleExtension` |
 
 ## Things to know before editing
@@ -48,10 +50,23 @@ version resolution.
   recovery (dead PID or > 60 min old) and signal handlers
   (SIGINT/SIGTERM/SIGHUP) that release before re-raising. Don't
   bypass it from new code paths.
-- **`apply` and `get` install an EPIPE handler before writing to
-  stdout** (`installStdoutEpipeHandler()` in `helpers.ts`). New
+- **`apply`, `edit`, and `get` install an EPIPE handler before writing
+  to stdout** (`installStdoutEpipeHandler()` in `helpers.ts`). New
   subcommands that write to stdout must do the same — otherwise
   `... | head -c N` closing the pipe early crashes the process.
+- **`apply` vs `edit`: applying a template is not the same operation as
+  editing one property on an already-applied element.** `apply` calls
+  `elementTemplates.applyTemplate()`, which unconditionally resets every
+  `Hidden`-typed template property to its template default on *every*
+  call — correct for first-time application or a version upgrade, but
+  it silently clobbers any hand-authored customization layered into a
+  Hidden-owned extension attribute (see c8ctl#466). `edit` never calls
+  `applyTemplate()` — it only writes into moddle children that already
+  exist via `modeling.updateModdleProperties`, so it can't create a
+  property whose gating condition wasn't previously met, but it also
+  can't reset anything the template doesn't explicitly touch. Don't
+  collapse these back into one code path without re-solving that
+  tension.
 - **JSON output uses element-templates schema field names verbatim.**
   No invented derivations — `binding`, `optional`, `value`, `condition`,
   `group` (id), `elementType: { value }`, `engines: { camunda }`. The

--- a/default-plugins/element-template/binding.ts
+++ b/default-plugins/element-template/binding.ts
@@ -1,0 +1,113 @@
+/**
+ * Shared moddle-tree lookup for element-template bindings: locating the
+ * extension containers on a BPMN element's `extensionElements`, and
+ * resolving which moddle child + property a given template binding writes
+ * to. Used by both `apply` and `edit` so the binding resolution logic —
+ * which BPMN location a `zeebe:input`/`zeebe:output`/etc. binding maps to —
+ * isn't duplicated between the two.
+ *
+ * This is a hand-rolled, 5-binding-type stand-in for the real dispatch
+ * logic inside bpmn-js-element-templates (`propertyUtil#setPropertyValue`,
+ * which handles 15+ binding types plus FEEL/Boolean casting). That logic
+ * isn't exported today — see bpmn-io/bpmn-js-element-templates#235/#236,
+ * which adds a `bpmn-js-element-templates/util` subpath exporting
+ * `getPropertyValue`/`setPropertyValue`/`validateProperty`/`applyConditions`/
+ * `isConditionMet`. Once #236 merges and ships in a release, this module
+ * should be replaced by calls into that subpath instead of maintained here.
+ */
+
+import type { TemplateBinding } from "./helpers.ts";
+
+export type ModdleElement = {
+	$type: string;
+	get(name: string): unknown;
+	[key: string]: unknown;
+};
+
+export type ExtensionContainers = {
+	ioMapping: ModdleElement | undefined;
+	taskHeaders: ModdleElement | undefined;
+	taskDefinition: ModdleElement | undefined;
+	zeebeProperties: ModdleElement | undefined;
+};
+
+/**
+ * Find the first child of `extensionElements` whose moddle `$type` matches.
+ * Avoids importing bpmn-js's `is()` helper just for one shape check.
+ */
+export function findExtensionByType(
+	extensionElements: ModdleElement | undefined,
+	type: string,
+): ModdleElement | undefined {
+	if (!extensionElements) {
+		return undefined;
+	}
+	// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped collections
+	const values = extensionElements.get("values") as ModdleElement[] | undefined;
+	return values?.find((v) => v.$type === type);
+}
+
+/** Locate the extension containers each binding type reads/writes to. */
+export function findExtensionContainers(
+	extensionElements: ModdleElement | undefined,
+): ExtensionContainers {
+	return {
+		ioMapping: findExtensionByType(extensionElements, "zeebe:IoMapping"),
+		taskHeaders: findExtensionByType(extensionElements, "zeebe:TaskHeaders"),
+		taskDefinition: findExtensionByType(
+			extensionElements,
+			"zeebe:TaskDefinition",
+		),
+		zeebeProperties: findExtensionByType(extensionElements, "zeebe:Properties"),
+	};
+}
+
+/**
+ * Resolve which existing moddle child + property a binding writes to.
+ * Returns `undefined` when the backing moddle entry doesn't exist yet
+ * (e.g. its gating condition wasn't met when the template was applied) —
+ * callers decide whether that's a create-it-via-reapply case (`apply`) or
+ * a hard error (`edit`, which never creates new entries).
+ */
+export function resolveBindingTarget(
+	binding: TemplateBinding,
+	containers: ExtensionContainers,
+): { child: ModdleElement; property: string } | undefined {
+	switch (binding.type) {
+		case "zeebe:input": {
+			// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped collections
+			const inputs = (containers.ioMapping?.get("inputParameters") ??
+				[]) as ModdleElement[];
+			const child = inputs.find((p) => p.target === binding.name);
+			return child ? { child, property: "source" } : undefined;
+		}
+		case "zeebe:output": {
+			// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped collections
+			const outputs = (containers.ioMapping?.get("outputParameters") ??
+				[]) as ModdleElement[];
+			const child = outputs.find((p) => p.source === binding.source);
+			return child ? { child, property: "target" } : undefined;
+		}
+		case "zeebe:taskHeader": {
+			// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped collections
+			const headers = (containers.taskHeaders?.get("values") ??
+				[]) as ModdleElement[];
+			const child = headers.find((h) => h.key === binding.key);
+			return child ? { child, property: "value" } : undefined;
+		}
+		case "zeebe:property": {
+			// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped collections
+			const props = (containers.zeebeProperties?.get("properties") ??
+				[]) as ModdleElement[];
+			const child = props.find((p) => p.name === binding.name);
+			return child ? { child, property: "value" } : undefined;
+		}
+		case "zeebe:taskDefinition": {
+			return containers.taskDefinition && binding.property
+				? { child: containers.taskDefinition, property: binding.property }
+				: undefined;
+		}
+		default:
+			return undefined;
+	}
+}

--- a/default-plugins/element-template/binding.ts
+++ b/default-plugins/element-template/binding.ts
@@ -17,12 +17,9 @@
  */
 
 import type { TemplateBinding } from "./helpers.ts";
+import { getModdleList, type ModdleElement } from "./moddle.ts";
 
-export type ModdleElement = {
-	$type: string;
-	get(name: string): unknown;
-	[key: string]: unknown;
-};
+export type { ModdleElement };
 
 export type ExtensionContainers = {
 	ioMapping: ModdleElement | undefined;
@@ -42,9 +39,8 @@ export function findExtensionByType(
 	if (!extensionElements) {
 		return undefined;
 	}
-	// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped collections
-	const values = extensionElements.get("values") as ModdleElement[] | undefined;
-	return values?.find((v) => v.$type === type);
+	const values = getModdleList(extensionElements, "values");
+	return values.find((v) => v.$type === type);
 }
 
 /** Locate the extension containers each binding type reads/writes to. */
@@ -75,30 +71,22 @@ export function resolveBindingTarget(
 ): { child: ModdleElement; property: string } | undefined {
 	switch (binding.type) {
 		case "zeebe:input": {
-			// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped collections
-			const inputs = (containers.ioMapping?.get("inputParameters") ??
-				[]) as ModdleElement[];
+			const inputs = getModdleList(containers.ioMapping, "inputParameters");
 			const child = inputs.find((p) => p.target === binding.name);
 			return child ? { child, property: "source" } : undefined;
 		}
 		case "zeebe:output": {
-			// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped collections
-			const outputs = (containers.ioMapping?.get("outputParameters") ??
-				[]) as ModdleElement[];
+			const outputs = getModdleList(containers.ioMapping, "outputParameters");
 			const child = outputs.find((p) => p.source === binding.source);
 			return child ? { child, property: "target" } : undefined;
 		}
 		case "zeebe:taskHeader": {
-			// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped collections
-			const headers = (containers.taskHeaders?.get("values") ??
-				[]) as ModdleElement[];
+			const headers = getModdleList(containers.taskHeaders, "values");
 			const child = headers.find((h) => h.key === binding.key);
 			return child ? { child, property: "value" } : undefined;
 		}
 		case "zeebe:property": {
-			// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped collections
-			const props = (containers.zeebeProperties?.get("properties") ??
-				[]) as ModdleElement[];
+			const props = getModdleList(containers.zeebeProperties, "properties");
 			const child = props.find((p) => p.name === binding.name);
 			return child ? { child, property: "value" } : undefined;
 		}

--- a/default-plugins/element-template/c8ctl-plugin.ts
+++ b/default-plugins/element-template/c8ctl-plugin.ts
@@ -5,6 +5,7 @@
  *
  * Usage:
  *   c8ctl element-template apply <template> <element-id> [<file.bpmn>] [--in-place] [--set key=value]
+ *   c8ctl element-template edit <element-id> [<file.bpmn>] [--in-place] --set key=value
  *   c8ctl element-template info <template> [--engine-version <x.y.z>]
  *   c8ctl element-template get-properties <template> [<name>...] [--group <id>] [--detailed] [--engine-version <x.y.z>]
  *   c8ctl element-template get <template>
@@ -22,6 +23,7 @@ import type {
 	PluginMetadata,
 } from "../../src/framework/plugins/plugin-loader.ts";
 import { applySubcommand } from "./commands/apply.ts";
+import { editSubcommand } from "./commands/edit.ts";
 import { getSubcommand } from "./commands/get.ts";
 import { getPropertiesSubcommand } from "./commands/get-properties.ts";
 import { infoSubcommand } from "./commands/info.ts";
@@ -87,6 +89,7 @@ const subcommandHandlers: Record<
 	info: infoSubcommand,
 	"get-properties": getPropertiesSubcommand,
 	apply: applySubcommand,
+	edit: editSubcommand,
 	get: getSubcommand,
 	sync: syncSubcommand,
 };
@@ -144,6 +147,12 @@ export const metadata = {
 				"Pass --set multiple times to set multiple properties. " +
 				"Prefix with a binding type (input | output | header | property | taskDefinition) when the same name " +
 				"is bound across multiple types — e.g. --set input:correlationKey=order-42.\n\n" +
+				"edit --set name=value updates a property on an element that already has a template applied, " +
+				"without re-running template application — it never resets other template-owned content " +
+				"(including hand-customized extension values a template doesn't fully control) and doesn't need " +
+				"a <template> argument (it reads zeebe:modelerTemplate/-Version off the element). " +
+				"The tradeoff: edit can only change bindings that already have a value; a property whose " +
+				"gating condition was never met has nothing to edit — use apply --set to materialize it first.\n\n" +
 				"FEEL values: properties with feel=required always store a FEEL expression (prefixed with `=`). " +
 				"For those properties, c8ctl auto-prepends `=` when it is missing, so `--set key=orderId` " +
 				"writes `=orderId` to the BPMN — equivalent to `--set key==orderId`. " +
@@ -174,6 +183,11 @@ export const metadata = {
 				{
 					name: "apply",
 					description: "Apply a Camunda element template to a BPMN element",
+				},
+				{
+					name: "edit",
+					description:
+						"Update a property on an element that already has a template applied, without re-applying it",
 				},
 				{
 					name: "get",
@@ -259,6 +273,12 @@ export const metadata = {
 				},
 				{
 					command:
+						"c8ctl element-template edit Task_1 process.bpmn --set method=PUT",
+					description:
+						"Update a single property on an already-templated element in place, without touching anything else the template governs",
+				},
+				{
+					command:
 						"c8ctl element-template get io.camunda.connectors.HttpJson.v2 > template.json",
 					description:
 						"Print the raw template JSON to stdout (redirect to save a copy)",
@@ -284,13 +304,13 @@ export const commands = {
 			"in-place": {
 				type: "boolean",
 				short: "i",
-				description: "Modify the BPMN file in place [apply]",
+				description: "Modify the BPMN file in place [apply|edit]",
 			},
 			set: {
 				type: "string",
 				multiple: true,
 				description:
-					"Set a property value: name=value (repeatable; binding name from get-properties; = auto-prepended for feel=required properties) [apply]",
+					"Set a property value: name=value (repeatable; binding name from get-properties; = auto-prepended for feel=required properties) [apply|edit]",
 			},
 			detailed: {
 				type: "boolean",

--- a/default-plugins/element-template/commands/apply.ts
+++ b/default-plugins/element-template/commands/apply.ts
@@ -18,6 +18,7 @@ import {
 	type TemplateProperty,
 	warnUnmetConditions,
 } from "../helpers.ts";
+import { getModdleElement } from "../moddle.ts";
 import {
 	elementExistsInBpmn,
 	getExecutionPlatformVersion,
@@ -28,7 +29,6 @@ import {
 } from "../template-ref.ts";
 import {
 	type BpmnElement,
-	type ModdleElement,
 	type ModelerInstance,
 	resolveVendorBundle,
 	type VendorBundle,
@@ -63,10 +63,10 @@ function forceSetValues(
 	setArgs: string[],
 ): void {
 	const modeling = modeler.get("modeling");
-	// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped ModdleElement
-	const extensionElements = element.businessObject.get("extensionElements") as
-		| ModdleElement
-		| undefined;
+	const extensionElements = getModdleElement(
+		element.businessObject,
+		"extensionElements",
+	);
 	if (!extensionElements) {
 		return;
 	}

--- a/default-plugins/element-template/commands/apply.ts
+++ b/default-plugins/element-template/commands/apply.ts
@@ -3,16 +3,14 @@
  * element via the prebuilt bpmn-js + bpmn-js-element-templates vendor bundle.
  */
 
-import { existsSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
-import { dirname, resolve as resolvePath } from "node:path";
-import { fileURLToPath } from "node:url";
 import type {} from "../../../src/core/runtime.ts";
+import { findExtensionContainers, resolveBindingTarget } from "../binding.ts";
 import {
 	applySetOverrides,
+	atomicOverwriteFile,
 	findPropertiesByBindingName,
 	installStdoutEpipeHandler,
-	isRecord,
 	maybePrependFeel,
 	parseArgs,
 	parseSetArg,
@@ -28,107 +26,17 @@ import {
 	readTemplateFromPathOrUrl,
 	resolveOotbTemplate,
 } from "../template-ref.ts";
+import {
+	type BpmnElement,
+	type ModdleElement,
+	type ModelerInstance,
+	resolveVendorBundle,
+	type VendorBundle,
+} from "../vendor.ts";
 
 if (!globalThis.c8ctl) throw new Error("c8ctl runtime not initialised");
 const c8ctl = globalThis.c8ctl;
 const require = createRequire(import.meta.url);
-
-// Minimal vendor-bundle surface — the bundle is loaded via require() with
-// an absolute path, so we type the local destination instead of declaring
-// the module name. Everything beyond this surface stays as `unknown` and
-// gets narrowed at the use site.
-type ModdleElement = {
-	$type: string;
-	get(name: string): unknown;
-	[key: string]: unknown;
-};
-type BpmnElement = { businessObject: ModdleElement };
-type ElementRegistry = { get(id: string): BpmnElement | undefined };
-type ElementTemplatesService = {
-	set(templates: Template[]): void;
-	applyTemplate(element: BpmnElement, template: Template): void;
-};
-type Modeling = {
-	updateModdleProperties(
-		element: BpmnElement,
-		moddleElement: ModdleElement,
-		properties: Record<string, unknown>,
-	): void;
-};
-type ModelerInstance = {
-	importXML(xml: string): Promise<unknown>;
-	get(name: "elementRegistry"): ElementRegistry;
-	get(name: "elementTemplates"): ElementTemplatesService;
-	get(name: "modeling"): Modeling;
-	get(name: string): unknown;
-	saveXML(options: { format?: boolean }): Promise<{ xml: string }>;
-};
-type ModelerCtor = new (options: {
-	additionalModules: unknown[];
-	moddleExtensions: Record<string, unknown>;
-}) => ModelerInstance;
-type VendorBundle = {
-	Modeler: ModelerCtor;
-	CloudElementTemplatesCoreModule: unknown;
-	ZeebeModdleExtension: unknown;
-	HeadlessTextRendererModule: unknown;
-};
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-/**
- * Locate the prebuilt vendor bundle. Plugins live in two places:
- *   - dev:        default-plugins/element-template/commands/apply.ts
- *                 vendor: ../../../dist/vendor/bpmn-element-templates.cjs
- *   - production: dist/default-plugins/element-template/commands/apply.js
- *                 vendor: ../../../vendor/bpmn-element-templates.cjs
- */
-function resolveVendorBundle(): string {
-	const candidates = [
-		resolvePath(
-			__dirname,
-			"..",
-			"..",
-			"..",
-			"dist",
-			"vendor",
-			"bpmn-element-templates.cjs",
-		),
-		resolvePath(
-			__dirname,
-			"..",
-			"..",
-			"..",
-			"vendor",
-			"bpmn-element-templates.cjs",
-		),
-	];
-	for (const path of candidates) {
-		if (existsSync(path)) {
-			return path;
-		}
-	}
-	throw new Error(
-		"Vendor bundle not found. Run `npm run build:vendor` to build it.\n" +
-			`Searched: ${candidates.join(", ")}`,
-	);
-}
-
-/**
- * Find the first child of `extensionElements` whose moddle `$type` matches.
- * Avoids importing bpmn-js's `is()` helper just for one shape check.
- */
-function findExtensionByType(
-	extensionElements: ModdleElement | undefined,
-	type: string,
-): ModdleElement | undefined {
-	if (!extensionElements) {
-		return undefined;
-	}
-	// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped collections
-	const values = extensionElements.get("values") as ModdleElement[] | undefined;
-	return values?.find((v) => v.$type === type);
-}
 
 /**
  * Force the source/value of each `--set` into the corresponding moddle child.
@@ -163,19 +71,7 @@ function forceSetValues(
 		return;
 	}
 
-	const ioMapping = findExtensionByType(extensionElements, "zeebe:IoMapping");
-	const taskHeaders = findExtensionByType(
-		extensionElements,
-		"zeebe:TaskHeaders",
-	);
-	const taskDefinition = findExtensionByType(
-		extensionElements,
-		"zeebe:TaskDefinition",
-	);
-	const zeebeProperties = findExtensionByType(
-		extensionElements,
-		"zeebe:Properties",
-	);
+	const containers = findExtensionContainers(extensionElements);
 
 	for (const arg of setArgs) {
 		const { bindingTypeFilter, name, value } = parseSetArg(arg);
@@ -185,82 +81,14 @@ function forceSetValues(
 			bindingTypeFilter,
 		);
 		for (const prop of matches) {
+			if (!prop.binding) continue;
 			const effectiveValue = maybePrependFeel(prop, value);
-			updateModdleForProperty(modeling, element, prop, effectiveValue, {
-				ioMapping,
-				taskHeaders,
-				taskDefinition,
-				zeebeProperties,
-			});
-		}
-	}
-}
-
-function updateModdleForProperty(
-	modeling: Modeling,
-	element: BpmnElement,
-	prop: TemplateProperty,
-	value: string,
-	containers: {
-		ioMapping: ModdleElement | undefined;
-		taskHeaders: ModdleElement | undefined;
-		taskDefinition: ModdleElement | undefined;
-		zeebeProperties: ModdleElement | undefined;
-	},
-): void {
-	const binding = prop.binding;
-	if (!binding) {
-		return;
-	}
-
-	switch (binding.type) {
-		case "zeebe:input": {
-			// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped collections
-			const inputs = (containers.ioMapping?.get("inputParameters") ??
-				[]) as ModdleElement[];
-			const child = inputs.find((p) => p.target === binding.name);
-			if (child) {
-				modeling.updateModdleProperties(element, child, { source: value });
-			}
-			return;
-		}
-		case "zeebe:output": {
-			// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped collections
-			const outputs = (containers.ioMapping?.get("outputParameters") ??
-				[]) as ModdleElement[];
-			const child = outputs.find((p) => p.source === binding.source);
-			if (child) {
-				modeling.updateModdleProperties(element, child, { target: value });
-			}
-			return;
-		}
-		case "zeebe:taskHeader": {
-			// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped collections
-			const headers = (containers.taskHeaders?.get("values") ??
-				[]) as ModdleElement[];
-			const child = headers.find((h) => h.key === binding.key);
-			if (child) {
-				modeling.updateModdleProperties(element, child, { value });
-			}
-			return;
-		}
-		case "zeebe:property": {
-			// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped collections
-			const props = (containers.zeebeProperties?.get("properties") ??
-				[]) as ModdleElement[];
-			const child = props.find((p) => p.name === binding.name);
-			if (child) {
-				modeling.updateModdleProperties(element, child, { value });
-			}
-			return;
-		}
-		case "zeebe:taskDefinition": {
-			if (containers.taskDefinition && binding.property) {
-				modeling.updateModdleProperties(element, containers.taskDefinition, {
-					[binding.property]: value,
+			const target = resolveBindingTarget(prop.binding, containers);
+			if (target) {
+				modeling.updateModdleProperties(element, target.child, {
+					[target.property]: effectiveValue,
 				});
 			}
-			return;
 		}
 	}
 }
@@ -467,38 +295,4 @@ export async function applySubcommand(args: string[]): Promise<void> {
 	}
 
 	process.stdout.write(resultXml);
-}
-
-/**
- * Overwrite `targetPath` atomically: write to a sibling temp file in
- * the same directory, then `renameSync` over the target. POSIX
- * `rename` is atomic on the same filesystem, so a kill mid-write
- * never destroys the user's BPMN file.
- *
- * Falls back to a direct `writeFileSync` if the rename fails with
- * EXDEV (cross-device link) — vanishingly rare for a file's own
- * sibling, but covers exotic setups like FUSE mounts.
- */
-function atomicOverwriteFile(targetPath: string, contents: string): void {
-	const target = resolvePath(targetPath);
-	const tmp = `${target}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
-	try {
-		writeFileSync(tmp, contents, "utf-8");
-		renameSync(tmp, target);
-	} catch (error) {
-		try {
-			unlinkSync(tmp);
-		} catch {
-			// Best-effort cleanup — the original error is what matters.
-		}
-		const code =
-			isRecord(error) && typeof error.code === "string"
-				? error.code
-				: undefined;
-		if (code === "EXDEV") {
-			writeFileSync(target, contents, "utf-8");
-			return;
-		}
-		throw error;
-	}
 }

--- a/default-plugins/element-template/commands/edit.ts
+++ b/default-plugins/element-template/commands/edit.ts
@@ -1,0 +1,292 @@
+/**
+ * `c8ctl element-template edit` — update property values on a BPMN element
+ * that already has an element template applied, without re-running
+ * template application.
+ *
+ * Unlike `apply --set`, `edit` never calls `elementTemplates.applyTemplate`.
+ * It only writes into moddle children that already exist, via the same
+ * `modeling.updateModdleProperties` command-stack writes `apply` uses.
+ * `applyTemplate` is what unconditionally resets Hidden-typed template
+ * properties to their template default on every (re-)application — see
+ * ChangeElementTemplateHandler#shouldKeepValue and c8ctl#466 — so skipping
+ * it means `edit` never clobbers template-owned extension content a user
+ * hand-customized beyond the template's own schema (e.g. a manually-added
+ * conditional inside a `zeebe:adHoc` `outputElement`).
+ *
+ * The tradeoff: `edit` can only set bindings whose moddle entry already
+ * exists — it can't create one whose gating condition wasn't previously
+ * met. Use `apply --set` for that; use `edit` once a template is already
+ * applied and you want to change one property without touching anything
+ * else the template governs.
+ *
+ * `edit` still round-trips through bpmn-js's `saveXML`, so it inherits
+ * that pipeline's unrelated BPMNDI shape/edge reordering — same as `apply`
+ * (see c8ctl#466; considered cosmetic/out of scope, not data loss).
+ *
+ * The template reference isn't a CLI argument — it's read off the target
+ * element's own `zeebe:modelerTemplate`/`zeebe:modelerTemplateVersion`
+ * attributes and resolved from the local OOTB cache, so `edit` only works
+ * against templates `sync` knows about.
+ */
+
+import { createRequire } from "node:module";
+import type {} from "../../../src/core/runtime.ts";
+import { findExtensionContainers, resolveBindingTarget } from "../binding.ts";
+import {
+	atomicOverwriteFile,
+	findPropertiesByBindingName,
+	installStdoutEpipeHandler,
+	maybePrependFeel,
+	parseArgs,
+	parseSetArg,
+	type Template,
+	validateDropdownValue,
+} from "../helpers.ts";
+import { readBpmnInput, resolveOotbTemplate } from "../template-ref.ts";
+import {
+	type BpmnElement,
+	type ModdleElement,
+	type ModelerInstance,
+	resolveVendorBundle,
+	type VendorBundle,
+} from "../vendor.ts";
+
+if (!globalThis.c8ctl) throw new Error("c8ctl runtime not initialised");
+const c8ctl = globalThis.c8ctl;
+const require = createRequire(import.meta.url);
+
+type PlannedWrite = {
+	child: ModdleElement;
+	property: string;
+	value: string;
+};
+
+type EditPlan = {
+	element: BpmnElement;
+	template: Template;
+	writes: PlannedWrite[];
+};
+
+/**
+ * Resolve the target element, its recorded template, and validate every
+ * `--set` arg against the element's *already-materialized* moddle tree.
+ * Shared by the real run and `--dry-run` so both use identical validation —
+ * a dry run that reports success is guaranteed to actually succeed.
+ */
+async function planEdit(
+	modeler: ModelerInstance,
+	elementId: string,
+	setArgs: string[],
+): Promise<EditPlan> {
+	const elementRegistry = modeler.get("elementRegistry");
+	const element = elementRegistry.get(elementId);
+	if (!element) {
+		throw new Error(`Element "${elementId}" not found in the BPMN diagram`);
+	}
+
+	// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped values
+	const templateId = element.businessObject.get("modelerTemplate") as
+		| string
+		| undefined;
+	if (!templateId) {
+		throw new Error(
+			`Element "${elementId}" has no element template applied (no zeebe:modelerTemplate attribute). ` +
+				"Use 'apply' to apply one first.",
+		);
+	}
+	// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped values
+	const templateVersion = element.businessObject.get(
+		"modelerTemplateVersion",
+	) as number | undefined;
+	if (templateVersion === undefined) {
+		throw new Error(
+			`Element "${elementId}" has zeebe:modelerTemplate="${templateId}" but no recorded ` +
+				"zeebe:modelerTemplateVersion. 'edit' requires a pinned version to resolve the exact " +
+				"template that was applied — use 'apply' with an explicit template reference instead.",
+		);
+	}
+
+	const template = await resolveOotbTemplate({
+		kind: "id",
+		id: templateId,
+		version: templateVersion,
+	});
+
+	// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped ModdleElement
+	const extensionElements = element.businessObject.get("extensionElements") as
+		| ModdleElement
+		| undefined;
+	const containers = findExtensionContainers(extensionElements);
+
+	// Keyed by (child, property) so conditional duplicate properties (same
+	// binding name+type, different `condition`) collapse into one write per
+	// pair instead of redundant `updateModdleProperties` calls. Keying via a
+	// nested Map also gives "--set wins" last-write semantics — matching
+	// `apply`'s behavior — when two distinct --set args resolve to the same
+	// target, e.g. `--set method=PUT --set method=DELETE`.
+	const writesByChild = new Map<ModdleElement, Map<string, PlannedWrite>>();
+	for (const arg of setArgs) {
+		const { bindingTypeFilter, name, value } = parseSetArg(arg);
+		const matches = findPropertiesByBindingName(
+			template.properties,
+			name,
+			bindingTypeFilter,
+		);
+
+		let materialized = false;
+		for (const prop of matches) {
+			if (!prop.binding) continue;
+			const effectiveValue = maybePrependFeel(prop, value);
+			if (prop.choices) {
+				validateDropdownValue(prop, name, effectiveValue);
+			}
+			const target = resolveBindingTarget(prop.binding, containers);
+			if (target) {
+				materialized = true;
+				let byProperty = writesByChild.get(target.child);
+				if (!byProperty) {
+					byProperty = new Map();
+					writesByChild.set(target.child, byProperty);
+				}
+				byProperty.set(target.property, {
+					child: target.child,
+					property: target.property,
+					value: effectiveValue,
+				});
+			}
+		}
+		if (!materialized) {
+			throw new Error(
+				`Property "${name}" has no existing value on this element to edit (its condition may not ` +
+					"be met, its binding type isn't supported by 'edit', or the template was never fully " +
+					`applied). Use 'apply --set ${name}=...' to materialize it first.`,
+			);
+		}
+	}
+
+	const writes: PlannedWrite[] = [];
+	for (const byProperty of writesByChild.values()) {
+		writes.push(...byProperty.values());
+	}
+
+	return { element, template, writes };
+}
+
+export async function editSubcommand(args: string[]): Promise<void> {
+	const logger = c8ctl.getLogger();
+	// editSubcommand writes BPMN XML to stdout in the non-in-place path;
+	// install the EPIPE handler before any downstream `head -c N` or
+	// `| less` can sever the pipe.
+	installStdoutEpipeHandler();
+	const parsed = parseArgs(args);
+
+	if (parsed.error) {
+		throw new Error(parsed.error);
+	}
+
+	const [elementId, bpmnFilePath] = parsed.positionals;
+
+	if (parsed.positionals.length > 2) {
+		throw new Error(
+			`Unexpected argument: ${parsed.positionals[2]}. Usage: c8ctl element-template edit <element-id> [<file.bpmn>] --set name=value`,
+		);
+	}
+	if (!elementId) {
+		throw new Error(
+			"Missing element-id argument. Usage: c8ctl element-template edit <element-id> [<file.bpmn>] --set name=value",
+		);
+	}
+	if (parsed.setArgs.length === 0) {
+		throw new Error(
+			"edit requires at least one --set name=value (nothing to edit). Usage: c8ctl element-template edit <element-id> [<file.bpmn>] --set name=value",
+		);
+	}
+
+	// Reject incompatible flag combinations before reading stdin —
+	// otherwise a piped BPMN stream is consumed (and a long-running
+	// producer can hang) just to surface a usage error.
+	if (parsed.inPlace && !bpmnFilePath) {
+		throw new Error("--in-place cannot be used with stdin input");
+	}
+
+	const input = await readBpmnInput(bpmnFilePath);
+	if (!input) {
+		throw new Error(
+			"No BPMN input provided. Pass a file path or pipe BPMN XML via stdin.",
+		);
+	}
+
+	const vendorPath = resolveVendorBundle();
+	const vendor: VendorBundle = require(vendorPath);
+	const { Modeler, ZeebeModdleExtension, HeadlessTextRendererModule } = vendor;
+
+	// HeadlessTextRendererModule overrides bpmn-js's default textRenderer,
+	// which would otherwise call document.createElementNS during importXML
+	// (to measure external label bounds) and throw "document is not defined"
+	// in Node. The errors are non-fatal but produce noisy stack traces.
+	const modeler = new Modeler({
+		additionalModules: [HeadlessTextRendererModule],
+		moddleExtensions: { zeebe: ZeebeModdleExtension },
+	});
+
+	let plan: EditPlan;
+	try {
+		await modeler.importXML(input.xml);
+		plan = await planEdit(modeler, elementId, parsed.setArgs);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(`Error editing element: ${message}`);
+	}
+
+	if (c8ctl.dryRun) {
+		const info = {
+			dryRun: true,
+			command: "element-template edit",
+			template: {
+				id: plan.template.id,
+				name: plan.template.name,
+				version: plan.template.version,
+			},
+			elementId,
+			source: input.source,
+			inPlace: parsed.inPlace && !!bpmnFilePath,
+			setOverrides: parsed.setArgs,
+		};
+		if (c8ctl.outputMode === "json") {
+			logger.json(info);
+		} else {
+			logger.output("Dry run — no changes applied.");
+			logger.output(
+				`  Template: ${info.template.name ?? info.template.id}${
+					info.template.version != null ? ` v${info.template.version}` : ""
+				}`,
+			);
+			logger.output(`  Element:  ${elementId}`);
+			logger.output(`  Source:   ${input.source}`);
+			if (info.inPlace) {
+				logger.output(`  Mode:     in-place (would overwrite ${bpmnFilePath})`);
+			} else {
+				logger.output("  Mode:     stdout (would print transformed XML)");
+			}
+			logger.output(`  --set:    ${parsed.setArgs.join(", ")}`);
+		}
+		return;
+	}
+
+	const modeling = modeler.get("modeling");
+	for (const write of plan.writes) {
+		modeling.updateModdleProperties(plan.element, write.child, {
+			[write.property]: write.value,
+		});
+	}
+	const result = await modeler.saveXML({ format: true });
+	const resultXml = result.xml;
+
+	if (parsed.inPlace && bpmnFilePath) {
+		atomicOverwriteFile(bpmnFilePath, resultXml);
+		logger.info(`Updated ${bpmnFilePath}`);
+		return;
+	}
+
+	process.stdout.write(resultXml);
+}

--- a/default-plugins/element-template/commands/edit.ts
+++ b/default-plugins/element-template/commands/edit.ts
@@ -42,6 +42,11 @@ import {
 	type Template,
 	validateDropdownValue,
 } from "../helpers.ts";
+import {
+	getModdleElement,
+	getModdleNumber,
+	getModdleString,
+} from "../moddle.ts";
 import { readBpmnInput, resolveOotbTemplate } from "../template-ref.ts";
 import {
 	type BpmnElement,
@@ -84,20 +89,17 @@ async function planEdit(
 		throw new Error(`Element "${elementId}" not found in the BPMN diagram`);
 	}
 
-	// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped values
-	const templateId = element.businessObject.get("modelerTemplate") as
-		| string
-		| undefined;
+	const templateId = getModdleString(element.businessObject, "modelerTemplate");
 	if (!templateId) {
 		throw new Error(
 			`Element "${elementId}" has no element template applied (no zeebe:modelerTemplate attribute). ` +
 				"Use 'apply' to apply one first.",
 		);
 	}
-	// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped values
-	const templateVersion = element.businessObject.get(
+	const templateVersion = getModdleNumber(
+		element.businessObject,
 		"modelerTemplateVersion",
-	) as number | undefined;
+	);
 	if (templateVersion === undefined) {
 		throw new Error(
 			`Element "${elementId}" has zeebe:modelerTemplate="${templateId}" but no recorded ` +
@@ -112,10 +114,10 @@ async function planEdit(
 		version: templateVersion,
 	});
 
-	// biome-ignore lint/plugin: moddle API contract boundary — get() returns untyped ModdleElement
-	const extensionElements = element.businessObject.get("extensionElements") as
-		| ModdleElement
-		| undefined;
+	const extensionElements = getModdleElement(
+		element.businessObject,
+		"extensionElements",
+	);
 	const containers = findExtensionContainers(extensionElements);
 
 	// Keyed by (child, property) so conditional duplicate properties (same

--- a/default-plugins/element-template/helpers.ts
+++ b/default-plugins/element-template/helpers.ts
@@ -3,7 +3,13 @@
  * shared element-template schema types.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import {
+	existsSync,
+	readFileSync,
+	renameSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { resolve as resolvePath } from "node:path";
 import semver from "semver";
 import type {} from "../../src/core/runtime.ts";
@@ -46,6 +52,43 @@ export function installStdoutEpipeHandler(): void {
 
 export function isRecord(value: unknown): value is Record<string, unknown> {
 	return value != null && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * Overwrite `targetPath` atomically: write to a sibling temp file in
+ * the same directory, then `renameSync` over the target. POSIX
+ * `rename` is atomic on the same filesystem, so a kill mid-write
+ * never destroys the user's BPMN file.
+ *
+ * Falls back to a direct `writeFileSync` if the rename fails with
+ * EXDEV (cross-device link) — vanishingly rare for a file's own
+ * sibling, but covers exotic setups like FUSE mounts.
+ */
+export function atomicOverwriteFile(
+	targetPath: string,
+	contents: string,
+): void {
+	const target = resolvePath(targetPath);
+	const tmp = `${target}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
+	try {
+		writeFileSync(tmp, contents, "utf-8");
+		renameSync(tmp, target);
+	} catch (error) {
+		try {
+			unlinkSync(tmp);
+		} catch {
+			// Best-effort cleanup — the original error is what matters.
+		}
+		const code =
+			isRecord(error) && typeof error.code === "string"
+				? error.code
+				: undefined;
+		if (code === "EXDEV") {
+			writeFileSync(target, contents, "utf-8");
+			return;
+		}
+		throw error;
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/default-plugins/element-template/moddle.ts
+++ b/default-plugins/element-template/moddle.ts
@@ -1,0 +1,84 @@
+/**
+ * Typed accessors for the moddle object graph — the single place in the
+ * plugin where the untyped `moddleElement.get(name)` boundary is crossed.
+ *
+ * moddle's `get()` is declared to return `unknown`: its schema is dynamic
+ * (driven by the loaded moddle extensions) and isn't expressed in the type
+ * system. Historically every read site cast the result with `as` and pinned a
+ * `biome-ignore lint/plugin` suppression next to it. Instead, all reads now
+ * funnel through these guard-based accessors, which narrow `get()`'s result
+ * with runtime checks rather than assertions. That keeps the rest of the
+ * plugin cast-free and confines the moddle contract to this one module.
+ *
+ * Because the accessors narrow with type guards (never `as`), this file itself
+ * carries no suppression — see `tests/unit/no-plugin-ignore-boundary.test.ts`,
+ * which forbids the `biome-ignore lint/plugin` comment outside an explicit
+ * allow-list (moddle is not on it).
+ */
+
+export type ModdleElement = {
+	$type: string;
+	get(name: string): unknown;
+	[key: string]: unknown;
+};
+
+/**
+ * Structural guard for a moddle element. A moddle element is an object that
+ * exposes a `get` method; that is the only shape this plugin relies on. The
+ * `$type` string is asserted by the predicate but not verified at runtime —
+ * every real moddle element carries one, and the accessors only ever read it
+ * for diagnostics/filtering.
+ */
+export function isModdleElement(value: unknown): value is ModdleElement {
+	if (typeof value !== "object" || value === null) {
+		return false;
+	}
+	if (!("get" in value)) {
+		return false;
+	}
+	return typeof value.get === "function";
+}
+
+/** Read a string-valued moddle property, or `undefined` if absent/other type. */
+export function getModdleString(
+	element: ModdleElement,
+	name: string,
+): string | undefined {
+	const value = element.get(name);
+	return typeof value === "string" ? value : undefined;
+}
+
+/** Read a number-valued moddle property, or `undefined` if absent/other type. */
+export function getModdleNumber(
+	element: ModdleElement,
+	name: string,
+): number | undefined {
+	const value = element.get(name);
+	return typeof value === "number" ? value : undefined;
+}
+
+/** Read a child moddle element, or `undefined` if absent/not an element. */
+export function getModdleElement(
+	element: ModdleElement,
+	name: string,
+): ModdleElement | undefined {
+	const value = element.get(name);
+	return isModdleElement(value) ? value : undefined;
+}
+
+/**
+ * Read a moddle collection property as a list of moddle elements. Returns an
+ * empty array when the property is absent, not an array, or holds non-element
+ * entries — callers treat "no backing collection" and "empty collection"
+ * identically.
+ */
+export function getModdleList(
+	element: ModdleElement | undefined,
+	name: string,
+): ModdleElement[] {
+	if (!element) {
+		return [];
+	}
+	const value = element.get(name);
+	return Array.isArray(value) ? value.filter(isModdleElement) : [];
+}

--- a/default-plugins/element-template/vendor.ts
+++ b/default-plugins/element-template/vendor.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared bpmn-js vendor-bundle loading + minimal type surface for commands
+ * that round-trip BPMN through bpmn-js-headless (`apply`, `edit`).
+ */
+
+import { existsSync } from "node:fs";
+import { dirname, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { ModdleElement } from "./binding.ts";
+import type { Template } from "./helpers.ts";
+
+export type { ModdleElement };
+export type BpmnElement = { businessObject: ModdleElement };
+export type ElementRegistry = { get(id: string): BpmnElement | undefined };
+export type ElementTemplatesService = {
+	set(templates: Template[]): void;
+	applyTemplate(element: BpmnElement, template: Template): void;
+};
+export type Modeling = {
+	updateModdleProperties(
+		element: BpmnElement,
+		moddleElement: ModdleElement,
+		properties: Record<string, unknown>,
+	): void;
+};
+export type ModelerInstance = {
+	importXML(xml: string): Promise<unknown>;
+	get(name: "elementRegistry"): ElementRegistry;
+	get(name: "elementTemplates"): ElementTemplatesService;
+	get(name: "modeling"): Modeling;
+	get(name: string): unknown;
+	saveXML(options: { format?: boolean }): Promise<{ xml: string }>;
+};
+export type ModelerCtor = new (options: {
+	additionalModules: unknown[];
+	moddleExtensions: Record<string, unknown>;
+}) => ModelerInstance;
+export type VendorBundle = {
+	Modeler: ModelerCtor;
+	CloudElementTemplatesCoreModule: unknown;
+	ZeebeModdleExtension: unknown;
+	HeadlessTextRendererModule: unknown;
+};
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Locate the prebuilt vendor bundle. Plugins live in two places:
+ *   - dev:        default-plugins/element-template/{vendor.ts,commands/*.ts}
+ *                 vendor: ../../dist/vendor/bpmn-element-templates.cjs
+ *   - production: dist/default-plugins/element-template/{vendor.js,commands/*.js}
+ *                 vendor: ../../vendor/bpmn-element-templates.cjs
+ */
+export function resolveVendorBundle(): string {
+	const candidates = [
+		resolvePath(
+			__dirname,
+			"..",
+			"..",
+			"dist",
+			"vendor",
+			"bpmn-element-templates.cjs",
+		),
+		resolvePath(__dirname, "..", "..", "vendor", "bpmn-element-templates.cjs"),
+	];
+	for (const path of candidates) {
+		if (existsSync(path)) {
+			return path;
+		}
+	}
+	throw new Error(
+		"Vendor bundle not found. Run `npm run build:vendor` to build it.\n" +
+			`Searched: ${candidates.join(", ")}`,
+	);
+}

--- a/tests/unit/element-template.test.ts
+++ b/tests/unit/element-template.test.ts
@@ -2049,6 +2049,515 @@ describe("CLI behavioural: element-template apply --dry-run", () => {
 });
 
 // ---------------------------------------------------------------------------
+// element-template edit
+// ---------------------------------------------------------------------------
+
+/**
+ * Run a sequence of CLI invocations against a single persistent, pre-seeded
+ * OOTB cache directory. `edit` resolves its target template from the local
+ * cache by the id/version recorded on the element (zeebe:modelerTemplate/
+ * -Version), so tests that apply a template and then edit it need the same
+ * cache available across both invocations.
+ */
+async function withSeededElementTemplateCache(
+	templates: Array<Record<string, unknown>>,
+	fn: (
+		run: (...args: string[]) => ReturnType<typeof asyncSpawn>,
+	) => Promise<void>,
+): Promise<void> {
+	const dataDir = mkdtempSync(join(tmpdir(), "c8ctl-et-test-"));
+	writeFileSync(
+		join(dataDir, "session.json"),
+		JSON.stringify({ outputMode: "text" }),
+	);
+	const cacheDir = join(dataDir, "element-templates");
+	mkdirSync(cacheDir, { recursive: true });
+	writeFileSync(
+		join(cacheDir, "templates.json"),
+		JSON.stringify(templates, null, 2),
+	);
+	writeFileSync(join(cacheDir, "fetched-at"), String(Date.now()));
+	const run = (...args: string[]) =>
+		asyncSpawn("node", ["--experimental-strip-types", CLI, ...args], {
+			env: {
+				...process.env,
+				CAMUNDA_BASE_URL: "http://test-cluster/v2",
+				HOME: "/tmp/c8ctl-test-nonexistent-home",
+				C8CTL_DATA_DIR: dataDir,
+			},
+		});
+	try {
+		await fn(run);
+	} finally {
+		rmSync(dataDir, { recursive: true, force: true });
+	}
+}
+
+describe("CLI behavioural: element-template edit", () => {
+	test("--set updates an already-materialized value and preserves hand-authored content the template doesn't own", async () => {
+		const httpJsonTemplate = JSON.parse(readFileSync(TEMPLATE_FILE, "utf-8"));
+		await withSeededElementTemplateCache([httpJsonTemplate], async (run) => {
+			const tempDir = mkdtempSync(join(tmpdir(), "c8ctl-et-test-"));
+			const tempBpmn = join(tempDir, "test.bpmn");
+			writeFileSync(tempBpmn, readFileSync(BPMN_FILE, "utf-8"));
+			try {
+				const applied = await run(
+					"element-template",
+					"apply",
+					"-i",
+					TEMPLATE_FILE,
+					"Activity_17s7axj",
+					tempBpmn,
+					"--set",
+					"method=POST",
+				);
+				assert.strictEqual(applied.status, 0, `stderr: ${applied.stderr}`);
+
+				// Simulate a hand-authored customization layered into an
+				// existing templated field — the way a Modeler user extends
+				// beyond what the template itself declares (c8ctl#466).
+				const beforeEdit = readFileSync(tempBpmn, "utf-8");
+				assert.ok(
+					beforeEdit.includes('key="resultExpression"'),
+					"fixture should already carry a resultExpression header to customize",
+				);
+				const customized = beforeEdit.replace(
+					/(key="resultExpression" value="=\{)/,
+					"$1&#10;  customHandAuthoredField: 1,",
+				);
+				assert.notStrictEqual(
+					customized,
+					beforeEdit,
+					"the resultExpression replace should have matched",
+				);
+				writeFileSync(tempBpmn, customized);
+
+				const edited = await run(
+					"element-template",
+					"edit",
+					"Activity_17s7axj",
+					tempBpmn,
+					"--set",
+					"method=PUT",
+				);
+				assert.strictEqual(edited.status, 0, `stderr: ${edited.stderr}`);
+				assert.strictEqual(getInputValue(edited.stdout, "method"), "PUT");
+				assert.ok(
+					edited.stdout.includes("customHandAuthoredField"),
+					"hand-authored content outside the template's own schema should survive edit",
+				);
+			} finally {
+				rmSync(tempDir, { recursive: true, force: true });
+			}
+		});
+	});
+
+	test("--set never resets a Hidden-typed property, even one hand-modified after apply", async () => {
+		// This is the actual c8ctl#466 regression: bpmn-js-element-templates'
+		// applyTemplate() unconditionally force-overwrites Hidden-typed
+		// properties back to their template default on every call
+		// (ChangeElementTemplateHandler#shouldKeepValue). `edit` never calls
+		// applyTemplate, so a Hidden binding's value — however it got there —
+		// must survive untouched across an unrelated --set.
+		const httpJsonTemplate = JSON.parse(readFileSync(TEMPLATE_FILE, "utf-8"));
+		const hiddenTaskDefType = httpJsonTemplate.properties.find(
+			(p: { binding?: { type?: string; property?: string }; type?: string }) =>
+				p.type === "Hidden" &&
+				p.binding?.type === "zeebe:taskDefinition" &&
+				p.binding?.property === "type",
+		);
+		assert.ok(
+			hiddenTaskDefType,
+			"fixture template should declare a Hidden zeebe:taskDefinition/type property",
+		);
+		await withSeededElementTemplateCache([httpJsonTemplate], async (run) => {
+			const tempDir = mkdtempSync(join(tmpdir(), "c8ctl-et-test-"));
+			const tempBpmn = join(tempDir, "test.bpmn");
+			writeFileSync(tempBpmn, readFileSync(BPMN_FILE, "utf-8"));
+			try {
+				const applied = await run(
+					"element-template",
+					"apply",
+					"-i",
+					TEMPLATE_FILE,
+					"Activity_17s7axj",
+					tempBpmn,
+					"--set",
+					"method=POST",
+				);
+				assert.strictEqual(applied.status, 0, `stderr: ${applied.stderr}`);
+				assert.strictEqual(
+					getTaskDefinitionType(readFileSync(tempBpmn, "utf-8")),
+					hiddenTaskDefType.value,
+					"apply should have set the Hidden property to the template default",
+				);
+
+				// Hand-modify the Hidden field itself to a value the template
+				// doesn't own/generate — apply --set would silently stomp this
+				// back to the template default on any re-apply; edit must not.
+				const marker = "custom-hand-authored-task-type:1";
+				const beforeEdit = readFileSync(tempBpmn, "utf-8");
+				const customized = beforeEdit.replace(
+					`type="${hiddenTaskDefType.value}"`,
+					`type="${marker}"`,
+				);
+				assert.notStrictEqual(
+					customized,
+					beforeEdit,
+					"the taskDefinition type replace should have matched",
+				);
+				writeFileSync(tempBpmn, customized);
+
+				const edited = await run(
+					"element-template",
+					"edit",
+					"Activity_17s7axj",
+					tempBpmn,
+					"--set",
+					"method=PUT",
+				);
+				assert.strictEqual(edited.status, 0, `stderr: ${edited.stderr}`);
+				assert.strictEqual(
+					getInputValue(edited.stdout, "method"),
+					"PUT",
+					"the requested property should still be updated",
+				);
+				assert.strictEqual(
+					getTaskDefinitionType(edited.stdout),
+					marker,
+					"edit must not reset the Hidden zeebe:taskDefinition/type property " +
+						"to its template default",
+				);
+			} finally {
+				rmSync(tempDir, { recursive: true, force: true });
+			}
+		});
+	});
+
+	test("errors clearly when the element has no template applied", async () => {
+		await withSeededElementTemplateCache([], async (run) => {
+			const result = await run(
+				"element-template",
+				"edit",
+				"Activity_17s7axj",
+				BPMN_FILE,
+				"--set",
+				"method=PUT",
+			);
+			assert.strictEqual(result.status, 1);
+			const output = result.stdout + result.stderr;
+			assert.ok(
+				output.includes("no element template applied"),
+				`Should report the missing template. Got: ${output.slice(0, 300)}`,
+			);
+		});
+	});
+
+	test("later --set wins when two --set args target the same property", async () => {
+		// Distinct from the conditional-duplicate dedup: two *different* --set
+		// args resolving to the same moddle target must behave like `apply`
+		// ("--set wins", last one specified), not silently keep the first.
+		const httpJsonTemplate = JSON.parse(readFileSync(TEMPLATE_FILE, "utf-8"));
+		await withSeededElementTemplateCache([httpJsonTemplate], async (run) => {
+			const tempDir = mkdtempSync(join(tmpdir(), "c8ctl-et-test-"));
+			const tempBpmn = join(tempDir, "test.bpmn");
+			writeFileSync(tempBpmn, readFileSync(BPMN_FILE, "utf-8"));
+			try {
+				const applied = await run(
+					"element-template",
+					"apply",
+					"-i",
+					TEMPLATE_FILE,
+					"Activity_17s7axj",
+					tempBpmn,
+					"--set",
+					"method=POST",
+				);
+				assert.strictEqual(applied.status, 0, `stderr: ${applied.stderr}`);
+
+				const edited = await run(
+					"element-template",
+					"edit",
+					"Activity_17s7axj",
+					tempBpmn,
+					"--set",
+					"method=PUT",
+					"--set",
+					"method=DELETE",
+				);
+				assert.strictEqual(edited.status, 0, `stderr: ${edited.stderr}`);
+				assert.strictEqual(
+					getInputValue(edited.stdout, "method"),
+					"DELETE",
+					"the later --set method=DELETE should win over the earlier --set method=PUT",
+				);
+			} finally {
+				rmSync(tempDir, { recursive: true, force: true });
+			}
+		});
+	});
+
+	test("errors clearly when the property's condition was never met (not materialized)", async () => {
+		const httpJsonTemplate = JSON.parse(readFileSync(TEMPLATE_FILE, "utf-8"));
+		await withSeededElementTemplateCache([httpJsonTemplate], async (run) => {
+			const tempDir = mkdtempSync(join(tmpdir(), "c8ctl-et-test-"));
+			const tempBpmn = join(tempDir, "test.bpmn");
+			writeFileSync(tempBpmn, readFileSync(BPMN_FILE, "utf-8"));
+			try {
+				// Apply without setting `method`, so the `body` property's
+				// gating condition (method=POST) is never met and no
+				// zeebe:input target="body" entry is ever materialized.
+				const applied = await run(
+					"element-template",
+					"apply",
+					"-i",
+					TEMPLATE_FILE,
+					"Activity_17s7axj",
+					tempBpmn,
+				);
+				assert.strictEqual(applied.status, 0, `stderr: ${applied.stderr}`);
+
+				const result = await run(
+					"element-template",
+					"edit",
+					"Activity_17s7axj",
+					tempBpmn,
+					"--set",
+					'body={"hello":"world"}',
+				);
+				assert.strictEqual(result.status, 1);
+				const output = result.stdout + result.stderr;
+				assert.ok(
+					output.includes("has no existing value on this element to edit"),
+					`Should report the unmaterialized property. Got: ${output.slice(0, 300)}`,
+				);
+			} finally {
+				rmSync(tempDir, { recursive: true, force: true });
+			}
+		});
+	});
+
+	test("rejects unknown property name", async () => {
+		const httpJsonTemplate = JSON.parse(readFileSync(TEMPLATE_FILE, "utf-8"));
+		await withSeededElementTemplateCache([httpJsonTemplate], async (run) => {
+			const tempDir = mkdtempSync(join(tmpdir(), "c8ctl-et-test-"));
+			const tempBpmn = join(tempDir, "test.bpmn");
+			writeFileSync(tempBpmn, readFileSync(BPMN_FILE, "utf-8"));
+			try {
+				const applied = await run(
+					"element-template",
+					"apply",
+					"-i",
+					TEMPLATE_FILE,
+					"Activity_17s7axj",
+					tempBpmn,
+				);
+				assert.strictEqual(applied.status, 0, `stderr: ${applied.stderr}`);
+
+				const result = await run(
+					"element-template",
+					"edit",
+					"Activity_17s7axj",
+					tempBpmn,
+					"--set",
+					"nonexistent=value",
+				);
+				assert.strictEqual(result.status, 1);
+				const output = result.stdout + result.stderr;
+				assert.ok(
+					output.includes('Unknown property "nonexistent"'),
+					"Should report unknown property",
+				);
+			} finally {
+				rmSync(tempDir, { recursive: true, force: true });
+			}
+		});
+	});
+
+	test("requires at least one --set", async () => {
+		await withSeededElementTemplateCache([], async (run) => {
+			const result = await run(
+				"element-template",
+				"edit",
+				"Activity_17s7axj",
+				BPMN_FILE,
+			);
+			assert.strictEqual(result.status, 1);
+			const output = result.stdout + result.stderr;
+			assert.ok(
+				output.includes("at least one --set"),
+				`Should require --set. Got: ${output.slice(0, 300)}`,
+			);
+		});
+	});
+
+	test("requires an element-id argument", async () => {
+		await withSeededElementTemplateCache([], async (run) => {
+			const result = await run("element-template", "edit");
+			assert.strictEqual(result.status, 1);
+			const output = result.stdout + result.stderr;
+			assert.ok(
+				output.includes("Missing element-id argument"),
+				`Should require element-id. Got: ${output.slice(0, 300)}`,
+			);
+		});
+	});
+
+	test("rejects unexpected extra positional argument", async () => {
+		await withSeededElementTemplateCache([], async (run) => {
+			const result = await run(
+				"element-template",
+				"edit",
+				"Activity_17s7axj",
+				BPMN_FILE,
+				"extra-arg",
+				"--set",
+				"method=PUT",
+			);
+			assert.strictEqual(result.status, 1);
+			const output = result.stdout + result.stderr;
+			assert.ok(
+				output.includes("Unexpected argument") && output.includes("extra-arg"),
+				`Should report the unexpected argument. Got: ${output.slice(0, 300)}`,
+			);
+		});
+	});
+
+	test("--dry-run reports without mutating the file", async () => {
+		const httpJsonTemplate = JSON.parse(readFileSync(TEMPLATE_FILE, "utf-8"));
+		await withSeededElementTemplateCache([httpJsonTemplate], async (run) => {
+			const tempDir = mkdtempSync(join(tmpdir(), "c8ctl-et-test-"));
+			const tempBpmn = join(tempDir, "test.bpmn");
+			writeFileSync(tempBpmn, readFileSync(BPMN_FILE, "utf-8"));
+			try {
+				const applied = await run(
+					"element-template",
+					"apply",
+					"-i",
+					TEMPLATE_FILE,
+					"Activity_17s7axj",
+					tempBpmn,
+					"--set",
+					"method=POST",
+				);
+				assert.strictEqual(applied.status, 0, `stderr: ${applied.stderr}`);
+				const beforeDryRun = readFileSync(tempBpmn, "utf-8");
+
+				const result = await run(
+					"--dry-run",
+					"element-template",
+					"edit",
+					"--in-place",
+					"Activity_17s7axj",
+					tempBpmn,
+					"--set",
+					"method=PUT",
+				);
+				assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+				assert.ok(
+					result.stdout.includes("Dry run"),
+					"stdout should contain 'Dry run' summary line",
+				);
+				assert.ok(
+					result.stdout.toLowerCase().includes("in-place"),
+					"stdout should describe in-place mode",
+				);
+				assert.strictEqual(
+					readFileSync(tempBpmn, "utf-8"),
+					beforeDryRun,
+					"--dry-run must not modify the BPMN file",
+				);
+			} finally {
+				rmSync(tempDir, { recursive: true, force: true });
+			}
+		});
+	});
+
+	test("--in-place writes atomically and leaves no .tmp file", async () => {
+		const httpJsonTemplate = JSON.parse(readFileSync(TEMPLATE_FILE, "utf-8"));
+		await withSeededElementTemplateCache([httpJsonTemplate], async (run) => {
+			const tempDir = mkdtempSync(join(tmpdir(), "c8ctl-et-test-"));
+			const tempBpmn = join(tempDir, "test.bpmn");
+			writeFileSync(tempBpmn, readFileSync(BPMN_FILE, "utf-8"));
+			try {
+				const applied = await run(
+					"element-template",
+					"apply",
+					"-i",
+					TEMPLATE_FILE,
+					"Activity_17s7axj",
+					tempBpmn,
+					"--set",
+					"method=POST",
+				);
+				assert.strictEqual(applied.status, 0, `stderr: ${applied.stderr}`);
+
+				const result = await run(
+					"element-template",
+					"edit",
+					"-i",
+					"Activity_17s7axj",
+					tempBpmn,
+					"--set",
+					"method=PUT",
+				);
+				assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+				const leftovers = readdirSync(tempDir).filter((name) =>
+					name.endsWith(".tmp"),
+				);
+				assert.deepStrictEqual(
+					leftovers,
+					[],
+					`No .tmp file should survive a clean edit. Found: ${leftovers.join(", ")}`,
+				);
+				const updated = readFileSync(tempBpmn, "utf-8");
+				assert.strictEqual(getInputValue(updated, "method"), "PUT");
+			} finally {
+				rmSync(tempDir, { recursive: true, force: true });
+			}
+		});
+	});
+
+	test("cold cache: exits 1 with a 'run sync first' hint", async () => {
+		const httpJsonTemplate = JSON.parse(readFileSync(TEMPLATE_FILE, "utf-8"));
+		const tempDir = mkdtempSync(join(tmpdir(), "c8ctl-et-test-"));
+		const tempBpmn = join(tempDir, "test.bpmn");
+		writeFileSync(tempBpmn, readFileSync(BPMN_FILE, "utf-8"));
+		try {
+			// Produce a templated fixture under a seeded cache...
+			await withSeededElementTemplateCache([httpJsonTemplate], async (run) => {
+				const applied = await run(
+					"element-template",
+					"apply",
+					"-i",
+					TEMPLATE_FILE,
+					"Activity_17s7axj",
+					tempBpmn,
+				);
+				assert.strictEqual(applied.status, 0, `stderr: ${applied.stderr}`);
+			});
+
+			// ...then edit it against a cold (empty) cache.
+			const result = await spawnAgainstEmptyCache(
+				"edit",
+				"Activity_17s7axj",
+				tempBpmn,
+				"--set",
+				"method=PUT",
+			);
+			assert.strictEqual(result.status, 1);
+			const output = result.stdout + result.stderr;
+			assert.ok(
+				output.includes("element-template sync"),
+				`Should point at 'sync'. Got: ${output.slice(0, 300)}`,
+			);
+		} finally {
+			rmSync(tempDir, { recursive: true, force: true });
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
 // element-template — cold-cache failures (no auto-bootstrap)
 // ---------------------------------------------------------------------------
 

--- a/tests/unit/element-template.test.ts
+++ b/tests/unit/element-template.test.ts
@@ -108,6 +108,14 @@ function getTaskDefinitionType(xml: string): string | null {
 	return match ? match[1] : null;
 }
 
+function getTaskHeaderValue(xml: string, key: string): string | null {
+	const re = new RegExp(
+		`<zeebe:header\\s+(?=[^>]*key="${key}")(?=[^>]*value="([^"]*)")`,
+	);
+	const match = xml.match(re);
+	return match ? match[1] : null;
+}
+
 // ---------------------------------------------------------------------------
 // element-template verb
 // ---------------------------------------------------------------------------
@@ -2227,6 +2235,64 @@ describe("CLI behavioural: element-template edit", () => {
 					marker,
 					"edit must not reset the Hidden zeebe:taskDefinition/type property " +
 						"to its template default",
+				);
+			} finally {
+				rmSync(tempDir, { recursive: true, force: true });
+			}
+		});
+	});
+
+	test("--set updates a zeebe:taskHeader value (and prepends FEEL) without touching other bindings", async () => {
+		// Coverage for the zeebe:taskHeader branch of resolveBindingTarget,
+		// which is asymmetric to zeebe:input (keyed by binding.key, writing
+		// the header's `value` property) and was otherwise exercised by no
+		// --set path — apply or edit. `resultExpression` is a Text/FEEL header
+		// the fixture materializes with a default on apply, so editing it also
+		// proves maybePrependFeel runs on the edit path (feel: "required" =>
+		// a bare value gets an "=" prefix).
+		const httpJsonTemplate = JSON.parse(readFileSync(TEMPLATE_FILE, "utf-8"));
+		await withSeededElementTemplateCache([httpJsonTemplate], async (run) => {
+			const tempDir = mkdtempSync(join(tmpdir(), "c8ctl-et-test-"));
+			const tempBpmn = join(tempDir, "test.bpmn");
+			writeFileSync(tempBpmn, readFileSync(BPMN_FILE, "utf-8"));
+			try {
+				const applied = await run(
+					"element-template",
+					"apply",
+					"-i",
+					TEMPLATE_FILE,
+					"Activity_17s7axj",
+					tempBpmn,
+					"--set",
+					"method=POST",
+				);
+				assert.strictEqual(applied.status, 0, `stderr: ${applied.stderr}`);
+				assert.ok(
+					getTaskHeaderValue(
+						readFileSync(tempBpmn, "utf-8"),
+						"resultExpression",
+					)?.startsWith("="),
+					"apply should have materialized the resultExpression header with its FEEL default",
+				);
+
+				const edited = await run(
+					"element-template",
+					"edit",
+					"Activity_17s7axj",
+					tempBpmn,
+					"--set",
+					"resultExpression=response.body",
+				);
+				assert.strictEqual(edited.status, 0, `stderr: ${edited.stderr}`);
+				assert.strictEqual(
+					getTaskHeaderValue(edited.stdout, "resultExpression"),
+					"=response.body",
+					"edit must update the taskHeader's value and prepend '=' for a feel:required header",
+				);
+				assert.strictEqual(
+					getInputValue(edited.stdout, "method"),
+					"POST",
+					"editing the taskHeader must not disturb the unrelated zeebe:input value",
 				);
 			} finally {
 				rmSync(tempDir, { recursive: true, force: true });

--- a/tests/unit/no-plugin-ignore-boundary.test.ts
+++ b/tests/unit/no-plugin-ignore-boundary.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Architectural ratchet guard: `biome-ignore lint/plugin` suppressions are
+ * banned outside an explicit, shrink-only allow-list.
+ *
+ * The `no-unsafe-type-assertion` Biome plugin (`plugins/*.grit`) forbids `as`
+ * type assertions repo-wide. A `// biome-ignore lint/plugin:` comment silences
+ * it locally — a necessary escape hatch at genuine type-system boundaries, but
+ * an anti-pattern when it spreads: each suppression is an unchecked `as` cast
+ * that the plugin can no longer protect.
+ *
+ * This guard freezes the current, reviewed set of suppressions and prevents
+ * new ones. Two rules:
+ *   1. A file not on `ALLOWED` must contain zero suppressions.
+ *   2. A file on `ALLOWED` must contain *exactly* its listed count — no more
+ *      (no new suppressions) and no fewer (when you remove one, decrement the
+ *      entry so the ratchet only ever tightens; drop the entry at zero).
+ *
+ * The moddle object graph was the largest offender (9 suppressions across
+ * `binding.ts`/`apply.ts`/`edit.ts`, each an `as` on an untyped
+ * `moddleElement.get()`). It is deliberately absent from the list: those reads
+ * now funnel through the guard-based accessors in
+ * `default-plugins/element-template/moddle.ts`, which narrow with runtime type
+ * guards instead of `as`. The remaining allow-listed boundaries (framework
+ * `InferFlags` structural assertions, logger widening, CLI trust-boundary
+ * indexing) are tracked for the same treatment in camunda/c8ctl#472.
+ *
+ * Matching is on the suppression *comment* form (`// biome-ignore lint/plugin`)
+ * — exactly what Biome recognises — so JSDoc prose mentioning the directive
+ * (as this file and `moddle.ts` do) is not counted.
+ */
+
+import assert from "node:assert";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, test } from "node:test";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
+const SCAN_ROOTS = ["src", "default-plugins"];
+
+/**
+ * Frozen set of files permitted to suppress the `no-unsafe-type-assertion`
+ * plugin, with the exact number of suppressions each may contain. This list
+ * can only shrink: never raise a count or add an entry to make a new `as`
+ * pass. Retire boundaries by routing them through a typed helper (see
+ * `moddle.ts`) and decrementing here.
+ */
+const ALLOWED: Record<string, number> = {
+	"src/core/logger.ts": 3,
+	"src/framework/command-framework.ts": 5,
+	"src/framework/command-registry.ts": 4,
+	"src/framework/ui/help.ts": 1,
+	"src/index.ts": 1,
+	"src/utils/command-local/open-helpers.ts": 1,
+	"default-plugins/element-template/template-ref.ts": 1,
+};
+
+/** Matches the Biome suppression comment, not JSDoc/string mentions. */
+const SUPPRESSION = /\/\/\s*biome-ignore\s+lint\/plugin\b/;
+
+function listTsFiles(dir: string): string[] {
+	const out: string[] = [];
+	for (const entry of readdirSync(dir)) {
+		const abs = join(dir, entry);
+		if (statSync(abs).isDirectory()) {
+			out.push(...listTsFiles(abs));
+		} else if (entry.endsWith(".ts") && !entry.endsWith(".d.ts")) {
+			out.push(abs);
+		}
+	}
+	return out;
+}
+
+function toRelative(absPath: string): string {
+	return absPath
+		.slice(PROJECT_ROOT.length + 1)
+		.split(/[\\/]/)
+		.join("/");
+}
+
+function countSuppressions(absPath: string): number {
+	return readFileSync(absPath, "utf-8")
+		.split("\n")
+		.filter((line) => SUPPRESSION.test(line)).length;
+}
+
+describe("architectural guard: no new `biome-ignore lint/plugin` suppressions", () => {
+	const counts = new Map<string, number>();
+	for (const root of SCAN_ROOTS) {
+		for (const abs of listTsFiles(join(PROJECT_ROOT, root))) {
+			const n = countSuppressions(abs);
+			if (n > 0) counts.set(toRelative(abs), n);
+		}
+	}
+
+	test("every suppression sits in an allow-listed file (no new offenders)", () => {
+		const offenders = [...counts.keys()]
+			.filter((file) => !(file in ALLOWED))
+			.sort();
+		assert.deepStrictEqual(
+			offenders,
+			[],
+			"These files introduced a `// biome-ignore lint/plugin` suppression but are not " +
+				"allow-listed. Remove the `as` cast (prefer a guard-based typed accessor, as " +
+				`moddle.ts does) instead of suppressing the plugin:\n  ${offenders.join("\n  ")}`,
+		);
+	});
+
+	test("no allow-listed file exceeds its frozen suppression count", () => {
+		const overspill = [...counts.entries()]
+			.filter(([file, n]) => file in ALLOWED && n > ALLOWED[file])
+			.map(([file, n]) => `${file}: ${n} > allowed ${ALLOWED[file]}`)
+			.sort();
+		assert.deepStrictEqual(
+			overspill,
+			[],
+			`These files added suppressions beyond their frozen count:\n  ${overspill.join("\n  ")}`,
+		);
+	});
+
+	test("the allow-list has no stale entries (ratchet only tightens)", () => {
+		const stale = Object.keys(ALLOWED)
+			.filter((file) => (counts.get(file) ?? 0) < ALLOWED[file])
+			.map(
+				(file) =>
+					`${file}: listed ${ALLOWED[file]}, found ${counts.get(file) ?? 0}`,
+			)
+			.sort();
+		assert.deepStrictEqual(
+			stale,
+			[],
+			"Suppressions were removed — decrement (or drop) these allow-list entries so the " +
+				`ratchet reflects reality:\n  ${stale.join("\n  ")}`,
+		);
+	});
+});


### PR DESCRIPTION
## Summary

- `element-template apply --set` calls `elementTemplates.applyTemplate()` twice per invocation. That call unconditionally resets every `Hidden`-typed template property to its template default (`ChangeElementTemplateHandler#shouldKeepValue`), silently clobbering hand-authored content layered into a Hidden-owned extension attribute that isn't part of the template's own declared schema — e.g. a custom conditional merged into a `zeebe:adHoc` `outputElement` expression on an AI Agent ad-hoc sub-process. Closes #466.
- Add `element-template edit <element-id> [<file.bpmn>] --set name=value`: updates already-materialized property values on an element that already has a template applied, without re-running template application. It reads the target template from the element's own `zeebe:modelerTemplate`/`-Version` attributes (no `<template>` argument needed), and writes only via `modeling.updateModdleProperties` on moddle entries that already exist. It never calls `applyTemplate`, so it can't create a property whose gating condition was never met, but it also can't reset anything the template doesn't explicitly touch.
- Extract the binding-target dispatch (`zeebe:input`/`output`/`taskHeader`/`property`/`taskDefinition` lookup) out of `apply.ts` into a shared `binding.ts`, and the vendor-bundle loading + `bpmn-js` type surface into `vendor.ts`, so `apply` and `edit` share both instead of duplicating them. `binding.ts` is a hand-rolled, 5-binding-type stand-in for `bpmn-js-element-templates`' internal `setPropertyValue` dispatch (15+ binding types, FEEL/Boolean casting) — see [bpmn-io/bpmn-js-element-templates#236](https://github.com/bpmn-io/bpmn-js-element-templates/pull/236), which exports the real thing but hasn't merged/shipped yet. Tracked in camunda/c8ctl#467 to swap out once it does.
- `edit` still round-trips through `bpmn-js`'s `saveXML`, so it inherits that pipeline's unrelated BPMNDI shape/edge reordering, same as `apply` — cosmetic reordering with no data loss, out of scope here (still tracked on #466).

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `node --experimental-strip-types --test tests/unit/element-template.test.ts` — 100/100 passing, including 10 new `edit` tests (materialized-value update + preserved hand-authored content, no-template-applied error, unmaterialized-property error, unknown-property error, missing-args errors, `--dry-run`, `--in-place` atomicity, cold-cache error)
- [x] Manually reproduced the exact #466 scenario against the live `io.camunda.connectors.agenticai.aiagent.jobworker.v1@7` OOTB template: confirmed `apply --set` still drops the hand-authored `accessLog` conditional, then confirmed `edit --set` preserves it byte-for-byte with a minimal one-line diff
