### PR TITLE
feat(plugins)!: expose the cross-platform npm runner on the plugin runtime

### DIFF
--- a/PLUGIN-HELP.md
+++ b/PLUGIN-HELP.md
@@ -183,8 +183,24 @@ At runtime, c8ctl injects a global `c8ctl` object for plugins via `globalThis.c8
 - SDK client factory: `createClient(profile?, sdkConfig?)`
 - Tenant resolver: `resolveTenantId(profile?)`
 - Logger accessor: `getLogger()`
+- User data directory: `getUserDataDir()`
+- Cross-platform npm runner: `npm({ args, stdout?, stdio? })`
 
 Use the client factory when your plugin needs direct Camunda API access, `resolveTenantId` to mirror c8ctl tenant fallback behavior, and `getLogger()` to emit output-mode-aware logs.
+
+### Running npm from a plugin
+
+Use `c8ctl.npm()` rather than spawning npm yourself. On Windows npm is a `npm.cmd` shim: a bare `npm` spawn fails with `ENOENT`, and `npm.cmd` alone fails with `EINVAL` under the CVE-2024-27980 hardening in Node 18.20.2 / 20.12.2 / 21.7.3+. The runtime helper routes the call through `cmd.exe` with every argument quoted (plugin paths routinely contain spaces) and rejects arguments that cannot be passed safely — an embedded `"`, a line break, or a `%VAR%` reference.
+
+```typescript
+// Capture stdout
+const { stdout } = c8ctl.npm({ args: ['view', 'c8ctl-plugin-foo', 'version'], stdout: true });
+
+// Stream to the terminal instead (stdio is forwarded to the child)
+c8ctl.npm({ args: ['install', 'c8ctl-plugin-foo'], stdio: 'inherit' });
+```
+
+`stdout: true` returns `{ stdout: string }`; omitting it returns `undefined`. A non-zero npm exit throws.
 
 For TypeScript autocomplete, use the exported runtime type:
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -173,8 +173,8 @@ Spawning npm directly is not portable. On Windows npm is a `npm.cmd` shim: a bar
 ```typescript
 import type { C8ctlPluginRuntime } from "@camunda8/cli/runtime";
 
-const c8ctl = globalThis.c8ctl as C8ctlPluginRuntime;
-
+const c8ctl: C8ctlPluginRuntime | undefined = globalThis.c8ctl;
+if (!c8ctl) throw new Error("c8ctl runtime is not available");
 // Capture stdout
 const { stdout } = c8ctl.npm({ args: ["view", "c8ctl-plugin-foo", "version"], stdout: true });
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -155,6 +155,8 @@ At runtime, `c8ctl` injects a global object via `globalThis.c8ctl` that plugins 
 | `createClient(profile?, sdkConfig?)` | Create a Camunda SDK client. Optionally pass a profile name to use specific credentials. |
 | `resolveTenantId(profile?)`          | Resolve the active tenant ID using the same fallback logic as built-in commands.         |
 | `getLogger()`                        | Get the `c8ctl` logger instance (respects the current output mode).                      |
+| `getUserDataDir()`                   | Absolute path of the `c8ctl` user data directory (honours `C8CTL_DATA_DIR`).             |
+| `npm({ args, stdout?, stdio? })`     | Run npm the way `c8ctl` does, portably. See [Running npm from a plugin](#running-npm-from-a-plugin). |
 | `version`                            | `c8ctl` version string.                                                                  |
 | `nodeVersion`                        | Node.js version.                                                                         |
 | `platform`                           | Operating system (`linux`, `darwin`, `win32`).                                           |
@@ -163,6 +165,24 @@ At runtime, `c8ctl` injects a global object via `globalThis.c8ctl` that plugins 
 | `outputMode`                         | Current output mode (`text` or `json`).                                                  |
 | `activeProfile`                      | Name of the active profile.                                                              |
 | `activeTenant`                       | Active tenant ID.                                                                        |
+
+### Running npm from a plugin
+
+Spawning npm directly is not portable. On Windows npm is a `npm.cmd` shim: a bare `npm` spawn fails with `ENOENT`, and `npm.cmd` alone fails with `EINVAL` under the CVE-2024-27980 hardening in Node 18.20.2 / 20.12.2 / 21.7.3 and later. `c8ctl.npm()` is the same helper the CLI uses for its own plugin installs — it routes the call through `cmd.exe` with every argument quoted (plugin paths routinely contain spaces) and rejects arguments that cannot be passed safely: an embedded `"`, a line break, or a `%VAR%` reference.
+
+```typescript
+import type { C8ctlPluginRuntime } from "@camunda8/cli/runtime";
+
+const c8ctl = globalThis.c8ctl as C8ctlPluginRuntime;
+
+// Capture stdout
+const { stdout } = c8ctl.npm({ args: ["view", "c8ctl-plugin-foo", "version"], stdout: true });
+
+// Stream to the terminal instead
+c8ctl.npm({ args: ["install", "c8ctl-plugin-foo"], stdio: "inherit" });
+```
+
+`stdout: true` returns `{ stdout: string }`; omitting it returns `undefined`. A non-zero npm exit throws.
 
 ### TypeScript autocomplete
 

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   },
   "exports": {
     "./runtime": {
-      "types": "./dist/runtime.d.ts",
-      "default": "./dist/runtime.js"
+      "types": "./dist/core/runtime.d.ts",
+      "default": "./dist/core/runtime.js"
     }
   },
   "files": [

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -2,6 +2,7 @@
  * c8ctl runtime object with environment information and session state
  */
 
+import type { ExecFileSyncOptions } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -23,11 +24,39 @@ export interface C8ctlEnv {
 	rootDir: string;
 }
 
+/** Options for the npm runner when its stdout is captured. */
+export interface NpmRunOptionsWithOutput {
+	args: readonly string[];
+	stdout: true;
+}
+
+/** Options for the npm runner when its output is inherited or discarded. */
+export interface NpmRunOptionsWithoutOutput {
+	args: readonly string[];
+	stdio?: ExecFileSyncOptions["stdio"];
+	stdout?: false;
+}
+
+/**
+ * Cross-platform npm runner.
+ *
+ * Declared structurally here rather than imported from
+ * `utils/shared/npm-exec.ts` because `core/` may not import `utils/` — not
+ * even type-only (see tests/unit/layering-import-boundary.test.ts). The real
+ * implementation is checked against this contract where it is injected, at
+ * the composition root.
+ */
+export interface NpmRunner {
+	(options: NpmRunOptionsWithOutput): { stdout: string };
+	(options: NpmRunOptionsWithoutOutput): undefined;
+}
+
 /**
  * Functions injected into the runtime via init() to break circular imports.
  * client.ts, config.ts, and logger.ts all import c8ctl from this module,
  * so this module cannot import runtime values from them at the top level
- * (type-only imports are OK).
+ * (type-only imports are OK). `npm` is injected for a different reason: it
+ * lives in `utils/`, which `core/` may not import from at all.
  */
 export interface C8ctlDeps {
 	createClient(
@@ -37,6 +66,7 @@ export interface C8ctlDeps {
 	resolveTenantId(profileFlag?: string): string;
 	getLogger(mode?: OutputMode): Logger;
 	getUserDataDir(): string;
+	npm: NpmRunner;
 }
 
 export interface C8ctlPluginRuntime {
@@ -69,6 +99,22 @@ export interface C8ctlPluginRuntime {
 	 * Overridable via C8CTL_DATA_DIR.
 	 */
 	getUserDataDir(): string;
+	/**
+	 * Run npm the way c8ctl itself does, portably.
+	 *
+	 * Spawning npm directly is not portable: on Windows npm is a `npm.cmd`
+	 * shim, bare `"npm"` fails with ENOENT and `"npm.cmd"` fails with EINVAL
+	 * under the CVE-2024-27980 hardening, so the invocation has to go through
+	 * cmd.exe with every argument quoted. Use this instead of hand-rolling a
+	 * spawn.
+	 *
+	 *   const { stdout } = c8ctl.npm({ args: ["view", pkg, "version"], stdout: true });
+	 *   c8ctl.npm({ args: ["install", pkg], stdio: "inherit" });
+	 *
+	 * Throws if an argument cannot be passed safely to cmd.exe (embedded
+	 * quote, line break, or a `%VAR%` reference).
+	 */
+	npm: NpmRunner;
 }
 
 declare global {
@@ -154,6 +200,21 @@ class C8ctl implements C8ctlPluginRuntime {
 			throw new Error("c8ctl.init() must be called before getUserDataDir()");
 		}
 		return this._deps.getUserDataDir();
+	}
+
+	npm(options: NpmRunOptionsWithOutput): { stdout: string };
+	npm(options: NpmRunOptionsWithoutOutput): undefined;
+	npm(
+		options: NpmRunOptionsWithOutput | NpmRunOptionsWithoutOutput,
+	): { stdout: string } | undefined {
+		if (!this._deps) {
+			throw new Error("c8ctl.init() must be called before npm()");
+		}
+		// Narrow on the discriminant so each branch resolves a single overload
+		// of the injected runner.
+		return options.stdout === true
+			? this._deps.npm(options)
+			: this._deps.npm(options);
 	}
 
 	// Expose env properties directly for plugin compatibility

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import {
 	showVersion,
 	validateFlags,
 } from "./framework/index.ts";
+import { npm } from "./utils/index.ts";
 
 /**
  * Type guard: extract a string value from parseArgs values, or undefined.
@@ -382,11 +383,15 @@ async function main() {
 	}
 
 	// Inject dependencies into the runtime (breaks circular imports)
+	// `npm` is the cross-platform runner from utils/. Assigning it here is also
+	// the compile-time check that it still satisfies the `NpmRunner` contract
+	// core/ declares structurally (core/ may not import utils/).
 	c8ctl.init({
 		createClient,
 		resolveTenantId,
 		getLogger,
 		getUserDataDir,
+		npm,
 	});
 
 	// Load installed plugins

--- a/src/templates/AGENTS.md
+++ b/src/templates/AGENTS.md
@@ -42,6 +42,8 @@ Methods:
 - `c8ctl.createClient(profileFlag?, sdkConfig?)`
 - `c8ctl.resolveTenantId(profileFlag?)`
 - `c8ctl.getLogger(mode?)`
+- `c8ctl.getUserDataDir()`
+- `c8ctl.npm({ args, stdout?, stdio? })`
 
 ## Development Loop
 
@@ -57,6 +59,7 @@ Methods:
 - Use `c8ctl.getLogger()` for output-mode-aware logs.
 - Use `c8ctl.createClient()` for Camunda API interactions.
 - Use `c8ctl.resolveTenantId()` instead of duplicating tenant fallback logic.
+- Use `c8ctl.npm()` instead of spawning npm yourself — a bare `npm` spawn breaks on Windows.
 - Prefer clear, actionable error messages.
 - Avoid command names that conflict with built-in c8ctl commands.
 - For any non-trivial implementation or behavior change, always cross-check against upstream `c8ctl` repository: <https://github.com/camunda/c8ctl> before finalizing

--- a/tests/fixtures/plugins/plugin-with-npm/c8ctl-plugin.js
+++ b/tests/fixtures/plugins/plugin-with-npm/c8ctl-plugin.js
@@ -1,0 +1,30 @@
+/**
+ * Test fixture: consuming `c8ctl.npm()` from a plugin.
+ *
+ * Verb `npm-version` runs `npm --version` through the runtime's
+ * cross-platform npm runner and echoes the captured stdout, proving that
+ * plugins reach the same Windows-safe invocation path the CLI uses instead
+ * of hand-rolling `execSync('npm ...')`.
+ *
+ * Verb `npm-shape` reports what the runtime exposes without spawning
+ * anything, so the surface can be asserted on hosts where npm is slow.
+ */
+
+export const commands = {
+  'npm-version': async () => {
+    const { stdout } = globalThis.c8ctl.npm({ args: ['--version'], stdout: true });
+    console.log(JSON.stringify({ version: stdout.trim() }));
+  },
+  'npm-shape': async () => {
+    console.log(JSON.stringify({ npmType: typeof globalThis.c8ctl.npm }));
+  },
+};
+
+export const metadata = {
+  name: 'plugin-with-npm',
+  description: 'Fixture: plugin consumption of the runtime npm runner',
+  commands: {
+    'npm-version': { description: 'Print npm --version via c8ctl.npm()' },
+    'npm-shape': { description: 'Report the type of c8ctl.npm' },
+  },
+};

--- a/tests/fixtures/plugins/plugin-with-npm/package.json
+++ b/tests/fixtures/plugins/plugin-with-npm/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "c8ctl-plugin-npm-runtime",
+  "version": "1.0.0",
+  "description": "Fixture: a plugin consuming the cross-platform npm runner from the c8ctl plugin runtime",
+  "type": "module",
+  "main": "c8ctl-plugin.js",
+  "keywords": ["c8ctl-plugin"]
+}

--- a/tests/unit/package-exports.test.ts
+++ b/tests/unit/package-exports.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Guard: every published entry point in package.json points at a file that
+ * the build actually emits.
+ *
+ * `tsc` mirrors `src/` into `dist/` (rootDir: ./src, outDir: ./dist), so a
+ * `dist/**` target is emitted if and only if the corresponding `src/**.ts`
+ * file exists. Checking the source side keeps the guard build-independent:
+ * it fails in a clean checkout instead of only after `npm run build`.
+ *
+ * Defect class this pins (#414 fallout): moving a source file without
+ * updating `exports`/`bin` leaves a dangling subpath that resolves to
+ * nothing. `@camunda8/cli/runtime` — the type entry point every TypeScript
+ * plugin imports `C8ctlPluginRuntime` from — silently pointed at
+ * `dist/runtime.js` after `src/runtime.ts` moved to `src/core/runtime.ts`.
+ * Nothing failed at build time because a missing export target is only
+ * observable from a consuming package.
+ */
+
+import assert from "node:assert";
+import { existsSync, readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, test } from "node:test";
+import { isRecord } from "../../src/core/logger.ts";
+
+const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
+const packageJson: unknown = JSON.parse(
+	readFileSync(join(PROJECT_ROOT, "package.json"), "utf-8"),
+);
+
+/** Map a published `./dist/**` path back to the `src/**.ts` file tsc emits it from. */
+function sourceFileFor(distPath: string): string {
+	const relative = distPath.replace(/^\.\//, "").replace(/^dist\//, "");
+	const source = relative.replace(/\.d\.ts$/, ".ts").replace(/\.js$/, ".ts");
+	return join(PROJECT_ROOT, "src", source);
+}
+
+/** Collect every string leaf of an `exports` entry (conditions nest arbitrarily deep). */
+function collectTargets(value: unknown, path: string): [string, string][] {
+	if (typeof value === "string") return [[path, value]];
+	if (!isRecord(value)) return [];
+	return Object.entries(value).flatMap(([key, nested]) =>
+		collectTargets(nested, `${path}.${key}`),
+	);
+}
+
+describe("package.json entry points resolve to emitted files", () => {
+	test("every exports condition maps to a source file", () => {
+		assert.ok(isRecord(packageJson), "package.json parses to an object");
+		const targets = collectTargets(packageJson.exports, "exports");
+		assert.ok(targets.length > 0, "package.json declares subpath exports");
+
+		const dangling = targets.filter(
+			([, target]) => !existsSync(sourceFileFor(target)),
+		);
+		assert.deepStrictEqual(
+			dangling,
+			[],
+			`These exports point at files the build does not emit: ${dangling
+				.map(([path, target]) => `${path} -> ${target}`)
+				.join(", ")}`,
+		);
+	});
+
+	test("every bin entry maps to a source file", () => {
+		assert.ok(isRecord(packageJson), "package.json parses to an object");
+		const targets = collectTargets(packageJson.bin, "bin");
+		assert.ok(targets.length > 0, "package.json declares bin entries");
+
+		const dangling = targets.filter(
+			([, target]) => !existsSync(sourceFileFor(target)),
+		);
+		assert.deepStrictEqual(
+			dangling,
+			[],
+			`These bin entries point at files the build does not emit: ${dangling
+				.map(([path, target]) => `${path} -> ${target}`)
+				.join(", ")}`,
+		);
+	});
+});

--- a/tests/unit/plugin-runtime-npm.test.ts
+++ b/tests/unit/plugin-runtime-npm.test.ts
@@ -53,10 +53,17 @@ afterEach(() => {
 });
 
 async function c8Plugin(...args: string[]): Promise<SpawnResult> {
+	// HOME/USERPROFILE are redirected into the per-test temp dir rather than
+	// pointed at a nonexistent path (as sibling plugin tests do): npm resolves
+	// ~/.npmrc from the home directory, so this isolates the spawned npm from
+	// the developer's real npm config without handing it a broken HOME.
+	// USERPROFILE matters on Windows, where os.homedir() reads it (#488).
 	const env: NodeJS.ProcessEnv = {
 		...process.env,
 		CAMUNDA_BASE_URL: "http://test-cluster/v2",
 		C8CTL_DATA_DIR: testDataDir,
+		HOME: testDataDir,
+		USERPROFILE: testDataDir,
 	};
 	delete env.DEBUG;
 	delete env.C8CTL_DEBUG;

--- a/tests/unit/plugin-runtime-npm.test.ts
+++ b/tests/unit/plugin-runtime-npm.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Contract: plugins can run npm through the c8ctl runtime.
+ *
+ * `npm()` (src/utils/shared/npm-exec.ts) is the only sanctioned way to
+ * invoke npm from this codebase — on Windows a bare `npm` spawn is ENOENT
+ * and `npm.cmd` alone is EINVAL under the CVE-2024-27980 hardening, so the
+ * helper routes through cmd.exe with per-argument quoting. Plugins install
+ * and query packages too, and without an exposed runner they can only
+ * hand-roll a spawn that breaks on Windows.
+ *
+ * These tests drive a fixture plugin through the real CLI, so they pin the
+ * whole path: `c8ctl.init()` runs before plugin code, `globalThis.c8ctl`
+ * carries the runner, and it actually executes npm.
+ */
+
+import assert from "node:assert";
+import { cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, test } from "node:test";
+import { isRecord } from "../../src/core/logger.ts";
+import { asyncSpawn, type SpawnResult } from "../utils/spawn.ts";
+
+const FIXTURE_DIR = join(
+	process.cwd(),
+	"tests",
+	"fixtures",
+	"plugins",
+	"plugin-with-npm",
+);
+const PLUGIN_PKG_NAME = "c8ctl-plugin-npm-runtime";
+
+let testDataDir: string;
+
+beforeEach(() => {
+	testDataDir = mkdtempSync(join(tmpdir(), "c8ctl-plugin-npm-"));
+	writeFileSync(
+		join(testDataDir, "session.json"),
+		JSON.stringify({ outputMode: "json" }),
+	);
+	const installDir = join(
+		testDataDir,
+		"plugins",
+		"node_modules",
+		PLUGIN_PKG_NAME,
+	);
+	mkdirSync(installDir, { recursive: true });
+	cpSync(FIXTURE_DIR, installDir, { recursive: true });
+});
+
+afterEach(() => {
+	rmSync(testDataDir, { recursive: true, force: true });
+});
+
+async function c8Plugin(...args: string[]): Promise<SpawnResult> {
+	const env: NodeJS.ProcessEnv = {
+		...process.env,
+		CAMUNDA_BASE_URL: "http://test-cluster/v2",
+		C8CTL_DATA_DIR: testDataDir,
+	};
+	delete env.DEBUG;
+	delete env.C8CTL_DEBUG;
+	delete env.NODE_DEBUG;
+	delete env.NODE_OPTIONS;
+	return asyncSpawn(
+		"node",
+		["--experimental-strip-types", "src/index.ts", ...args],
+		// Generous: spawning npm on a loaded CI runner is slow. This is a
+		// safety net, not a correctness assertion — do not tighten it into
+		// a race.
+		{ env, timeout: 60_000 },
+	);
+}
+
+/** Walk stdout from the end for the last line that parses to a record. */
+function lastJsonRecord(stdout: string): Record<string, unknown> {
+	const lines = stdout
+		.trim()
+		.split("\n")
+		.filter((l) => l.length > 0);
+	for (let i = lines.length - 1; i >= 0; i--) {
+		const line = lines[i];
+		if (line === undefined) continue;
+		try {
+			const parsed: unknown = JSON.parse(line);
+			if (isRecord(parsed)) return parsed;
+		} catch {
+			// keep walking
+		}
+	}
+	throw new Error(`No JSON object found in stdout:\n${stdout}`);
+}
+
+describe("plugin runtime: c8ctl.npm()", () => {
+	test("is exposed on globalThis.c8ctl by the time plugin code runs", async () => {
+		const result = await c8Plugin("npm-shape");
+		assert.strictEqual(
+			result.status,
+			0,
+			`expected exit 0, got ${result.status}. stderr: ${result.stderr}`,
+		);
+		assert.strictEqual(lastJsonRecord(result.stdout).npmType, "function");
+	});
+
+	test("runs npm and captures its stdout", async () => {
+		const result = await c8Plugin("npm-version");
+		assert.strictEqual(
+			result.status,
+			0,
+			`expected exit 0, got ${result.status}. stderr: ${result.stderr}`,
+		);
+		const version = lastJsonRecord(result.stdout).version;
+		assert.ok(
+			typeof version === "string" && /^\d+\.\d+\.\d+/.test(version),
+			`expected a semver from 'npm --version', got: ${JSON.stringify(version)}`,
+		);
+	});
+});

--- a/tests/unit/runtime.test.ts
+++ b/tests/unit/runtime.test.ts
@@ -4,7 +4,27 @@
 
 import assert from "node:assert";
 import { describe, test } from "node:test";
-import { c8ctl } from "../../src/core/runtime.ts";
+import {
+	c8ctl,
+	type NpmRunOptionsWithOutput,
+	type NpmRunOptionsWithoutOutput,
+} from "../../src/core/runtime.ts";
+
+/** Args every `npmStub` invocation was called with, newest last. */
+const npmCalls: string[][] = [];
+
+/** Stands in for the real cross-platform npm runner injected by the composition root. */
+function npmStub(options: NpmRunOptionsWithOutput): { stdout: string };
+function npmStub(options: NpmRunOptionsWithoutOutput): undefined;
+function npmStub({
+	args,
+	...opts
+}: NpmRunOptionsWithOutput | NpmRunOptionsWithoutOutput):
+	| { stdout: string }
+	| undefined {
+	npmCalls.push([...args]);
+	return opts.stdout ? { stdout: "<stub-stdout>" } : undefined;
+}
 
 describe("c8ctl Runtime", () => {
 	test("should have env property", () => {
@@ -116,5 +136,61 @@ describe("c8ctl Runtime", () => {
 			"text",
 			"outputMode can be set back to text",
 		);
+	});
+});
+
+/**
+ * Injected-dependency seam.
+ *
+ * `core/` may not import `utils/`, so the cross-platform npm runner reaches
+ * the runtime through `init()` like every other injected capability. These
+ * tests pin both halves of that seam: the pre-init guard and the delegation.
+ *
+ * Order matters — `init()` may only be called once per process, so the
+ * pre-init assertion has to run first. Unit tests use per-file process
+ * isolation, so this file owns a fresh, uninitialised singleton.
+ */
+describe("c8ctl.npm (injected dependency)", () => {
+	const stubDeps = {
+		createClient: () => {
+			throw new Error("not used by these tests");
+		},
+		resolveTenantId: () => "<test-tenant>",
+		getLogger: () => {
+			throw new Error("not used by these tests");
+		},
+		getUserDataDir: () => "/tmp/c8ctl-runtime-test",
+		npm: npmStub,
+	};
+
+	test("throws a pointed error before init()", () => {
+		assert.throws(
+			() => c8ctl.npm({ args: ["--version"], stdout: true }),
+			/init\(\) must be called before npm\(\)/,
+			"npm() names the missing init() call rather than failing on undefined",
+		);
+	});
+
+	test("delegates to the injected runner and returns its stdout", () => {
+		c8ctl.init(stubDeps);
+		npmCalls.length = 0;
+
+		const result = c8ctl.npm({ args: ["--version"], stdout: true });
+
+		assert.deepStrictEqual(
+			npmCalls,
+			[["--version"]],
+			"args are passed through",
+		);
+		assert.strictEqual(result.stdout, "<stub-stdout>", "stdout is returned");
+	});
+
+	test("delegates the no-output overload and returns undefined", () => {
+		npmCalls.length = 0;
+
+		const result = c8ctl.npm({ args: ["install", "pkg"], stdio: "ignore" });
+
+		assert.deepStrictEqual(npmCalls, [["install", "pkg"]]);
+		assert.strictEqual(result, undefined);
 	});
 });


### PR DESCRIPTION
## What

Plugins had no sanctioned way to run npm — `globalThis.c8ctl` exposed no runner, so a plugin author's only option was a hand-rolled spawn, which breaks on Windows (bare `npm` → ENOENT; `npm.cmd` → EINVAL under the CVE-2024-27980 hardening). This exposes the CLI's own helper as `c8ctl.npm({ args, stdout?, stdio? })`.

Wired through the existing `init()` DI seam alongside `createClient`/`getLogger`/`getUserDataDir`. `core/` may not import `utils/` (not even type-only), so `NpmRunner` is declared structurally in `core/runtime.ts`; assigning the real `npm()` at the composition root is the compile-time check that it still matches.

Also fixes a dangling `@camunda8/cli/runtime` subpath export: it still pointed at `dist/runtime.js` after `src/runtime.ts` moved to `src/core/runtime.ts` in #414, so TypeScript plugin authors could not typecheck against `C8ctlPluginRuntime` at all. Guarded by a new test that maps every `exports`/`bin` target back to a source file.

## ⚠️ Breaking change

`C8ctlDeps` and `C8ctlPluginRuntime` each gain a **required** `npm` member. Plugins that only *consume* the runtime are unaffected. Anything that *implements* either interface — a custom host, a typed test double, a mock of the plugin runtime — no longer typechecks until it supplies `npm`.
