### PR TITLE
ci: add :white_check_mark: reaction to Slack notification on merge

### DIFF
--- a/.github/workflows/community-notify.yml
+++ b/.github/workflows/community-notify.yml
@@ -10,6 +10,10 @@ permissions: {}
 
 jobs:
   notify:
+    # `closed` fires on every close, not just merges. An unmerged close is a
+    # no-op inside the reusable workflow, so skip the call entirely rather
+    # than producing an empty run and materialising secrets for nothing.
+    if: github.event.action == 'opened' || github.event.pull_request.merged == true
     permissions:
       # The Slack message reference is recorded via the Issues Comments API,
       # which is shared between issues and PRs. Both scopes are granted because

--- a/.github/workflows/community-notify.yml
+++ b/.github/workflows/community-notify.yml
@@ -4,19 +4,23 @@ on:
   issues:
     types: [opened]
   pull_request_target:
-    types: [opened]
+    types: [opened, closed]
 
 permissions: {}
 
 jobs:
   notify:
+    permissions:
+      pull-requests: write
     uses: camunda/sdk-infra/.github/workflows/sdk-slack-community-notify.yml@v1
     with:
       repo-name: c8ctl
       mention-group: ${{ vars.SLACK_MENTION_GROUP }}
+      slack-channel-id: ${{ vars.SLACK_SDK_ALERTS_CHANNEL_ID }}
       author-association: ${{ github.event.pull_request.author_association || github.event.issue.author_association }}
     secrets:
       slack-webhook-url: ${{ secrets.SLACK_SDK_ALERTS }}
+      slack-bot-token: ${{ secrets.SLACK_SDK_BOT_TOKEN }}
       vault-addr: ${{ secrets.VAULT_ADDR }}
       vault-role-id: ${{ secrets.VAULT_ROLE_ID }}
       vault-secret-id: ${{ secrets.VAULT_SECRET_ID }}

--- a/.github/workflows/community-notify.yml
+++ b/.github/workflows/community-notify.yml
@@ -11,6 +11,10 @@ permissions: {}
 jobs:
   notify:
     permissions:
+      # The Slack message reference is recorded via the Issues Comments API,
+      # which is shared between issues and PRs. Both scopes are granted because
+      # GitHub does not document which one is checked for a PR target.
+      issues: write
       pull-requests: write
     uses: camunda/sdk-infra/.github/workflows/sdk-slack-community-notify.yml@v1
     with:


### PR DESCRIPTION
## What

Extends the shared Slack notification workflow so the bot adds a
:white_check_mark: reaction to its own message when the corresponding pull
request is merged.

Changes to this caller:

- listen to `pull_request_target: [opened, closed]` (was `[opened]`)
- guard the job so an **unmerged** close is skipped entirely
- grant `issues: write` + `pull-requests: write` so the reusable workflow can
  record a marker comment (permissions cannot be escalated by a called
  workflow, so the caller must grant them)
- pass `slack-channel-id` and `slack-bot-token`

## Why

Incoming webhooks return a bare `ok` with no message timestamp, so there is
nothing to react to. `chat.postMessage` with a bot token returns `channel` and
`ts`, which are stored in a hidden marker comment on the PR and read back on
merge by `reactions.add`.

The webhook path is retained as a fallback and is used automatically whenever
no bot token is configured, so this is not a breaking change for any repo that
has not been migrated.

## Verification

Validated end to end in `orchestration-cluster-api-csharp` before rollout,
using a SHA-pinned pilot so a defect could not affect the other repos:

| run | outcome |
| --- | --- |
| [30506026939](https://github.com/camunda/orchestration-cluster-api-csharp/actions/runs/30506026939) | posted the message, recorded the marker comment |
| [30507098721](https://github.com/camunda/orchestration-cluster-api-csharp/actions/runs/30507098721) | `react-on-merge` added the reaction on merge |

The pilot also caught two real misconfigurations (a missing `chat:write` scope
and the bot not being a member of the channel) that would otherwise have taken
all four repos' notifications offline at once.

Repo config confirmed present here: `SLACK_SDK_ALERTS_CHANNEL_ID` (variable,
same channel as the other SDK repos) and `SLACK_SDK_BOT_TOKEN` (secret).

## Guard behaviour

| event | calls the workflow |
| --- | --- |
| issue opened | yes |
| PR opened (including from a fork) | yes |
| PR closed **without** merge | no |
| PR closed **and** merged | yes |
