### PR TITLE
feat(plugins): enforce a plugin's declared engines.c8ctl

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,21 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # AGENTS.md documents `npm run build` before `npm test` locally, because
+      # some tests exercise the *published* dist layout and skip themselves when
+      # it is absent (tests/unit/plugin-host-compat.test.ts needs a dist/ whose
+      # package.json carries a real version). Without a build step CI silently ran
+      # the weaker subset — a skipped test looks identical to a passing one in the
+      # summary.
+      #
+      # One leg only. Those tests assert OS-agnostic logic, and `npm run build`
+      # re-runs `npm run lint` (already its own job) and rewrites the synced
+      # README/docs blocks, so paying for it six times buys nothing. The other
+      # legs keep skipping them, which is what the skip reason is for.
+      - name: Build (for tests that exercise the published dist layout)
+        if: matrix.os == 'ubuntu-latest' && matrix.node == 22
+        run: npm run build
+
       - name: Run unit tests
         run: npm run test:unit
 

--- a/.gitignore
+++ b/.gitignore
@@ -147,5 +147,10 @@ vite.config.ts.timestamp-*
 c8ctl-test-*
 test-plugin-temp
 
+# Repo-local temp trees for tests that need dist/ under a patched package.json
+# (tests/unit/plugin-host-compat.test.ts). They sit inside the repo on purpose,
+# so Node still resolves the real node_modules from them.
+tests/.tmp-*
+
 # Temp tsconfig created by .githooks/pre-commit
 .tsconfig.pre-commit.*.json

--- a/PLUGIN-HELP.md
+++ b/PLUGIN-HELP.md
@@ -202,9 +202,9 @@ This surface grows: `npm({ ... })` is newer than the rest of it, and a plugin ca
 
 c8ctl then refuses `load plugin` / `upgrade plugin` / `downgrade plugin` on a host that is too old, and disables the plugin's commands with a message naming the required and running versions, rather than letting them fail deeper in. `doctor plugin` reports the requirement and any incompatibility in text and `--json`.
 
-Supported comparators are `>=`, `>`, `<=`, `<`, `^`, `~`, an exact version, and `*`; space- or comma-separated comparators are ANDed, and every operand must be a full `major.minor.patch` version. Prereleases order as semver specifies (`>=4.0.0` excludes `4.0.0-alpha.1`, and `^4.1.0` excludes `5.0.0-alpha.1`).
+Range evaluation delegates to `semver` (npm's own library for `engines` fields), with `includePrerelease` on, so the full npm range grammar is supported — comparators (`>=`, `>`, `<=`, `<`, `^`, `~`, an exact version, `*`), set unions (`"^3 || ^4"`), hyphen ranges (`"3.3.0 - 4.0.0"`), and partial or wildcard versions (`"^4"`, `"4.x"`). Prereleases order as semver specifies (`>=4.0.0` excludes `4.0.0-alpha.1`, and `^4.1.0` excludes `5.0.0-alpha.1`).
 
-Set unions (`"^3 || ^4"`), hyphen ranges, and partial versions (`"^4"`, `"4.x"`) are valid npm syntax that c8ctl does **not** evaluate — they land on the same fail-open path as an unparseable range, alongside c8ctl running as an unpublished development build: the plugin stays fully enabled, because the check never disables a plugin over a question it could not answer. See [docs/plugins.md](docs/plugins.md#the-c8ctl-version-a-plugin-needs) for the user-facing view.
+A range `semver` cannot parse (`"latest"`, `">=four"`) lands on the same fail-open path as c8ctl running as an unpublished development build: the plugin stays fully enabled, because the check never disables a plugin over a question it could not answer. See [docs/plugins.md](docs/plugins.md#the-c8ctl-version-a-plugin-needs) for the user-facing view.
 
 ### Running npm from a plugin
 

--- a/PLUGIN-HELP.md
+++ b/PLUGIN-HELP.md
@@ -188,6 +188,24 @@ At runtime, c8ctl injects a global `c8ctl` object for plugins via `globalThis.c8
 
 Use the client factory when your plugin needs direct Camunda API access, `resolveTenantId` to mirror c8ctl tenant fallback behavior, and `getLogger()` to emit output-mode-aware logs.
 
+### Declaring the c8ctl version you need
+
+This surface grows: `npm({ ... })` is newer than the rest of it, and a plugin calling it on an older c8ctl gets `TypeError: c8ctl.npm is not a function` from inside its own handler. Declare the floor instead, in the plugin's `package.json` (#523):
+
+```json
+{
+  "engines": {
+    "c8ctl": ">=4.0.0-alpha.1"
+  }
+}
+```
+
+c8ctl then refuses `load plugin` / `upgrade plugin` / `downgrade plugin` on a host that is too old, and disables the plugin's commands with a message naming the required and running versions, rather than letting them fail deeper in. `doctor plugin` reports the requirement and any incompatibility in text and `--json`.
+
+Supported comparators are `>=`, `>`, `<=`, `<`, `^`, `~`, an exact version, and `*`; space- or comma-separated comparators are ANDed, and every operand must be a full `major.minor.patch` version. Prereleases order as semver specifies (`>=4.0.0` excludes `4.0.0-alpha.1`, and `^4.1.0` excludes `5.0.0-alpha.1`).
+
+Set unions (`"^3 || ^4"`), hyphen ranges, and partial versions (`"^4"`, `"4.x"`) are valid npm syntax that c8ctl does **not** evaluate — they land on the same fail-open path as an unparseable range, alongside c8ctl running as an unpublished development build: the plugin stays fully enabled, because the check never disables a plugin over a question it could not answer. See [docs/plugins.md](docs/plugins.md#the-c8ctl-version-a-plugin-needs) for the user-facing view.
+
 ### Running npm from a plugin
 
 Use `c8ctl.npm()` rather than spawning npm yourself. On Windows npm is a `npm.cmd` shim: a bare `npm` spawn fails with `ENOENT`, and `npm.cmd` alone fails with `EINVAL` under the CVE-2024-27980 hardening in Node 18.20.2 / 20.12.2 / 21.7.3+. The runtime helper routes the call through `cmd.exe` with every argument quoted (plugin paths routinely contain spaces) and rejects arguments that cannot be passed safely — an embedded `"`, a line break, or a `%VAR%` reference.

--- a/default-plugins/element-template/package.json
+++ b/default-plugins/element-template/package.json
@@ -6,11 +6,9 @@
   "keywords": ["c8ctl", "c8ctl-plugin", "element-template", "camunda"],
   "main": "c8ctl-plugin.ts",
   "dependencies": {
-    "bpmn-moddle": "^9.0.1",
-    "semver": "^7.6.3"
+    "bpmn-moddle": "^9.0.1"
   },
   "devDependencies": {
-    "@types/semver": "^7.7.1",
     "bpmn-js-element-templates": "^2.23.1",
     "bpmn-js-headless": "^0.2.0",
     "zeebe-bpmn-moddle": "^1.11.0"

--- a/docs/plugin-collisions.md
+++ b/docs/plugin-collisions.md
@@ -68,6 +68,24 @@ install-directory entry for command-name comparisons).
   before its module body is imported. Its top-level side effects do not
   run; none of its commands register.
 
+### The one exception: a plugin disabled by `engines.c8ctl`
+
+A plugin whose declared host requirement this c8ctl does not satisfy
+([plugins.md](plugins.md#the-c8ctl-version-a-plugin-needs)) loses a
+command-name collision to a compatible plugin **regardless of load
+order**. Its own copy of that command exists only to report which c8ctl it
+needs, so letting alphabetical order hand it the name would leave the user
+with a command that always throws while a working implementation sits
+unreachable.
+
+The disabled plugin keeps its entry in `c8ctl help` and its other
+commands. `doctor plugin` reports the takeover as an ordinary command-name
+collision whose `winner` is the compatible plugin, and lists the disabled
+plugin separately under its incompatibility. A default plugin can never be
+on the losing side of this: the requirement is enforced for
+user-installed plugins only, which are the ones versioned independently of
+the c8ctl they run on.
+
 ### Why not stricter policies
 
 The issue listed several candidates; we deliberately picked the cheapest

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -134,17 +134,14 @@ The field is optional — a plugin that declares nothing is treated exactly as i
 - The plugin still loads and still appears in `c8 help`, but every one of its commands refuses to run and prints which c8ctl it needs. A visible command that explains itself beats a missing one that reads as a typo.
 - `c8 doctor plugin` lists it under incompatible plugins, in text and in `--json`.
 
-Supported comparators: `>=`, `>`, `<=`, `<`, `^`, `~`, an exact version, and `*`. Space- or comma-separated comparators are ANDed (`">=3.3.0 <5.0.0"`), and each operand must be a full `major.minor.patch` version. Prereleases order as semver specifies, so `>=4.0.0` is *not* satisfied by `4.0.0-alpha.1` — declare `>=4.0.0-alpha.1` when an alpha is enough — and `^`/`~` exclude prereleases of the version they bound (`^4.1.0` does not admit `5.0.0-alpha.1`).
-
-**Not evaluated**, even though npm accepts them: set unions (`"^3 || ^4"`), hyphen ranges (`"3.3.0 - 4.0.0"`), and partial or wildcard versions (`"4"`, `"4.x"`, `"^4"`). c8ctl treats each of these as "cannot evaluate" — see below — so a plugin that needs a floor should spell it with a full version.
+Range evaluation is npm's own `semver` — the same library `npm install` uses for `engines` fields — so the full range grammar is supported: comparators (`>=`, `>`, `<=`, `<`, `^`, `~`, an exact version, `*`), set unions (`"^3 || ^4"`), hyphen ranges (`"3.3.0 - 4.0.0"`), and partial or wildcard versions (`"4"`, `"4.x"`). Prereleases order as semver specifies, so `>=4.0.0` is *not* satisfied by `4.0.0-alpha.1` — declare `>=4.0.0-alpha.1` when an alpha is enough — and `^`/`~` exclude prereleases of the version they bound (`^4.1.0` does not admit `5.0.0-alpha.1`).
 
 **Prereleases count.** Unlike `npm install`, which excludes prerelease versions from a range unless you opt in, this check treats them as ordinary versions: a host on `4.1.0-alpha.3` satisfies `>=4.0.0-alpha.1`. That is deliberate — c8ctl publishes alphas, and refusing to run a plugin on the very channel its requirement was written for would disable working setups. One consequence to know: `^`/`~` still desugar the way npm does, to an upper bound that excludes prereleases (`^4.1.0` means `>=4.1.0 <5.0.0-0`), while a hand-written `<5.0.0` means exactly what it says and does admit `5.0.0-alpha.1`. Spell the bound explicitly if that distinction matters to your plugin.
 
-Three cases deliberately disable nothing, because c8ctl could not evaluate the requirement rather than having found it unmet:
+Two cases deliberately disable nothing, because c8ctl could not evaluate the requirement rather than having found it unmet:
 
 - c8ctl running from an unpublished development build, whose version says nothing about its API surface.
-- A range c8ctl cannot parse (`"latest"`, `">=four"`), which is reported as a warning naming the supported forms.
-- Any of the valid-but-unevaluated npm forms above, reported the same way.
+- A range c8ctl cannot parse (`"latest"`, `">=four"`), which is reported as a warning pointing at npm's semver range syntax.
 
 To resolve a genuine incompatibility, either upgrade c8ctl (`npm install -g @camunda8/cli@latest`) or install a plugin release that supports the c8ctl you have.
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -113,7 +113,7 @@ c8 doctor plugin
 c8 doctor plugin --json
 ```
 
-Built-in commands always take precedence over plugin commands, and the first plugin to register a given command wins. `doctor plugin` shows which registrations were kept and which were shadowed, plus each plugin's declared `engines.c8ctl` requirement and whether this c8ctl satisfies it.
+Built-in commands always take precedence over plugin commands, and the first plugin to register a given command wins — with one exception: a plugin disabled by its declared `engines.c8ctl` (see below) yields the command name to a compatible plugin regardless of load order, because its own copy could only ever refuse to run. `doctor plugin` shows which registrations were kept and which were shadowed, plus each plugin's declared requirement and whether this c8ctl satisfies it.
 
 ## The c8ctl version a plugin needs
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -103,17 +103,50 @@ c8 sync plugins
 
 ### Diagnose plugin issues
 
-Use `doctor plugin` to inspect the plugin loading state and surface any command collisions (for example, when two plugins register the same command). The report always exits `0` — it describes state rather than failing.
+Use `doctor plugin` to inspect the plugin loading state and surface any command collisions (for example, when two plugins register the same command) or version incompatibilities. The report always exits `0` — it describes state rather than failing.
 
 ```bash
-# Human-readable summary of loaded plugins and any collisions
+# Human-readable summary of loaded plugins, their requirements, and any problems
 c8 doctor plugin
 
 # Machine-readable output for scripts and agents
 c8 doctor plugin --json
 ```
 
-Built-in commands always take precedence over plugin commands, and the first plugin to register a given command wins. `doctor plugin` shows which registrations were kept and which were shadowed.
+Built-in commands always take precedence over plugin commands, and the first plugin to register a given command wins. `doctor plugin` shows which registrations were kept and which were shadowed, plus each plugin's declared `engines.c8ctl` requirement and whether this c8ctl satisfies it.
+
+## The c8ctl version a plugin needs
+
+The plugin runtime grows over time — `c8ctl.npm()`, for instance, does not exist in every published c8ctl. A plugin that uses a newer runtime API declares the floor it needs in its own `package.json`:
+
+```json
+{
+  "name": "c8ctl-plugin-example",
+  "engines": {
+    "c8ctl": ">=4.0.0-alpha.1"
+  }
+}
+```
+
+The field is optional — a plugin that declares nothing is treated exactly as it was before. When it *is* declared and this c8ctl does not satisfy it:
+
+- `c8 load plugin`, `c8 upgrade plugin`, and `c8 downgrade plugin` **fail** instead of reporting success. The plugin is still installed; what you don't get is a green exit code on an install that cannot work. (Pinning an older release is the likeliest way to land on one built for an older c8ctl, so `downgrade` matters most here.)
+- The plugin still loads and still appears in `c8 help`, but every one of its commands refuses to run and prints which c8ctl it needs. A visible command that explains itself beats a missing one that reads as a typo.
+- `c8 doctor plugin` lists it under incompatible plugins, in text and in `--json`.
+
+Supported comparators: `>=`, `>`, `<=`, `<`, `^`, `~`, an exact version, and `*`. Space- or comma-separated comparators are ANDed (`">=3.3.0 <5.0.0"`), and each operand must be a full `major.minor.patch` version. Prereleases order as semver specifies, so `>=4.0.0` is *not* satisfied by `4.0.0-alpha.1` — declare `>=4.0.0-alpha.1` when an alpha is enough — and `^`/`~` exclude prereleases of the version they bound (`^4.1.0` does not admit `5.0.0-alpha.1`).
+
+**Not evaluated**, even though npm accepts them: set unions (`"^3 || ^4"`), hyphen ranges (`"3.3.0 - 4.0.0"`), and partial or wildcard versions (`"4"`, `"4.x"`, `"^4"`). c8ctl treats each of these as "cannot evaluate" — see below — so a plugin that needs a floor should spell it with a full version.
+
+**Prereleases count.** Unlike `npm install`, which excludes prerelease versions from a range unless you opt in, this check treats them as ordinary versions: a host on `4.1.0-alpha.3` satisfies `>=4.0.0-alpha.1`. That is deliberate — c8ctl publishes alphas, and refusing to run a plugin on the very channel its requirement was written for would disable working setups. One consequence to know: `^`/`~` still desugar the way npm does, to an upper bound that excludes prereleases (`^4.1.0` means `>=4.1.0 <5.0.0-0`), while a hand-written `<5.0.0` means exactly what it says and does admit `5.0.0-alpha.1`. Spell the bound explicitly if that distinction matters to your plugin.
+
+Three cases deliberately disable nothing, because c8ctl could not evaluate the requirement rather than having found it unmet:
+
+- c8ctl running from an unpublished development build, whose version says nothing about its API surface.
+- A range c8ctl cannot parse (`"latest"`, `">=four"`), which is reported as a warning naming the supported forms.
+- Any of the valid-but-unevaluated npm forms above, reported the same way.
+
+To resolve a genuine incompatibility, either upgrade c8ctl (`npm install -g @camunda8/cli@latest`) or install a plugin release that supports the c8ctl you have.
 
 ## Plugin structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
       ],
       "dependencies": {
         "@camunda8/orchestration-cluster-api": "^9.1.0",
-        "@modelcontextprotocol/sdk": "^1.29.0"
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "semver": "^7.6.3"
       },
       "bin": {
         "c8": "dist/index.js",
@@ -52,11 +53,9 @@
       "name": "c8ctl-plugin-element-template",
       "version": "0.1.0",
       "dependencies": {
-        "bpmn-moddle": "^9.0.1",
-        "semver": "^7.6.3"
+        "bpmn-moddle": "^9.0.1"
       },
       "devDependencies": {
-        "@types/semver": "^7.7.1",
         "bpmn-js-element-templates": "^2.23.1",
         "bpmn-js-headless": "^0.2.0",
         "zeebe-bpmn-moddle": "^1.11.0"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
   ],
   "dependencies": {
     "@camunda8/orchestration-cluster-api": "^9.1.0",
-    "@modelcontextprotocol/sdk": "^1.29.0"
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "semver": "^7.6.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.11",

--- a/src/commands/plugins.ts
+++ b/src/commands/plugins.ts
@@ -6,21 +6,27 @@ import { existsSync, readdirSync, readFileSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
+	c8ctl,
 	ensurePluginsDir,
 	getLogger,
 	handleCommandError,
+	type Logger,
+	SilentError,
 } from "../core/index.ts";
 import {
 	addPluginToRegistry,
+	checkHostCompat,
 	clearLoadedPlugins,
 	defineCommand,
 	getInstalledPluginVersion,
 	getLoadedPluginSummaries,
 	getPluginCollisions,
 	getPluginEntry,
+	getPluginIncompatibilities,
 	getRegisteredPlugins,
 	getVersionFromSource,
 	isPluginRegistered,
+	readHostRequirement,
 	removePluginFromRegistry,
 } from "../framework/index.ts";
 import { npm } from "../utils/index.ts";
@@ -56,6 +62,89 @@ function renderTemplate(
 		content = content.replaceAll(`{{${key}}}`, value);
 	}
 	return content;
+}
+
+/**
+ * Fail the command when a just-installed plugin declares an `engines.c8ctl`
+ * this c8ctl does not satisfy (#523).
+ *
+ * Install time is the one moment the user is already thinking about plugin
+ * versions, so this is where the mismatch has to be reported — the alternative
+ * is what #523 describes: a successful "Plugin loaded successfully", then a
+ * stack trace from a different command later on.
+ *
+ * The plugin is left installed and registered, because it *is* installed. What
+ * this changes is that the command stops claiming success, so a script with
+ * `set -e` stops here instead of building on a plugin that cannot run.
+ *
+ * Throws `SilentError` after rendering, which `handleCommandError` turns into a
+ * bare non-zero exit — the caller can therefore run this inside its own
+ * try/catch without the failure being relabelled as an npm/network problem.
+ */
+function assertHostCompatible({
+	logger,
+	pluginsDir,
+	pluginName,
+}: {
+	logger: Logger;
+	pluginsDir: string;
+	pluginName: string;
+}): void {
+	const nodeModules = join(pluginsDir, "node_modules");
+	// `c8 load plugin foo@1.2.3` passes the version spec through as the name, but
+	// npm installs to `node_modules/foo`. Fall back to the name without its
+	// version suffix so a versioned install is still checked. `@scope/pkg`
+	// resolves directly and must not be mangled — only a suffix *after* the
+	// first character counts as a version separator.
+	const candidates = [pluginName];
+	const specAt = pluginName.indexOf("@", 1);
+	if (specAt > 0) candidates.push(pluginName.slice(0, specAt));
+
+	const packageJsonPath = candidates
+		.map((name) => join(resolvePackagePath(nodeModules, name), "package.json"))
+		.find((path) => existsSync(path));
+	if (packageJsonPath === undefined) {
+		// Reachable whenever the name we were given does not lead to the install
+		// directory npm actually used. Say so rather than silently reporting
+		// success: the loader still catches it on the next invocation, so this is a
+		// deferred check, not an absent one.
+		logger.debug(
+			`Skipping the host-compatibility check for '${pluginName}': no installed ` +
+				`package.json under ${nodeModules}.`,
+		);
+		return;
+	}
+
+	let packageJson: unknown;
+	try {
+		packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+	} catch {
+		// An unreadable package.json is not this check's business to report —
+		// the loader will surface it on the next invocation.
+		return;
+	}
+
+	const verdict = checkHostCompat({
+		pluginName,
+		declaredRange: readHostRequirement(packageJson),
+		hostVersion: c8ctl.version,
+	});
+	if (
+		verdict.status === "unverifiable" &&
+		verdict.reason === "unreadable-range"
+	) {
+		logger.warn(verdict.message ?? "");
+		return;
+	}
+	if (verdict.status !== "incompatible") return;
+
+	const summary = `Plugin '${pluginName}' is not compatible with this c8ctl`;
+	logger.error(summary);
+	logger.info(verdict.message ?? "");
+	logger.info(
+		"The plugin is installed but none of its commands will run. Run 'c8ctl doctor plugin' to see this again.",
+	);
+	throw new SilentError(summary);
 }
 
 /**
@@ -102,6 +191,10 @@ export const loadPluginCommand = defineCommand(
 		try {
 			let pluginName: string;
 			let pluginSource: string;
+			// Deferred until the host-compatibility check has had its say: a tick
+			// on the line above an "incompatible" cross reads as two verdicts on
+			// the same action.
+			let successDetail: string;
 
 			if (fromUrl) {
 				// Snapshot existing plugins before installation so we can identify the new one
@@ -130,7 +223,7 @@ export const loadPluginCommand = defineCommand(
 					throw new Error("Failed to extract plugin name from URL");
 				}
 
-				logger.success("Plugin loaded successfully from URL", fromUrl);
+				successDetail = fromUrl;
 			} else {
 				// Install from npm registry by package name
 				if (!packageName)
@@ -145,13 +238,26 @@ export const loadPluginCommand = defineCommand(
 				pluginName = packageName;
 				pluginSource = packageName;
 
-				logger.success("Plugin loaded successfully", packageName);
+				successDetail = packageName;
 			}
 
 			// Add to plugin registry
 			addPluginToRegistry(pluginName, pluginSource);
 			logger.debug(`Added ${pluginName} to plugin registry`);
 
+			// Before reporting success: a plugin this c8ctl is too old for will
+			// never become available, and saying otherwise is how #523's failure
+			// reached a later command as somebody else's stack trace. The registry
+			// entry is written first on purpose — the package is on disk either
+			// way, and `list`/`doctor plugin` should agree about that.
+			assertHostCompatible({ logger, pluginsDir, pluginName });
+
+			logger.success(
+				fromUrl
+					? "Plugin loaded successfully from URL"
+					: "Plugin loaded successfully",
+				successDetail,
+			);
 			// Note: Plugin will be available on next CLI invocation
 			// We don't reload in the same process to avoid module cache issues
 			logger.info("Plugin will be available on next command execution");
@@ -826,6 +932,11 @@ export const upgradePluginCommand = defineCommand(
 			// Clear plugin cache
 			clearLoadedPlugins();
 
+			// An upgrade can land on a release that raised its host floor — the
+			// same check as in `load plugin`, reported before success for the same
+			// reason.
+			assertHostCompatible({ logger, pluginsDir, pluginName: packageName });
+
 			logger.success("Plugin upgraded successfully", packageName);
 			logger.info("Plugin will be available on next command execution");
 		} catch (error) {
@@ -900,6 +1011,11 @@ export const downgradePluginCommand = defineCommand(
 
 			// Clear plugin cache
 			clearLoadedPlugins();
+
+			// Deliberately pinning an older release is the likeliest way to land on
+			// one built for an older c8ctl, so this is the highest-yield place for
+			// the check — same contract as `load` and `upgrade`.
+			assertHostCompatible({ logger, pluginsDir, pluginName: packageName });
 
 			logger.success("Plugin downgraded successfully", packageName);
 			logger.info("Plugin will be available on next command execution");
@@ -1034,9 +1150,10 @@ export const doctorPluginCommand = defineCommand(
 
 		const loaded = getLoadedPluginSummaries();
 		const collisions = getPluginCollisions();
+		const incompatible = getPluginIncompatibilities();
 
 		if (logger.mode === "json") {
-			logger.json({ loaded, collisions });
+			logger.json({ loaded, collisions, incompatible });
 			return;
 		}
 
@@ -1048,7 +1165,31 @@ export const doctorPluginCommand = defineCommand(
 				loaded.map((p) => ({
 					Plugin: p.name,
 					Commands: p.commands.length === 0 ? "(none)" : p.commands.join(", "),
+					Requires: p.requires ?? "—",
 				})),
+			);
+		}
+
+		if (incompatible.length > 0) {
+			logger.info("");
+			logger.info(`Incompatible with this c8ctl (${incompatible.length}):`);
+			logger.table(
+				incompatible.map((i) => ({
+					Plugin: i.plugin,
+					Version: i.pluginVersion,
+					Requires: i.required,
+					Running: i.running,
+				})),
+			);
+			logger.info("");
+			logger.info(
+				"These plugins are installed and still listed in help, but their commands refuse to run: " +
+					"the c8ctl they declare (engines.c8ctl) is not the one you have. If one of their command " +
+					"names appears above under a different plugin, that plugin has taken it over and it works.",
+			);
+			logger.info(
+				"To resolve: upgrade c8ctl with 'npm install -g @camunda8/cli@latest', or install a plugin " +
+					"release that supports this version. See docs/plugins.md for the requirement contract.",
 			);
 		}
 

--- a/src/core/runtime.ts
+++ b/src/core/runtime.ts
@@ -124,15 +124,42 @@ declare global {
 }
 
 /**
+ * The version in the repo's `package.json` — semantic-release replaces it at
+ * publish time, so seeing it means c8ctl is running from an unpublished source
+ * checkout.
+ */
+export const UNVERSIONED_DEV_BUILD = "0.0.0-semantically-released";
+
+/**
+ * Whether `version` identifies an unpublished development build.
+ *
+ * Such a version carries no information about the API surface it exposes, so
+ * anything that reasons about "which c8ctl is this" has to opt out rather than
+ * draw a conclusion: the self-update check skips notifying, and the plugin host
+ * requirement (`engines.c8ctl`, #523) skips enforcing.
+ */
+export function isUnversionedDevBuild(version: string): boolean {
+	return version === UNVERSIONED_DEV_BUILD;
+}
+
+/**
  * Get c8ctl version from package.json
+ *
+ * An unreadable or version-less `package.json` falls back to
+ * {@link UNVERSIONED_DEV_BUILD} rather than `0.0.0`. `0.0.0` is a real,
+ * parseable version that happens to satisfy no requirement, so anything
+ * comparing against it would draw a confident *wrong* conclusion — a plugin
+ * declaring `engines.c8ctl: ">=3.0.0"` would be reported as unsupported. The
+ * sentinel says "unknown", which every consumer already treats as "do not
+ * conclude anything from this".
  */
 function getVersion(): string {
 	try {
 		const packageJsonPath = join(__dirname, "..", "..", "package.json");
 		const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
-		return packageJson.version || "0.0.0";
+		return packageJson.version || UNVERSIONED_DEV_BUILD;
 	} catch {
-		return "0.0.0";
+		return UNVERSIONED_DEV_BUILD;
 	}
 }
 

--- a/src/core/update-check.ts
+++ b/src/core/update-check.ts
@@ -27,7 +27,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { getUserDataDir } from "./config.ts";
 import { isRecord } from "./logger.ts";
-import { c8ctl } from "./runtime.ts";
+import { c8ctl, isUnversionedDevBuild } from "./runtime.ts";
 
 /** npm registry metadata endpoint (returns JSON with dist-tags). */
 const REGISTRY_URL = "https://registry.npmjs.org/@camunda8/cli";
@@ -189,7 +189,7 @@ export function startUpdateCheck(currentVersion: string): void {
 	if (process.env.CI) return;
 
 	// Suppress for the development placeholder version
-	if (currentVersion === "0.0.0-semantically-released") return;
+	if (isUnversionedDevBuild(currentVersion)) return;
 
 	const channel = detectChannel(currentVersion);
 

--- a/src/framework/index.ts
+++ b/src/framework/index.ts
@@ -7,6 +7,7 @@
 export * from "./command-framework.ts";
 export * from "./command-registry.ts";
 export * from "./command-validation.ts";
+export * from "./plugins/plugin-compat.ts";
 export * from "./plugins/plugin-loader.ts";
 export * from "./plugins/plugin-registry.ts";
 export * from "./plugins/plugin-version.ts";

--- a/src/framework/plugins/plugin-compat.ts
+++ b/src/framework/plugins/plugin-compat.ts
@@ -19,11 +19,20 @@
  * `TypeError`. With one, c8ctl can say which version is needed, at install
  * time, before anything is run.
  *
+ * Range evaluation is delegated to `semver` — the library npm itself uses for
+ * `engines` fields — rather than hand-parsed. That gets the full npm range
+ * grammar (set unions, hyphen ranges, wildcards) for free, and correctness for
+ * the parts that are easy to get wrong by hand (prerelease ordering, 0.x caret
+ * carve-outs, build-metadata stripping). It is a genuine root dependency of
+ * this module (see `CORE_DEPENDENCIES` in
+ * `tests/unit/root-dependencies-isolation.test.ts`), not something bundled
+ * per-plugin the way a default plugin's own dependencies are.
+ *
  * **Failing open is a design rule, not an oversight.** Three situations mean
  * "cannot evaluate": an unpublished development build of c8ctl, a host version
- * this module cannot parse, and a range this module cannot parse. All three
- * yield `unverifiable` and leave the plugin fully working. Disabling a plugin
- * over a question we could not answer would turn a diagnostic into an outage.
+ * `semver` cannot parse, and a range `semver` cannot parse. All three yield
+ * `unverifiable` and leave the plugin fully working. Disabling a plugin over a
+ * question we could not answer would turn a diagnostic into an outage.
  *
  * **Prereleases participate in ranges**, unlike `npm install`'s default. A host
  * on `4.1.0-alpha.3` satisfies `>=4.0.0-alpha.1` here; npm would exclude it
@@ -34,13 +43,11 @@
  * says.
  */
 
+import semver from "semver";
 import { isRecord, isUnversionedDevBuild } from "../../core/index.ts";
 
 /** The `engines` key a plugin declares its host requirement under. */
 export const HOST_ENGINE_KEY = "c8ctl";
-
-/** The comparator forms {@link satisfiesRange} understands, for error text. */
-const SUPPORTED_FORMS = ">=, >, <=, <, ^, ~, an exact version, or *";
 
 /**
  * - `undeclared` — the plugin declared no requirement (the common case).
@@ -75,172 +82,12 @@ export interface HostCompatVerdict {
 	reason?: "dev-build" | "unreadable-range" | "unreadable-host-version";
 }
 
-interface SemverCore {
-	major: number;
-	minor: number;
-	patch: number;
-}
-
-interface ParsedVersion extends SemverCore {
-	/**
-	 * Dot-separated prerelease identifiers, or `null` for a release.
-	 *
-	 * An empty array is impossible: `1.0.0-` does not parse.
-	 */
-	prerelease: string[] | null;
-}
-
 /**
- * Parse a full `major.minor.patch[-prerelease]` version.
+ * Whether `version` satisfies `range`, evaluated by `semver` with
+ * `includePrerelease` on (see the module doc for why).
  *
- * Build metadata (`+sha`) is stripped rather than rejected — semver excludes it
- * from precedence entirely, so `4.0.0+build.5` and `4.0.0` are the same version
- * as far as any comparison here is concerned.
- *
- * Partial versions (`4`, `4.1`) are *not* accepted: they are legitimate npm
- * range syntax that this module does not implement, and returning `null` routes
- * them to the fail-open path instead of guessing at a bound.
- */
-function parseVersion(version: string): ParsedVersion | null {
-	const withoutBuild = version.trim().split("+", 1)[0];
-	const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(
-		withoutBuild,
-	);
-	if (!match) return null;
-	return {
-		major: Number(match[1]),
-		minor: Number(match[2]),
-		patch: Number(match[3]),
-		prerelease: match[4] === undefined ? null : match[4].split("."),
-	};
-}
-
-/** Compare two prerelease identifiers per semver §11: numeric < alphanumeric. */
-function comparePrereleaseIdentifier(a: string, b: string): number {
-	const aNumeric = /^\d+$/.test(a);
-	const bNumeric = /^\d+$/.test(b);
-	if (aNumeric && bNumeric) return Number(a) - Number(b);
-	// "Numeric identifiers always have lower precedence than alphanumeric ones."
-	if (aNumeric) return -1;
-	if (bNumeric) return 1;
-	return a < b ? -1 : a > b ? 1 : 0;
-}
-
-/**
- * Three-way version compare implementing semver §11 precedence, including
- * identifier-wise prerelease ordering.
- *
- * Deliberately **not** delegating to `core`'s `isNewer`, which the update
- * notifier uses: that one compares only a prerelease's trailing number and
- * discards the tag, so it reads `4.0.0-rc.1` as older than `4.0.0-alpha.5`.
- * Wrong ordering there costs a mistimed "update available" notice; here it would
- * disable every command of a plugin whose requirement the host actually meets.
- */
-function compareVersions(a: ParsedVersion, b: ParsedVersion): number {
-	if (a.major !== b.major) return a.major - b.major;
-	if (a.minor !== b.minor) return a.minor - b.minor;
-	if (a.patch !== b.patch) return a.patch - b.patch;
-
-	// A release outranks any prerelease of the same core version.
-	if (a.prerelease === null && b.prerelease === null) return 0;
-	if (a.prerelease === null) return 1;
-	if (b.prerelease === null) return -1;
-
-	const shared = Math.min(a.prerelease.length, b.prerelease.length);
-	for (let i = 0; i < shared; i++) {
-		const result = comparePrereleaseIdentifier(
-			a.prerelease[i],
-			b.prerelease[i],
-		);
-		if (result !== 0) return result;
-	}
-	// "A larger set of pre-release fields has a higher precedence."
-	return a.prerelease.length - b.prerelease.length;
-}
-
-/** Exclusive upper bound for a `^` range, per npm's 0.x carve-outs. */
-function caretUpperBound(core: SemverCore): SemverCore {
-	if (core.major > 0) return { major: core.major + 1, minor: 0, patch: 0 };
-	if (core.minor > 0) return { major: 0, minor: core.minor + 1, patch: 0 };
-	return { major: 0, minor: 0, patch: core.patch + 1 };
-}
-
-/** Exclusive upper bound for a `~` range. */
-function tildeUpperBound(core: SemverCore): SemverCore {
-	return { major: core.major, minor: core.minor + 1, patch: 0 };
-}
-
-/**
- * The upper bound as a parsed version, carrying the lowest possible prerelease
- * so that prereleases *of* the bound fall outside the range.
- *
- * npm spells this `<5.0.0-0`: `^4.1.0` must not admit `5.0.0-alpha.1`, which is
- * a build of the major this range excludes. c8ctl's own `main` publishes
- * `X.Y.0-alpha.N` of the next version, so anyone on the alpha channel would hit
- * this without the `-0`.
- */
-function exclusiveUpperBound(core: SemverCore): ParsedVersion {
-	return { ...core, prerelease: ["0"] };
-}
-
-/**
- * Evaluate one comparator against a version.
- *
- * Returns `null` when the comparator is not one of the supported forms, which
- * propagates all the way out as "cannot evaluate" rather than "not satisfied".
- */
-function satisfiesComparator(
-	version: ParsedVersion,
-	comparator: string,
-): boolean | null {
-	if (comparator === "*" || comparator === "x" || comparator === "X")
-		return true;
-
-	const match = /^(>=|<=|>|<|\^|~|=)?(.+)$/.exec(comparator);
-	if (!match) return null;
-	const operator = match[1] ?? "=";
-	const operand = parseVersion(match[2]);
-	if (operand === null) return null;
-
-	switch (operator) {
-		case ">=":
-			return compareVersions(version, operand) >= 0;
-		case ">":
-			return compareVersions(version, operand) > 0;
-		case "<=":
-			return compareVersions(version, operand) <= 0;
-		case "<":
-			return compareVersions(version, operand) < 0;
-		case "=":
-			return compareVersions(version, operand) === 0;
-		case "^":
-		case "~": {
-			const upper = exclusiveUpperBound(
-				operator === "^" ? caretUpperBound(operand) : tildeUpperBound(operand),
-			);
-			return (
-				compareVersions(version, operand) >= 0 &&
-				compareVersions(version, upper) < 0
-			);
-		}
-		default:
-			return null;
-	}
-}
-
-/**
- * Whether `version` satisfies `range`.
- *
- * Space- or comma-separated comparators are ANDed, like npm. Returns `null` when
- * the range or the version cannot be evaluated — callers must treat that as
- * "cannot evaluate", never as "not satisfied".
- *
- * **Every comparator is parsed before any is judged.** Short-circuiting on the
- * first unsatisfied one would let an unreadable *later* comparator go unnoticed
- * and turn "cannot evaluate" into a confident `false` — which disables the
- * plugin. `"^3.0.0 || ^4.0.0"` on 4.1.0 is the case that makes this concrete:
- * `^3.0.0` alone is unsatisfied, so a short-circuiting AND would report a
- * compatible plugin as incompatible instead of noticing the unsupported `||`.
+ * Returns `null` when either `version` or `range` cannot be parsed — callers
+ * must treat that as "cannot evaluate", never as "not satisfied".
  */
 export function satisfiesRange({
 	version,
@@ -249,30 +96,9 @@ export function satisfiesRange({
 	version: string;
 	range: string;
 }): boolean | null {
-	const parsedVersion = parseVersion(version);
-	if (parsedVersion === null) return null;
-
-	// Set union (`||`) and hyphen ranges (`1.2.3 - 2.0.0`) are valid npm syntax
-	// that this module does not evaluate. Rejecting them up front — rather than
-	// letting `||`/`-` fall through as a nonsense comparator — is what keeps them
-	// on the fail-open path.
-	if (range.includes("||") || / - /.test(range)) return null;
-
-	const comparators = range
-		// `>= 4.0.0` is one comparator with a space in it, not two. Join the
-		// operator to its operand before splitting, or the split turns a valid
-		// floor into two unreadable halves.
-		.replace(/([<>=~^]+)\s+/g, "$1")
-		.split(/[\s,]+/)
-		.map((part) => part.trim())
-		.filter((part) => part.length > 0);
-	if (comparators.length === 0) return null;
-
-	const results = comparators.map((comparator) =>
-		satisfiesComparator(parsedVersion, comparator),
-	);
-	if (results.includes(null)) return null;
-	return results.every((result) => result === true);
+	if (semver.valid(version) === null) return null;
+	if (semver.validRange(range) === null) return null;
+	return semver.satisfies(version, range, { includePrerelease: true });
 }
 
 /**
@@ -327,7 +153,7 @@ export function checkHostCompat({
 	// string — and since the scaffold ships `engines.c8ctl: "*"`, any host whose
 	// version this module cannot parse (a fork, a nightly tag, a hand-edited
 	// manifest) would make every scaffolded plugin warn about itself.
-	if (parseVersion(hostVersion) === null) {
+	if (semver.valid(hostVersion) === null) {
 		return {
 			status: "unverifiable",
 			range: declaredRange,
@@ -350,8 +176,8 @@ export function checkHostCompat({
 			reason: "unreadable-range",
 			message:
 				`Plugin '${pluginName}' declares engines.${HOST_ENGINE_KEY} '${declaredRange}', which is not a ` +
-				`version range c8ctl understands (supported: ${SUPPORTED_FORMS}). Ignoring the ` +
-				"requirement — the plugin stays enabled.",
+				"version range c8ctl understands (npm's semver range syntax — see " +
+				"https://github.com/npm/node-semver#ranges). Ignoring the requirement — the plugin stays enabled.",
 		};
 	}
 

--- a/src/framework/plugins/plugin-compat.ts
+++ b/src/framework/plugins/plugin-compat.ts
@@ -1,0 +1,368 @@
+/**
+ * The plugin → host version contract (#523).
+ *
+ * A plugin declares the c8ctl it needs in its own `package.json`:
+ *
+ * ```json
+ * { "engines": { "c8ctl": ">=4.0.0-alpha.1" } }
+ * ```
+ *
+ * `engines` is the conventional home for a host requirement and npm ignores
+ * engine keys it does not know, so declaring one changes nothing about how the
+ * plugin installs. The field is optional — a plugin that declares nothing is
+ * `undeclared` and behaves exactly as it did before this module existed.
+ *
+ * Why this exists: the plugin runtime grows over time (`c8ctl.npm()` is the
+ * case that prompted #523). Without a declared requirement, a plugin built
+ * against a newer runtime fails inside the plugin, at command time, with
+ * whatever error the missing API happens to raise — usually a bare
+ * `TypeError`. With one, c8ctl can say which version is needed, at install
+ * time, before anything is run.
+ *
+ * **Failing open is a design rule, not an oversight.** Three situations mean
+ * "cannot evaluate": an unpublished development build of c8ctl, a host version
+ * this module cannot parse, and a range this module cannot parse. All three
+ * yield `unverifiable` and leave the plugin fully working. Disabling a plugin
+ * over a question we could not answer would turn a diagnostic into an outage.
+ *
+ * **Prereleases participate in ranges**, unlike `npm install`'s default. A host
+ * on `4.1.0-alpha.3` satisfies `>=4.0.0-alpha.1` here; npm would exclude it
+ * without `includePrerelease`. c8ctl publishes alphas, so the npm default would
+ * disable plugins on the exact channel their requirement was written for. `^`
+ * and `~` still desugar to npm's prerelease-excluding upper bound (`^4.1.0` is
+ * `>=4.1.0 <5.0.0-0`); an explicit `<5.0.0` does not, because it says what it
+ * says.
+ */
+
+import { isRecord, isUnversionedDevBuild } from "../../core/index.ts";
+
+/** The `engines` key a plugin declares its host requirement under. */
+export const HOST_ENGINE_KEY = "c8ctl";
+
+/** The comparator forms {@link satisfiesRange} understands, for error text. */
+const SUPPORTED_FORMS = ">=, >, <=, <, ^, ~, an exact version, or *";
+
+/**
+ * - `undeclared` — the plugin declared no requirement (the common case).
+ * - `satisfied` — the running c8ctl meets it.
+ * - `incompatible` — it does not. The plugin's commands are disabled and
+ *   `message` explains why.
+ * - `unverifiable` — the question could not be answered; the plugin keeps
+ *   working and `message` says what was skipped.
+ */
+export type HostCompatStatus =
+	| "undeclared"
+	| "satisfied"
+	| "incompatible"
+	| "unverifiable";
+
+export interface HostCompatVerdict {
+	status: HostCompatStatus;
+	/** The declared range, verbatim, when there was one. */
+	range?: string;
+	/** Ready-to-print explanation. Set for `incompatible` and `unverifiable`. */
+	message?: string;
+	/**
+	 * Why the question could not be answered, on `unverifiable` only.
+	 *
+	 * Callers log these differently on purpose. `unreadable-range` is a mistake
+	 * in a published plugin and somebody should hear about it, so it warns.
+	 * `dev-build` is the expected state of every source checkout, and
+	 * `unreadable-host-version` is a property of the host rather than of the
+	 * plugin it would name — warning about either would blame a plugin for
+	 * something its author cannot fix, on every single invocation.
+	 */
+	reason?: "dev-build" | "unreadable-range" | "unreadable-host-version";
+}
+
+interface SemverCore {
+	major: number;
+	minor: number;
+	patch: number;
+}
+
+interface ParsedVersion extends SemverCore {
+	/**
+	 * Dot-separated prerelease identifiers, or `null` for a release.
+	 *
+	 * An empty array is impossible: `1.0.0-` does not parse.
+	 */
+	prerelease: string[] | null;
+}
+
+/**
+ * Parse a full `major.minor.patch[-prerelease]` version.
+ *
+ * Build metadata (`+sha`) is stripped rather than rejected — semver excludes it
+ * from precedence entirely, so `4.0.0+build.5` and `4.0.0` are the same version
+ * as far as any comparison here is concerned.
+ *
+ * Partial versions (`4`, `4.1`) are *not* accepted: they are legitimate npm
+ * range syntax that this module does not implement, and returning `null` routes
+ * them to the fail-open path instead of guessing at a bound.
+ */
+function parseVersion(version: string): ParsedVersion | null {
+	const withoutBuild = version.trim().split("+", 1)[0];
+	const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(
+		withoutBuild,
+	);
+	if (!match) return null;
+	return {
+		major: Number(match[1]),
+		minor: Number(match[2]),
+		patch: Number(match[3]),
+		prerelease: match[4] === undefined ? null : match[4].split("."),
+	};
+}
+
+/** Compare two prerelease identifiers per semver §11: numeric < alphanumeric. */
+function comparePrereleaseIdentifier(a: string, b: string): number {
+	const aNumeric = /^\d+$/.test(a);
+	const bNumeric = /^\d+$/.test(b);
+	if (aNumeric && bNumeric) return Number(a) - Number(b);
+	// "Numeric identifiers always have lower precedence than alphanumeric ones."
+	if (aNumeric) return -1;
+	if (bNumeric) return 1;
+	return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/**
+ * Three-way version compare implementing semver §11 precedence, including
+ * identifier-wise prerelease ordering.
+ *
+ * Deliberately **not** delegating to `core`'s `isNewer`, which the update
+ * notifier uses: that one compares only a prerelease's trailing number and
+ * discards the tag, so it reads `4.0.0-rc.1` as older than `4.0.0-alpha.5`.
+ * Wrong ordering there costs a mistimed "update available" notice; here it would
+ * disable every command of a plugin whose requirement the host actually meets.
+ */
+function compareVersions(a: ParsedVersion, b: ParsedVersion): number {
+	if (a.major !== b.major) return a.major - b.major;
+	if (a.minor !== b.minor) return a.minor - b.minor;
+	if (a.patch !== b.patch) return a.patch - b.patch;
+
+	// A release outranks any prerelease of the same core version.
+	if (a.prerelease === null && b.prerelease === null) return 0;
+	if (a.prerelease === null) return 1;
+	if (b.prerelease === null) return -1;
+
+	const shared = Math.min(a.prerelease.length, b.prerelease.length);
+	for (let i = 0; i < shared; i++) {
+		const result = comparePrereleaseIdentifier(
+			a.prerelease[i],
+			b.prerelease[i],
+		);
+		if (result !== 0) return result;
+	}
+	// "A larger set of pre-release fields has a higher precedence."
+	return a.prerelease.length - b.prerelease.length;
+}
+
+/** Exclusive upper bound for a `^` range, per npm's 0.x carve-outs. */
+function caretUpperBound(core: SemverCore): SemverCore {
+	if (core.major > 0) return { major: core.major + 1, minor: 0, patch: 0 };
+	if (core.minor > 0) return { major: 0, minor: core.minor + 1, patch: 0 };
+	return { major: 0, minor: 0, patch: core.patch + 1 };
+}
+
+/** Exclusive upper bound for a `~` range. */
+function tildeUpperBound(core: SemverCore): SemverCore {
+	return { major: core.major, minor: core.minor + 1, patch: 0 };
+}
+
+/**
+ * The upper bound as a parsed version, carrying the lowest possible prerelease
+ * so that prereleases *of* the bound fall outside the range.
+ *
+ * npm spells this `<5.0.0-0`: `^4.1.0` must not admit `5.0.0-alpha.1`, which is
+ * a build of the major this range excludes. c8ctl's own `main` publishes
+ * `X.Y.0-alpha.N` of the next version, so anyone on the alpha channel would hit
+ * this without the `-0`.
+ */
+function exclusiveUpperBound(core: SemverCore): ParsedVersion {
+	return { ...core, prerelease: ["0"] };
+}
+
+/**
+ * Evaluate one comparator against a version.
+ *
+ * Returns `null` when the comparator is not one of the supported forms, which
+ * propagates all the way out as "cannot evaluate" rather than "not satisfied".
+ */
+function satisfiesComparator(
+	version: ParsedVersion,
+	comparator: string,
+): boolean | null {
+	if (comparator === "*" || comparator === "x" || comparator === "X")
+		return true;
+
+	const match = /^(>=|<=|>|<|\^|~|=)?(.+)$/.exec(comparator);
+	if (!match) return null;
+	const operator = match[1] ?? "=";
+	const operand = parseVersion(match[2]);
+	if (operand === null) return null;
+
+	switch (operator) {
+		case ">=":
+			return compareVersions(version, operand) >= 0;
+		case ">":
+			return compareVersions(version, operand) > 0;
+		case "<=":
+			return compareVersions(version, operand) <= 0;
+		case "<":
+			return compareVersions(version, operand) < 0;
+		case "=":
+			return compareVersions(version, operand) === 0;
+		case "^":
+		case "~": {
+			const upper = exclusiveUpperBound(
+				operator === "^" ? caretUpperBound(operand) : tildeUpperBound(operand),
+			);
+			return (
+				compareVersions(version, operand) >= 0 &&
+				compareVersions(version, upper) < 0
+			);
+		}
+		default:
+			return null;
+	}
+}
+
+/**
+ * Whether `version` satisfies `range`.
+ *
+ * Space- or comma-separated comparators are ANDed, like npm. Returns `null` when
+ * the range or the version cannot be evaluated — callers must treat that as
+ * "cannot evaluate", never as "not satisfied".
+ *
+ * **Every comparator is parsed before any is judged.** Short-circuiting on the
+ * first unsatisfied one would let an unreadable *later* comparator go unnoticed
+ * and turn "cannot evaluate" into a confident `false` — which disables the
+ * plugin. `"^3.0.0 || ^4.0.0"` on 4.1.0 is the case that makes this concrete:
+ * `^3.0.0` alone is unsatisfied, so a short-circuiting AND would report a
+ * compatible plugin as incompatible instead of noticing the unsupported `||`.
+ */
+export function satisfiesRange({
+	version,
+	range,
+}: {
+	version: string;
+	range: string;
+}): boolean | null {
+	const parsedVersion = parseVersion(version);
+	if (parsedVersion === null) return null;
+
+	// Set union (`||`) and hyphen ranges (`1.2.3 - 2.0.0`) are valid npm syntax
+	// that this module does not evaluate. Rejecting them up front — rather than
+	// letting `||`/`-` fall through as a nonsense comparator — is what keeps them
+	// on the fail-open path.
+	if (range.includes("||") || / - /.test(range)) return null;
+
+	const comparators = range
+		// `>= 4.0.0` is one comparator with a space in it, not two. Join the
+		// operator to its operand before splitting, or the split turns a valid
+		// floor into two unreadable halves.
+		.replace(/([<>=~^]+)\s+/g, "$1")
+		.split(/[\s,]+/)
+		.map((part) => part.trim())
+		.filter((part) => part.length > 0);
+	if (comparators.length === 0) return null;
+
+	const results = comparators.map((comparator) =>
+		satisfiesComparator(parsedVersion, comparator),
+	);
+	if (results.includes(null)) return null;
+	return results.every((result) => result === true);
+}
+
+/**
+ * Read a plugin's declared host requirement from its parsed `package.json`.
+ * Returns `null` for anything that is not a non-empty string, so a malformed
+ * declaration is indistinguishable from no declaration at all.
+ */
+export function readHostRequirement(packageJson: unknown): string | null {
+	if (!isRecord(packageJson)) return null;
+	const { engines } = packageJson;
+	if (!isRecord(engines)) return null;
+	const declared = engines[HOST_ENGINE_KEY];
+	if (typeof declared !== "string") return null;
+	const trimmed = declared.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Decide whether a plugin can run on this c8ctl.
+ *
+ * `hostVersion` is a parameter rather than a read of the runtime singleton so
+ * both this decision and the loader that consumes it can be tested against
+ * arbitrary versions — a source checkout always reports the unpublished
+ * development version, which by design answers `unverifiable`.
+ */
+export function checkHostCompat({
+	pluginName,
+	declaredRange,
+	hostVersion,
+}: {
+	pluginName: string;
+	declaredRange: string | null;
+	hostVersion: string;
+}): HostCompatVerdict {
+	if (declaredRange === null) return { status: "undeclared" };
+
+	if (isUnversionedDevBuild(hostVersion)) {
+		return {
+			status: "unverifiable",
+			range: declaredRange,
+			reason: "dev-build",
+			message:
+				`Plugin '${pluginName}' requires c8ctl ${declaredRange}, but this is an unpublished ` +
+				`development build (${hostVersion}) whose version says nothing about its API surface. ` +
+				"Skipping the check — the plugin stays enabled.",
+		};
+	}
+
+	// Checked before the range, because `satisfiesRange` answers `null` for both
+	// "unreadable range" and "unreadable version" and only the plugin author can
+	// act on the first. Collapsing them blames a plugin for the host's version
+	// string — and since the scaffold ships `engines.c8ctl: "*"`, any host whose
+	// version this module cannot parse (a fork, a nightly tag, a hand-edited
+	// manifest) would make every scaffolded plugin warn about itself.
+	if (parseVersion(hostVersion) === null) {
+		return {
+			status: "unverifiable",
+			range: declaredRange,
+			reason: "unreadable-host-version",
+			message:
+				`Plugin '${pluginName}' requires c8ctl ${declaredRange}, but this c8ctl reports its version ` +
+				`as '${hostVersion}', which is not a version this check can compare. Skipping the check — ` +
+				"the plugin stays enabled.",
+		};
+	}
+
+	const satisfied = satisfiesRange({
+		version: hostVersion,
+		range: declaredRange,
+	});
+	if (satisfied === null) {
+		return {
+			status: "unverifiable",
+			range: declaredRange,
+			reason: "unreadable-range",
+			message:
+				`Plugin '${pluginName}' declares engines.${HOST_ENGINE_KEY} '${declaredRange}', which is not a ` +
+				`version range c8ctl understands (supported: ${SUPPORTED_FORMS}). Ignoring the ` +
+				"requirement — the plugin stays enabled.",
+		};
+	}
+
+	if (satisfied) return { status: "satisfied", range: declaredRange };
+
+	return {
+		status: "incompatible",
+		range: declaredRange,
+		message:
+			`Plugin '${pluginName}' requires c8ctl ${declaredRange}, but this is c8ctl ${hostVersion}. ` +
+			"Upgrade with 'npm install -g @camunda8/cli@latest', or install a plugin release that " +
+			`supports c8ctl ${hostVersion}.`,
+	};
+}

--- a/src/framework/plugins/plugin-loader.ts
+++ b/src/framework/plugins/plugin-loader.ts
@@ -11,6 +11,7 @@ import {
 	getLogger,
 	type Logger,
 	type OutputMode,
+	SilentError,
 } from "../../core/index.ts";
 import type { FlagDef } from "../command-registry.ts";
 import type {
@@ -19,6 +20,7 @@ import type {
 	SelectConfig,
 	SelectResult,
 } from "../ui/prompt.ts";
+import { checkHostCompat, readHostRequirement } from "./plugin-compat.ts";
 
 /**
  * Typed, documented host context passed to plugin command handlers as
@@ -135,6 +137,15 @@ interface LoadedPlugin {
 	version: string;
 	commands: PluginCommands;
 	metadata?: PluginMetadata;
+	/** The plugin's declared `engines.c8ctl` range, when it declared one (#523). */
+	hostRequirement?: string;
+	/**
+	 * True once `enforceHostRequirement` has disabled this plugin's commands
+	 * because this c8ctl does not satisfy `hostRequirement` (#523). Read by
+	 * `rejectDuplicateCommandNames`, which lets a disabled plugin lose a
+	 * command-name collision to a working one.
+	 */
+	hostIncompatible?: boolean;
 }
 
 const loadedPlugins = new Map<string, LoadedPlugin>();
@@ -144,14 +155,20 @@ const loadedPlugins = new Map<string, LoadedPlugin>();
  * surfaced by `c8ctl doctor plugin` (#363). Two flavours:
  *
  * - `command-name`: two plugins exported a command under the same name.
- *   The earlier-loaded plugin's command stays in dispatch; the later
- *   plugin's was dropped. `winner`/`loser` reflect that ordering.
+ *   Normally the earlier-loaded plugin's command stays in dispatch and the
+ *   later plugin's was dropped, so `winner`/`loser` reflect load order. The
+ *   exception is a `hostIncompatible` incumbent (#523), which loses the name
+ *   to a working newcomer regardless of order.
  * - `plugin-name`: two plugins shared the same `package.json#name`.
  *   The entire later plugin was rejected (its module body was never
  *   imported); `command` is undefined for this kind.
  *
- * The doctor command is the only consumer; the loader appends to this
- * list as it discovers collisions and never reads from it. Cleared by
+ * `winner` always names the plugin that ends up owning the command. When a
+ * takeover supersedes an earlier decision, `rejectDuplicateCommandNames`
+ * re-points the affected records rather than dropping them — the losers are
+ * still losers, and erasing their records would hide a real collision.
+ *
+ * The doctor command is the only external consumer. Cleared by
  * `clearLoadedPlugins()` so test fixtures stay isolated.
  */
 export interface PluginCollision {
@@ -162,6 +179,33 @@ export interface PluginCollision {
 }
 
 const pluginCollisions: PluginCollision[] = [];
+
+/**
+ * Structured record of a plugin whose declared `engines.c8ctl` this c8ctl does
+ * not satisfy (#523), surfaced by `c8ctl doctor plugin`.
+ *
+ * The plugin stays loaded and keeps its place in help — what changed is that its
+ * commands now refuse to run and print `message` instead (bar any a working
+ * plugin has taken over). Removing it from help would trade one confusing
+ * failure ("unknown command os") for another; leaving it visible means the
+ * command that a user or an agent already knows about is the one that explains
+ * itself.
+ *
+ * The loader only appends and the doctor command only reads;
+ * `clearLoadedPlugins()` resets it so test fixtures stay isolated.
+ */
+export interface PluginIncompatibility {
+	plugin: string;
+	/** The plugin's own version, for "which release did this come from". */
+	pluginVersion: string;
+	/** The declared range, verbatim. */
+	required: string;
+	/** The c8ctl the requirement was evaluated against. */
+	running: string;
+	message: string;
+}
+
+const pluginIncompatibilities: PluginIncompatibility[] = [];
 
 /**
  * Validate the passthrough/flags mutual-exclusion rule (#366). Removes
@@ -259,6 +303,11 @@ function validatePassthroughCommands(plugin: LoadedPlugin): void {
  * different name. Default plugins always load first, so user-installed
  * plugins cannot override default commands by name.
  *
+ * **One exception (#523):** an incumbent whose declared `engines.c8ctl` this
+ * c8ctl does not satisfy loses the name to a working newcomer — its command
+ * could only ever throw. A default plugin can never be on the losing side of
+ * this, since `enforceHostRequirement` runs for installed plugins only.
+ *
  * This guarantees that the merged map returned by `getPluginCommands()`
  * has a single owning plugin per command name, which keeps dispatch and
  * `isPassthroughPluginCommand()` consistent: the help renderer and the
@@ -272,21 +321,61 @@ function rejectDuplicateCommandNames(plugin: LoadedPlugin): void {
 	const logger = getLogger();
 	for (const commandName of Object.keys(plugin.commands)) {
 		for (const existing of loadedPlugins.values()) {
-			if (Object.hasOwn(existing.commands, commandName)) {
-				logger.warn(
-					`Plugin '${plugin.name}' tried to register command '${commandName}' but it is ` +
-						`already provided by plugin '${existing.name}'. The first registration wins; ` +
-						`dropping the duplicate from '${plugin.name}'.`,
+			if (!Object.hasOwn(existing.commands, commandName)) continue;
+
+			// One exception to first-registration-wins: an incumbent that cannot
+			// run on this c8ctl (#523) yields to a newcomer that can. Otherwise
+			// load order — lexicographic by package path — would decide that a
+			// disabled `aaa-plugin` keeps the command name and a working
+			// `zzz-plugin` loses it, leaving the user with a command that only
+			// ever throws while a functioning implementation sits unreachable.
+			// The incumbent keeps its plugin entry in help, but loses this command.
+			if (existing.hostIncompatible && !plugin.hostIncompatible) {
+				logger.debug(
+					`Plugin '${plugin.name}' takes over command '${commandName}' from ` +
+						`'${existing.name}', which is disabled on this c8ctl.`,
 				);
+				// Re-point, don't delete. Earlier records for this name are still
+				// true about who *lost* it — a third plugin that lost to the
+				// incumbent has genuinely lost the command — but their `winner` is
+				// now stale. Dropping them would erase that plugin's collision from
+				// `doctor plugin` entirely; leaving them unedited would credit a win
+				// to a plugin that no longer owns the name.
+				for (const record of pluginCollisions) {
+					if (
+						record.kind === "command-name" &&
+						record.command === commandName &&
+						record.winner === existing.name
+					) {
+						record.winner = plugin.name;
+					}
+				}
 				pluginCollisions.push({
 					kind: "command-name",
-					winner: existing.name,
-					loser: plugin.name,
+					winner: plugin.name,
+					loser: existing.name,
 					command: commandName,
 				});
-				delete plugin.commands[commandName];
-				break;
+				// `continue`, not `break`: this function is what maintains "at most
+				// one loaded plugin owns a given command name", so there is nothing
+				// further to find for this name.
+				delete existing.commands[commandName];
+				continue;
 			}
+
+			logger.warn(
+				`Plugin '${plugin.name}' tried to register command '${commandName}' but it is ` +
+					`already provided by plugin '${existing.name}'. The first registration wins; ` +
+					`dropping the duplicate from '${plugin.name}'.`,
+			);
+			pluginCollisions.push({
+				kind: "command-name",
+				winner: existing.name,
+				loser: plugin.name,
+				command: commandName,
+			});
+			delete plugin.commands[commandName];
+			break;
 		}
 	}
 }
@@ -320,6 +409,78 @@ function isDuplicatePluginName(pluginName: string): boolean {
 		return true;
 	}
 	return false;
+}
+
+/**
+ * Enforce a plugin's declared `engines.c8ctl` (#523).
+ *
+ * On an unmet requirement, every command the plugin registered is replaced with
+ * a handler that throws the explanation. The plugin stays in `loadedPlugins` and
+ * therefore in help — see {@link PluginIncompatibility} for why disabling is
+ * done this way round.
+ *
+ * Runs *before* the collision passes, which read `hostIncompatible` to let a
+ * disabled incumbent lose a command name to a working newcomer. Takes the host
+ * version as an argument so the behaviour is testable against versions other
+ * than whatever this build happens to report.
+ *
+ * Mutates `plugin.commands` in place.
+ */
+function enforceHostRequirement(
+	plugin: LoadedPlugin,
+	hostVersion: string,
+): void {
+	const logger = getLogger();
+	const verdict = checkHostCompat({
+		pluginName: plugin.name,
+		declaredRange: plugin.hostRequirement ?? null,
+		hostVersion,
+	});
+
+	if (verdict.status === "unverifiable") {
+		// Only an unreadable *range* warns: that is an authoring mistake, and the
+		// plugin is silently not getting the guarantee it asked for. The other two
+		// reasons are properties of the host — a source checkout, or a version
+		// string this check cannot parse — and would name a blameless plugin on
+		// every single invocation.
+		const message = verdict.message ?? "";
+		if (verdict.reason === "unreadable-range") logger.warn(message);
+		else logger.debug(message);
+		return;
+	}
+
+	if (verdict.status !== "incompatible") return;
+
+	const message = verdict.message ?? "";
+	plugin.hostIncompatible = true;
+	// Debug, not warn: unlike a dropped colliding command — which has no other
+	// channel to announce itself — a disabled plugin explains itself the moment
+	// one of its commands is used, and `doctor plugin` lists it on demand.
+	// Warning on every unrelated invocation would be noise with no new signal.
+	logger.debug(message);
+	pluginIncompatibilities.push({
+		plugin: plugin.name,
+		pluginVersion: plugin.version,
+		required: verdict.range ?? "",
+		running: hostVersion,
+		message,
+	});
+
+	// SilentError: the message is the whole diagnosis and is rendered as one
+	// error line by the top-level handler. A plain Error would come back out as
+	// "Unexpected error" plus a stack trace — the shape of failure this check
+	// exists to replace.
+	const refuse: PluginCommandHandler = async () => {
+		throw new SilentError(message);
+	};
+	for (const commandName of Object.keys(plugin.commands)) {
+		const command = plugin.commands[commandName];
+		// Keep the `{ flags, handler }` shape intact: help rendering and flag
+		// parsing both branch on it, and a command that loses its flags would
+		// fail with a parse error instead of the explanation.
+		plugin.commands[commandName] =
+			typeof command === "function" ? refuse : { ...command, handler: refuse };
+	}
 }
 
 /**
@@ -455,8 +616,16 @@ async function loadDefaultPlugins(): Promise<void> {
 
 /**
  * Load all installed plugins from global plugins directory
+ *
+ * `hostVersion` defaults to the running c8ctl and exists so the `engines.c8ctl`
+ * enforcement (#523) can be exercised against other versions: a source checkout
+ * reports the unpublished development version, which by design skips the check.
  */
-export async function loadInstalledPlugins(): Promise<void> {
+export async function loadInstalledPlugins({
+	hostVersion = c8ctl.version,
+}: {
+	hostVersion?: string;
+} = {}): Promise<void> {
 	const logger = getLogger();
 
 	// Expose the runtime to plugins via globalThis.
@@ -597,13 +766,21 @@ export async function loadInstalledPlugins(): Promise<void> {
 				const plugin = await import(pluginUrl);
 
 				if (plugin.commands && typeof plugin.commands === "object") {
+					const hostRequirement = readHostRequirement(packageJson);
 					const loaded: LoadedPlugin = {
 						name: pluginName,
 						version: pluginVersion,
 						commands: { ...plugin.commands },
 						metadata: plugin.metadata || {},
+						...(hostRequirement === null ? {} : { hostRequirement }),
 					};
 					validatePassthroughCommands(loaded);
+					// Before the collision pass, which needs to know whether either
+					// side of a command-name clash is disabled. Installed plugins
+					// only: a default plugin ships inside the c8ctl package, so its
+					// host is itself and there is no version skew for
+					// `engines.c8ctl` (#523) to catch.
+					enforceHostRequirement(loaded, hostVersion);
 					rejectDuplicateCommandNames(loaded);
 					loadedPlugins.set(pluginName, loaded);
 					const commandNames = Object.keys(loaded.commands);
@@ -768,11 +945,29 @@ export function isPassthroughPluginCommand(commandName: string): boolean {
 }
 
 /**
+ * True if the named command belongs to a plugin disabled by its declared
+ * `engines.c8ctl` (#523).
+ *
+ * The dispatcher uses this to skip flag validation for such a command: its
+ * handler exists only to report which c8ctl the plugin needs, and rejecting the
+ * invocation for a missing required flag first would replace that explanation
+ * with an instruction the user cannot usefully follow.
+ */
+export function isHostIncompatiblePluginCommand(commandName: string): boolean {
+	for (const plugin of loadedPlugins.values()) {
+		if (!Object.hasOwn(plugin.commands, commandName)) continue;
+		if (plugin.hostIncompatible === true) return true;
+	}
+	return false;
+}
+
+/**
  * Clear all loaded plugins (useful for testing and after uninstall)
  */
 export function clearLoadedPlugins(): void {
 	loadedPlugins.clear();
 	pluginCollisions.length = 0;
+	pluginIncompatibilities.length = 0;
 }
 
 /**
@@ -787,6 +982,17 @@ export function getPluginCollisions(): readonly Readonly<PluginCollision>[] {
 }
 
 /**
+ * Snapshot of plugins whose declared `engines.c8ctl` this c8ctl does not
+ * satisfy (#523). Same defensive-copy contract as
+ * {@link getPluginCollisions}; order reflects load order.
+ */
+export function getPluginIncompatibilities(): readonly Readonly<PluginIncompatibility>[] {
+	return Object.freeze(
+		pluginIncompatibilities.map((i) => Object.freeze({ ...i })),
+	);
+}
+
+/**
  * Snapshot of currently loaded plugins (#363). Returns the canonical
  * `package.json#name` of each plugin together with the command names
  * it actually registered (after duplicate-name rejection). Used by
@@ -796,6 +1002,8 @@ export function getPluginCollisions(): readonly Readonly<PluginCollision>[] {
 export interface LoadedPluginSummary {
 	name: string;
 	commands: string[];
+	/** Declared `engines.c8ctl` range, when the plugin declared one (#523). */
+	requires?: string;
 }
 
 export function getLoadedPluginSummaries(): LoadedPluginSummary[] {
@@ -804,6 +1012,9 @@ export function getLoadedPluginSummaries(): LoadedPluginSummary[] {
 		summaries.push({
 			name: plugin.name,
 			commands: Object.keys(plugin.commands),
+			...(plugin.hostRequirement === undefined
+				? {}
+				: { requires: plugin.hostRequirement }),
 		});
 	}
 	return summaries;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
 	loadSessionState,
 	printUpdateNotification,
 	resolveTenantId,
+	SilentError,
 	type SortOrder,
 	startUpdateCheck,
 } from "./core/index.ts";
@@ -31,6 +32,7 @@ import {
 	getCommandDef,
 	getPluginCommands,
 	getPluginVersionForCommand,
+	isHostIncompatiblePluginCommand,
 	isPassthroughPluginCommand,
 	loadInstalledPlugins,
 	type PluginCtx,
@@ -638,7 +640,15 @@ async function main() {
 				if (value !== undefined) {
 					extractedFlags[flagName] = value;
 				}
-				if (def.required === true && value === undefined) {
+				// A disabled plugin (#523) is exempt: its handler exists only to
+				// explain which c8ctl it needs, and "--label is required" would
+				// send the user off to satisfy a flag for a command that cannot
+				// run whatever they pass.
+				if (
+					def.required === true &&
+					value === undefined &&
+					!isHostIncompatiblePluginCommand(verb)
+				) {
 					logger.error(`--${flagName} is required`);
 					process.exit(1);
 				}
@@ -767,6 +777,13 @@ try {
 			.catch((error) => {
 				if (c8ctl.verbose) {
 					throw error;
+				}
+				// A SilentError carries a message that is already the complete,
+				// user-facing diagnosis (see core/errors.ts). Render it as one
+				// error line — "Unexpected error" plus a stack would bury it.
+				if (error instanceof SilentError) {
+					getLogger(c8ctl.outputMode).error(error.message);
+					process.exit(1);
 				}
 				console.error("Unexpected error:", error);
 				process.exit(1);

--- a/src/templates/AGENTS.md
+++ b/src/templates/AGENTS.md
@@ -14,6 +14,11 @@ Build and maintain a plugin that exposes useful commands through `export const c
 - Required export: `commands` object mapping command name -> async handler
 - Optional export: `metadata` object for help descriptions
 - Package keywords must include `c8ctl` or `c8ctl-plugin`
+- `engines.c8ctl` declares the c8ctl version this plugin needs. It ships as `"*"`
+  (any version). Tighten it — e.g. `">=4.0.0-alpha.1"` — as soon as a handler
+  starts using a runtime API that older c8ctl versions do not expose: c8ctl then
+  refuses the install and disables the commands with an explanation, instead of
+  letting them fail somewhere inside this plugin
 
 ## Runtime API (available as global `c8ctl`)
 

--- a/src/templates/package.json
+++ b/src/templates/package.json
@@ -11,6 +11,9 @@
     "README.md",
     "AGENTS.md"
   ],
+  "engines": {
+    "c8ctl": "*"
+  },
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch"

--- a/tests/fixtures/plugins/README.md
+++ b/tests/fixtures/plugins/README.md
@@ -69,6 +69,13 @@ export const commands = {
 };
 ```
 
+### plugin-with-host-requirement/
+
+Declares `engines.c8ctl` (#523) — the c8ctl version the plugin needs — and
+exports one command of each form (bare function, `{ flags, handler }`) so the
+loader's fail-fast substitution can be checked against both. Used by
+`tests/unit/plugin-host-compat.test.ts`.
+
 ## Plugin Requirements
 
 For a package to be recognized as a c8ctl plugin:
@@ -81,6 +88,10 @@ For a package to be recognized as a c8ctl plugin:
 6. Access c8ctl runtime via `globalThis.c8ctl` (automatically injected by c8ctl)
 7. Use `globalThis.c8ctl.createClient(profile?, sdkConfig?)` to create Camunda SDK clients
 8. Declare `@camunda8/cli` with wildcard `*` as peer dependency
+9. Optionally declare `engines.c8ctl` (e.g. `">=4.0.0-alpha.1"`) when the plugin
+   uses a runtime API that older c8ctl versions do not expose — c8ctl then
+   refuses the install and disables the commands instead of letting them fail
+   inside the plugin (#523)
 
 > **Note on TypeScript plugins**: The `c8ctl-plugin.js` entry point must be JavaScript. Node.js doesn't currently support type stripping in `node_modules`. If your plugin is written in TypeScript, you must transpile it to JavaScript before publishing. Your `c8ctl-plugin.ts` source can be TypeScript, but ensure your build process produces a `c8ctl-plugin.js` file.
 

--- a/tests/fixtures/plugins/plugin-with-host-requirement/c8ctl-plugin.js
+++ b/tests/fixtures/plugins/plugin-with-host-requirement/c8ctl-plugin.js
@@ -1,0 +1,43 @@
+/**
+ * Test fixture: a plugin declaring `engines.c8ctl` (#523).
+ *
+ * Both command forms are represented on purpose. When the host requirement is
+ * not met the loader swaps each handler for one that throws the explanation,
+ * and the `{ flags, handler }` form has to survive that swap with its `flags`
+ * intact — otherwise the user gets a flag-parse error instead of the reason.
+ */
+
+export const commands = {
+  'host-bare': async () => {
+    console.log(JSON.stringify({ ran: 'host-bare' }));
+  },
+  'host-flagged': {
+    flags: {
+      label: { type: 'string', description: 'Echoed back verbatim' },
+    },
+    handler: async (_args, flags) => {
+      console.log(JSON.stringify({ ran: 'host-flagged', label: flags?.label ?? null }));
+    },
+  },
+  // A required flag is validated by the host before dispatch, so a disabled
+  // plugin has to be exempt from that check or "--label is required" replaces
+  // the explanation of why the command cannot run at all.
+  'host-required-flag': {
+    flags: {
+      label: { type: 'string', description: 'Required', required: true },
+    },
+    handler: async (_args, flags) => {
+      console.log(JSON.stringify({ ran: 'host-required-flag', label: flags?.label ?? null }));
+    },
+  },
+};
+
+export const metadata = {
+  name: 'plugin-with-host-requirement',
+  description: 'Fixture: plugin declaring a c8ctl host requirement',
+  commands: {
+    'host-bare': { description: 'Bare-function command' },
+    'host-flagged': { description: 'Command declaring typed flags' },
+    'host-required-flag': { description: 'Command declaring a required flag' },
+  },
+};

--- a/tests/fixtures/plugins/plugin-with-host-requirement/package.json
+++ b/tests/fixtures/plugins/plugin-with-host-requirement/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "c8ctl-plugin-host-requirement",
+  "version": "2.1.0",
+  "description": "Fixture: a plugin that declares the c8ctl it needs via engines.c8ctl (#523)",
+  "type": "module",
+  "main": "c8ctl-plugin.js",
+  "keywords": ["c8ctl-plugin"],
+  "engines": {
+    "node": ">=22",
+    "c8ctl": ">=4.0.0-alpha.1"
+  }
+}

--- a/tests/unit/plugin-host-compat.test.ts
+++ b/tests/unit/plugin-host-compat.test.ts
@@ -743,6 +743,13 @@ describe("enforcement against a published host version (built dist)", () => {
 				...process.env,
 				CAMUNDA_BASE_URL: "http://test-cluster/v2",
 				C8CTL_DATA_DIR: dataDir,
+				// The staged host reports a *real* semver version, which is exactly
+				// what makes `startUpdateCheck` fire: it self-suppresses only for the
+				// development sentinel. A registry round-trip would then print an
+				// update notice into the output these tests assert on, so the result
+				// would depend on the machine's network and notification cache.
+				// `CI` is the switch update-check already honours.
+				CI: "1",
 			},
 		});
 	}

--- a/tests/unit/plugin-host-compat.test.ts
+++ b/tests/unit/plugin-host-compat.test.ts
@@ -257,7 +257,7 @@ describe("satisfiesRange", () => {
 	test("returns null for a range c8ctl cannot parse", () => {
 		// `null` is "cannot evaluate", which callers fail open on — distinct
 		// from `false`, which disables the plugin's commands.
-		for (const range of ["latest", ">=four", "1.x || 2.x", ">=", "~>3.3"]) {
+		for (const range of ["latest", ">=four", ">=", "not-a-range", "1.2.3.4"]) {
 			assert.equal(satisfiesRange({ version: "4.0.0", range }), null, range);
 		}
 	});
@@ -266,22 +266,39 @@ describe("satisfiesRange", () => {
 		assert.equal(satisfiesRange({ version: "wat", range: ">=3.3.0" }), null);
 	});
 
-	test("an unsupported range never resolves to `false`, whatever the comparator order", () => {
-		// The failure this guards: evaluating comparators left to right and
-		// returning on the first unsatisfied one. `^3.0.0` is unsatisfied by
-		// 4.1.0, so a short-circuiting AND answers `false` — reporting a plugin
-		// that npm considers compatible as incompatible, and disabling it. Every
-		// comparator has to be parsed before any verdict is reached.
-		const unsupported = [
-			"^3.0.0 || ^4.0.0",
-			">=5.0.0 || >=1.0.0",
-			">=4.0.0 || garbage",
-			"3.3.0 - 4.0.0",
-			"5.0.0 - 6.0.0",
-		];
-		for (const range of unsupported) {
-			assert.equal(satisfiesRange({ version: "4.1.0", range }), null, range);
-		}
+	test("set unions and hyphen ranges are evaluated, not treated as unsupported", () => {
+		// Delegating to `semver` gets the full npm range grammar for free — these
+		// forms are valid npm syntax that a hand-rolled comparator parser would
+		// have to special-case.
+		assert.equal(
+			satisfiesRange({ version: "4.1.0", range: "^3.0.0 || ^4.0.0" }),
+			true,
+		);
+		assert.equal(
+			satisfiesRange({ version: "2.9.0", range: "^3.0.0 || ^4.0.0" }),
+			false,
+		);
+		assert.equal(
+			satisfiesRange({ version: "1.5.0", range: ">=5.0.0 || >=1.0.0" }),
+			true,
+		);
+		assert.equal(
+			satisfiesRange({ version: "3.5.0", range: "3.3.0 - 4.0.0" }),
+			true,
+		);
+		assert.equal(
+			satisfiesRange({ version: "4.0.1", range: "3.3.0 - 4.0.0" }),
+			false,
+		);
+	});
+
+	test("a union with one unparseable branch still fails open", () => {
+		// `semver` rejects the whole range rather than evaluating the readable
+		// half — this stays `null` ("cannot evaluate"), not a partial verdict.
+		assert.equal(
+			satisfiesRange({ version: "4.1.0", range: ">=4.0.0 || garbage" }),
+			null,
+		);
 	});
 
 	test("prerelease tags order by identifier, not just by trailing number", () => {
@@ -423,25 +440,25 @@ describe("checkHostCompat", () => {
 		const verdict = checkHostCompat({
 			pluginName,
 			declaredRange: "*",
-			hostVersion: "v4.0.0-nightly",
+			hostVersion: "nightly-build",
 		});
 		assert.equal(verdict.status, "unverifiable");
 		assert.equal(verdict.reason, "unreadable-host-version");
 		assert.match(verdict.message ?? "", /this c8ctl reports its version/);
-		assert.match(verdict.message ?? "", /v4\.0\.0-nightly/);
+		assert.match(verdict.message ?? "", /nightly-build/);
 		assert.doesNotMatch(verdict.message ?? "", /not a version range/);
 	});
 
-	test("a range c8ctl cannot read fails open and names the supported forms", () => {
+	test("a range c8ctl cannot read fails open and points at npm's range syntax", () => {
 		const verdict = checkHostCompat({
 			pluginName,
-			declaredRange: "1.x || 2.x",
+			declaredRange: "latest",
 			hostVersion: "4.0.0",
 		});
 		assert.equal(verdict.status, "unverifiable");
-		assert.equal(verdict.range, "1.x || 2.x");
-		assert.match(verdict.message ?? "", /1\.x \|\| 2\.x/);
-		assert.match(verdict.message ?? "", /\^/);
+		assert.equal(verdict.range, "latest");
+		assert.match(verdict.message ?? "", /latest/);
+		assert.match(verdict.message ?? "", /node-semver/);
 	});
 });
 
@@ -547,7 +564,7 @@ describe("loader enforcement of engines.c8ctl", () => {
 
 	test("a range c8ctl cannot read never disables a plugin", async () => {
 		const { commands, incompatibilities } = await loadFixture(
-			"1.x || 2.x",
+			"latest",
 			"3.3.0",
 		);
 		assert.deepEqual(incompatibilities, []);
@@ -893,7 +910,7 @@ describe("enforcement against a published host version (built dist)", () => {
 		const cli = stageHost("3.3.0");
 		const dataDir = mkdtempSync(join(tmpdir(), "c8ctl-host-compat-warn-"));
 		stagedDirs.push(dataDir);
-		const fixture = stageFixtureCopy("1.x || 2.x");
+		const fixture = stageFixtureCopy("latest");
 		const { status, stdout, stderr } = await runHost(
 			cli,
 			["load", "plugin", "--from", pathToFileURL(fixture).href],

--- a/tests/unit/plugin-host-compat.test.ts
+++ b/tests/unit/plugin-host-compat.test.ts
@@ -1,0 +1,923 @@
+/**
+ * Tests for the plugin → host version contract (#523): a plugin declares the
+ * c8ctl it needs via `engines.c8ctl`, and c8ctl enforces it.
+ *
+ * Class-scoped guards:
+ * - A plugin that declares nothing is `undeclared` — the pre-#523 behaviour,
+ *   which must stay untouched for every plugin already published.
+ * - A host below the declared floor is `incompatible`, and the message names
+ *   the requirement, the running version, and the way out.
+ * - Prereleases order the way semver says they do, so a plugin needing
+ *   `>=4.0.0-alpha.1` is not "satisfied" by 3.3.0 and is not held back by
+ *   4.0.0 — this is the exact pairing that motivated the issue.
+ * - An unpublished development build and an unreadable range both fail *open*
+ *   (`unverifiable`): c8ctl never disables a plugin because it could not
+ *   evaluate the question.
+ * - On an unmet requirement the loader keeps the plugin (and its place in help)
+ *   but every command refuses to run — both command forms, `{ flags, handler }`
+ *   included, since a command that lost its flags would fail with a parse error
+ *   rather than the explanation.
+ * - `doctor plugin` can recover all of it after the fact, in text and JSON.
+ */
+
+import assert from "node:assert";
+import {
+	cpSync,
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { after, describe, test } from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+	checkHostCompat,
+	readHostRequirement,
+	satisfiesRange,
+} from "../../src/framework/plugins/plugin-compat.ts";
+import {
+	clearLoadedPlugins,
+	getPluginCollisions,
+	getPluginCommands,
+	getPluginIncompatibilities,
+	loadInstalledPlugins,
+} from "../../src/framework/plugins/plugin-loader.ts";
+import { asyncSpawn } from "../utils/spawn.ts";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CLI = "src/index.ts";
+const FIXTURE_DIR = join(
+	__dirname,
+	"../fixtures/plugins/plugin-with-host-requirement",
+);
+const PLUGIN_NAME = "c8ctl-plugin-host-requirement";
+
+/** Every data dir staged by this file, removed in `after`. */
+const stagedDirs: string[] = [];
+
+after(() => {
+	for (const dir of stagedDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+/**
+ * Stage a plugin in a throwaway data dir, optionally rewriting the declared
+ * range. Rewriting beats carrying one fixture per range: the declaration is the
+ * variable under test, and every other file stays identical.
+ *
+ * `installDirName` exists for the collision cases, where load order matters —
+ * the loader scans `node_modules` lexicographically, so the directory name is
+ * what decides who loads first.
+ */
+function stagePlugin(
+	declaredRange?: string | null,
+	{
+		installDirName = PLUGIN_NAME,
+		pluginName = PLUGIN_NAME,
+		dataDir = mkdtempSync(join(tmpdir(), "c8ctl-host-compat-")),
+	}: {
+		installDirName?: string;
+		pluginName?: string;
+		dataDir?: string;
+	} = {},
+): string {
+	if (!stagedDirs.includes(dataDir)) stagedDirs.push(dataDir);
+	writeFileSync(
+		join(dataDir, "session.json"),
+		JSON.stringify({ outputMode: "text" }),
+	);
+	const installDir = join(dataDir, "plugins", "node_modules", installDirName);
+	mkdirSync(installDir, { recursive: true });
+	cpSync(FIXTURE_DIR, installDir, { recursive: true });
+
+	if (declaredRange !== undefined || pluginName !== PLUGIN_NAME) {
+		const manifestPath = join(installDir, "package.json");
+		const manifest = {
+			name: pluginName,
+			version: "2.1.0",
+			type: "module",
+			main: "c8ctl-plugin.js",
+			keywords: ["c8ctl-plugin"],
+			...(declaredRange === null || declaredRange === undefined
+				? {}
+				: { engines: { c8ctl: declaredRange } }),
+		};
+		writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+	}
+	return dataDir;
+}
+
+/**
+ * A copy of the fixture *package* (not an installed store) with its declared
+ * range rewritten — an install source for `load plugin --from file://…`.
+ */
+function stageFixtureCopy(declaredRange: string): string {
+	const dir = mkdtempSync(join(tmpdir(), "c8ctl-host-compat-src-"));
+	stagedDirs.push(dir);
+	cpSync(FIXTURE_DIR, dir, { recursive: true });
+	writeFileSync(
+		join(dir, "package.json"),
+		JSON.stringify(
+			{
+				name: PLUGIN_NAME,
+				version: "2.1.0",
+				type: "module",
+				main: "c8ctl-plugin.js",
+				keywords: ["c8ctl-plugin"],
+				engines: { c8ctl: declaredRange },
+			},
+			null,
+			2,
+		),
+	);
+	return dir;
+}
+
+describe("readHostRequirement", () => {
+	test("reads engines.c8ctl", () => {
+		assert.equal(
+			readHostRequirement({ engines: { c8ctl: ">=4.0.0-alpha.1" } }),
+			">=4.0.0-alpha.1",
+		);
+	});
+
+	test("trims surrounding whitespace", () => {
+		assert.equal(
+			readHostRequirement({ engines: { c8ctl: "  >=3.0.0 " } }),
+			">=3.0.0",
+		);
+	});
+
+	test("returns null when nothing is declared", () => {
+		assert.equal(readHostRequirement({ engines: { node: ">=22" } }), null);
+		assert.equal(readHostRequirement({ engines: {} }), null);
+		assert.equal(readHostRequirement({}), null);
+	});
+
+	test("returns null for non-string and empty declarations", () => {
+		assert.equal(readHostRequirement({ engines: { c8ctl: 4 } }), null);
+		assert.equal(readHostRequirement({ engines: { c8ctl: "" } }), null);
+		assert.equal(readHostRequirement({ engines: { c8ctl: "   " } }), null);
+	});
+
+	test("survives a package.json that is not an object", () => {
+		assert.equal(readHostRequirement(null), null);
+		assert.equal(readHostRequirement("not json"), null);
+		assert.equal(readHostRequirement({ engines: "broken" }), null);
+	});
+});
+
+describe("satisfiesRange", () => {
+	const cases: {
+		range: string;
+		satisfied: string[];
+		unsatisfied: string[];
+	}[] = [
+		{
+			range: ">=4.0.0-alpha.1",
+			satisfied: ["4.0.0-alpha.1", "4.0.0-alpha.2", "4.0.0", "4.1.0", "5.0.0"],
+			unsatisfied: ["3.3.0", "3.4.0-alpha.3", "0.9.0"],
+		},
+		{
+			range: ">=3.3.0",
+			// A prerelease sorts below its own release, so 3.3.0-alpha.10 does
+			// not satisfy a >=3.3.0 floor.
+			satisfied: ["3.3.0", "3.3.1", "4.0.0-alpha.1"],
+			unsatisfied: ["3.3.0-alpha.10", "3.2.9"],
+		},
+		{
+			range: ">3.3.0",
+			satisfied: ["3.3.1", "4.0.0"],
+			unsatisfied: ["3.3.0", "3.2.0"],
+		},
+		{
+			range: "<4.0.0",
+			satisfied: ["3.9.9", "4.0.0-alpha.1"],
+			unsatisfied: ["4.0.0", "4.0.1"],
+		},
+		{
+			range: "<=3.3.0",
+			satisfied: ["3.3.0", "3.2.0"],
+			unsatisfied: ["3.3.1"],
+		},
+		{
+			range: "3.3.0",
+			satisfied: ["3.3.0"],
+			unsatisfied: ["3.3.1", "3.2.9"],
+		},
+		{
+			range: "=3.3.0",
+			satisfied: ["3.3.0"],
+			unsatisfied: ["3.4.0"],
+		},
+		{
+			range: "^4.1.0",
+			satisfied: ["4.1.0", "4.2.0", "4.9.9"],
+			unsatisfied: ["4.0.9", "5.0.0", "3.9.0"],
+		},
+		{
+			// npm's 0.x caret semantics: the minor is the breaking axis.
+			range: "^0.2.1",
+			satisfied: ["0.2.1", "0.2.9"],
+			unsatisfied: ["0.3.0", "0.2.0"],
+		},
+		{
+			range: "~4.1.0",
+			satisfied: ["4.1.0", "4.1.9"],
+			unsatisfied: ["4.2.0", "4.0.9"],
+		},
+		{
+			range: "*",
+			satisfied: ["0.0.1", "3.3.0", "99.0.0"],
+			unsatisfied: [],
+		},
+		{
+			// Multiple comparators are ANDed, like npm.
+			range: ">=3.3.0 <5.0.0",
+			satisfied: ["3.3.0", "4.9.9"],
+			unsatisfied: ["3.2.0", "5.0.0"],
+		},
+	];
+
+	for (const { range, satisfied, unsatisfied } of cases) {
+		for (const version of satisfied) {
+			test(`'${range}' is satisfied by ${version}`, () => {
+				assert.equal(satisfiesRange({ version, range }), true);
+			});
+		}
+		for (const version of unsatisfied) {
+			test(`'${range}' is not satisfied by ${version}`, () => {
+				assert.equal(satisfiesRange({ version, range }), false);
+			});
+		}
+	}
+
+	test("returns null for a range c8ctl cannot parse", () => {
+		// `null` is "cannot evaluate", which callers fail open on — distinct
+		// from `false`, which disables the plugin's commands.
+		for (const range of ["latest", ">=four", "1.x || 2.x", ">=", "~>3.3"]) {
+			assert.equal(satisfiesRange({ version: "4.0.0", range }), null, range);
+		}
+	});
+
+	test("returns null for a host version that is not a version", () => {
+		assert.equal(satisfiesRange({ version: "wat", range: ">=3.3.0" }), null);
+	});
+
+	test("an unsupported range never resolves to `false`, whatever the comparator order", () => {
+		// The failure this guards: evaluating comparators left to right and
+		// returning on the first unsatisfied one. `^3.0.0` is unsatisfied by
+		// 4.1.0, so a short-circuiting AND answers `false` — reporting a plugin
+		// that npm considers compatible as incompatible, and disabling it. Every
+		// comparator has to be parsed before any verdict is reached.
+		const unsupported = [
+			"^3.0.0 || ^4.0.0",
+			">=5.0.0 || >=1.0.0",
+			">=4.0.0 || garbage",
+			"3.3.0 - 4.0.0",
+			"5.0.0 - 6.0.0",
+		];
+		for (const range of unsupported) {
+			assert.equal(satisfiesRange({ version: "4.1.0", range }), null, range);
+		}
+	});
+
+	test("prerelease tags order by identifier, not just by trailing number", () => {
+		// `4.0.0-rc.1` satisfies `>=4.0.0-alpha.5`; reading the tags as
+		// interchangeable and comparing only the trailing numbers (1 < 5) would
+		// disable a plugin on a host that meets its floor.
+		assert.equal(
+			satisfiesRange({ version: "4.0.0-rc.1", range: ">=4.0.0-alpha.5" }),
+			true,
+		);
+		assert.equal(
+			satisfiesRange({ version: "4.0.0-alpha.5", range: ">=4.0.0-beta.1" }),
+			false,
+		);
+		// A shorter identifier set sorts lower: 4.0.0-alpha < 4.0.0-alpha.5.
+		assert.equal(
+			satisfiesRange({ version: "4.0.0-alpha", range: ">=4.0.0-alpha.5" }),
+			false,
+		);
+		// Numeric identifiers rank below alphanumeric ones.
+		assert.equal(
+			satisfiesRange({ version: "4.0.0-1", range: ">=4.0.0-alpha" }),
+			false,
+		);
+	});
+
+	test("build metadata is ignored rather than corrupting the comparison", () => {
+		// Semver excludes build metadata from precedence. Letting `+build` reach
+		// a numeric parse yields NaN, and NaN comparisons make every operator
+		// answer the same way regardless of the versions involved.
+		assert.equal(
+			satisfiesRange({ version: "4.0.0+build.5", range: ">=4.0.1" }),
+			false,
+		);
+		assert.equal(
+			satisfiesRange({ version: "4.0.2+build.5", range: ">=4.0.1" }),
+			true,
+		);
+		assert.equal(
+			satisfiesRange({ version: "4.0.0", range: ">=4.0.0+build" }),
+			true,
+		);
+		assert.equal(
+			satisfiesRange({ version: "3.9.0", range: "<4.0.0+build" }),
+			true,
+		);
+	});
+
+	test("a space between operator and operand is one comparator, not two", () => {
+		assert.equal(satisfiesRange({ version: "4.0.0", range: ">= 4.0.0" }), true);
+		assert.equal(
+			satisfiesRange({ version: "3.9.0", range: ">= 4.0.0" }),
+			false,
+		);
+		assert.equal(
+			satisfiesRange({ version: "4.1.0", range: ">=  3.3.0  <5.0.0" }),
+			true,
+		);
+	});
+
+	test("caret and tilde exclude prereleases of the version they bound", () => {
+		// c8ctl's own main branch publishes X.Y.0-alpha.N of the *next* version,
+		// so someone on the alpha channel would otherwise read as satisfying a
+		// caret range on the major that range excludes.
+		assert.equal(
+			satisfiesRange({ version: "5.0.0-alpha.1", range: "^4.1.0" }),
+			false,
+		);
+		assert.equal(
+			satisfiesRange({ version: "4.2.0-alpha.1", range: "~4.1.0" }),
+			false,
+		);
+		// Prereleases *inside* the range still satisfy it.
+		assert.equal(
+			satisfiesRange({ version: "4.2.0-alpha.1", range: "^4.1.0" }),
+			true,
+		);
+	});
+});
+
+describe("checkHostCompat", () => {
+	const pluginName = "c8ctl-plugin-os";
+
+	test("undeclared requirements are left alone", () => {
+		const verdict = checkHostCompat({
+			pluginName,
+			declaredRange: null,
+			hostVersion: "3.3.0",
+		});
+		assert.equal(verdict.status, "undeclared");
+		assert.equal(verdict.range, undefined);
+		assert.equal(verdict.message, undefined);
+	});
+
+	test("a satisfied requirement carries the range and no message", () => {
+		const verdict = checkHostCompat({
+			pluginName,
+			declaredRange: ">=4.0.0-alpha.1",
+			hostVersion: "4.0.0-alpha.1",
+		});
+		assert.equal(verdict.status, "satisfied");
+		assert.equal(verdict.range, ">=4.0.0-alpha.1");
+		assert.equal(verdict.message, undefined);
+	});
+
+	test("an unmet requirement explains itself actionably", () => {
+		const verdict = checkHostCompat({
+			pluginName,
+			declaredRange: ">=4.0.0-alpha.1",
+			hostVersion: "3.3.0",
+		});
+		assert.equal(verdict.status, "incompatible");
+		assert.equal(verdict.range, ">=4.0.0-alpha.1");
+		const message = verdict.message ?? "";
+		assert.match(message, /c8ctl-plugin-os/);
+		assert.match(message, />=4\.0\.0-alpha\.1/);
+		assert.match(message, /3\.3\.0/);
+		// The way out has to be in the message itself — this string is the
+		// only thing a user sees when a plugin command refuses to run.
+		assert.match(message, /npm install -g @camunda8\/cli@latest/);
+	});
+
+	test("an unpublished development build fails open", () => {
+		const verdict = checkHostCompat({
+			pluginName,
+			declaredRange: ">=4.0.0-alpha.1",
+			hostVersion: "0.0.0-semantically-released",
+		});
+		assert.equal(verdict.status, "unverifiable");
+		assert.equal(verdict.range, ">=4.0.0-alpha.1");
+		assert.match(verdict.message ?? "", /development build/);
+	});
+
+	test("an unreadable host version blames the host, not the plugin", () => {
+		// Both cases make `satisfiesRange` answer `null`, but only one of them is
+		// the plugin author's to fix. Collapsing them would have every plugin
+		// declaring a range — including the `"*"` the scaffold ships — warn about
+		// itself on a host whose version string this check cannot parse.
+		const verdict = checkHostCompat({
+			pluginName,
+			declaredRange: "*",
+			hostVersion: "v4.0.0-nightly",
+		});
+		assert.equal(verdict.status, "unverifiable");
+		assert.equal(verdict.reason, "unreadable-host-version");
+		assert.match(verdict.message ?? "", /this c8ctl reports its version/);
+		assert.match(verdict.message ?? "", /v4\.0\.0-nightly/);
+		assert.doesNotMatch(verdict.message ?? "", /not a version range/);
+	});
+
+	test("a range c8ctl cannot read fails open and names the supported forms", () => {
+		const verdict = checkHostCompat({
+			pluginName,
+			declaredRange: "1.x || 2.x",
+			hostVersion: "4.0.0",
+		});
+		assert.equal(verdict.status, "unverifiable");
+		assert.equal(verdict.range, "1.x || 2.x");
+		assert.match(verdict.message ?? "", /1\.x \|\| 2\.x/);
+		assert.match(verdict.message ?? "", /\^/);
+	});
+});
+
+describe("loader enforcement of engines.c8ctl", () => {
+	/**
+	 * `hostVersion` is injected rather than read off the runtime because a
+	 * source checkout always reports the unpublished development version, which
+	 * by design answers `unverifiable` — the blocking path would be unreachable
+	 * from a test otherwise.
+	 */
+	async function loadDataDir(dataDir: string, hostVersion: string) {
+		const previous = process.env.C8CTL_DATA_DIR;
+		process.env.C8CTL_DATA_DIR = dataDir;
+		clearLoadedPlugins();
+		try {
+			await loadInstalledPlugins({ hostVersion });
+			// Snapshot inside the try: the `finally` clears the loader's
+			// bookkeeping, so anything read after this call would come back empty.
+			return {
+				commands: getPluginCommands(),
+				incompatibilities: getPluginIncompatibilities(),
+				collisions: getPluginCollisions(),
+			};
+		} finally {
+			clearLoadedPlugins();
+			if (previous === undefined) delete process.env.C8CTL_DATA_DIR;
+			else process.env.C8CTL_DATA_DIR = previous;
+		}
+	}
+
+	async function loadFixture(
+		declaredRange: string | null | undefined,
+		hostVersion: string,
+	) {
+		return loadDataDir(stagePlugin(declaredRange), hostVersion);
+	}
+
+	test("a satisfied requirement leaves the plugin's commands runnable", async () => {
+		const { commands, incompatibilities } = await loadFixture(
+			">=4.0.0-alpha.1",
+			"4.0.0",
+		);
+		assert.deepEqual(incompatibilities, []);
+		const bare = commands["host-bare"];
+		assert.equal(typeof bare, "function");
+		if (typeof bare === "function") await bare([]);
+	});
+
+	test("an unmet requirement is recorded with both versions", async () => {
+		const { incompatibilities } = await loadFixture(">=4.0.0-alpha.1", "3.3.0");
+		assert.equal(incompatibilities.length, 1);
+		const [record] = incompatibilities;
+		assert.equal(record.plugin, PLUGIN_NAME);
+		assert.equal(record.pluginVersion, "2.1.0");
+		assert.equal(record.required, ">=4.0.0-alpha.1");
+		assert.equal(record.running, "3.3.0");
+		assert.match(record.message, /npm install -g @camunda8\/cli@latest/);
+	});
+
+	test("an unmet requirement makes a bare-function command refuse to run", async () => {
+		const { commands } = await loadFixture(">=4.0.0-alpha.1", "3.3.0");
+		const bare = commands["host-bare"];
+		assert.equal(typeof bare, "function");
+		if (typeof bare !== "function") return;
+		await assert.rejects(
+			async () => bare([]),
+			/requires c8ctl >=4\.0\.0-alpha\.1, but this is c8ctl 3\.3\.0/,
+		);
+	});
+
+	test("an unmet requirement keeps the declared flags of a `{ flags, handler }` command", async () => {
+		const { commands } = await loadFixture(">=4.0.0-alpha.1", "3.3.0");
+		const flagged = commands["host-flagged"];
+		assert.notEqual(typeof flagged, "function");
+		if (typeof flagged === "function") return;
+		// The flags have to survive: without them argv parsing rejects
+		// `--label` before dispatch ever reaches the refusing handler.
+		assert.deepEqual(Object.keys(flagged.flags), ["label"]);
+		await assert.rejects(
+			async () => flagged.handler([], { label: "x" }),
+			/requires c8ctl >=4\.0\.0-alpha\.1/,
+		);
+	});
+
+	test("a plugin declaring nothing is untouched", async () => {
+		const { commands, incompatibilities } = await loadFixture(null, "3.3.0");
+		assert.deepEqual(incompatibilities, []);
+		const bare = commands["host-bare"];
+		assert.equal(typeof bare, "function");
+		if (typeof bare === "function") await bare([]);
+	});
+
+	test("a development build never disables a plugin", async () => {
+		const { commands, incompatibilities } = await loadFixture(
+			">=999.0.0",
+			"0.0.0-semantically-released",
+		);
+		assert.deepEqual(incompatibilities, []);
+		const bare = commands["host-bare"];
+		assert.equal(typeof bare, "function");
+		if (typeof bare === "function") await bare([]);
+	});
+
+	test("a range c8ctl cannot read never disables a plugin", async () => {
+		const { commands, incompatibilities } = await loadFixture(
+			"1.x || 2.x",
+			"3.3.0",
+		);
+		assert.deepEqual(incompatibilities, []);
+		const bare = commands["host-bare"];
+		assert.equal(typeof bare, "function");
+		if (typeof bare === "function") await bare([]);
+	});
+
+	test("a disabled plugin loses a command-name collision to a working one", async () => {
+		// Load order is lexicographic by install directory, so `aaa-` loads first
+		// and would otherwise reserve the command name under the usual
+		// first-registration-wins rule — leaving the user with a command that only
+		// throws while `zzz-`'s working implementation is dropped as a duplicate.
+		const dataDir = stagePlugin(">=999.0.0", {
+			installDirName: "aaa-plugin-disabled",
+			pluginName: "c8ctl-plugin-aaa-disabled",
+		});
+		stagePlugin(null, {
+			dataDir,
+			installDirName: "zzz-plugin-working",
+			pluginName: "c8ctl-plugin-zzz-working",
+		});
+
+		const { commands, incompatibilities } = await loadDataDir(dataDir, "3.3.0");
+		assert.equal(incompatibilities.length, 1);
+		assert.equal(incompatibilities[0].plugin, "c8ctl-plugin-aaa-disabled");
+
+		const bare = commands["host-bare"];
+		assert.equal(typeof bare, "function");
+		// The surviving handler must be the working one — it resolves rather than
+		// throwing the incompatibility message.
+		if (typeof bare === "function") await bare([]);
+	});
+
+	test("a takeover re-points earlier records without erasing them", async () => {
+		// Two disabled plugins then a working one. `mmm` genuinely loses the
+		// command to `aaa`, then `zzz` takes it over from `aaa`. Both losses are
+		// real and must still be reported — but neither may credit `aaa`, which no
+		// longer owns the name. Deleting the first record would drop `mmm`'s
+		// collision from `doctor plugin` altogether; leaving it unedited would
+		// assert a win for `aaa`.
+		const dataDir = stagePlugin(">=999.0.0", {
+			installDirName: "aaa-plugin-disabled",
+			pluginName: "c8ctl-plugin-aaa-disabled",
+		});
+		stagePlugin(">=999.0.0", {
+			dataDir,
+			installDirName: "mmm-plugin-disabled",
+			pluginName: "c8ctl-plugin-mmm-disabled",
+		});
+		stagePlugin(null, {
+			dataDir,
+			installDirName: "zzz-plugin-working",
+			pluginName: "c8ctl-plugin-zzz-working",
+		});
+
+		const { collisions } = await loadDataDir(dataDir, "3.3.0");
+		const forCommand = collisions.filter(
+			(collision) => collision.command === "host-bare",
+		);
+		// Every record credits the plugin that actually owns the name…
+		assert.deepEqual(
+			[...new Set(forCommand.map((collision) => collision.winner))],
+			["c8ctl-plugin-zzz-working"],
+		);
+		// …and both plugins that lost it are still accounted for.
+		assert.deepEqual(forCommand.map((collision) => collision.loser).sort(), [
+			"c8ctl-plugin-aaa-disabled",
+			"c8ctl-plugin-mmm-disabled",
+		]);
+	});
+});
+
+interface DoctorReport {
+	loaded: { name: string; commands: string[]; requires?: string }[];
+	collisions: {
+		kind: "command-name" | "plugin-name";
+		winner: string;
+		loser: string;
+		command?: string;
+	}[];
+	incompatible: {
+		plugin: string;
+		pluginVersion: string;
+		required: string;
+		running: string;
+		message: string;
+	}[];
+}
+
+function parseDoctorJson(stdout: string): DoctorReport {
+	// biome-ignore lint/plugin: parsed-JSON contract boundary; shape asserted by callers
+	const parsed = JSON.parse(stdout) as DoctorReport;
+	return parsed;
+}
+
+function findLoaded(report: DoctorReport, name: string) {
+	return report.loaded.find((plugin) => plugin.name === name);
+}
+
+describe("doctor plugin surfaces the declared requirement", () => {
+	async function runDoctor(dataDir: string, extraArgs: string[] = []) {
+		return asyncSpawn(
+			"node",
+			["--experimental-strip-types", CLI, "doctor", "plugin", ...extraArgs],
+			{
+				env: {
+					...process.env,
+					CAMUNDA_BASE_URL: "http://test-cluster/v2",
+					C8CTL_DATA_DIR: dataDir,
+				},
+			},
+		);
+	}
+
+	test("--json reports the range under the loaded plugin", async () => {
+		const dataDir = stagePlugin(">=4.0.0-alpha.1");
+		const { status, stdout } = await runDoctor(dataDir, ["--json"]);
+		assert.equal(status, 0);
+		const report = parseDoctorJson(stdout);
+		const entry = findLoaded(report, PLUGIN_NAME);
+		assert.ok(entry, `${PLUGIN_NAME} should be loaded: ${stdout}`);
+		assert.equal(entry.requires, ">=4.0.0-alpha.1");
+		// This CLI runs from source, so its version is the unpublished
+		// development placeholder and the requirement is deliberately not
+		// enforced — the plugin is reported, never quarantined.
+		assert.deepEqual(report.incompatible, []);
+	});
+
+	test("text output has a Requires column", async () => {
+		const dataDir = stagePlugin(">=4.0.0-alpha.1");
+		const { status, stdout } = await runDoctor(dataDir);
+		assert.equal(status, 0);
+		assert.match(stdout, /Requires/);
+		assert.match(stdout, />=4\.0\.0-alpha\.1/);
+	});
+
+	test("a plugin declaring nothing shows no requirement", async () => {
+		const dataDir = stagePlugin(null);
+		const { status, stdout } = await runDoctor(dataDir, ["--json"]);
+		assert.equal(status, 0);
+		const report = parseDoctorJson(stdout);
+		const entry = findLoaded(report, PLUGIN_NAME);
+		assert.ok(entry, `${PLUGIN_NAME} should be loaded: ${stdout}`);
+		assert.equal(entry.requires, undefined);
+	});
+});
+
+/**
+ * End-to-end coverage of the half that reads the *running* c8ctl version
+ * (`c8ctl.version`) rather than an injected one: the `load plugin` gate, and
+ * `doctor plugin` with a populated incompatibility.
+ *
+ * A source checkout always reports `0.0.0-semantically-released`, which by
+ * design answers "unverifiable" — so from `src/` these paths are unreachable.
+ * The workaround is to run the *built* CLI from a tree whose `package.json`
+ * carries a real version: `dist/` is copied next to a hand-written manifest,
+ * inside the repo so Node still resolves the real `node_modules`. Requires
+ * `npm run build` (which `npm test` documents as a prerequisite); skipped with a
+ * reason when `dist/` is absent so a source-only run stays green.
+ *
+ * These assert against `dist/`, so a **stale** build fails them — that is the
+ * intended signal, not a flake. `npm run build && npm test` is the documented
+ * order for exactly this reason.
+ */
+describe("enforcement against a published host version (built dist)", () => {
+	const REPO_ROOT = join(__dirname, "../..");
+	const DIST_DIR = join(REPO_ROOT, "dist");
+	const distMissing = !existsSync(join(DIST_DIR, "index.js"));
+	const skip = distMissing
+		? "requires `npm run build` — dist/index.js is absent"
+		: false;
+
+	/** A copy of `dist/` under a package.json claiming `version`. */
+	function stageHost(version: string): string {
+		const hostDir = mkdtempSync(join(REPO_ROOT, "tests", ".tmp-hostver-"));
+		stagedDirs.push(hostDir);
+		cpSync(DIST_DIR, join(hostDir, "dist"), { recursive: true });
+		writeFileSync(
+			join(hostDir, "package.json"),
+			JSON.stringify({ name: "@camunda8/cli", version, type: "module" }),
+		);
+		return join(hostDir, "dist", "index.js");
+	}
+
+	async function runHost(
+		cli: string,
+		args: string[],
+		dataDir: string,
+	): Promise<{ status: number | null; stdout: string; stderr: string }> {
+		return asyncSpawn("node", [cli, ...args], {
+			env: {
+				...process.env,
+				CAMUNDA_BASE_URL: "http://test-cluster/v2",
+				C8CTL_DATA_DIR: dataDir,
+			},
+		});
+	}
+
+	test("the built CLI reports the staged version", { skip }, async () => {
+		// Guards the harness itself: if the staged package.json stopped being
+		// the version source, every assertion below would silently degrade
+		// into the fail-open path and keep passing.
+		const cli = stageHost("3.3.0");
+		const { stdout } = await runHost(cli, ["--version"], stagePlugin(null));
+		assert.match(stdout, /3\.3\.0/);
+	});
+
+	test("a disabled plugin's command exits 1 with one actionable line", {
+		skip,
+	}, async () => {
+		const cli = stageHost("3.3.0");
+		const dataDir = stagePlugin(">=4.0.0-alpha.1");
+		const { status, stdout, stderr } = await runHost(
+			cli,
+			["host-bare"],
+			dataDir,
+		);
+		assert.equal(status, 1);
+		const output = stdout + stderr;
+		assert.match(output, /requires c8ctl >=4\.0\.0-alpha\.1/);
+		assert.match(output, /this is c8ctl 3\.3\.0/);
+		assert.match(output, /npm install -g @camunda8\/cli@latest/);
+		// The failure this replaces: a raw stack trace out of the plugin.
+		assert.doesNotMatch(output, /Unexpected error/);
+		assert.doesNotMatch(output, /\bat \w+ \(/);
+	});
+
+	test("doctor plugin reports the incompatibility in --json", {
+		skip,
+	}, async () => {
+		const cli = stageHost("3.3.0");
+		const dataDir = stagePlugin(">=4.0.0-alpha.1");
+		const { status, stdout } = await runHost(
+			cli,
+			["doctor", "plugin", "--json"],
+			dataDir,
+		);
+		assert.equal(status, 0);
+		const report = parseDoctorJson(stdout);
+		assert.equal(report.incompatible.length, 1);
+		const [record] = report.incompatible;
+		assert.equal(record.plugin, PLUGIN_NAME);
+		assert.equal(record.required, ">=4.0.0-alpha.1");
+		assert.equal(record.running, "3.3.0");
+		// Still listed as loaded: a disabled plugin keeps its help entry so the
+		// command a user already knows about is the one that explains itself.
+		assert.ok(findLoaded(report, PLUGIN_NAME));
+	});
+
+	test("doctor plugin names the incompatibility in text output", {
+		skip,
+	}, async () => {
+		const cli = stageHost("3.3.0");
+		const dataDir = stagePlugin(">=4.0.0-alpha.1");
+		const { status, stdout } = await runHost(
+			cli,
+			["doctor", "plugin"],
+			dataDir,
+		);
+		assert.equal(status, 0);
+		assert.match(stdout, /Incompatible with this c8ctl \(1\)/);
+		assert.match(stdout, new RegExp(PLUGIN_NAME));
+	});
+
+	test("load plugin fails instead of reporting success", { skip }, async () => {
+		const cli = stageHost("3.3.0");
+		const dataDir = mkdtempSync(join(tmpdir(), "c8ctl-host-compat-load-"));
+		stagedDirs.push(dataDir);
+		const { status, stdout, stderr } = await runHost(
+			cli,
+			["load", "plugin", "--from", pathToFileURL(FIXTURE_DIR).href],
+			dataDir,
+		);
+		const output = stdout + stderr;
+		assert.equal(status, 1, `expected a failing exit: ${output}`);
+		assert.match(output, /is not compatible with this c8ctl/);
+		assert.match(output, /requires c8ctl >=4\.0\.0-alpha\.1/);
+		// The two claims a failing install must not make.
+		assert.doesNotMatch(output, /will be available on next command/);
+		assert.doesNotMatch(output, /Plugin loaded successfully/);
+	});
+
+	test("a missing required flag does not shadow the explanation", {
+		skip,
+	}, async () => {
+		// A required flag is validated by the host before dispatch. Without an
+		// exemption for a disabled plugin, `c8ctl host-required-flag` answers
+		// "--label is required" — sending the user to satisfy a flag for a command
+		// that cannot run whatever they pass.
+		const cli = stageHost("3.3.0");
+		const dataDir = stagePlugin(">=4.0.0-alpha.1");
+		const { status, stdout, stderr } = await runHost(
+			cli,
+			["host-required-flag"],
+			dataDir,
+		);
+		const output = stdout + stderr;
+		assert.equal(status, 1);
+		assert.match(output, /requires c8ctl >=4\.0\.0-alpha\.1/);
+		assert.doesNotMatch(output, /--label is required/);
+	});
+
+	test("a required flag is still enforced for a working plugin", {
+		skip,
+	}, async () => {
+		// The exemption must not leak into the normal path.
+		const cli = stageHost("4.0.0");
+		const dataDir = stagePlugin(">=4.0.0-alpha.1");
+		const { status, stdout, stderr } = await runHost(
+			cli,
+			["host-required-flag"],
+			dataDir,
+		);
+		assert.equal(status, 1);
+		assert.match(stdout + stderr, /--label is required/);
+	});
+
+	test("a disabled plugin's commands stay listed in help", {
+		skip,
+	}, async () => {
+		// The design trade: a disabled command stays visible and explains itself
+		// when run, rather than vanishing into "unknown command".
+		const cli = stageHost("3.3.0");
+		const dataDir = stagePlugin(">=4.0.0-alpha.1");
+		const { status, stdout } = await runHost(cli, ["--help"], dataDir);
+		assert.equal(status, 0);
+		assert.match(stdout, /host-bare/);
+	});
+
+	test("an unreadable range warns but installs cleanly", {
+		skip,
+	}, async () => {
+		// Fail-open, end to end: a range c8ctl cannot evaluate must not turn into
+		// a failed install.
+		const cli = stageHost("3.3.0");
+		const dataDir = mkdtempSync(join(tmpdir(), "c8ctl-host-compat-warn-"));
+		stagedDirs.push(dataDir);
+		const fixture = stageFixtureCopy("1.x || 2.x");
+		const { status, stdout, stderr } = await runHost(
+			cli,
+			["load", "plugin", "--from", pathToFileURL(fixture).href],
+			dataDir,
+		);
+		const output = stdout + stderr;
+		assert.equal(status, 0, output);
+		assert.match(output, /not a version range c8ctl understands/);
+		assert.match(output, /Plugin loaded successfully/);
+	});
+
+	test("a satisfied requirement installs and runs normally", {
+		skip,
+	}, async () => {
+		const cli = stageHost("4.0.0");
+		const dataDir = mkdtempSync(join(tmpdir(), "c8ctl-host-compat-ok-"));
+		stagedDirs.push(dataDir);
+		const install = await runHost(
+			cli,
+			["load", "plugin", "--from", pathToFileURL(FIXTURE_DIR).href],
+			dataDir,
+		);
+		assert.equal(
+			install.status,
+			0,
+			`expected a clean install: ${install.stdout}${install.stderr}`,
+		);
+		assert.match(install.stdout, /Plugin loaded successfully/);
+
+		const run = await runHost(cli, ["host-bare"], dataDir);
+		assert.equal(run.status, 0, run.stdout + run.stderr);
+		assert.match(run.stdout, /"ran":"host-bare"/);
+	});
+});

--- a/tests/unit/root-dependencies-isolation.test.ts
+++ b/tests/unit/root-dependencies-isolation.test.ts
@@ -25,6 +25,9 @@ const PROJECT_ROOT = resolve(import.meta.dirname, "..", "..");
 const CORE_DEPENDENCIES = [
 	"@camunda8/orchestration-cluster-api",
 	"@modelcontextprotocol/sdk",
+	// Range evaluation for a plugin's declared `engines.c8ctl` (#523) —
+	// src/framework/plugins/plugin-compat.ts imports it directly.
+	"semver",
 ];
 
 /** Default plugins that declare their own runtime dependencies. */


### PR DESCRIPTION
Closes #523.

A plugin can now declare the c8ctl it needs — `"engines": { "c8ctl": ">=4.0.0-alpha.1" }` — and c8ctl enforces it. Without this, a plugin built against a newer runtime fails *inside the plugin*, at command time, with whatever the missing API happens to raise (usually a bare `TypeError`), while `load plugin` reports success right up until then. Not hypothetical: `c8ctl-plugin-process-os` adopted `c8ctl.npm()`, absent in 3.3.0 — still `latest` on npm — so every `c8 os install` on stable c8ctl dies with a stack trace from inside the plugin.

- **`load` / `upgrade` / `downgrade plugin` fail** before reporting success, so a `set -e` script stops at the cause instead of one layer away. The plugin stays installed — it *is* installed; what it no longer gets is a green exit code. (`downgrade` matters most: pinning an older release is the likeliest way to land on one built for an older host.)
- **At load time** the plugin keeps its place in help, but its commands refuse to run and print which c8ctl they need. Dropping it from help would trade one confusing failure for another — "unknown command os" reads as a typo. A `required: true` flag no longer pre-empts that explanation.
- **A disabled incumbent loses a command-name collision to a working plugin**, so load order can't leave a throwing command shadowing a functioning one.
- **`doctor plugin`** reports each requirement and any incompatibility, in text and `--json`.

**Failing open is a design rule**, not an oversight: an unpublished dev build, a host version that can't be parsed, and a range c8ctl doesn't evaluate all leave the plugin fully working. Disabling a plugin over a question we couldn't answer would turn a diagnostic into an outage.

**Update:** range evaluation now delegates to npm's own [`semver`](https://www.npmjs.com/package/semver) package (a genuine root dependency of `plugin-compat.ts` — see `CORE_DEPENDENCIES` in `tests/unit/root-dependencies-isolation.test.ts`) rather than a hand-rolled comparator, per @vobu's review. That's the full npm range grammar for free — `>=`, `>`, `<=`, `<`, `^`, `~`, exact, `*`, set unions (`||`), hyphen ranges, and partial/wildcard versions (`4.x`) all evaluate correctly now, including prerelease ordering per semver §11 and the 0.x caret carve-outs, instead of the ~200 lines the initial version used to hand-parse comparators and punt on `||`/hyphen/partial forms as "cannot evaluate." There's no npm equivalent for the *enforcement* side (disabling commands, `doctor plugin` reporting, install-time gating) — npm's own `engines.node`/`engines.npm` checking only ever affects `npm install` itself and has no concept of "commands," so that part is still c8ctl-specific.

Two decisions worth a reviewer's eye:

1. **Prereleases participate in ranges**, unlike `npm install`'s default (`4.1.0-alpha.3` satisfies `>=4.0.0-alpha.1`). c8ctl publishes alphas, so npm's default would disable plugins on the exact channel their requirement was written for. Documented in `docs/plugins.md`.
2. **The CI build step is gated to `ubuntu-latest` + Node 22.** The dist-based tests below need a built `dist/`, but `npm run build` also re-runs `npm run lint` — already its own job — and rewrites the synced README/docs blocks, so paying for it on all six matrix legs buys nothing. The trade is that those tests run on one leg and skip on five. Happy to widen it if you'd rather.

Incidental fixes the work surfaced, each in its own commit: `getVersion()`'s `"0.0.0"` fallback (a real version that satisfies no requirement, so it failed *closed*) now returns the dev-build sentinel; and the top-level catch renders a `SilentError` as one line rather than "Unexpected error" plus a stack — the shape of failure this whole change exists to replace.

## Test plan

- [x] 91 tests in `tests/unit/plugin-host-compat.test.ts`: range/prerelease/caret/tilde/AND/set-union/hyphen-range evaluation and every `null` "cannot evaluate" case; verdict messages; loader enforcement (records the incompatibility, both command forms refuse, `{ flags, handler }` keeps its flags, collision takeover, dev build and unreadable range never disable).
- [x] End-to-end against a **published** host version: the built `dist/` runs from a temp tree with a patched `package.json#version`, covering the `load plugin` gate, the CLI refusal (one line, exit 1, no stack), `doctor plugin`'s populated `incompatible[]` in text and JSON, help visibility, the required-flag exemption, and a fail-open install. Skipped with a reason when `dist/` is absent; a *stale* `dist/` fails loudly, which is the intended signal.
- [x] Every fix verified to fail without its production change (stubbed each one and re-ran).
- [x] `npm run build`, `npm run typecheck`, `npm run lint`, `npm run check:layering` clean.
- [x] **CI green on all six OS × Node legs.** The built ubuntu/Node 22 leg reports **2116 passing, 0 failed, 0 skipped**, with the dist-based suite genuinely running rather than skipping — which was the point of the CI change. The five unbuilt legs skip those 11 tests with a stated reason.

**One caveat, stated plainly.** `downgrade plugin`'s gate is wired identically to `load`/`upgrade` but is not covered end-to-end: reaching it needs a registry-version install, which isn't available offline.

Separately, and not caused by this branch: 26 unit tests (`.c8ignore` / `Deployment Logging` / `Deployment Validation`) fail on my machine both here and on unmodified `main`, because they pick up the local Camunda Modeler connections ("Multiple profiles configured but no profile specified"). CI is green, so this is a test-isolation gap rather than a regression — worth its own issue if you agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

