### PR TITLE
fix(element-template): recover forbidden marketplace templates

### DIFF
--- a/default-plugins/element-template/README.md
+++ b/default-plugins/element-template/README.md
@@ -312,6 +312,15 @@ warning at the end (the property won't be applied).
    cache is missing — no auto-download. This keeps pipelines clean:
    bootstrap progress would otherwise land on stdout and corrupt
    `apply | bpmn lint` or `get <id> > template.json`.
+   If an indexed template ref is forbidden (HTTP 403), sync stops scheduling
+   new raw-ref downloads, selects the newest connector release for the highest
+   Camunda engine line in the index (including prereleases), and downloads one
+   template ZIP. It keeps only indexed `id` + `version` entries and uses the
+   archive for every template that did not already download successfully.
+   Non-403 ref errors do not start ZIP recovery. Set
+   `C8CTL_CONNECTOR_RELEASES_URL` or
+   `C8CTL_CONNECTOR_TEMPLATES_ARCHIVE_URL` to override the release lookup
+   during testing or in restricted environments.
 3. **Local file or URL** template args (paths containing `/` or `\`,
    starting with `.`, ending in `.json`, or starting with `http(s)://`)
    skip the index entirely.

--- a/default-plugins/element-template/README.md
+++ b/default-plugins/element-template/README.md
@@ -317,10 +317,7 @@ warning at the end (the property won't be applied).
    Camunda engine line in the index (including prereleases), and downloads one
    template ZIP. It keeps only indexed `id` + `version` entries and uses the
    archive for every template that did not already download successfully.
-   Non-403 ref errors do not start ZIP recovery. Set
-   `C8CTL_CONNECTOR_RELEASES_URL` or
-   `C8CTL_CONNECTOR_TEMPLATES_ARCHIVE_URL` to override the release lookup
-   during testing or in restricted environments.
+   Non-403 ref errors do not start ZIP recovery.
 3. **Local file or URL** template args (paths containing `/` or `\`,
    starting with `.`, ending in `.json`, or starting with `http(s)://`)
    skip the index entirely.

--- a/default-plugins/element-template/docs/design.md
+++ b/default-plugins/element-template/docs/design.md
@@ -48,6 +48,23 @@ We chose the **marketplace endpoint** for parity with Desktop Modeler:
 The endpoint is overridable via `C8CTL_OOTB_ELEMENT_TEMPLATES_URL`
 (useful for testing).
 
+When an indexed template ref returns HTTP 403, `sync` stops scheduling new
+raw-ref downloads. It lets requests already in flight finish, retains the
+successful direct results, and resolves every unfinished template from one
+release archive. The release is the newest in the highest Camunda engine line
+present in the index (including prereleases), and its
+`connectors-bundle-templates-<tag>.zip` asset is filtered to templates whose
+`id` + `version` appear in the marketplace index. The archive is a recovery
+source, not a second catalogue: archive-only templates are ignored and a
+non-403 error alone does not trigger it.
+`C8CTL_CONNECTOR_RELEASES_URL` and `C8CTL_CONNECTOR_TEMPLATES_ARCHIVE_URL`
+override the GitHub API and archive URL for tests or restricted environments.
+
+The release also offers a `.tar.gz` asset, but Node supports gzip
+decompression without a TAR reader. ZIP plus the plugin-local `fflate`
+dependency provides complete archive handling without invoking platform
+utilities, so it remains portable across macOS, Linux, and native Windows.
+
 ## Cache strategy
 
 We mirror Desktop Modeler's approach
@@ -61,6 +78,9 @@ We mirror Desktop Modeler's approach
   Since each `ref` is a commit-pinned `raw.githubusercontent.com` URL,
   "upstreamRef unchanged" ⇒ "content unchanged" ⇒ no re-fetch needed.
   Subsequent syncs only fetch refs that aren't already in the cache.
+- A 403 fallback stores the original indexed `upstreamRef`, so templates
+  recovered from a release archive participate in the same incremental cache
+  reuse as directly fetched templates.
 - Per-template fetch failures are logged + counted, never abort the run.
 
 ### Lifecycle

--- a/default-plugins/element-template/docs/design.md
+++ b/default-plugins/element-template/docs/design.md
@@ -57,8 +57,6 @@ present in the index (including prereleases), and its
 `id` + `version` appear in the marketplace index. The archive is a recovery
 source, not a second catalogue: archive-only templates are ignored and a
 non-403 error alone does not trigger it.
-`C8CTL_CONNECTOR_RELEASES_URL` and `C8CTL_CONNECTOR_TEMPLATES_ARCHIVE_URL`
-override the GitHub API and archive URL for tests or restricted environments.
 
 The release also offers a `.tar.gz` asset, but Node supports gzip
 decompression without a TAR reader. ZIP plus the plugin-local `fflate`

--- a/default-plugins/element-template/marketplace-fallback.ts
+++ b/default-plugins/element-template/marketplace-fallback.ts
@@ -1,0 +1,260 @@
+/**
+ * Connector release archive recovery for forbidden marketplace template refs.
+ *
+ * The marketplace index remains authoritative. This module selects an archive
+ * compatible with that index and exposes only indexed template versions.
+ */
+
+import { strFromU8, unzipSync } from "fflate";
+import semver from "semver";
+import { isRecord, type Logger, type Template, USER_AGENT } from "./helpers.ts";
+
+const DEFAULT_CONNECTOR_RELEASES_URL =
+	"https://api.github.com/repos/camunda/connectors/releases?per_page=100";
+const FETCH_TIMEOUT_MS = 30_000; // 30 s per HTTP request
+
+export type MarketplaceTemplateEntry = {
+	id: string;
+	version: number;
+	ref: string;
+	engine: { camunda?: string } | undefined;
+};
+
+type ConnectorRelease = {
+	tag: string;
+	major: number;
+	minor: number;
+	archiveUrl: string;
+};
+
+type ArchivedTemplate = {
+	name: string;
+	template: Template;
+};
+
+export type MarketplaceReleaseArchive = {
+	url: string;
+	templates: Map<string, ArchivedTemplate[]>;
+};
+
+export class HttpResponseError extends Error {
+	readonly status: number;
+
+	constructor(status: number, statusText: string, url: string) {
+		super(`HTTP ${status} ${statusText} for ${url}`);
+		this.name = "HttpResponseError";
+		this.status = status;
+	}
+}
+
+export function isForbiddenResponse(error: unknown): boolean {
+	return error instanceof HttpResponseError && error.status === 403;
+}
+
+async function fetchResponse(
+	url: string,
+	headers: Record<string, string> = {},
+): Promise<Response> {
+	const response = await fetch(url, {
+		headers: { "User-Agent": USER_AGENT, ...headers },
+		signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+	});
+	if (!response.ok) {
+		throw new HttpResponseError(response.status, response.statusText, url);
+	}
+	return response;
+}
+
+async function fetchJson(
+	url: string,
+	headers: Record<string, string> = {},
+): Promise<unknown> {
+	return (await fetchResponse(url, headers)).json();
+}
+
+async function fetchBytes(url: string): Promise<Uint8Array> {
+	return new Uint8Array(await (await fetchResponse(url)).arrayBuffer());
+}
+
+function isTemplateLike(value: unknown): value is Template {
+	return isRecord(value) && Array.isArray(value.properties);
+}
+
+function templateKey(id: string, version: number): string {
+	return `${id}@${version}`;
+}
+
+function getEntryKey(entry: MarketplaceTemplateEntry): string {
+	return templateKey(entry.id, entry.version);
+}
+
+function getTemplateKey(template: Template): string | null {
+	if (
+		typeof template.id !== "string" ||
+		typeof template.version !== "number" ||
+		!Number.isFinite(template.version)
+	) {
+		return null;
+	}
+	return templateKey(template.id, template.version);
+}
+
+function getEngineLine(
+	entries: MarketplaceTemplateEntry[],
+): { major: number; minor: number } | null {
+	let latest: { major: number; minor: number } | null = null;
+	for (const entry of entries) {
+		const constraint = entry.engine?.camunda;
+		if (!constraint) continue;
+		const match = constraint.match(/(\d+)\.(\d+)/);
+		if (!match) continue;
+		const major = Number(match[1]);
+		const minor = Number(match[2]);
+		if (
+			latest === null ||
+			major > latest.major ||
+			(major === latest.major && minor > latest.minor)
+		) {
+			latest = { major, minor };
+		}
+	}
+	return latest;
+}
+
+function getArchiveFileNames(entry: MarketplaceTemplateEntry): Set<string> {
+	const names = new Set<string>();
+	try {
+		const pathname = new URL(entry.ref).pathname;
+		const basename = pathname.slice(pathname.lastIndexOf("/") + 1);
+		if (!basename.endsWith(".json")) return names;
+		const stem = basename.slice(0, -".json".length);
+		names.add(`${stem}-${entry.version}.json`);
+		names.add(basename);
+	} catch {
+		// The index ref remains the primary source; an invalid ref simply
+		// prevents filename-based disambiguation in the archive fallback.
+	}
+	return names;
+}
+
+function parseConnectorRelease(value: unknown): ConnectorRelease | null {
+	if (!isRecord(value) || value.draft === true) return null;
+	if (typeof value.tag_name !== "string") return null;
+	const parsed = semver.parse(value.tag_name);
+	if (!parsed) return null;
+	if (!Array.isArray(value.assets)) return null;
+
+	const assetName = `connectors-bundle-templates-${value.tag_name}.zip`;
+	for (const asset of value.assets) {
+		if (!isRecord(asset) || asset.name !== assetName) continue;
+		if (typeof asset.browser_download_url !== "string") continue;
+		return {
+			tag: value.tag_name,
+			major: parsed.major,
+			minor: parsed.minor,
+			archiveUrl: asset.browser_download_url,
+		};
+	}
+	return null;
+}
+
+async function getConnectorArchiveUrl(
+	entries: MarketplaceTemplateEntry[],
+): Promise<string> {
+	const override = process.env.C8CTL_CONNECTOR_TEMPLATES_ARCHIVE_URL;
+	if (override) return override;
+
+	const releasesUrl =
+		process.env.C8CTL_CONNECTOR_RELEASES_URL || DEFAULT_CONNECTOR_RELEASES_URL;
+	const raw = await fetchJson(releasesUrl, {
+		Accept: "application/vnd.github+json",
+	});
+	if (!Array.isArray(raw)) {
+		throw new Error("GitHub releases response is not an array");
+	}
+
+	const releases = raw
+		.map(parseConnectorRelease)
+		.filter((release): release is ConnectorRelease => release !== null);
+	const engineLine = getEngineLine(entries);
+	const compatible = engineLine
+		? releases.filter(
+				(release) =>
+					release.major === engineLine.major &&
+					release.minor === engineLine.minor,
+			)
+		: releases;
+	if (compatible.length === 0) {
+		const line = engineLine
+			? `Camunda ${engineLine.major}.${engineLine.minor}`
+			: "the marketplace catalogue";
+		throw new Error(`No connector template release found for ${line}`);
+	}
+
+	compatible.sort((a, b) => semver.rcompare(a.tag, b.tag));
+	return compatible[0].archiveUrl;
+}
+
+export async function fetchReleaseArchive({
+	entries,
+	logger,
+}: {
+	entries: MarketplaceTemplateEntry[];
+	logger: Logger;
+}): Promise<MarketplaceReleaseArchive> {
+	const url = await getConnectorArchiveUrl(entries);
+	logger.info(`Fetching connector template release archive from ${url} ...`);
+	let files: Record<string, Uint8Array>;
+	try {
+		files = unzipSync(await fetchBytes(url));
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		throw new Error(
+			`Failed to read connector template archive ${url}: ${message}`,
+		);
+	}
+
+	const wanted = new Set(entries.map(getEntryKey));
+	const templates = new Map<string, ArchivedTemplate[]>();
+	for (const [name, bytes] of Object.entries(files)) {
+		if (!name.toLowerCase().endsWith(".json")) continue;
+		let parsed: unknown;
+		try {
+			parsed = JSON.parse(strFromU8(bytes));
+		} catch {
+			continue;
+		}
+		if (!isTemplateLike(parsed)) continue;
+		const key = getTemplateKey(parsed);
+		if (!key || !wanted.has(key)) continue;
+		const candidates = templates.get(key) || [];
+		candidates.push({ name, template: parsed });
+		templates.set(key, candidates);
+	}
+	return { url, templates };
+}
+
+export function getArchivedTemplate(
+	entry: MarketplaceTemplateEntry,
+	archive: MarketplaceReleaseArchive,
+): Template {
+	const candidates = archive.templates.get(getEntryKey(entry)) || [];
+	if (candidates.length === 0) {
+		throw new Error(
+			`Release archive ${archive.url} does not contain ${getEntryKey(entry)}`,
+		);
+	}
+	if (candidates.length === 1) return candidates[0].template;
+
+	const expectedNames = getArchiveFileNames(entry);
+	const named = candidates.filter((candidate) =>
+		expectedNames.has(
+			candidate.name.slice(candidate.name.lastIndexOf("/") + 1),
+		),
+	);
+	if (named.length === 1) return named[0].template;
+
+	throw new Error(
+		`Release archive ${archive.url} contains ambiguous entries for ${getEntryKey(entry)}`,
+	);
+}

--- a/default-plugins/element-template/marketplace-fallback.ts
+++ b/default-plugins/element-template/marketplace-fallback.ts
@@ -161,12 +161,7 @@ function parseConnectorRelease(value: unknown): ConnectorRelease | null {
 async function getConnectorArchiveUrl(
 	entries: MarketplaceTemplateEntry[],
 ): Promise<string> {
-	const override = process.env.C8CTL_CONNECTOR_TEMPLATES_ARCHIVE_URL;
-	if (override) return override;
-
-	const releasesUrl =
-		process.env.C8CTL_CONNECTOR_RELEASES_URL || DEFAULT_CONNECTOR_RELEASES_URL;
-	const raw = await fetchJson(releasesUrl, {
+	const raw = await fetchJson(DEFAULT_CONNECTOR_RELEASES_URL, {
 		Accept: "application/vnd.github+json",
 	});
 	if (!Array.isArray(raw)) {

--- a/default-plugins/element-template/marketplace.ts
+++ b/default-plugins/element-template/marketplace.ts
@@ -8,7 +8,8 @@
  * We download every ref once, inline the templates into a single
  * `templates.json` cache file, and inject `metadata.upstreamRef = <ref>` so
  * subsequent syncs can skip already-cached entries (matches Modeler's
- * approach in `app/lib/template-updater/util.js`).
+ * approach in `app/lib/template-updater/util.js`). A 403 from a ref is
+ * recovered from a compatible connector release archive.
  */
 
 import {
@@ -25,6 +26,14 @@ import {
 import { join } from "node:path";
 import semver from "semver";
 import { isRecord, type Logger, type Template, USER_AGENT } from "./helpers.ts";
+import {
+	fetchReleaseArchive,
+	getArchivedTemplate,
+	HttpResponseError,
+	isForbiddenResponse,
+	type MarketplaceReleaseArchive,
+	type MarketplaceTemplateEntry,
+} from "./marketplace-fallback.ts";
 
 const DEFAULT_OOTB_URL =
 	"https://marketplace.cloud.camunda.io/api/v1/ootb-connectors";
@@ -48,12 +57,7 @@ type IndexVersionEntry = {
 	engine?: IndexEngine;
 };
 
-type FlatIndexEntry = {
-	id: string;
-	version: number;
-	ref: string;
-	engine: IndexEngine | undefined;
-};
+type FlatIndexEntry = MarketplaceTemplateEntry;
 
 export type SyncSummary = {
 	total: number;
@@ -360,17 +364,25 @@ export function nudgeIfStale(logger: Logger): void {
 // HTTP
 // ---------------------------------------------------------------------------
 
-async function fetchJson(url: string): Promise<unknown> {
+async function fetchResponse(
+	url: string,
+	headers: Record<string, string> = {},
+): Promise<Response> {
 	const response = await fetch(url, {
-		headers: { "User-Agent": USER_AGENT },
+		headers: { "User-Agent": USER_AGENT, ...headers },
 		signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
 	});
 	if (!response.ok) {
-		throw new Error(
-			`HTTP ${response.status} ${response.statusText} for ${url}`,
-		);
+		throw new HttpResponseError(response.status, response.statusText, url);
 	}
-	return response.json();
+	return response;
+}
+
+async function fetchJson(
+	url: string,
+	headers: Record<string, string> = {},
+): Promise<unknown> {
+	return (await fetchResponse(url, headers)).json();
 }
 
 async function fetchIndex(): Promise<Record<string, IndexVersionEntry[]>> {
@@ -419,27 +431,43 @@ async function fetchTemplate(url: string): Promise<Template> {
 // Sync
 // ---------------------------------------------------------------------------
 
+type DirectFetchResults = {
+	templates: Map<FlatIndexEntry, Template>;
+	errors: Map<FlatIndexEntry, unknown>;
+	fallbackRequired: boolean;
+};
+
 /**
- * Run `fn` over `items` with at most `concurrency` in flight.
- * Each fn() must handle its own errors — exceptions abort the pool.
+ * Fetch raw refs concurrently until a forbidden response makes archive
+ * recovery necessary. Workers already awaiting a response drain, but no worker
+ * dequeues another ref once archive mode has started.
  */
-async function pool<T>(
-	items: T[],
-	concurrency: number,
-	fn: (item: T) => Promise<void>,
-): Promise<void> {
-	const queue = items.slice();
+async function fetchDirectTemplates(
+	entries: FlatIndexEntry[],
+): Promise<DirectFetchResults> {
+	const queue = entries.slice();
+	const templates = new Map<FlatIndexEntry, Template>();
+	const errors = new Map<FlatIndexEntry, unknown>();
+	let fallbackRequired = false;
 	const workers = Array.from(
-		{ length: Math.min(concurrency, queue.length) },
+		{ length: Math.min(FETCH_CONCURRENCY, queue.length) },
 		async () => {
-			while (queue.length > 0) {
-				const item = queue.shift();
-				if (item === undefined) break;
-				await fn(item);
+			while (!fallbackRequired) {
+				const entry = queue.shift();
+				if (entry === undefined) break;
+				try {
+					templates.set(entry, await fetchTemplate(entry.ref));
+				} catch (error) {
+					errors.set(entry, error);
+					if (isForbiddenResponse(error)) {
+						fallbackRequired = true;
+					}
+				}
 			}
 		},
 	);
 	await Promise.all(workers);
+	return { templates, errors, fallbackRequired };
 }
 
 /**
@@ -528,26 +556,49 @@ async function syncTemplatesLocked({
 
 	let fetched = 0;
 	let errors = 0;
-	let progress = 0;
 	const fetchedTemplates: Template[] = [];
+	const direct = await fetchDirectTemplates(toFetch);
+	let archiveError: unknown;
+	let releaseArchive: MarketplaceReleaseArchive | null = null;
+	if (direct.fallbackRequired) {
+		try {
+			releaseArchive = await fetchReleaseArchive({ entries, logger });
+		} catch (error) {
+			archiveError = error;
+		}
+	}
 
-	await pool(toFetch, FETCH_CONCURRENCY, async (entry) => {
-		progress += 1;
-		const myProgress = progress;
+	for (const [index, entry] of toFetch.entries()) {
+		const progress = index + 1;
 		const label = `${entry.id}@${entry.version}`;
 		try {
-			const template = await fetchTemplate(entry.ref);
+			let template = direct.templates.get(entry);
+			if (template === undefined) {
+				if (releaseArchive !== null) {
+					template = getArchivedTemplate(entry, releaseArchive);
+				} else if (direct.fallbackRequired) {
+					throw (
+						archiveError ??
+						new Error("Connector template release archive could not be loaded")
+					);
+				} else {
+					throw (
+						direct.errors.get(entry) ??
+						new Error(`Template fetch did not complete for ${entry.ref}`)
+					);
+				}
+			}
 			template.metadata = template.metadata || {};
 			template.metadata.upstreamRef = entry.ref;
 			fetchedTemplates.push(template);
 			fetched += 1;
-			logger.info(`  [${myProgress}/${toFetch.length}] ${label}`);
+			logger.info(`  [${progress}/${toFetch.length}] ${label}`);
 		} catch (error) {
 			errors += 1;
 			const message = error instanceof Error ? error.message : String(error);
-			logger.warn(`  [${myProgress}/${toFetch.length}] ${label} — ${message}`);
+			logger.warn(`  [${progress}/${toFetch.length}] ${label} — ${message}`);
 		}
-	});
+	}
 
 	// Build the new cache: keep cached entries that are still in the index,
 	// plus everything we just fetched. Sort fetched entries by id+version so

--- a/default-plugins/element-template/package.json
+++ b/default-plugins/element-template/package.json
@@ -7,6 +7,7 @@
   "main": "c8ctl-plugin.ts",
   "dependencies": {
     "bpmn-moddle": "^9.0.1",
+    "fflate": "^0.8.3",
     "semver": "^7.6.3"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
       "version": "0.1.0",
       "dependencies": {
         "bpmn-moddle": "^9.0.1",
+        "fflate": "^0.8.3",
         "semver": "^7.6.3"
       },
       "devDependencies": {
@@ -3149,6 +3150,12 @@
       "engines": {
         "node": ">= 20.12.0"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/figures": {
       "version": "6.1.0",

--- a/tests/fixtures/mock-connector-releases.mjs
+++ b/tests/fixtures/mock-connector-releases.mjs
@@ -1,0 +1,25 @@
+const CONNECTOR_RELEASES_URL =
+	"https://api.github.com/repos/camunda/connectors/releases?per_page=100";
+
+const marketplaceUrl = process.env.C8CTL_OOTB_ELEMENT_TEMPLATES_URL;
+if (!marketplaceUrl) {
+	throw new Error(
+		"C8CTL_OOTB_ELEMENT_TEMPLATES_URL is required for the connector release mock.",
+	);
+}
+
+const fixtureReleasesUrl = new URL("/releases", marketplaceUrl);
+const originalFetch = globalThis.fetch;
+
+globalThis.fetch = async (input, init) => {
+	const url =
+		input instanceof Request
+			? input.url
+			: input instanceof URL
+				? input.href
+				: input;
+	if (url === CONNECTOR_RELEASES_URL) {
+		return originalFetch(fixtureReleasesUrl, init);
+	}
+	return originalFetch(input, init);
+};

--- a/tests/unit/element-template.test.ts
+++ b/tests/unit/element-template.test.ts
@@ -18,6 +18,7 @@ import { createServer, type Server } from "node:http";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, test } from "node:test";
+import { zipSync } from "fflate";
 import { isRecord } from "../../src/core/logger.ts";
 import { c8 } from "../utils/cli.ts";
 import { asyncSpawn, asyncSpawnWithStdin } from "../utils/spawn.ts";
@@ -2818,6 +2819,330 @@ async function startMarketplaceStub(
 			new Promise<void>((resolveClose) => server.close(() => resolveClose())),
 	};
 }
+
+type ArchiveFallbackStub = {
+	marketplaceUrl: string;
+	releasesUrl: string;
+	releaseRequests: () => number;
+	archiveRequests: () => number;
+	rawRequests: () => number;
+	close: () => Promise<void>;
+};
+
+async function startArchiveFallbackStub({
+	indexTemplates,
+	archiveTemplates,
+	rawStatus = 403,
+	rawStatusesByIndex = {},
+	rawTemplatesByIndex = {},
+}: {
+	indexTemplates: Array<Record<string, unknown>>;
+	archiveTemplates: Array<Record<string, unknown>>;
+	rawStatus?: number;
+	rawStatusesByIndex?: Record<number, number>;
+	rawTemplatesByIndex?: Record<number, Record<string, unknown>>;
+}): Promise<ArchiveFallbackStub> {
+	const index: Record<
+		string,
+		Array<{ version: number; ref: string; engine: { camunda: string } }>
+	> = {};
+	const archiveFiles: Record<string, Uint8Array> = {};
+	for (const [indexPosition, template] of indexTemplates.entries()) {
+		if (
+			typeof template.id !== "string" ||
+			typeof template.version !== "number"
+		) {
+			throw new Error("Archive fallback test templates need id and version");
+		}
+		index[template.id] ||= [];
+		index[template.id].push({
+			version: template.version,
+			ref: `__BASE__/raw/${indexPosition}.json`,
+			engine: { camunda: "^8.10" },
+		});
+	}
+	for (const [archivePosition, template] of archiveTemplates.entries()) {
+		archiveFiles[`template-${archivePosition}.json`] = new TextEncoder().encode(
+			JSON.stringify(template),
+		);
+	}
+	const archive = zipSync(archiveFiles);
+	const stableArchive = zipSync({});
+	let releaseRequestCount = 0;
+	let archiveRequestCount = 0;
+	let rawRequestCount = 0;
+
+	const server: Server = createServer((req, res) => {
+		if (!req.url) {
+			res.statusCode = 400;
+			res.end();
+			return;
+		}
+		const baseUrl = `http://127.0.0.1:${getServerPort(server)}`;
+		if (req.url === "/ootb-connectors") {
+			const rewritten = Object.fromEntries(
+				Object.entries(index).map(([id, entries]) => [
+					id,
+					entries.map((entry) => ({
+						...entry,
+						ref: entry.ref.replace("__BASE__", baseUrl),
+					})),
+				]),
+			);
+			res.setHeader("content-type", "application/json");
+			res.end(JSON.stringify(rewritten));
+			return;
+		}
+		if (req.url.startsWith("/raw/")) {
+			rawRequestCount += 1;
+			const indexPosition = Number(
+				req.url.slice("/raw/".length, -".json".length),
+			);
+			const rawTemplate = rawTemplatesByIndex[indexPosition];
+			if (rawTemplate) {
+				res.setHeader("content-type", "application/json");
+				res.end(JSON.stringify(rawTemplate));
+				return;
+			}
+			res.statusCode = rawStatusesByIndex[indexPosition] ?? rawStatus;
+			res.end();
+			return;
+		}
+		if (req.url === "/releases") {
+			releaseRequestCount += 1;
+			res.setHeader("content-type", "application/json");
+			res.end(
+				JSON.stringify([
+					{
+						draft: false,
+						tag_name: "8.9.7",
+						assets: [
+							{
+								name: "connectors-bundle-templates-8.9.7.zip",
+								browser_download_url: `${baseUrl}/stable.zip`,
+							},
+						],
+					},
+					{
+						draft: false,
+						tag_name: "8.10.0-alpha4",
+						assets: [
+							{
+								name: "connectors-bundle-templates-8.10.0-alpha4.zip",
+								browser_download_url: `${baseUrl}/archive.zip`,
+							},
+						],
+					},
+				]),
+			);
+			return;
+		}
+		if (req.url === "/archive.zip") {
+			archiveRequestCount += 1;
+			res.setHeader("content-type", "application/zip");
+			res.end(archive);
+			return;
+		}
+		if (req.url === "/stable.zip") {
+			res.setHeader("content-type", "application/zip");
+			res.end(stableArchive);
+			return;
+		}
+		res.statusCode = 404;
+		res.end();
+	});
+
+	await new Promise<void>((resolveListen, reject) => {
+		server.once("error", reject);
+		server.listen(0, "127.0.0.1", () => resolveListen());
+	});
+	const port = getServerPort(server);
+	return {
+		marketplaceUrl: `http://127.0.0.1:${port}/ootb-connectors`,
+		releasesUrl: `http://127.0.0.1:${port}/releases`,
+		releaseRequests: () => releaseRequestCount,
+		archiveRequests: () => archiveRequestCount,
+		rawRequests: () => rawRequestCount,
+		close: () =>
+			new Promise<void>((resolveClose) => server.close(() => resolveClose())),
+	};
+}
+
+describe("CLI behavioural: element-template sync 403 archive fallback", () => {
+	test("switches to one compatible archive and keeps only indexed templates", async () => {
+		const requested = Array.from({ length: 24 }, (_, index) => ({
+			id: `io.example.requested-${index}`,
+			name: `Requested ${index}`,
+			version: 1,
+			properties: [],
+		}));
+		const archiveOnly = {
+			id: "io.example.archive-only",
+			name: "Archive only",
+			version: 1,
+			properties: [],
+		};
+		const stub = await startArchiveFallbackStub({
+			indexTemplates: requested,
+			archiveTemplates: [...requested.slice(1), archiveOnly],
+			rawTemplatesByIndex: { 0: requested[0] },
+		});
+		const dataDir = mkdtempSync(join(tmpdir(), "c8ctl-et-archive-"));
+		try {
+			const result = await asyncSpawn(
+				"node",
+				[
+					"--experimental-strip-types",
+					CLI,
+					"--json",
+					"element-template",
+					"sync",
+				],
+				{
+					env: {
+						...process.env,
+						HOME: "/tmp/c8ctl-test-nonexistent-home",
+						C8CTL_DATA_DIR: dataDir,
+						C8CTL_OOTB_ELEMENT_TEMPLATES_URL: stub.marketplaceUrl,
+						C8CTL_CONNECTOR_RELEASES_URL: stub.releasesUrl,
+					},
+				},
+			);
+			assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+			assert.strictEqual(stub.releaseRequests(), 1);
+			assert.strictEqual(stub.archiveRequests(), 1);
+			assert.ok(
+				stub.rawRequests() < requested.length,
+				"Raw downloads should stop when archive recovery begins.",
+			);
+			const cache = JSON.parse(
+				readFileSync(
+					join(dataDir, "element-templates", "templates.json"),
+					"utf8",
+				),
+			);
+			assert.strictEqual(cache.length, requested.length);
+			assert.deepStrictEqual(
+				cache
+					.map((template: { id: string }) => template.id)
+					.sort((a: string, b: string) => a.localeCompare(b)),
+				requested
+					.map((template) => template.id)
+					.sort((a, b) => a.localeCompare(b)),
+			);
+			for (const template of cache) {
+				assert.strictEqual(
+					template.metadata.upstreamRef.includes("/raw/"),
+					true,
+				);
+			}
+		} finally {
+			await stub.close();
+			rmSync(dataDir, { recursive: true, force: true });
+		}
+	});
+
+	test("recovers every unfinished template after another ref returns 403", async () => {
+		const requested = [
+			{
+				id: "io.example.forbidden",
+				name: "Forbidden",
+				version: 1,
+				properties: [],
+			},
+			{
+				id: "io.example.not-found",
+				name: "Not found",
+				version: 1,
+				properties: [],
+			},
+		];
+		const stub = await startArchiveFallbackStub({
+			indexTemplates: requested,
+			archiveTemplates: requested,
+			rawStatusesByIndex: { 0: 403, 1: 404 },
+		});
+		const dataDir = mkdtempSync(join(tmpdir(), "c8ctl-et-archive-"));
+		try {
+			const result = await asyncSpawn(
+				"node",
+				[
+					"--experimental-strip-types",
+					CLI,
+					"--json",
+					"element-template",
+					"sync",
+				],
+				{
+					env: {
+						...process.env,
+						HOME: "/tmp/c8ctl-test-nonexistent-home",
+						C8CTL_DATA_DIR: dataDir,
+						C8CTL_OOTB_ELEMENT_TEMPLATES_URL: stub.marketplaceUrl,
+						C8CTL_CONNECTOR_RELEASES_URL: stub.releasesUrl,
+					},
+				},
+			);
+			assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+			assert.strictEqual(stub.releaseRequests(), 1);
+			assert.strictEqual(stub.archiveRequests(), 1);
+			const cache = JSON.parse(
+				readFileSync(
+					join(dataDir, "element-templates", "templates.json"),
+					"utf8",
+				),
+			);
+			assert.strictEqual(cache.length, requested.length);
+			assert.doesNotMatch(result.stderr, /HTTP 404/);
+		} finally {
+			await stub.close();
+			rmSync(dataDir, { recursive: true, force: true });
+		}
+	});
+
+	test("does not use the archive fallback for non-403 template errors", async () => {
+		const requested = {
+			id: "io.example.not-found",
+			name: "Not found",
+			version: 1,
+			properties: [],
+		};
+		const stub = await startArchiveFallbackStub({
+			indexTemplates: [requested],
+			archiveTemplates: [requested],
+			rawStatus: 404,
+		});
+		const dataDir = mkdtempSync(join(tmpdir(), "c8ctl-et-archive-"));
+		try {
+			const result = await asyncSpawn(
+				"node",
+				[
+					"--experimental-strip-types",
+					CLI,
+					"--json",
+					"element-template",
+					"sync",
+				],
+				{
+					env: {
+						...process.env,
+						HOME: "/tmp/c8ctl-test-nonexistent-home",
+						C8CTL_DATA_DIR: dataDir,
+						C8CTL_OOTB_ELEMENT_TEMPLATES_URL: stub.marketplaceUrl,
+						C8CTL_CONNECTOR_RELEASES_URL: stub.releasesUrl,
+					},
+				},
+			);
+			assert.strictEqual(result.status, 0, `stderr: ${result.stderr}`);
+			assert.strictEqual(stub.releaseRequests(), 0);
+			assert.strictEqual(stub.archiveRequests(), 0);
+			assert.match(result.stderr, /HTTP 404/);
+		} finally {
+			await stub.close();
+			rmSync(dataDir, { recursive: true, force: true });
+		}
+	});
+});
 
 describe("CLI behavioural: element-template sync lockfile", () => {
 	test("second concurrent sync exits non-zero pointing at the lockfile", async () => {

--- a/tests/unit/element-template.test.ts
+++ b/tests/unit/element-template.test.ts
@@ -26,6 +26,12 @@ import { asyncSpawn, asyncSpawnWithStdin } from "../utils/spawn.ts";
 const FIXTURES_DIR = resolve(import.meta.dirname, "..", "fixtures");
 const REPO_ROOT = resolve(import.meta.dirname, "..", "..");
 const CLI = "src/index.ts";
+const CONNECTOR_RELEASES_FETCH_MOCK = join(
+	REPO_ROOT,
+	"tests",
+	"fixtures",
+	"mock-connector-releases.mjs",
+);
 const BPMN_FILE = join(FIXTURES_DIR, "simple.bpmn");
 const TEMPLATE_FILE = join(FIXTURES_DIR, "http-json-connector.json");
 
@@ -2822,7 +2828,6 @@ async function startMarketplaceStub(
 
 type ArchiveFallbackStub = {
 	marketplaceUrl: string;
-	releasesUrl: string;
 	releaseRequests: () => number;
 	archiveRequests: () => number;
 	rawRequests: () => number;
@@ -2959,7 +2964,6 @@ async function startArchiveFallbackStub({
 	const port = getServerPort(server);
 	return {
 		marketplaceUrl: `http://127.0.0.1:${port}/ootb-connectors`,
-		releasesUrl: `http://127.0.0.1:${port}/releases`,
 		releaseRequests: () => releaseRequestCount,
 		archiveRequests: () => archiveRequestCount,
 		rawRequests: () => rawRequestCount,
@@ -2992,6 +2996,8 @@ describe("CLI behavioural: element-template sync 403 archive fallback", () => {
 			const result = await asyncSpawn(
 				"node",
 				[
+					"--import",
+					CONNECTOR_RELEASES_FETCH_MOCK,
 					"--experimental-strip-types",
 					CLI,
 					"--json",
@@ -3004,7 +3010,6 @@ describe("CLI behavioural: element-template sync 403 archive fallback", () => {
 						HOME: "/tmp/c8ctl-test-nonexistent-home",
 						C8CTL_DATA_DIR: dataDir,
 						C8CTL_OOTB_ELEMENT_TEMPLATES_URL: stub.marketplaceUrl,
-						C8CTL_CONNECTOR_RELEASES_URL: stub.releasesUrl,
 					},
 				},
 			);
@@ -3067,6 +3072,8 @@ describe("CLI behavioural: element-template sync 403 archive fallback", () => {
 			const result = await asyncSpawn(
 				"node",
 				[
+					"--import",
+					CONNECTOR_RELEASES_FETCH_MOCK,
 					"--experimental-strip-types",
 					CLI,
 					"--json",
@@ -3079,7 +3086,6 @@ describe("CLI behavioural: element-template sync 403 archive fallback", () => {
 						HOME: "/tmp/c8ctl-test-nonexistent-home",
 						C8CTL_DATA_DIR: dataDir,
 						C8CTL_OOTB_ELEMENT_TEMPLATES_URL: stub.marketplaceUrl,
-						C8CTL_CONNECTOR_RELEASES_URL: stub.releasesUrl,
 					},
 				},
 			);
@@ -3129,7 +3135,6 @@ describe("CLI behavioural: element-template sync 403 archive fallback", () => {
 						HOME: "/tmp/c8ctl-test-nonexistent-home",
 						C8CTL_DATA_DIR: dataDir,
 						C8CTL_OOTB_ELEMENT_TEMPLATES_URL: stub.marketplaceUrl,
-						C8CTL_CONNECTOR_RELEASES_URL: stub.releasesUrl,
 					},
 				},
 			);


### PR DESCRIPTION
## Summary
- recover marketplace templates from a compatible connector release archive after a raw ref returns HTTP 403
- stop scheduling raw downloads after the first 403 while preserving successful direct downloads
- keep the release API fixed in production and intercept it only in CLI behavioral tests

## Testing
- npm run build
- npm test (isolated home and Camunda credentials removed)